### PR TITLE
Floating Snap-O during recording/preview

### DIFF
--- a/Snap-O/CaptureWindow/CaptureDeviceView.swift
+++ b/Snap-O/CaptureWindow/CaptureDeviceView.swift
@@ -38,6 +38,10 @@ struct CaptureDeviceView: View {
       WindowSizingController(displayInfo: controller.displayInfo)
         .frame(width: 0, height: 0)
     )
+    .background(
+      WindowLevelController(shouldFloat: controller.isRecording || controller.isLivePreviewActive)
+        .frame(width: 0, height: 0)
+    )
     .onOpenURL { controller.handle(url: $0) }
     .focusedSceneObject(controller)
     .toolbar {

--- a/Snap-O/CaptureWindow/WindowLevelController.swift
+++ b/Snap-O/CaptureWindow/WindowLevelController.swift
@@ -1,0 +1,41 @@
+import AppKit
+import SwiftUI
+
+/// Adjusts the window's level so Snap-O stays above other windows while a
+/// recording or live preview session is active. When activity stops, the
+/// window returns to the default level so it behaves like a normal document
+/// window.
+struct WindowLevelController: NSViewRepresentable {
+  let shouldFloat: Bool
+
+  func makeCoordinator() -> Coordinator {
+    Coordinator()
+  }
+
+  func makeNSView(context: Context) -> NSView {
+    let view = NSView()
+    DispatchQueue.main.async {
+      context.coordinator.updateWindowLevel(shouldFloat: shouldFloat, for: view.window)
+    }
+    return view
+  }
+
+  func updateNSView(_ nsView: NSView, context: Context) {
+    DispatchQueue.main.async {
+      context.coordinator.updateWindowLevel(shouldFloat: shouldFloat, for: nsView.window)
+    }
+  }
+
+  // MARK: - Coordinator
+
+  final class Coordinator {
+    private var lastAppliedLevel: NSWindow.Level?
+
+    func updateWindowLevel(shouldFloat: Bool, for window: NSWindow?) {
+      guard let window else { return }
+      DispatchQueue.main.async {
+        window.level = shouldFloat ? .floating : .normal
+      }
+    }
+  }
+}


### PR DESCRIPTION
Make Snap-O’s capture window float while recording the emulator in Android Studio. This ensures the Snap-O window remains visible and accessible, so you can easily stop the recording without it being covered by Android Studio.