### PR TITLE
Copy all button for SSE

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
+# working files
+.modulecache/
+
 # macOS system files
 .DS_Store
 .AppleDouble

--- a/snapo-app-mac/Snap-O/NetworkInspector/NetworkInspectorCopyExporter.swift
+++ b/snapo-app-mac/Snap-O/NetworkInspector/NetworkInspectorCopyExporter.swift
@@ -11,6 +11,11 @@ enum NetworkInspectorCopyExporter {
     setPasteboard(string: command)
   }
 
+  static func copyStreamEventsRaw(_ events: [NetworkInspectorRequestViewModel.StreamEvent]) {
+    let payload = makeStreamEventsPayload(from: events)
+    setPasteboard(string: payload)
+  }
+
   private static func setPasteboard(string: String) {
     let pasteboard = NSPasteboard.general
     pasteboard.clearContents()
@@ -40,6 +45,14 @@ enum NetworkInspectorCopyExporter {
 
     let warningLines = warnings.map { "# \($0)" }
     return (warningLines + [command]).joined(separator: "\n")
+  }
+
+  private static func makeStreamEventsPayload(from events: [NetworkInspectorRequestViewModel.StreamEvent]) -> String {
+    events.map { event in
+      let normalized = event.raw
+        .replacingOccurrences(of: #"\n+$"#, with: "", options: .regularExpression)
+      return normalized + "\n\n"
+    }.joined()
   }
 
   private static func makeBodyArgument(for request: NetworkInspectorRequestViewModel) -> (argument: String, warnings: [String])? {


### PR DESCRIPTION
Copies all the events into the pasteboard, including the newline separators.