### PR TITLE
Update snapo-desktop-compose dependencies and fix local snapo-app-mac builds

### DIFF
--- a/snapo-app-mac/Config/Base.xcconfig
+++ b/snapo-app-mac/Config/Base.xcconfig
@@ -5,6 +5,8 @@
 
 CODE_SIGN_STYLE = Automatic
 DEVELOPMENT_TEAM = $(SNAPO_DEVELOPMENT_TEAM)
+// Default to ad-hoc signing so local builds work without Signing.xcconfig.
+SNAPO_CODE_SIGN_IDENTITY = -
 CODE_SIGN_IDENTITY = $(SNAPO_CODE_SIGN_IDENTITY)
 ENABLE_HARDENED_RUNTIME = YES
 

--- a/snapo-desktop-compose/gradle/libs.versions.toml
+++ b/snapo-desktop-compose/gradle/libs.versions.toml
@@ -1,21 +1,20 @@
 [versions]
-detektComposeRules = "0.4.23"
-kotlin = "2.3.0"
-metro = "0.9.3"
-composeMultiplatform = "1.10.0"
-composeMaterial3 = "1.10.0-alpha05"
-composeHotReload = "1.1.0-alpha03"
+detektComposeRules = "0.5.6"
+kotlin = "2.3.10"
+metro = "0.10.2"
+composeMultiplatform = "1.11.0-alpha02"
+composeHotReload = "1.1.0-alpha04"
 coroutines = "1.10.2"
-serialization = "1.9.0"
+serialization = "1.10.0"
 detekt = "1.23.8"
-clikt = "5.0.3"
+clikt = "5.1.0"
 
 [libraries]
 detekt-formatting = { module = "io.gitlab.arturbosch.detekt:detekt-formatting", version.ref = "detekt" }
 detekt-compose-rules = { module = "io.nlopez.compose.rules:detekt", version.ref = "detektComposeRules" }
 kotlinx-coroutines-core = { group = "org.jetbrains.kotlinx", name = "kotlinx-coroutines-core", version.ref = "coroutines" }
 serialization-json = { group = "org.jetbrains.kotlinx", name = "kotlinx-serialization-json", version.ref = "serialization" }
-compose-material3 = { group = "org.jetbrains.compose.material3", name = "material3", version.ref = "composeMaterial3" }
+compose-material3 = { group = "org.jetbrains.compose.material3", name = "material3", version.ref = "composeMultiplatform" }
 compose-components-resources = { group = "org.jetbrains.compose.components", name = "components-resources", version.ref = "composeMultiplatform" }
 compose-components-splitpane = { group = "org.jetbrains.compose.components", name = "components-splitpane", version.ref = "composeMultiplatform" }
 compose-ui-tooling-preview = { group = "org.jetbrains.compose.ui", name = "ui-tooling-preview", version.ref = "composeMultiplatform" }


### PR DESCRIPTION
## Summary
- Update `snapo-desktop-compose` dependency versions in `gradle/libs.versions.toml`.
- Set a default ad-hoc code signing identity in `snapo-app-mac/Config/Base.xcconfig` so local builds work without `Signing.xcconfig`.

## Why
- Keep desktop-compose dependencies current.
- Prevent local mac target build failures when signing config is not present.

## Testing
- Build `snapo-desktop-compose`.
- Build `snapo-app-mac` locally without `Signing.xcconfig`.
