### PR TITLE
Bug report setting

### DIFF
--- a/Snap-O/ADB/ADBExec.swift
+++ b/Snap-O/ADB/ADBExec.swift
@@ -24,7 +24,8 @@ struct ADBExec: Sendable {
   func startScreenrecord(
     deviceID: String,
     bitRateMbps: Int = 8,
-    timeLimitSeconds: Int = 60 * 60 * 3
+    timeLimitSeconds: Int = 60 * 60 * 3,
+    bugReport: Bool = false
   ) async throws -> RecordingSession {
     let sizeHint = try? await displaySize(deviceID: deviceID)
     let remote = "/data/local/tmp/snapo_recording_\(UUID().uuidString).mp4"
@@ -32,7 +33,8 @@ struct ADBExec: Sendable {
       bitRateMbps: bitRateMbps,
       timeLimitSeconds: timeLimitSeconds,
       size: sizeHint,
-      destination: remote
+      destination: remote,
+      bugReport: bugReport
     )
 
     let connection = try await makeConnection()
@@ -308,11 +310,13 @@ struct ADBExec: Sendable {
     timeLimitSeconds: Int,
     size: String?,
     destination: String,
-    outputFormat: String? = nil
+    outputFormat: String? = nil,
+    bugReport: Bool = false
   ) -> String {
     var command = "screenrecord --bit-rate \(bitRateMbps * 1_000_000) --time-limit \(timeLimitSeconds)"
     if let outputFormat, !outputFormat.isEmpty { command += " --output-format=\(outputFormat)" }
     if let size, !size.isEmpty { command += " --size \(size)" }
+    if bugReport { command += " --bugreport" }
     command += " \(destination)"
     return command
   }

--- a/Snap-O/App/AppSettings.swift
+++ b/Snap-O/App/AppSettings.swift
@@ -7,13 +7,21 @@ final class AppSettings: ObservableObject {
 
   @Published var showTouchesDuringCapture: Bool {
     didSet {
-      UserDefaults.standard.set(showTouchesDuringCapture, forKey: Self.key)
+      UserDefaults.standard.set(showTouchesDuringCapture, forKey: Self.showTouchesKey)
     }
   }
 
-  private static let key = "showTouchesDuringCapture"
+  @Published var recordAsBugReport: Bool {
+    didSet {
+      UserDefaults.standard.set(recordAsBugReport, forKey: Self.bugReportKey)
+    }
+  }
+
+  private static let showTouchesKey = "showTouchesDuringCapture"
+  private static let bugReportKey = "recordAsBugReport"
 
   init() {
-    showTouchesDuringCapture = UserDefaults.standard.object(forKey: Self.key) as? Bool ?? true
+    showTouchesDuringCapture = UserDefaults.standard.object(forKey: Self.showTouchesKey) as? Bool ?? true
+    recordAsBugReport = UserDefaults.standard.object(forKey: Self.bugReportKey) as? Bool ?? false
   }
 }

--- a/Snap-O/App/SnapOCommands.swift
+++ b/Snap-O/App/SnapOCommands.swift
@@ -114,6 +114,7 @@ struct SnapOCommands: Commands {
       .disabled(!hasAlternativeMedia)
       Divider()
       Toggle("Show Touches During Capture", isOn: $settings.showTouchesDuringCapture)
+      Toggle("Record Screen as Bug Report", isOn: $settings.recordAsBugReport)
     }
     CommandMenu("ADB") {
       Button("Set ADB path…") {

--- a/Snap-O/CaptureWindow/CaptureWindow.swift
+++ b/Snap-O/CaptureWindow/CaptureWindow.swift
@@ -2,6 +2,7 @@ import SwiftUI
 
 struct CaptureWindow: View {
   @StateObject private var controller = CaptureWindowController()
+  @StateObject private var settings = AppSettings.shared
 
   var body: some View {
     ZStack {
@@ -40,7 +41,7 @@ struct CaptureWindow: View {
       .frame(width: 0, height: 0)
     )
     .toolbar {
-      CaptureToolbar(controller: controller)
+      CaptureToolbar(controller: controller, settings: settings)
 
       if let progress = controller.captureProgressText {
         ToolbarItem(placement: .status) {


### PR DESCRIPTION
A new feature to enable the `--bugreport` flag in screenrecord.

`Device` -> `Record Screen as Bug Report`

When enabled, the toolbar button will now feature an ant, with a chevron to give an easy access to disable the bug report feature.

<img width="128" height="47" alt="image" src="https://github.com/user-attachments/assets/33b94145-9989-4f49-9840-00d2533a5007" />

<img width="119" height="45" alt="image" src="https://github.com/user-attachments/assets/70b7eea9-b6b8-40fe-abc3-e01abad7265a" />
