### PR TITLE
Remove SwiftUI imports from non-UI classes

### DIFF
--- a/Snap-O/ADB/ADBPathManager.swift
+++ b/Snap-O/ADB/ADBPathManager.swift
@@ -1,5 +1,4 @@
 import AppKit
-import SwiftUI
 import UniformTypeIdentifiers
 
 actor ADBPathManager {

--- a/Snap-O/App/ADBService.swift
+++ b/Snap-O/App/ADBService.swift
@@ -1,5 +1,4 @@
-import AppKit
-import SwiftUI
+import Foundation
 
 actor ADBService {
   private var adbURL: URL?

--- a/Snap-O/App/AppServices.swift
+++ b/Snap-O/App/AppServices.swift
@@ -1,5 +1,4 @@
-import AppKit
-import SwiftUI
+import Foundation
 
 final actor AppServices {
   static let shared = AppServices()

--- a/Snap-O/App/AppSettings.swift
+++ b/Snap-O/App/AppSettings.swift
@@ -1,5 +1,5 @@
 import Combine
-import SwiftUI
+import Foundation
 
 @MainActor
 final class AppSettings: ObservableObject {

--- a/Snap-O/CaptureWindow/CaptureController.swift
+++ b/Snap-O/CaptureWindow/CaptureController.swift
@@ -1,6 +1,5 @@
 import AppKit
 import Combine
-import SwiftUI
 
 private let log = SnapOLog.recording
 

--- a/Snap-O/CaptureWindow/DeviceSelection.swift
+++ b/Snap-O/CaptureWindow/DeviceSelection.swift
@@ -1,5 +1,4 @@
 import Combine
-import SwiftUI
 
 @MainActor
 final class DeviceSelection: ObservableObject {

--- a/Snap-O/DeviceStore.swift
+++ b/Snap-O/DeviceStore.swift
@@ -1,5 +1,4 @@
 import Combine
-import SwiftUI
 
 @MainActor
 final class DeviceStore: ObservableObject {


### PR DESCRIPTION
## Summary
- remove SwiftUI imports from service and controller classes that no longer use SwiftUI
- add Foundation/Combine imports where needed to support @Published and other attributes
- leave SwiftUI usage only in files that still define views or representables

## Testing
- swift test *(fails: no Package.swift in repository)*

------
https://chatgpt.com/codex/tasks/task_i_68bafbc4607483258b436894a4f6a00e