### PR TITLE
Fix stale pending requests in Network Inspector

### DIFF
--- a/snapo-desktop-compose/src/main/kotlin/com/openai/snapo/desktop/inspector/HttpBodySemantics.kt
+++ b/snapo-desktop-compose/src/main/kotlin/com/openai/snapo/desktop/inspector/HttpBodySemantics.kt
@@ -13,3 +13,20 @@ internal fun responseIsDefinedAsBodyless(
     if (status == 304) return true
     return responseContentLength == 0L
 }
+
+internal fun responseIsDefinedAsBodyless(
+    requestMethod: String?,
+    responseStatus: Int?,
+    responseHeaders: List<Header>?,
+): Boolean {
+    val contentLength = responseHeaders
+        ?.firstOrNull { header -> header.name.equals("Content-Length", ignoreCase = true) }
+        ?.value
+        ?.trim()
+        ?.toLongOrNull()
+    return responseIsDefinedAsBodyless(
+        requestMethod = requestMethod,
+        responseStatus = responseStatus,
+        responseContentLength = contentLength,
+    )
+}

--- a/snapo-desktop-compose/src/main/kotlin/com/openai/snapo/desktop/inspector/NetworkInspectorDetailViewModels.kt
+++ b/snapo-desktop-compose/src/main/kotlin/com/openai/snapo/desktop/inspector/NetworkInspectorDetailViewModels.kt
@@ -236,8 +236,8 @@ private fun requestStatus(request: NetworkInspectorRequest): NetworkInspectorReq
             NetworkInspectorRequestStatus.Success(request.response?.code ?: 200)
 
         request.isLikelyStreamingResponse -> NetworkInspectorRequestStatus.Pending
-        request.response != null && request.finished != null ->
-            NetworkInspectorRequestStatus.Success(request.response.code)
+        request.hasCompleteResponse ->
+            NetworkInspectorRequestStatus.Success(request.response?.code ?: 200)
 
         request.response != null -> NetworkInspectorRequestStatus.Pending
         else -> NetworkInspectorRequestStatus.Pending

--- a/snapo-desktop-compose/src/main/kotlin/com/openai/snapo/desktop/inspector/NetworkInspectorModels.kt
+++ b/snapo-desktop-compose/src/main/kotlin/com/openai/snapo/desktop/inspector/NetworkInspectorModels.kt
@@ -64,6 +64,19 @@ val NetworkInspectorRequest.isLikelyStreamingResponse: Boolean
         return false
     }
 
