### PR TITLE
Upgrade GitHub Actions to latest versions

### DIFF
--- a/.github/workflows/android-inspector.yml
+++ b/.github/workflows/android-inspector.yml
@@ -30,7 +30,7 @@ jobs:
           distribution: temurin
           java-version: '17'
       - name: Set up Gradle
-        uses: gradle/actions/setup-gradle@748248ddd2a24f49513d8f472f81c3a07d4d50e1
+        uses: gradle/actions/setup-gradle@4c125117fe7c5aed11272ec4213f602f012f89f2  # v5
       - name: Grant execute permission for Gradle wrapper
         working-directory: snapo-desktop-compose
         run: chmod +x gradlew
@@ -49,7 +49,7 @@ jobs:
           distribution: temurin
           java-version: '17'
       - name: Set up Gradle
-        uses: gradle/actions/setup-gradle@748248ddd2a24f49513d8f472f81c3a07d4d50e1
+        uses: gradle/actions/setup-gradle@4c125117fe7c5aed11272ec4213f602f012f89f2  # v5
       - name: Grant execute permission for Gradle wrapper
         working-directory: snapo-desktop-compose
         run: chmod +x gradlew

--- a/.github/workflows/android-link.yml
+++ b/.github/workflows/android-link.yml
@@ -30,7 +30,7 @@ jobs:
           distribution: temurin
           java-version: '17'
       - name: Set up Gradle
-        uses: gradle/actions/setup-gradle@748248ddd2a24f49513d8f472f81c3a07d4d50e1
+        uses: gradle/actions/setup-gradle@4c125117fe7c5aed11272ec4213f602f012f89f2  # v5
       - name: Prepare local.properties
         working-directory: snapo-link-android
         run: |
@@ -55,7 +55,7 @@ jobs:
           distribution: temurin
           java-version: '17'
       - name: Set up Gradle
-        uses: gradle/actions/setup-gradle@748248ddd2a24f49513d8f472f81c3a07d4d50e1
+        uses: gradle/actions/setup-gradle@4c125117fe7c5aed11272ec4213f602f012f89f2  # v5
       - name: Prepare local.properties
         working-directory: snapo-link-android
         run: |


### PR DESCRIPTION
Bumps GitHub Actions to their latest versions for bug fixes and security patches.

## Changes

| Action | Old Version(s) | New Version | Release | Files |
|--------|---------------|-------------|---------|-------|
| `gradle/actions/setup-gradle` | [`748248d`](https://github.com/gradle/actions/setup-gradle/commit/748248ddd2a24f49513d8f472f81c3a07d4d50e1) | [`4c12511`](https://github.com/gradle/actions/setup-gradle/commit/4c125117fe7c5aed11272ec4213f602f012f89f2) | [Release](https://github.com/gradle/actions/setup-gradle/releases/tag/v5) | android-inspector.yml, android-link.yml |

## Notes

Actions that were previously pinned to commit SHAs remain pinned to SHAs (updated to the latest release SHA).

Worth running the workflows on a branch before merging to make sure everything still works.
