### PR TITLE
Align CDP network lifecycle semantics and make body replay/order reliable

### DIFF
--- a/snapo-desktop-compose/src/main/kotlin/com/openai/snapo/desktop/cli/SnapOCli.kt
+++ b/snapo-desktop-compose/src/main/kotlin/com/openai/snapo/desktop/cli/SnapOCli.kt
@@ -373,6 +373,9 @@ object SnapOCli {
                                 val error = message.error
                                 if (error != null) {
                                     val messageText = error.message
+                                    if (!details.loadingFailedMessage.isNullOrBlank()) {
+                                        return FetchRequestDetailsResult.Failure(details.loadingFailedMessage)
+                                    }
                                     return if (messageText.contains("No response body captured", ignoreCase = true)) {
                                         FetchRequestDetailsResult.MissingBody(messageText)
                                     } else {

--- a/snapo-desktop-compose/src/main/kotlin/com/openai/snapo/desktop/inspector/CdpNetworkMessageTranslator.kt
+++ b/snapo-desktop-compose/src/main/kotlin/com/openai/snapo/desktop/inspector/CdpNetworkMessageTranslator.kt
@@ -96,10 +96,16 @@ internal class CdpNetworkMessageTranslator {
         )
     }
 
-    private fun toLoadingFinished(params: CdpLoadingFinishedParams): ResponseStreamClosed? {
-        if (!sseRequestIds.contains(params.requestId)) return null
+    private fun toLoadingFinished(params: CdpLoadingFinishedParams): PerRequestRecord {
         val wallMs = resolveWallMs(timestampSeconds = params.timestamp)
         val monoNs = resolveMonoNs(params.timestamp)
+        if (!sseRequestIds.contains(params.requestId)) {
+            return ResponseFinished(
+                params = params,
+                tWallMs = wallMs,
+                tMonoNs = monoNs,
+            )
+        }
         val totalEvents = sseEventCountByRequestId.remove(params.requestId) ?: 0L
         sseSequenceByRequestId.remove(params.requestId)
         sseRequestIds.remove(params.requestId)

--- a/snapo-desktop-compose/src/main/kotlin/com/openai/snapo/desktop/inspector/CdpNetworkMessageTranslator.kt
+++ b/snapo-desktop-compose/src/main/kotlin/com/openai/snapo/desktop/inspector/CdpNetworkMessageTranslator.kt
@@ -67,7 +67,7 @@ internal class CdpNetworkMessageTranslator {
     ): NetworkEventRecord? {
         val decoded = runCatching {
             Ndjson.decodeFromJsonElement(serializer, params)
-        }.getOrNull() ?: return null
+        }.getOrElse { return null }
         return transform(decoded)
     }
 

--- a/snapo-desktop-compose/src/main/kotlin/com/openai/snapo/desktop/inspector/HttpBodySemantics.kt
+++ b/snapo-desktop-compose/src/main/kotlin/com/openai/snapo/desktop/inspector/HttpBodySemantics.kt
@@ -1,0 +1,12 @@
+package com.openai.snapo.desktop.inspector
+
+internal fun responseIsDefinedAsBodyless(
+    requestMethod: String?,
+    responseStatus: Int?,
+    responseContentLength: Long?,
+): Boolean {
+    if (requestMethod.equals("HEAD", ignoreCase = true)) return true
+    val status = responseStatus ?: return false
+    if (status in 100..199 || status == 204 || status == 304) return true
+    return responseContentLength == 0L
+}

--- a/snapo-desktop-compose/src/main/kotlin/com/openai/snapo/desktop/inspector/NetworkInspectorDetailViewModels.kt
+++ b/snapo-desktop-compose/src/main/kotlin/com/openai/snapo/desktop/inspector/NetworkInspectorDetailViewModels.kt
@@ -235,7 +235,10 @@ private fun requestStatus(request: NetworkInspectorRequest): NetworkInspectorReq
 
 private fun requestTiming(request: NetworkInspectorRequest): InspectorTiming {
     val startMillis = request.request?.tWallMs
-    val endMillis = request.failure?.tWallMs ?: request.response?.tWallMs
+    val endMillis = request.failure?.tWallMs
+        ?: request.streamClosed?.tWallMs
+        ?: request.finished?.tWallMs
+        ?: request.response?.tWallMs
     return InspectorTiming(
         startMillis = startMillis,
         endMillis = endMillis,

--- a/snapo-desktop-compose/src/main/kotlin/com/openai/snapo/desktop/inspector/NetworkInspectorDetailViewModels.kt
+++ b/snapo-desktop-compose/src/main/kotlin/com/openai/snapo/desktop/inspector/NetworkInspectorDetailViewModels.kt
@@ -229,7 +229,17 @@ data class NetworkInspectorWebSocketUiModel(
 private fun requestStatus(request: NetworkInspectorRequest): NetworkInspectorRequestStatus =
     when {
         request.failure != null -> NetworkInspectorRequestStatus.Failure(request.failure.message)
-        request.response != null -> NetworkInspectorRequestStatus.Success(request.response.code)
+        request.isLikelyStreamingResponse && request.streamClosed?.reason.equals("error", ignoreCase = true) ->
+            NetworkInspectorRequestStatus.Failure(request.streamClosed?.message)
+
+        request.isLikelyStreamingResponse && request.streamClosed != null ->
+            NetworkInspectorRequestStatus.Success(request.response?.code ?: 200)
+
+        request.isLikelyStreamingResponse -> NetworkInspectorRequestStatus.Pending
+        request.response != null && request.finished != null ->
+            NetworkInspectorRequestStatus.Success(request.response.code)
+
+        request.response != null -> NetworkInspectorRequestStatus.Pending
         else -> NetworkInspectorRequestStatus.Pending
     }
 

--- a/snapo-desktop-compose/src/main/kotlin/com/openai/snapo/desktop/inspector/NetworkInspectorModels.kt
+++ b/snapo-desktop-compose/src/main/kotlin/com/openai/snapo/desktop/inspector/NetworkInspectorModels.kt
@@ -46,6 +46,7 @@ data class NetworkInspectorRequest(
     val requestId: String,
     val request: RequestWillBeSent? = null,
     val response: ResponseReceived? = null,
+    val finished: ResponseFinished? = null,
     val failure: RequestFailed? = null,
     val streamEvents: List<ResponseStreamEvent> = emptyList(),
     val streamClosed: ResponseStreamClosed? = null,

--- a/snapo-desktop-compose/src/main/kotlin/com/openai/snapo/desktop/inspector/NetworkInspectorRecords.kt
+++ b/snapo-desktop-compose/src/main/kotlin/com/openai/snapo/desktop/inspector/NetworkInspectorRecords.kt
@@ -2,6 +2,7 @@ package com.openai.snapo.desktop.inspector
 
 import com.openai.snapo.desktop.protocol.CdpEventSourceMessageReceivedParams
 import com.openai.snapo.desktop.protocol.CdpLoadingFailedParams
+import com.openai.snapo.desktop.protocol.CdpLoadingFinishedParams
 import com.openai.snapo.desktop.protocol.CdpRequestWillBeSentParams
 import com.openai.snapo.desktop.protocol.CdpResponseReceivedParams
 import com.openai.snapo.desktop.protocol.CdpWebSocketClosedParams
@@ -69,6 +70,15 @@ data class RequestFailed(
     override val id: String get() = params.requestId
     val errorKind: String get() = params.type ?: "NetworkError"
     val message: String? get() = params.errorText
+}
+
+data class ResponseFinished(
+    val params: CdpLoadingFinishedParams,
+    override val tWallMs: Long,
+    override val tMonoNs: Long,
+) : PerRequestRecord {
+    override val id: String get() = params.requestId
+    val bodySize: Long? get() = params.encodedDataLength?.toLong()
 }
 
 data class ResponseStreamEvent(

--- a/snapo-desktop-compose/src/main/kotlin/com/openai/snapo/desktop/inspector/NetworkInspectorService.kt
+++ b/snapo-desktop-compose/src/main/kotlin/com/openai/snapo/desktop/inspector/NetworkInspectorService.kt
@@ -141,7 +141,9 @@ class NetworkInspectorService(
     ) {
         var commandId: Int? = null
         commandMutex.withLock {
-            if (!inFlightBodyRequests.add(key)) return@withLock
+            if (!inFlightBodyRequests.add(key)) {
+                return@withLock
+            }
             val id = nextCommandId
             nextCommandId += 1
             pendingBodyCommands[id] = PendingBodyCommand(key = key, method = method)
@@ -187,19 +189,19 @@ class NetworkInspectorService(
 
     private suspend fun prefetchBodiesIfNeeded(serverId: SnapOLinkServerId, event: NetworkEventRecord) {
         when (event) {
-            is RequestWillBeSent -> {
-                requestBodyIfNeeded(
-                    NetworkInspectorRequestId(serverId = serverId, requestId = event.id)
-                )
-            }
+            is RequestWillBeSent -> requestBodyIfNeeded(
+                NetworkInspectorRequestId(serverId = serverId, requestId = event.id)
+            )
+
+            is ResponseReceived -> responseBodyIfNeeded(
+                NetworkInspectorRequestId(serverId = serverId, requestId = event.id)
+            )
 
             is ResponseFinished,
             is ResponseStreamClosed,
-            -> {
-                responseBodyIfNeeded(
-                    NetworkInspectorRequestId(serverId = serverId, requestId = event.id)
-                )
-            }
+            -> responseBodyIfNeeded(
+                NetworkInspectorRequestId(serverId = serverId, requestId = event.id)
+            )
 
             else -> Unit
         }
@@ -221,16 +223,28 @@ class NetworkInspectorService(
         if (resolvedPending.key.requestId.serverId != serverId) return true
         if (payload.error != null) return true
 
-        when (resolvedPending.method) {
+        applyBodyCommandResult(resolvedPending, payload)
+
+        return true
+    }
+
+    private suspend fun applyBodyCommandResult(
+        pending: PendingBodyCommand,
+        payload: CdpMessage,
+    ) {
+        when (pending.method) {
             CdpNetworkMethod.GetRequestPostData -> {
                 val result = payload.result
                     ?.let { element ->
                         runCatching {
-                            Ndjson.decodeFromJsonElement(CdpGetRequestPostDataResult.serializer(), element)
+                            Ndjson.decodeFromJsonElement(
+                                CdpGetRequestPostDataResult.serializer(),
+                                element,
+                            )
                         }.getOrNull()
-                    } ?: return true
+                    } ?: return
                 requestStore.applyRequestBody(
-                    id = resolvedPending.key.requestId,
+                    id = pending.key.requestId,
                     body = result.postData,
                 )
             }
@@ -239,18 +253,19 @@ class NetworkInspectorService(
                 val result = payload.result
                     ?.let { element ->
                         runCatching {
-                            Ndjson.decodeFromJsonElement(CdpGetResponseBodyResult.serializer(), element)
+                            Ndjson.decodeFromJsonElement(
+                                CdpGetResponseBodyResult.serializer(),
+                                element,
+                            )
                         }.getOrNull()
-                    } ?: return true
+                    } ?: return
                 requestStore.applyResponseBody(
-                    id = resolvedPending.key.requestId,
+                    id = pending.key.requestId,
                     body = result.body,
                     base64Encoded = result.base64Encoded,
                 )
             }
         }
-
-        return true
     }
 
     private suspend fun handleServerRemoved(serverId: SnapOLinkServerId) {

--- a/snapo-desktop-compose/src/main/kotlin/com/openai/snapo/desktop/inspector/NetworkInspectorService.kt
+++ b/snapo-desktop-compose/src/main/kotlin/com/openai/snapo/desktop/inspector/NetworkInspectorService.kt
@@ -193,7 +193,9 @@ class NetworkInspectorService(
                 )
             }
 
-            is ResponseReceived -> {
+            is ResponseFinished,
+            is ResponseStreamClosed,
+            -> {
                 responseBodyIfNeeded(
                     NetworkInspectorRequestId(serverId = serverId, requestId = event.id)
                 )

--- a/snapo-desktop-compose/src/main/kotlin/com/openai/snapo/desktop/inspector/RequestEventStore.kt
+++ b/snapo-desktop-compose/src/main/kotlin/com/openai/snapo/desktop/inspector/RequestEventStore.kt
@@ -343,14 +343,15 @@ internal class RequestEventStore {
         state: NetworkInspectorRequest,
         response: ResponseReceived,
     ): Boolean {
-        if (state.request?.method.equals("HEAD", ignoreCase = true)) return true
-        val status = response.code
-        if (status in 100..199 || status == 204 || status == 304) return true
         val contentLength = response.headers
             .firstOrNull { header -> header.name.equals("Content-Length", ignoreCase = true) }
             ?.value
             ?.trim()
             ?.toLongOrNull()
-        return contentLength == 0L
+        return responseIsDefinedAsBodyless(
+            requestMethod = state.request?.method,
+            responseStatus = response.code,
+            responseContentLength = contentLength,
+        )
     }
 }

--- a/snapo-desktop-compose/src/main/kotlin/com/openai/snapo/desktop/inspector/RequestEventStore.kt
+++ b/snapo-desktop-compose/src/main/kotlin/com/openai/snapo/desktop/inspector/RequestEventStore.kt
@@ -230,7 +230,6 @@ internal class RequestEventStore {
             } else {
                 existing.copy(
                     failure = record,
-                    response = null,
                     finished = null,
                     lastUpdatedAt = now,
                 )

--- a/snapo-desktop-compose/src/main/kotlin/com/openai/snapo/desktop/inspector/RequestEventStore.kt
+++ b/snapo-desktop-compose/src/main/kotlin/com/openai/snapo/desktop/inspector/RequestEventStore.kt
@@ -166,8 +166,6 @@ internal class RequestEventStore {
             } else {
                 existing.copy(
                     request = record,
-                    finished = null,
-                    failure = null,
                     lastUpdatedAt = now,
                 )
             }
@@ -199,7 +197,6 @@ internal class RequestEventStore {
             } else {
                 existing.copy(
                     response = record,
-                    failure = null,
                     lastUpdatedAt = now,
                 )
             }
@@ -231,7 +228,6 @@ internal class RequestEventStore {
             } else {
                 existing.copy(
                     failure = record,
-                    finished = null,
                     lastUpdatedAt = now,
                 )
             }

--- a/snapo-link-android/network-okhttp3/src/main/java/com/openai/snapo/network/okhttp3/SnapOOkHttpInterceptor.kt
+++ b/snapo-link-android/network-okhttp3/src/main/java/com/openai/snapo/network/okhttp3/SnapOOkHttpInterceptor.kt
@@ -7,6 +7,7 @@ import com.openai.snapo.link.core.SnapOLink
 import com.openai.snapo.network.NetworkEventRecord
 import com.openai.snapo.network.NetworkInspector
 import com.openai.snapo.network.RequestFailed
+import com.openai.snapo.network.ResponseFinished
 import com.openai.snapo.network.Timings
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.CoroutineScope
@@ -21,7 +22,9 @@ import okhttp3.Response
 import okhttp3.ResponseBody
 import okio.Buffer
 import okio.BufferedSink
+import okio.BufferedSource
 import okio.ForwardingSink
+import okio.ForwardingSource
 import okio.buffer
 import java.io.Closeable
 import java.io.IOException
@@ -30,6 +33,7 @@ import java.nio.charset.Charset
 import java.nio.charset.CodingErrorAction
 import java.util.UUID
 import java.util.concurrent.TimeUnit
+import java.util.concurrent.atomic.AtomicBoolean
 import kotlin.math.max
 
 /** OkHttp interceptor that mirrors traffic to the active SnapO link if present. */
@@ -145,7 +149,19 @@ class SnapOOkHttpInterceptor @JvmOverloads constructor(
             handleStreamingResponse(context, response, responseBody, endWall = endWall, endMono = endMono)
         } else {
             publishStandardResponse(context, response, responseBody, endWall = endWall, endMono = endMono)
-            response
+            response.newBuilder()
+                .body(
+                    CompletionTrackingResponseBody(
+                        delegate = responseBody,
+                        onFinished = { totalBytes ->
+                            publishLoadingFinished(context, totalBytes)
+                        },
+                        onFailed = { error ->
+                            handleFailure(context, error)
+                        },
+                    ),
+                )
+                .build()
         }
     }
 
@@ -224,6 +240,19 @@ class SnapOOkHttpInterceptor @JvmOverloads constructor(
                 errorKind = error.javaClass.simpleName.ifEmpty { error.javaClass.name },
                 message = error.message,
                 timings = Timings(totalMs = nanosToMillis(failMono - context.startMono)),
+            )
+        }
+    }
+
+    private fun publishLoadingFinished(context: InterceptContext, bodySize: Long?) {
+        val finishWall = System.currentTimeMillis()
+        val finishMono = SystemClock.elapsedRealtimeNanos()
+        publish {
+            ResponseFinished(
+                id = context.requestId,
+                tWallMs = finishWall,
+                tMonoNs = finishMono,
+                bodySize = bodySize,
             )
         }
     }
@@ -327,6 +356,70 @@ private class CapturingRequestBody(
         } finally {
             captured = capture.snapshot(contentType())
         }
+    }
+}
+
+private class CompletionTrackingResponseBody(
+    private val delegate: ResponseBody,
+    private val onFinished: (Long?) -> Unit,
+    private val onFailed: (Throwable) -> Unit,
+) : ResponseBody() {
+    private val closed = AtomicBoolean(false)
+    private val completionNotified = AtomicBoolean(false)
+    private var totalBytes: Long = 0L
+
+    private val bufferedSource: BufferedSource by lazy {
+        object : ForwardingSource(delegate.source()) {
+            override fun read(sink: Buffer, byteCount: Long): Long {
+                return runCatching {
+                    val read = super.read(sink, byteCount)
+                    if (read > 0L) {
+                        totalBytes += read
+                    } else if (read == -1L) {
+                        completeSuccessfully()
+                    }
+                    read
+                }.onFailure { error ->
+                    completeWithError(error)
+                }.getOrThrow()
+            }
+
+            override fun close() {
+                val result = runCatching { super.close() }
+                result.onFailure { error -> completeWithError(error) }
+                if (result.isSuccess) {
+                    completeSuccessfully()
+                }
+                result.getOrThrow()
+            }
+        }.buffer()
+    }
+
+    override fun contentType(): MediaType? = delegate.contentType()
+
+    override fun contentLength(): Long = delegate.contentLength()
+
+    override fun source(): BufferedSource = bufferedSource
+
+    override fun close() {
+        if (closed.compareAndSet(false, true)) {
+            bufferedSource.close()
+        }
+    }
+
+    private fun completeSuccessfully() {
+        if (!completionNotified.compareAndSet(false, true)) return
+        val total = if (totalBytes > 0L) {
+            totalBytes
+        } else {
+            delegate.safeContentLength()
+        }
+        onFinished(total)
+    }
+
+    private fun completeWithError(error: Throwable) {
+        if (!completionNotified.compareAndSet(false, true)) return
+        onFailed(error)
     }
 }
 

--- a/snapo-link-android/network-okhttp3/src/main/java/com/openai/snapo/network/okhttp3/SnapOOkHttpInterceptor.kt
+++ b/snapo-link-android/network-okhttp3/src/main/java/com/openai/snapo/network/okhttp3/SnapOOkHttpInterceptor.kt
@@ -145,6 +145,11 @@ class SnapOOkHttpInterceptor @JvmOverloads constructor(
         val endWall = System.currentTimeMillis()
         val endMono = SystemClock.elapsedRealtimeNanos()
         val responseBody = response.body
+        if (response.code == 101) {
+            publishStandardResponse(context, response, responseBody, endWall = endWall, endMono = endMono)
+            publishLoadingFinished(context, bodySize = 0L)
+            return response
+        }
         return if (responseBody.contentType().isEventStream()) {
             handleStreamingResponse(context, response, responseBody, endWall = endWall, endMono = endMono)
         } else {

--- a/snapo-link-android/network/src/main/java/com/openai/snapo/network/CdpNetworkMapper.kt
+++ b/snapo-link-android/network/src/main/java/com/openai/snapo/network/CdpNetworkMapper.kt
@@ -24,6 +24,7 @@ internal fun NetworkEventRecord.toCdpMessage(requestUrl: String?): CdpMessage {
     return when (this) {
         is RequestWillBeSent -> toCdpRequestWillBeSent()
         is ResponseReceived -> toCdpResponseReceived(requestUrl)
+        is ResponseFinished -> toCdpLoadingFinished()
         is RequestFailed -> toCdpLoadingFailed()
         is ResponseStreamEvent -> toCdpEventSourceMessageReceived()
         is ResponseStreamClosed -> toCdpStreamClosed()
@@ -93,6 +94,20 @@ private fun RequestFailed.toCdpLoadingFailed(): CdpMessage {
                 timestamp = tMonoNs.toMonotonicSeconds(),
                 type = "XHR",
                 errorText = message ?: errorKind,
+            ),
+        ),
+    )
+}
+
+private fun ResponseFinished.toCdpLoadingFinished(): CdpMessage {
+    return CdpMessage(
+        method = CdpNetworkMethod.LoadingFinished,
+        params = Ndjson.encodeToJsonElement(
+            CdpLoadingFinishedParams.serializer(),
+            CdpLoadingFinishedParams(
+                requestId = id,
+                timestamp = tMonoNs.toMonotonicSeconds(),
+                encodedDataLength = bodySize?.toDouble(),
             ),
         ),
     )

--- a/snapo-link-android/network/src/main/java/com/openai/snapo/network/EventBuffer.kt
+++ b/snapo-link-android/network/src/main/java/com/openai/snapo/network/EventBuffer.kt
@@ -23,6 +23,32 @@ internal class EventBuffer(
 
     fun snapshot(): List<NetworkEventRecord> = ArrayList(records)
 
+    fun updateLatestResponseBody(
+        requestId: String,
+        bodyPreview: String?,
+        body: String?,
+        bodyEncoding: String?,
+        bodyTruncatedBytes: Long?,
+        bodySize: Long?,
+    ): Boolean {
+        val index = records.indexOfLast { candidate ->
+            (candidate as? ResponseReceived)?.id == requestId
+        }
+        if (index < 0) return false
+        val existing = records[index] as? ResponseReceived ?: return false
+        val updated = existing.copy(
+            bodyPreview = bodyPreview,
+            body = body,
+            bodyEncoding = bodyEncoding,
+            bodyTruncatedBytes = bodyTruncatedBytes,
+            bodySize = bodySize ?: existing.bodySize,
+        )
+        records[index] = updated
+        subtractApproxBytes(existing)
+        approxBytes += estimateSize(updated)
+        return true
+    }
+
     private fun insertSorted(record: NetworkEventRecord) {
         val insertIndex = findInsertIndex(record)
         records.add(insertIndex, record)
@@ -118,6 +144,7 @@ internal class EventBuffer(
         when (record) {
             is ResponseStreamEvent -> activeResponseStreams.add(record.id)
             is ResponseStreamClosed -> activeResponseStreams.remove(record.id)
+            is ResponseFinished -> activeResponseStreams.remove(record.id)
             is RequestFailed -> activeResponseStreams.remove(record.id)
             else -> Unit
         }
@@ -126,6 +153,7 @@ internal class EventBuffer(
     private fun updateStreamStateOnRemove(record: NetworkEventRecord) {
         when (record) {
             is ResponseStreamClosed -> activeResponseStreams.remove(record.id)
+            is ResponseFinished -> activeResponseStreams.remove(record.id)
             is RequestFailed -> activeResponseStreams.remove(record.id)
             else -> Unit
         }
@@ -138,6 +166,7 @@ internal class EventBuffer(
                     head.id
                 )
 
+                is ResponseFinished -> candidate.id == head.id
                 is RequestFailed -> candidate.id == head.id
                 is ResponseStreamClosed -> candidate.id == head.id
                 else -> false
@@ -183,6 +212,12 @@ internal class EventBuffer(
             val record = iterator.next()
             when (record) {
                 is ResponseReceived -> if (record.id == requestId) {
+                    iterator.remove()
+                    subtractApproxBytes(record)
+                    updateStreamStateOnRemove(record)
+                }
+
+                is ResponseFinished -> if (record.id == requestId) {
                     iterator.remove()
                     subtractApproxBytes(record)
                     updateStreamStateOnRemove(record)
@@ -235,6 +270,7 @@ internal class EventBuffer(
                     record.bodyPreview.length +
                     record.body.length
 
+            is ResponseFinished -> 0
             is ResponseStreamEvent -> record.raw.length
             is ResponseStreamClosed -> record.reason.length + record.message.length
             is WebSocketWillOpen -> record.url.length + sizeOfHeaders(record.headers)

--- a/snapo-link-android/network/src/main/java/com/openai/snapo/network/EventBuffer.kt
+++ b/snapo-link-android/network/src/main/java/com/openai/snapo/network/EventBuffer.kt
@@ -2,26 +2,38 @@ package com.openai.snapo.network
 
 import java.util.ArrayList
 
+internal data class CapturedBody(
+    val body: String,
+    val encoding: String?,
+)
+
 internal class EventBuffer(
     private val config: NetworkInspectorConfig,
 ) {
 
     private val records: MutableList<NetworkEventRecord> = ArrayList()
     private var approxBytes: Long = 0L
+    private val requestBodiesById: MutableMap<String, CapturedBody> = mutableMapOf()
+    private val responseBodiesById: MutableMap<String, CapturedBody> = mutableMapOf()
     private val openWebSockets: MutableSet<String> = mutableSetOf()
     private val activeResponseStreams: MutableSet<String> = mutableSetOf()
 
     fun append(record: NetworkEventRecord) {
-        insertSorted(record)
-        approxBytes += estimateSize(record)
-        updateWebSocketStateOnAdd(record)
-        updateStreamStateOnAdd(record)
-        evictExpiredIfNeeded(record)
+        val normalizedRecord = normalizeRecord(record)
+        insertSorted(normalizedRecord)
+        approxBytes += estimateSize(normalizedRecord)
+        updateWebSocketStateOnAdd(normalizedRecord)
+        updateStreamStateOnAdd(normalizedRecord)
+        evictExpiredIfNeeded(normalizedRecord)
         trimToByteLimit()
         trimToCountLimit()
     }
 
     fun snapshot(): List<NetworkEventRecord> = ArrayList(records)
+
+    fun findRequestBody(requestId: String): CapturedBody? = requestBodiesById[requestId]
+
+    fun findResponseBody(requestId: String): CapturedBody? = responseBodiesById[requestId]
 
     fun updateLatestResponseBody(
         requestId: String,
@@ -31,14 +43,20 @@ internal class EventBuffer(
         bodyTruncatedBytes: Long?,
         bodySize: Long?,
     ): Boolean {
+        val hasRelatedRecords = records.any { candidate ->
+            (candidate as? PerRequestRecord)?.id == requestId
+        }
+        if (!body.isNullOrEmpty() && hasRelatedRecords) {
+            upsertResponseBody(requestId, body, bodyEncoding)
+        }
         val index = records.indexOfLast { candidate ->
             (candidate as? ResponseReceived)?.id == requestId
         }
-        if (index < 0) return false
+        if (index < 0) return !body.isNullOrEmpty() && hasRelatedRecords
         val existing = records[index] as? ResponseReceived ?: return false
         val updated = existing.copy(
             bodyPreview = bodyPreview,
-            body = body,
+            body = null,
             bodyEncoding = bodyEncoding,
             bodyTruncatedBytes = bodyTruncatedBytes,
             bodySize = bodySize ?: existing.bodySize,
@@ -47,6 +65,26 @@ internal class EventBuffer(
         subtractApproxBytes(existing)
         approxBytes += estimateSize(updated)
         return true
+    }
+
+    private fun normalizeRecord(record: NetworkEventRecord): NetworkEventRecord {
+        return when (record) {
+            is RequestWillBeSent -> {
+                if (!record.body.isNullOrEmpty()) {
+                    upsertRequestBody(record.id, record.body, record.bodyEncoding)
+                }
+                if (record.body == null) record else record.copy(body = null)
+            }
+
+            is ResponseReceived -> {
+                if (!record.body.isNullOrEmpty()) {
+                    upsertResponseBody(record.id, record.body, record.bodyEncoding)
+                }
+                if (record.body == null) record else record.copy(body = null)
+            }
+
+            else -> record
+        }
     }
 
     private fun insertSorted(record: NetworkEventRecord) {
@@ -175,9 +213,7 @@ internal class EventBuffer(
             .takeIf { it >= 0 }
             ?.let { index ->
                 val candidate = records.removeAt(index)
-                subtractApproxBytes(candidate)
-                updateWebSocketStateOnRemove(candidate)
-                updateStreamStateOnRemove(candidate)
+                onRecordRemoved(candidate)
                 removeAdditionalRequestRecords(head.id)
                 true
             }
@@ -197,9 +233,7 @@ internal class EventBuffer(
             val shouldRemove = perSocket != null && perSocket.id == wsHead.id && candidate !== head
             if (shouldRemove) {
                 iterator.remove()
-                subtractApproxBytes(candidate)
-                updateWebSocketStateOnRemove(candidate)
-                updateStreamStateOnRemove(candidate)
+                onRecordRemoved(candidate)
                 removedAny = true
             }
         }
@@ -213,20 +247,17 @@ internal class EventBuffer(
             when (record) {
                 is ResponseReceived -> if (record.id == requestId) {
                     iterator.remove()
-                    subtractApproxBytes(record)
-                    updateStreamStateOnRemove(record)
+                    onRecordRemoved(record)
                 }
 
                 is ResponseFinished -> if (record.id == requestId) {
                     iterator.remove()
-                    subtractApproxBytes(record)
-                    updateStreamStateOnRemove(record)
+                    onRecordRemoved(record)
                 }
 
                 is ResponseStreamEvent -> if (record.id == requestId) {
                     iterator.remove()
-                    subtractApproxBytes(record)
-                    updateStreamStateOnRemove(record)
+                    onRecordRemoved(record)
                 }
 
                 else -> Unit
@@ -240,9 +271,7 @@ internal class EventBuffer(
             val record = iterator.next()
             if (record is TimedRecord && record.tWallMs < cutoff) {
                 iterator.remove()
-                subtractApproxBytes(record)
-                updateWebSocketStateOnRemove(record)
-                updateStreamStateOnRemove(record)
+                onRecordRemoved(record)
             } else {
                 break
             }
@@ -251,9 +280,69 @@ internal class EventBuffer(
 
     private fun removeRecord(iterator: MutableIterator<NetworkEventRecord>, record: NetworkEventRecord) {
         iterator.remove()
+        onRecordRemoved(record)
+    }
+
+    private fun onRecordRemoved(record: NetworkEventRecord) {
         subtractApproxBytes(record)
         updateWebSocketStateOnRemove(record)
         updateStreamStateOnRemove(record)
+        maybeEvictBodiesFor(record)
+    }
+
+    private fun maybeEvictBodiesFor(record: NetworkEventRecord) {
+        val requestRecord = record as? PerRequestRecord ?: return
+        val requestId = requestRecord.id
+        val hasRemainingRequestRecords = records.any { candidate ->
+            (candidate as? PerRequestRecord)?.id == requestId
+        }
+        if (hasRemainingRequestRecords) return
+        removeRequestBody(requestId)
+        removeResponseBody(requestId)
+    }
+
+    private fun upsertRequestBody(
+        requestId: String,
+        body: String,
+        encoding: String?,
+    ) {
+        val captured = CapturedBody(body = body, encoding = encoding)
+        val previous = requestBodiesById.put(requestId, captured)
+        if (previous != null) {
+            approxBytes -= estimateBodyEntrySize(requestId, previous)
+        }
+        approxBytes += estimateBodyEntrySize(requestId, captured)
+    }
+
+    private fun upsertResponseBody(
+        requestId: String,
+        body: String,
+        encoding: String?,
+    ) {
+        val captured = CapturedBody(body = body, encoding = encoding)
+        val previous = responseBodiesById.put(requestId, captured)
+        if (previous != null) {
+            approxBytes -= estimateBodyEntrySize(requestId, previous)
+        }
+        approxBytes += estimateBodyEntrySize(requestId, captured)
+    }
+
+    private fun removeRequestBody(requestId: String) {
+        val removed = requestBodiesById.remove(requestId) ?: return
+        approxBytes -= estimateBodyEntrySize(requestId, removed)
+        if (approxBytes < 0) approxBytes = 0
+    }
+
+    private fun removeResponseBody(requestId: String) {
+        val removed = responseBodiesById.remove(requestId) ?: return
+        approxBytes -= estimateBodyEntrySize(requestId, removed)
+        if (approxBytes < 0) approxBytes = 0
+    }
+
+    private fun estimateBodyEntrySize(requestId: String, capturedBody: CapturedBody): Long {
+        val base = 48
+        val payload = requestId.length + capturedBody.body.length + capturedBody.encoding.length
+        return (base + payload).toLong()
     }
 
     private fun estimateSize(record: NetworkEventRecord): Long {

--- a/snapo-link-android/network/src/main/java/com/openai/snapo/network/Events.kt
+++ b/snapo-link-android/network/src/main/java/com/openai/snapo/network/Events.kt
@@ -52,6 +52,14 @@ data class ResponseReceived(
     val timings: Timings = Timings(),
 ) : PerRequestRecord
 
+/** Indicates a non-streaming response completed successfully. */
+data class ResponseFinished(
+    override val id: String,
+    override val tWallMs: Long,
+    override val tMonoNs: Long,
+    val bodySize: Long? = null,
+) : PerRequestRecord
+
 /** Failure with partial timings if available. */
 data class RequestFailed(
     override val id: String,

--- a/snapo-link-android/network/src/main/java/com/openai/snapo/network/NetworkInspectorFeature.kt
+++ b/snapo-link-android/network/src/main/java/com/openai/snapo/network/NetworkInspectorFeature.kt
@@ -109,7 +109,9 @@ class NetworkInspectorFeature(
             return
         }
 
-        val postData = findLatestRequest(params.requestId)?.body
+        val postData = bufferLock.withLock {
+            eventBuffer.findRequestBody(params.requestId)?.body
+        }
         if (postData.isNullOrEmpty()) {
             sink.sendError(commandId, "No request body captured for ${params.requestId}", target)
             return
@@ -139,13 +141,15 @@ class NetworkInspectorFeature(
             return
         }
 
-        val response = findLatestResponse(params.requestId)
-        val streamBody = if (response?.body.isNullOrEmpty()) {
+        val responseBody = bufferLock.withLock {
+            eventBuffer.findResponseBody(params.requestId)
+        }
+        val streamBody = if (responseBody?.body.isNullOrEmpty()) {
             joinSseBody(params.requestId)
         } else {
             null
         }
-        val resolvedBody = response?.body ?: streamBody
+        val resolvedBody = responseBody?.body ?: streamBody
         if (resolvedBody.isNullOrEmpty()) {
             sink.sendError(commandId, "No response body captured for ${params.requestId}", target)
             return
@@ -155,7 +159,7 @@ class NetworkInspectorFeature(
             id = commandId,
             result = CdpGetResponseBodyResult(
                 body = resolvedBody,
-                base64Encoded = response?.bodyEncoding.equals("base64", ignoreCase = true),
+                base64Encoded = responseBody?.encoding.equals("base64", ignoreCase = true),
             ),
             serializer = CdpGetResponseBodyResult.serializer(),
             clientId = target,
@@ -194,20 +198,6 @@ class NetworkInspectorFeature(
                 bodyTruncatedBytes = bodyTruncatedBytes,
                 bodySize = bodySize,
             )
-        }
-    }
-
-    private suspend fun findLatestRequest(requestId: String): RequestWillBeSent? {
-        val snapshot = bufferLock.withLock { eventBuffer.snapshot() }
-        return snapshot.asReversed().firstNotNullOfOrNull { record ->
-            (record as? RequestWillBeSent)?.takeIf { it.id == requestId }
-        }
-    }
-
-    private suspend fun findLatestResponse(requestId: String): ResponseReceived? {
-        val snapshot = bufferLock.withLock { eventBuffer.snapshot() }
-        return snapshot.asReversed().firstNotNullOfOrNull { record ->
-            (record as? ResponseReceived)?.takeIf { it.id == requestId }
         }
     }
 

--- a/snapo-link-android/network/src/main/java/com/openai/snapo/network/NetworkInspectorFeature.kt
+++ b/snapo-link-android/network/src/main/java/com/openai/snapo/network/NetworkInspectorFeature.kt
@@ -177,6 +177,26 @@ class NetworkInspectorFeature(
         currentSink.send(wireMessage)
     }
 
+    suspend fun updateLatestResponseBody(
+        requestId: String,
+        bodyPreview: String?,
+        body: String?,
+        bodyEncoding: String?,
+        bodyTruncatedBytes: Long?,
+        bodySize: Long?,
+    ) {
+        bufferLock.withLock {
+            eventBuffer.updateLatestResponseBody(
+                requestId = requestId,
+                bodyPreview = bodyPreview,
+                body = body,
+                bodyEncoding = bodyEncoding,
+                bodyTruncatedBytes = bodyTruncatedBytes,
+                bodySize = bodySize,
+            )
+        }
+    }
+
     private suspend fun findLatestRequest(requestId: String): RequestWillBeSent? {
         val snapshot = bufferLock.withLock { eventBuffer.snapshot() }
         return snapshot.asReversed().firstNotNullOfOrNull { record ->


### PR DESCRIPTION
This stack tightens our network event semantics and fixes body availability across desktop UI + CLI, especially after reconnect/replay.

### What’s in here
- Align HTTP lifecycle handling around terminal CDP events (`loadingFinished` / `loadingFailed`).
- Keep request status pending until terminal events, and preserve response metadata on failure paths.
- Gate body fetches on terminal readiness and skip response-body fetches for HTTP no-body responses.
- Use shared HTTP no-body semantics between desktop store and CLI output.
- Improve CLI failure behavior by preferring `loadingFailed` cause over generic missing-body errors.
- Store captured request/response bodies in `EventBuffer` so replayed sessions can still render bodies.
- Emit `loadingFinished` for empty `HttpURLConnection` responses.
- Queue desktop network records per server to preserve protocol/event order.

### Why
- Fixes stale “waiting for response” behavior after reconnect.
- Prevents body fetch races and duplicate/inconsistent lifecycle states.
- Makes request/response rendering more predictable and CDP-aligned across UI and CLI.