+val NetworkInspectorRequest.hasBodylessResponse: Boolean
+    get() {
+        val responseRecord = response ?: return false
+        return responseIsDefinedAsBodyless(
+            requestMethod = request?.method,
+            responseStatus = responseRecord.code,
+            responseHeaders = responseRecord.headers,
+        )
+    }
+
+val NetworkInspectorRequest.hasCompleteResponse: Boolean
+    get() = response != null && (finished != null || hasBodylessResponse)
+
 private fun hasEventStreamHeader(headers: List<Header>?): Boolean {
     if (headers.isNullOrEmpty()) return false
     return headers.any { header ->

--- a/snapo-desktop-compose/src/main/kotlin/com/openai/snapo/desktop/inspector/NetworkInspectorViewModels.kt
+++ b/snapo-desktop-compose/src/main/kotlin/com/openai/snapo/desktop/inspector/NetworkInspectorViewModels.kt
@@ -188,8 +188,8 @@ private fun resolveRequestStatus(request: NetworkInspectorRequest): NetworkInspe
             NetworkInspectorRequestStatus.Success(request.response?.code ?: 200)
 
         request.isLikelyStreamingResponse -> NetworkInspectorRequestStatus.Pending
-        request.response != null && request.finished != null ->
-            NetworkInspectorRequestStatus.Success(request.response.code)
+        request.hasCompleteResponse ->
+            NetworkInspectorRequestStatus.Success(request.response?.code ?: 200)
 
         request.response != null -> NetworkInspectorRequestStatus.Pending
         else -> NetworkInspectorRequestStatus.Pending

--- a/snapo-desktop-compose/src/main/kotlin/com/openai/snapo/desktop/inspector/RequestEventStore.kt
+++ b/snapo-desktop-compose/src/main/kotlin/com/openai/snapo/desktop/inspector/RequestEventStore.kt
@@ -53,7 +53,7 @@ internal class RequestEventStore {
                     request.streamClosed != null -> false
                     request.streamEvents.isNotEmpty() -> true
                     request.isLikelyStreamingResponse -> true
-                    request.response != null && request.finished != null -> false
+                    request.hasCompleteResponse -> false
                     else -> true
                 }
             }
@@ -96,9 +96,9 @@ internal class RequestEventStore {
                 return@withLock size == null || size != 0L
             }
 
-            if (state.finished == null) return@withLock false
             val response = state.response ?: return@withLock false
-            if (responseHasNoBody(state = state, response = response)) return@withLock false
+            if (state.hasBodylessResponse) return@withLock false
+            if (state.finished == null) return@withLock false
             if (!response.body.isNullOrEmpty()) return@withLock false
             // null means unknown size; still try.
             val size = response.bodySize
@@ -333,21 +333,5 @@ internal class RequestEventStore {
 
     private fun broadcastRequestsLocked() {
         _requests.value = requestOrder.mapNotNull { requestStates[it] }
-    }
-
-    private fun responseHasNoBody(
-        state: NetworkInspectorRequest,
-        response: ResponseReceived,
-    ): Boolean {
-        val contentLength = response.headers
-            .firstOrNull { header -> header.name.equals("Content-Length", ignoreCase = true) }
-            ?.value
-            ?.trim()
-            ?.toLongOrNull()
-        return responseIsDefinedAsBodyless(
-            requestMethod = state.request?.method,
-            responseStatus = response.code,
-            responseContentLength = contentLength,
-        )
     }
 }

--- a/snapo-link-android/network-okhttp3/src/main/java/com/openai/snapo/network/okhttp3/SnapOOkHttpInterceptor.kt
+++ b/snapo-link-android/network-okhttp3/src/main/java/com/openai/snapo/network/okhttp3/SnapOOkHttpInterceptor.kt
@@ -155,7 +155,17 @@ class SnapOOkHttpInterceptor @JvmOverloads constructor(
         return if (responseBody.contentType().isEventStream()) {
             handleStreamingResponse(context, response, responseBody, endWall = endWall, endMono = endMono)
         } else {
-            publishStandardResponse(context, response, responseBody, endWall = endWall, endMono = endMono)
+            val completeBodySize = publishStandardResponse(
+                context = context,
+                response = response,
+                body = responseBody,
+                endWall = endWall,
+                endMono = endMono,
+            )
+            if (completeBodySize != null) {
+                publishLoadingFinished(context, completeBodySize)
+                return response
+            }
             response.newBuilder()
                 .body(
                     CompletionTrackingResponseBody(
@@ -207,8 +217,9 @@ class SnapOOkHttpInterceptor @JvmOverloads constructor(
         body: ResponseBody,
         endWall: Long,
         endMono: Long,
-    ) {
+    ): Long? {
         val bodySize = body.safeContentLength()
+        var completeBodySize = bodySize.takeIf { it == 0L }
         publish {
             val textBody = response.captureTextBody(textBodyMaxBytes, responseBodyPreviewBytes)
             val binaryBody = if (textBody == null) {
@@ -216,6 +227,11 @@ class SnapOOkHttpInterceptor @JvmOverloads constructor(
             } else {
                 null
             }
+            completeBodySize = completeCapturedBodySize(
+                textBody = textBody,
+                binaryBody = binaryBody,
+                bodySize = bodySize,
+            )
             val bodyPreview = textBody?.preview
                 ?: binaryBody?.preview
                 ?: response.bodyPreview(responseBodyPreviewBytes)
@@ -234,6 +250,7 @@ class SnapOOkHttpInterceptor @JvmOverloads constructor(
                 bodySize = bodySize,
             )
         }
+        return completeBodySize
     }
 
     private fun handleFailure(context: InterceptContext, error: Throwable) {
@@ -573,6 +590,19 @@ private fun Response.captureBinaryBody(maxBytes: Int, previewBytes: Int): Binary
             null
         }
     }
+}
+
+private fun completeCapturedBodySize(
+    textBody: TextBodyCapture?,
+    binaryBody: BinaryBodyCapture?,
+    bodySize: Long?,
+): Long? {
+    if (bodySize == 0L) return 0L
+    val capturedBytes = textBody?.capturedBytes ?: binaryBody?.capturedBytes ?: return null
+    val truncated = textBody?.truncated ?: binaryBody?.truncated ?: return null
+    if (truncated) return null
+    if (bodySize != null && capturedBytes < bodySize) return null
+    return bodySize ?: capturedBytes
 }
 
 private fun Request.captureBody(maxBytes: Int): RequestBodyCapture? {


### PR DESCRIPTION
## Summary
- Treat bodyless HTTP responses as complete in the Android OkHttp interceptor so `loadingFinished` is emitted immediately
- Reuse shared HTTP body semantics on the desktop side to classify bodyless responses as complete
- Simplify the request status and cleanup logic to avoid leaving completed requests marked as pending

## Testing
- `env JAVA_HOME=/Library/Java/JavaVirtualMachines/temurin-17.jdk/Contents/Home ./gradlew :network-okhttp3:compileDebugKotlin`
- `env JAVA_HOME=/Library/Java/JavaVirtualMachines/temurin-17.jdk/Contents/Home ./gradlew :network-okhttp3:detekt`
- `env JAVA_HOME=/Library/Java/JavaVirtualMachines/temurin-17.jdk/Contents/Home ./gradlew compileKotlin`
- `env JAVA_HOME=/Library/Java/JavaVirtualMachines/temurin-17.jdk/Contents/Home ./gradlew detekt`