### PR TITLE
network: finalize no-body HTTP lifecycle semantics

### DIFF
--- a/snapo-desktop-compose/src/main/kotlin/com/openai/snapo/desktop/inspector/HttpBodySemantics.kt
+++ b/snapo-desktop-compose/src/main/kotlin/com/openai/snapo/desktop/inspector/HttpBodySemantics.kt
@@ -7,6 +7,6 @@ internal fun responseIsDefinedAsBodyless(
 ): Boolean {
     if (requestMethod.equals("HEAD", ignoreCase = true)) return true
     val status = responseStatus ?: return false
-    if (status in 100..199 || status == 204 || status == 304) return true
+    if (status in 100..199 || status == 204 || status == 205 || status == 304) return true
     return responseContentLength == 0L
 }

--- a/snapo-link-android/network-httpurlconnection/src/main/java/com/openai/snapo/network/httpurlconnection/SnapOHttpUrlInterceptor.kt
+++ b/snapo-link-android/network-httpurlconnection/src/main/java/com/openai/snapo/network/httpurlconnection/SnapOHttpUrlInterceptor.kt
@@ -494,12 +494,10 @@ private class InterceptingHttpURLConnection(
 
     private fun responseHasNoBody(method: String?, code: Int, contentLength: Long?): Boolean {
         if (method.equals("HEAD", ignoreCase = true)) return true
-        if (code in 100..199 ||
-            code == HttpURLConnection.HTTP_NO_CONTENT ||
-            code == HttpURLConnection.HTTP_NOT_MODIFIED
-        ) {
-            return true
-        }
+        if (code in 100..199) return true
+        if (code == HttpURLConnection.HTTP_NO_CONTENT) return true
+        if (code == HttpURLConnection.HTTP_RESET) return true
+        if (code == HttpURLConnection.HTTP_NOT_MODIFIED) return true
         return contentLength == 0L
     }
 

--- a/snapo-link-android/network-okhttp3/src/main/java/com/openai/snapo/network/okhttp3/SnapOOkHttpInterceptor.kt
+++ b/snapo-link-android/network-okhttp3/src/main/java/com/openai/snapo/network/okhttp3/SnapOOkHttpInterceptor.kt
@@ -145,7 +145,7 @@ class SnapOOkHttpInterceptor @JvmOverloads constructor(
         val endWall = System.currentTimeMillis()
         val endMono = SystemClock.elapsedRealtimeNanos()
         val responseBody = response.body
-        if (response.code == 101) {
+        if (response.hasNoBodyByProtocol()) {
             publishStandardResponse(context, response, responseBody, endWall = endWall, endMono = endMono)
             publishLoadingFinished(context, bodySize = 0L)
             return response
@@ -434,6 +434,14 @@ private fun ResponseBody?.safeContentLength(): Long? = this?.let {
     } catch (_: IOException) {
         null
     }
+}
+
+private fun Response.hasNoBodyByProtocol(): Boolean {
+    if (request.method.equals("HEAD", ignoreCase = true)) return true
+    return code in 100..199 ||
+        code == 204 ||
+        code == 205 ||
+        code == 304
 }
 
 private fun Response.bodyPreview(maxBytes: Int): String? {


### PR DESCRIPTION
## Summary
- emit `Network.loadingFinished` for protocol-defined no-body HTTP responses in the OkHttp interceptor
- keep websocket handshake (`101`) on the same shared no-body completion path
- align no-body detection across OkHttp, HttpURLConnection, and desktop inspector/CLI semantics

## Why
Some requests were getting `responseReceived` but never reaching a terminal lifecycle event, which left them stuck as pending.
This aligns terminal lifecycle behavior with expected CDP-style request completion.

## Testing
- `snapo-link-android`: `./gradlew :network-okhttp3:detekt :network-okhttp3:compileDebugKotlin`
- `snapo-link-android`: `./gradlew :network-httpurlconnection:detekt :network-httpurlconnection:compileDebugKotlin`
- `snapo-desktop-compose`: `./gradlew :compileKotlin`
