### PR TITLE
Fix image preview for base64-encoded CDP response bodies

### DIFF
--- a/snapo-desktop-compose/src/main/kotlin/com/openai/snapo/desktop/inspector/NetworkInspectorDetailViewModels.kt
+++ b/snapo-desktop-compose/src/main/kotlin/com/openai/snapo/desktop/inspector/NetworkInspectorDetailViewModels.kt
@@ -248,7 +248,7 @@ private fun requestBodyPayload(
     val resolved = record ?: return null
     val bodyText = resolved.body ?: resolved.bodyPreview ?: return null
     val contentType = contentTypeFor(resolved.headers)
-    val encoding = resolved.bodyEncoding ?: contentType
+    val encoding = resolved.bodyEncoding
     val truncated = resolved.bodyTruncatedBytes
     val isPreview = (resolved.body == null) || ((truncated ?: 0) > 0)
     return makeBodyPayload(
@@ -256,6 +256,7 @@ private fun requestBodyPayload(
         isPreview = isPreview,
         truncatedBytes = truncated,
         totalBytes = resolved.bodySize,
+        contentType = contentType,
         encoding = encoding,
     )
 }
@@ -276,6 +277,7 @@ private fun responseBodyPayload(
         isPreview = resolved.body == null,
         truncatedBytes = resolved.bodyTruncatedBytes,
         totalBytes = resolved.bodySize,
+        contentType = contentType,
         encoding = encoding,
     )
 }
@@ -407,6 +409,7 @@ private fun makeBodyPayload(
     isPreview: Boolean,
     truncatedBytes: Long?,
     totalBytes: Long?,
+    contentType: String?,
     encoding: String?,
 ): NetworkInspectorRequestUiModel.BodyPayload {
     val capturedBytes = text.toByteArray(Charsets.UTF_8).size.toLong()
@@ -419,7 +422,7 @@ private fun makeBodyPayload(
     val pretty = prettyPrintedJsonOrNull(text)
     val isLikelyJson = pretty != null || encodingMatchesJson || prefixSuggestsJson
 
-    val normalizedContentType = normalizeContentType(encoding)
+    val normalizedContentType = normalizeContentType(contentType) ?: normalizeContentType(encoding)
     val binaryData = decodeImageDataIfNeeded(trimmed, normalizedContentType)
 
     return NetworkInspectorRequestUiModel.BodyPayload(


### PR DESCRIPTION
## Summary
- preserve response `Content-Type` separately from body transfer encoding
- keep `base64` as encoding metadata instead of treating it as content type
- use header mime type (`image/jpeg`, etc.) for image decode/preview

## Validation
- reproduced with `snapo network show` on ChatGPT estuary image URL and observed:
  - `Content-Type: image/jpeg`
  - `responseBodyBase64Encoded: true`
- verified inspector now renders image preview instead of raw base64 text
- `./gradlew compileKotlin -Dorg.gradle.java.home=/Library/Java/JavaVirtualMachines/temurin-17.jdk/Contents/Home`
