### PR TITLE
desktop-compose: set packageBuildVersion for Network Inspector

### DIFF
--- a/snapo-desktop-compose/build.gradle.kts
+++ b/snapo-desktop-compose/build.gradle.kts
@@ -180,6 +180,7 @@ compose.desktop {
             packageName = "Snap-O Network Inspector"
             packageVersion = resolvedPackageVersion
             macOS {
+                packageBuildVersion = versionInfo.buildNumber
                 iconFile.set(project.file("src/main/resources/icons/network.icns"))
                 if (isReleaseDistribution) {
                     entitlementsFile.set(project.file("macos/NetworkInspector.entitlements"))


### PR DESCRIPTION
## Summary
- set `packageBuildVersion` in `snapo-desktop-compose` macOS packaging config to `versionInfo.buildNumber`
- keep `packageVersion` as the semantic app version
- fixes release About dialog showing `Version 1.0.0 (1.0.0)` instead of `Version 1.0.0 (20260210.00)`

## Testing
- not run (build config only)
