### PR TITLE
network: fix header size aggregation compile ambiguity

### DIFF
--- a/snapo-link-android/network/src/main/java/com/openai/snapo/network/EventBuffer.kt
+++ b/snapo-link-android/network/src/main/java/com/openai/snapo/network/EventBuffer.kt
@@ -378,7 +378,9 @@ internal class EventBuffer(
     }
 
     private fun sizeOfHeaders(headers: List<Header>): Int =
-        headers.sumOf { it.name.length + it.value.length }
+        headers.fold(0) { total, header ->
+            total + header.name.length + header.value.length
+        }
 }
 
 private val String?.length: Int get() = this?.length ?: 0


### PR DESCRIPTION
Fixes a Kotlin overload resolution ambiguity in `EventBuffer.sizeOfHeaders` by switching from `sumOf` to a typed `fold` accumulator.

No behavior change intended; this is a compile-stability fix.
