### PR TITLE
Improve Network Inspector parity and polish Electron output

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,11 +92,11 @@ Running these tools launches Snap-O (or brings it to the foreground) and immedia
 
 There is currently no support for choosing a specific device/emulator when starting Snap-O in this way.
 
-## Why not Compose Multiplatform?
+## Why Electron for the Network Inspector?
 
-The Network Inspector is now written with Compose Multiplatform, and that's working quite well.
+The Network Inspector is implemented with Electron. A web-based UI is easier to embed across more environments, and modern AI tools are especially effective at writing and iterating on web-based code. That makes Electron a practical fit for the inspector while keeping the UI portable beyond the macOS helper app.
 
-The screenshot tool uses SwiftUI because it delivers a better macOS experience for video playback today. Snap-O uses AVKit because it gives a polished video player on macOS and keeps the download small. VLC-based playback felt clunky and the viewing experience suffered. When Compose Multiplatform offers a better video playback experience, we'd like to move everything to Compose Multiplatform.
+The screenshot tool remains in SwiftUI because it delivers a better macOS experience for video playback today. Snap-O uses AVKit because it gives a polished video player on macOS and keeps the download small. VLC-based playback felt clunky and the viewing experience suffered.
 
 ## Alternatives
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,6 @@
+{
+  "name": "snap-o",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {}
+}

--- a/snapo-desktop-compose/src/main/kotlin/com/openai/snapo/desktop/ui/inspector/Sidebar.kt
+++ b/snapo-desktop-compose/src/main/kotlin/com/openai/snapo/desktop/ui/inspector/Sidebar.kt
@@ -470,13 +470,13 @@ internal fun sidebarContextMenuItems(
                     ?.let { NetworkInspectorRequestUiModel.from(it) }
                 if (model != null) NetworkInspectorCopyExporter.copyCurl(model)
             },
-            ContextMenuItem("Export (sanitized)...") {
+            ContextMenuItem("Export HAR (sanitized)...") {
                 exportSidebarSelectionAsHar(store = store, selection = exportSelection)
             },
         )
 
         is NetworkInspectorListItemUiModel.Kind.WebSocket -> listOf(
-            ContextMenuItem("Export (sanitized)...") {
+            ContextMenuItem("Export HAR (sanitized)...") {
                 exportSidebarSelectionAsHar(store = store, selection = exportSelection)
             },
         )

--- a/snapo-desktop-electron/README.md
+++ b/snapo-desktop-electron/README.md
@@ -2,7 +2,7 @@
 
 This is the web-technology implementation of Snap-O's Network Inspector. The renderer is a React app with no direct Electron imports; desktop-specific behavior lives behind an Electron preload bridge so the same UI can later be hosted by a browser or MCP app transport.
 
-The Electron backend talks directly to the local ADB server and Snap-O link sockets. It does not shell out to the Compose desktop app or the `snapo` CLI.
+The Electron backend talks directly to the local ADB server and Snap-O link sockets. It does not shell out to another desktop helper or the `snapo` CLI.
 
 ## Requirements
 

--- a/snapo-desktop-electron/electron/main.ts
+++ b/snapo-desktop-electron/electron/main.ts
@@ -148,6 +148,7 @@ app.on("child-process-gone", (_event, details) => {
 });
 
 function installIpcHandlers(): void {
+  ipcMain.handle("app:version", () => currentVersionInfo().version);
   ipcMain.handle("network:listServers", () => backend.listServers());
   ipcMain.handle("network:loadBodies", (_event, input: LoadBodiesInput) => backend.loadBodies(input));
   ipcMain.handle("network:startStream", (event, input: StartStreamInput) => backend.startStream(input, event.sender));

--- a/snapo-desktop-electron/electron/preload.ts
+++ b/snapo-desktop-electron/electron/preload.ts
@@ -11,6 +11,7 @@ import type {
 
 const api: SnapONetworkBridge = {
   platform: process.platform,
+  appVersion: () => ipcRenderer.invoke("app:version"),
   listServers: () => ipcRenderer.invoke("network:listServers"),
   loadBodies: (input: LoadBodiesInput) => ipcRenderer.invoke("network:loadBodies", input),
   startStream: (input: StartStreamInput) => ipcRenderer.invoke("network:startStream", input),

--- a/snapo-desktop-electron/src/features/network-inspector/components/PayloadView.tsx
+++ b/snapo-desktop-electron/src/features/network-inspector/components/PayloadView.tsx
@@ -45,7 +45,7 @@ export function PayloadView({
 }): JSX.Element {
   const defaultPretty = payload.prettyText != null;
   const pretty = uiState.prettyEnabled(storageKey, defaultPretty);
-  const displayText = pretty && payload.prettyText != null ? payload.prettyText : payload.rawText;
+  const displayText = pretty && payload.prettyText != null ? payload.prettyText : payload.displayText;
   const jsonRoot = useMemo(
     () => (pretty && payload.prettyText != null ? parseJsonNode(payload.prettyText) : null),
     [payload.prettyText, pretty]
@@ -150,6 +150,9 @@ function JsonOutline({
   const expandable = node.children.length > 0;
   const rowKey = `${storageKey}:${node.key}`;
   const expanded = expandable ? uiState.jsonExpanded(rowKey, depth === 0 ? initiallyExpanded : false) : false;
+  const stringValue = node.type === "string" ? String(node.rawValue) : null;
+  const stringIsCollapsible = stringValue != null && stringValue.split("\n").length > MaxCollapsedStringLines;
+  const [stringExpanded, setStringExpanded] = useState(false);
   const descendantRowKeys = useMemo(() => collectDescendantRowKeys(node, storageKey), [node, storageKey]);
   const closingSymbol = node.type === "array" ? "]" : "}";
 
@@ -167,7 +170,13 @@ function JsonOutline({
   return (
     <div className="json-outline">
       <div
-        className={trailing == null ? "json-row" : "json-row json-row-with-trailing"}
+        className={[
+          "json-row",
+          trailing == null ? "" : "json-row-with-trailing",
+          stringIsCollapsible ? "json-row-multiline" : ""
+        ]
+          .filter(Boolean)
+          .join(" ")}
         style={{ paddingLeft: `${depth * 14}px` }}
         onContextMenu={(event) => {
           event.preventDefault();
@@ -197,9 +206,17 @@ function JsonOutline({
         ) : (
           <span className="json-toggle-spacer" />
         )}
-        <JsonNodeLine node={node} expanded={expanded} />
+        <JsonNodeLine node={node} expanded={expanded} stringExpanded={stringExpanded} />
         {trailing}
       </div>
+      {stringIsCollapsible ? (
+        <div className="json-string-expander-row" style={{ paddingLeft: `${depth * 14}px` }}>
+          <span className="json-toggle-spacer" />
+          <button className="json-string-expander" type="button" onClick={() => setStringExpanded((value) => !value)}>
+            {stringExpanded ? "See less" : "See more"}
+          </button>
+        </div>
+      ) : null}
       {menu == null ? null : <ContextMenu menu={menu} onClose={() => setMenu(null)} />}
       {expanded ? (
         <>
@@ -223,7 +240,15 @@ function JsonOutline({
   );
 }
 
-function JsonNodeLine({ node, expanded }: { node: JsonNode; expanded: boolean }): JSX.Element {
+function JsonNodeLine({
+  node,
+  expanded,
+  stringExpanded
+}: {
+  node: JsonNode;
+  expanded: boolean;
+  stringExpanded: boolean;
+}): JSX.Element {
   return (
     <span className="json-line">
       {node.label.length === 0 ? null : (
@@ -232,12 +257,20 @@ function JsonNodeLine({ node, expanded }: { node: JsonNode; expanded: boolean })
           <span className="json-punctuation json-property-separator">:</span>
         </>
       )}
-      <JsonNodeValue node={node} expanded={expanded} />
+      <JsonNodeValue node={node} expanded={expanded} stringExpanded={stringExpanded} />
     </span>
   );
 }
 
-function JsonNodeValue({ node, expanded }: { node: JsonNode; expanded: boolean }): JSX.Element {
+function JsonNodeValue({
+  node,
+  expanded,
+  stringExpanded
+}: {
+  node: JsonNode;
+  expanded: boolean;
+  stringExpanded: boolean;
+}): JSX.Element {
   if (node.type === "object") {
     if (node.children.length === 0) return <span className="json-punctuation">{"{ }"}</span>;
     if (expanded) return <span className="json-punctuation">{"{"}</span>;
@@ -248,7 +281,15 @@ function JsonNodeValue({ node, expanded }: { node: JsonNode; expanded: boolean }
     if (expanded) return <span className="json-punctuation">[</span>;
     return <JsonInlinePreview node={node} />;
   }
-  if (node.type === "string") return <span className="json-string">{jsonQuoted(String(node.rawValue))}</span>;
+  if (node.type === "string") {
+    const value = String(node.rawValue);
+    const stringIsCollapsible = value.split("\n").length > MaxCollapsedStringLines;
+    return (
+      <span className={stringIsCollapsible ? "json-string json-string-multiline" : "json-string"}>
+        {jsonStringForDisplay(value, stringExpanded)}
+      </span>
+    );
+  }
   if (node.type === "number" || node.type === "boolean") {
     return <span className="json-number-bool">{String(node.rawValue)}</span>;
   }
@@ -322,6 +363,18 @@ function inlinePreviewText(node: JsonNode): string {
 
 function jsonQuoted(value: string): string {
   return JSON.stringify(value);
+}
+
+function jsonStringForDisplay(value: string, expanded: boolean): string {
+  const lines = value.split("\n");
+  const visibleLines =
+    lines.length <= MaxCollapsedStringLines || expanded ? lines : lines.slice(0, MaxCollapsedStringLines);
+  const suffix = lines.length <= MaxCollapsedStringLines || expanded ? [] : ["..."];
+  return `"${[...visibleLines.map(jsonStringLineForDisplay), ...suffix].join("\n")}"`;
+}
+
+function jsonStringLineForDisplay(value: string): string {
+  return jsonQuoted(value).slice(1, -1);
 }
 
 function jsonContextMenuItems({
@@ -418,3 +471,5 @@ function ImagePreview({ payload }: { payload: BodyPayload }): JSX.Element | null
     </div>
   );
 }
+
+const MaxCollapsedStringLines = 20;

--- a/snapo-desktop-electron/src/features/network-inspector/components/PayloadView.tsx
+++ b/snapo-desktop-electron/src/features/network-inspector/components/PayloadView.tsx
@@ -47,8 +47,11 @@ export function PayloadView({
   const pretty = uiState.prettyEnabled(storageKey, defaultPretty);
   const displayText = pretty && payload.prettyText != null ? payload.prettyText : payload.displayText;
   const jsonRoot = useMemo(
-    () => (pretty && payload.prettyText != null ? parseJsonNode(payload.prettyText) : null),
-    [payload.prettyText, pretty]
+    () =>
+      pretty && payload.jsonFormat === "single" && payload.prettyText != null
+        ? parseJsonNode(payload.prettyText)
+        : null,
+    [payload.jsonFormat, payload.prettyText, pretty]
   );
   const copyFeedback = useCopyFeedback(displayText);
   const hasToggle = showsToggle && payload.prettyText != null;
@@ -68,7 +71,7 @@ export function PayloadView({
 
   return (
     <div className={embedded ? "payload-view embedded" : "payload-card"}>
-      {payload.prettyText == null && payload.isLikelyJson ? (
+      {payload.jsonFormat === "invalid" ? (
         <div className="json-parse-hint">Unable to pretty print (invalid or truncated JSON)</div>
       ) : null}
       <div className="payload-scroll">

--- a/snapo-desktop-electron/src/features/network-inspector/components/RecordList.tsx
+++ b/snapo-desktop-electron/src/features/network-inspector/components/RecordList.tsx
@@ -121,6 +121,6 @@ function sidebarContextMenuItems(
   if (clicked.kind === "request") {
     items.push({ label: "Copy as cURL", action: () => void copyCurl(client, clicked) });
   }
-  items.push({ label: "Export (sanitized)...", action: () => void exportAsHar(client, exportRecords) });
+  items.push({ label: "Export HAR (sanitized)...", action: () => void exportAsHar(client, exportRecords) });
   return items;
 }

--- a/snapo-desktop-electron/src/features/network-inspector/components/RequestDetail.tsx
+++ b/snapo-desktop-electron/src/features/network-inspector/components/RequestDetail.tsx
@@ -1,8 +1,8 @@
-import { memo } from "react";
+import { memo, useEffect, useState } from "react";
 import { recordId, type Header, type RequestRecord } from "../../../network/cdp";
-import { makeBodyPayload } from "../../../network/payload";
+import { decodeRequestBodyForDisplay, makeBodyPayload } from "../../../network/payload";
 import type { InspectorUiState } from "../hooks/useInspectorUiState";
-import { formatTiming } from "../lib/format";
+import { useAdaptiveTimingText } from "../hooks/useAdaptiveTimingText";
 import { BodySection, payloadMetadata } from "./PayloadView";
 import { HeadersTable, Section } from "./Section";
 import { FailureMessage, StatusBadge } from "./Status";
@@ -16,8 +16,10 @@ export const RequestDetail = memo(function RequestDetail({
   uiState: InspectorUiState;
 }): JSX.Element {
   const isSseResponse = isLikelySseResponse(record);
+  const requestBodyDisplayText = useRequestBodyDisplayText(record);
   const requestBody = makeBodyPayload({
     body: record.requestBody,
+    displayText: requestBodyDisplayText,
     headers: record.requestHeaders,
     encoding: record.requestBodyEncoding
   });
@@ -30,6 +32,7 @@ export const RequestDetail = memo(function RequestDetail({
         totalBytes: record.encodedDataLength
       });
   const prefix = `request:${recordId(record)}`;
+  const timingText = useAdaptiveTimingText(record.startedAt, record.endedAt, record.status);
 
   return (
     <div className="detail-scroll">
@@ -40,7 +43,7 @@ export const RequestDetail = memo(function RequestDetail({
         </div>
         <div className="detail-meta">
           <StatusBadge record={record} />
-          <span>{formatTiming(record.startedAt, record.endedAt, record.status)}</span>
+          <span>{timingText}</span>
         </div>
         <FailureMessage status={record.status} />
       </header>
@@ -101,6 +104,51 @@ export const RequestDetail = memo(function RequestDetail({
   );
 });
 
+function useRequestBodyDisplayText(record: RequestRecord): string | null {
+  const contentEncoding = requestHeaderValue(record.requestHeaders, "content-encoding");
+  const [decodedBody, setDecodedBody] = useState<{
+    body: string;
+    encoding: string | null | undefined;
+    contentEncoding: string | null;
+    displayText: string;
+  } | null>(null);
+
+  useEffect(() => {
+    const body = record.requestBody;
+    if (body == null) return;
+
+    let disposed = false;
+    void decodeRequestBodyForDisplay({
+      body,
+      headers: record.requestHeaders,
+      encoding: record.requestBodyEncoding
+    }).then((decoded) => {
+      if (!disposed) {
+        setDecodedBody({
+          body,
+          encoding: record.requestBodyEncoding,
+          contentEncoding,
+          displayText: decoded
+        });
+      }
+    });
+
+    return () => {
+      disposed = true;
+    };
+  }, [contentEncoding, record.requestBody, record.requestBodyEncoding, record.requestHeaders]);
+
+  if (record.requestBody == null) return null;
+  if (
+    decodedBody?.body === record.requestBody &&
+    decodedBody.encoding === record.requestBodyEncoding &&
+    decodedBody.contentEncoding === contentEncoding
+  ) {
+    return decodedBody.displayText;
+  }
+  return record.requestBody;
+}
+
 function isLikelySseResponse(record: RequestRecord): boolean {
   if (record.streamEvents.length > 0) return true;
   if (record.responseType?.toLowerCase() === "eventsource") return true;
@@ -113,4 +161,8 @@ function hasEventStreamHeader(headers: Header[]): boolean {
     const value = header.value.toLowerCase();
     return (name === "content-type" || name === "accept") && value.includes("text/event-stream");
   });
+}
+
+function requestHeaderValue(headers: Header[], name: string): string | null {
+  return headers.find((header) => header.name.toLowerCase() === name)?.value ?? null;
 }

--- a/snapo-desktop-electron/src/features/network-inspector/components/StreamEvents.tsx
+++ b/snapo-desktop-electron/src/features/network-inspector/components/StreamEvents.tsx
@@ -1,6 +1,6 @@
 import { memo } from "react";
 import type { RequestRecord } from "../../../network/cdp";
-import { makeBodyPayload, prettyJsonOrNull } from "../../../network/payload";
+import { makeBodyPayload } from "../../../network/payload";
 import { streamEventsRaw } from "../../../network/exporters";
 import { useCopyFeedback } from "../hooks/useCopyFeedback";
 import type { InspectorUiState } from "../hooks/useInspectorUiState";
@@ -66,11 +66,11 @@ const SseEventCard = memo(function SseEventCard({
   uiState: InspectorUiState;
 }): JSX.Element {
   const rawText = event.data ?? event.raw;
-  const prettyText = prettyJsonOrNull(rawText);
+  const payload = makeBodyPayload({ body: rawText, headers: [] });
+  const prettyText = payload?.prettyText ?? null;
   const pretty = uiState.prettyEnabled(storageKey, prettyText != null);
   const displayText = pretty && prettyText != null ? prettyText : rawText;
   const copyFeedback = useCopyFeedback(displayText);
-  const payload = makeBodyPayload({ body: rawText, headers: [] });
 
   return (
     <div className="event-row">
@@ -92,7 +92,7 @@ const SseEventCard = memo(function SseEventCard({
         <pre>{event.raw || "<empty>"}</pre>
       ) : (
         <PayloadView
-          payload={{ ...payload, prettyText, isLikelyJson: prettyText != null || payload.isLikelyJson }}
+          payload={payload}
           storageKey={storageKey}
           uiState={uiState}
           showsToggle={false}

--- a/snapo-desktop-electron/src/features/network-inspector/components/WebSocketDetail.tsx
+++ b/snapo-desktop-electron/src/features/network-inspector/components/WebSocketDetail.tsx
@@ -1,7 +1,7 @@
 import { memo } from "react";
 import { recordId, type WebSocketRecord } from "../../../network/cdp";
 import type { InspectorUiState } from "../hooks/useInspectorUiState";
-import { formatTiming } from "../lib/format";
+import { useAdaptiveTimingText } from "../hooks/useAdaptiveTimingText";
 import { HeadersTable, Section } from "./Section";
 import { FailureMessage, StatusBadge } from "./Status";
 import { WebSocketMessageCard } from "./WebSocketMessages";
@@ -14,6 +14,7 @@ export const WebSocketDetail = memo(function WebSocketDetail({
   uiState: InspectorUiState;
 }): JSX.Element {
   const prefix = `websocket:${recordId(record)}`;
+  const timingText = useAdaptiveTimingText(record.startedAt, record.endedAt, record.status);
   return (
     <div className="detail-scroll">
       <header className="detail-header">
@@ -23,7 +24,7 @@ export const WebSocketDetail = memo(function WebSocketDetail({
         </div>
         <div className="detail-meta">
           <StatusBadge record={record} />
-          <span>{formatTiming(record.startedAt, record.endedAt, record.status)}</span>
+          <span>{timingText}</span>
         </div>
         <FailureMessage status={record.status} />
         <WebSocketCloseDetails record={record} />

--- a/snapo-desktop-electron/src/features/network-inspector/components/WebSocketMessages.tsx
+++ b/snapo-desktop-electron/src/features/network-inspector/components/WebSocketMessages.tsx
@@ -1,7 +1,7 @@
 import { Inbox, Send } from "lucide-react";
 import { memo } from "react";
 import type { WebSocketMessageRecord } from "../../../network/cdp";
-import { formatBytes, makeBodyPayload, prettyJsonOrNull } from "../../../network/payload";
+import { formatBytes, makeBodyPayload } from "../../../network/payload";
 import { useCopyFeedback } from "../hooks/useCopyFeedback";
 import type { InspectorUiState } from "../hooks/useInspectorUiState";
 import { formatTime } from "../lib/format";
@@ -17,11 +17,11 @@ export const WebSocketMessageCard = memo(function WebSocketMessageCard({
   uiState: InspectorUiState;
 }): JSX.Element {
   const preview = message.preview ?? "";
-  const prettyText = prettyJsonOrNull(preview);
+  const payload = makeBodyPayload({ body: preview, headers: [] });
+  const prettyText = payload?.prettyText ?? null;
   const pretty = uiState.prettyEnabled(storageKey, prettyText != null);
   const displayText = pretty && prettyText != null ? prettyText : preview;
   const copyFeedback = useCopyFeedback(displayText);
-  const payload = makeBodyPayload({ body: preview, headers: [] });
 
   return (
     <div className="message-card">
@@ -49,7 +49,7 @@ export const WebSocketMessageCard = memo(function WebSocketMessageCard({
       </div>
       {payload == null ? null : (
         <PayloadView
-          payload={{ ...payload, prettyText, isLikelyJson: prettyText != null || payload.isLikelyJson }}
+          payload={payload}
           storageKey={storageKey}
           uiState={uiState}
           showsToggle={false}

--- a/snapo-desktop-electron/src/features/network-inspector/hooks/useAdaptiveTimingText.ts
+++ b/snapo-desktop-electron/src/features/network-inspector/hooks/useAdaptiveTimingText.ts
@@ -1,0 +1,28 @@
+import { useEffect, useState } from "react";
+import type { RequestStatus } from "../../../network/cdp";
+import { formatTiming } from "../lib/format";
+
+export function useAdaptiveTimingText(startedAt: number, endedAt: number | undefined, status: RequestStatus): string {
+  const [now, setNow] = useState(() => Date.now());
+
+  useEffect(() => {
+    let timeoutId: number | null = null;
+    const scheduleNextTick = () => {
+      const elapsedSeconds = Math.max(0, Math.floor((Date.now() - startedAt) / 1_000));
+      timeoutId = window.setTimeout(
+        () => {
+          setNow(Date.now());
+          scheduleNextTick();
+        },
+        elapsedSeconds >= 60 ? 60_000 : 1_000
+      );
+    };
+
+    scheduleNextTick();
+    return () => {
+      if (timeoutId != null) window.clearTimeout(timeoutId);
+    };
+  }, [startedAt]);
+
+  return formatTiming(startedAt, endedAt, status, now);
+}

--- a/snapo-desktop-electron/src/features/network-inspector/lib/exportActions.ts
+++ b/snapo-desktop-electron/src/features/network-inspector/lib/exportActions.ts
@@ -38,9 +38,10 @@ export async function exportAsHar(client: NetworkClient, records: InspectorRecor
       }
     })
   );
+  const appVersion = await client.appVersion();
   await client.saveFile({
     defaultPath: harFileName(hydrated.length),
-    data: buildHar(hydrated),
+    data: buildHar(hydrated, appVersion),
     mimeType: "application/har+json"
   });
 }

--- a/snapo-desktop-electron/src/features/network-inspector/lib/format.ts
+++ b/snapo-desktop-electron/src/features/network-inspector/lib/format.ts
@@ -1,7 +1,12 @@
 import type { RequestStatus } from "../../../network/cdp";
 
-export function formatTiming(startedAt: number, endedAt: number | undefined, status: RequestStatus): string {
-  const startSegment = `Started ${formatRelative(startedAt)} at ${formatTimeWithMillis(startedAt)}`;
+export function formatTiming(
+  startedAt: number,
+  endedAt: number | undefined,
+  status: RequestStatus,
+  now = Date.now()
+): string {
+  const startSegment = `Started ${formatRelative(startedAt, now)} at ${formatTimeWithMillis(startedAt)}`;
   if (status.kind === "pending" || endedAt == null) return startSegment;
   return `${formatDuration(Math.max(0, endedAt - startedAt))} total • ${startSegment}`;
 }
@@ -31,8 +36,8 @@ function formatTimeWithMillis(value: number): string {
   return `${hours}:${minutes}:${seconds}.${millis}`;
 }
 
-function formatRelative(value: number): string {
-  const seconds = Math.round((Date.now() - value) / 1000);
+function formatRelative(value: number, now: number): string {
+  const seconds = Math.round((now - value) / 1000);
   if (seconds === 0) return "just now";
   const absoluteSeconds = Math.abs(seconds);
   const isFuture = seconds < 0;

--- a/snapo-desktop-electron/src/network/bridge-types.ts
+++ b/snapo-desktop-electron/src/network/bridge-types.ts
@@ -70,6 +70,7 @@ export interface StreamStatus {
 
 export interface SnapONetworkBridge {
   platform: NodeJS.Platform;
+  appVersion(): Promise<string>;
   listServers(): Promise<SnapOServer[]>;
   loadBodies(input: LoadBodiesInput): Promise<RequestBodies>;
   startStream(input: StartStreamInput): Promise<StreamStarted>;

--- a/snapo-desktop-electron/src/network/client.ts
+++ b/snapo-desktop-electron/src/network/client.ts
@@ -13,6 +13,7 @@ import type {
 } from "./bridge-types";
 
 export interface NetworkClient {
+  appVersion(): Promise<string>;
   listServers(): Promise<SnapOServer[]>;
   loadBodies(input: LoadBodiesInput): Promise<RequestBodies>;
   startStream(input: StartStreamInput): Promise<StreamStarted>;
@@ -34,6 +35,10 @@ export function createNetworkClient(): NetworkClient {
 
 class ElectronNetworkClient implements NetworkClient {
   constructor(private readonly bridge: SnapONetworkBridge) {}
+
+  appVersion(): Promise<string> {
+    return this.bridge.appVersion();
+  }
 
   listServers(): Promise<SnapOServer[]> {
     return this.bridge.listServers();
@@ -80,6 +85,10 @@ class HttpNetworkClient implements NetworkClient {
   private eventSource: EventSource | null = null;
   private statusCallbacks = new Set<(status: StreamStatus) => void>();
   private eventCallbacks = new Set<(event: StreamEvent) => void>();
+
+  async appVersion(): Promise<string> {
+    return "web";
+  }
 
   async listServers(): Promise<SnapOServer[]> {
     return fetchJson("/api/network/servers");

--- a/snapo-desktop-electron/src/network/exporters.ts
+++ b/snapo-desktop-electron/src/network/exporters.ts
@@ -40,7 +40,7 @@ export function streamEventsRaw(events: StreamEventRecord[]): string {
   return events.map((event) => event.raw.replace(/\n+$/u, "") + "\n\n").join("");
 }
 
-export function buildHar(records: InspectorRecord[]): string {
+export function buildHar(records: InspectorRecord[], creatorVersion: string): string {
   const entries = records
     .map((record) => (record.kind === "request" ? requestToEntry(record) : webSocketToEntry(record)))
     .sort((a, b) => a.startedDateTime.localeCompare(b.startedDateTime));
@@ -50,7 +50,7 @@ export function buildHar(records: InspectorRecord[]): string {
         version: "1.2",
         creator: {
           name: "Snap-O",
-          version: "electron"
+          version: creatorVersion
         },
         pages: [],
         entries

--- a/snapo-desktop-electron/src/network/payload.ts
+++ b/snapo-desktop-electron/src/network/payload.ts
@@ -10,6 +10,7 @@ export interface JsonNode {
 
 export interface BodyPayload {
   rawText: string;
+  displayText: string;
   prettyText: string | null;
   isLikelyJson: boolean;
   contentType: string | null;
@@ -21,6 +22,7 @@ export interface BodyPayload {
 
 export function makeBodyPayload(input: {
   body: string | null | undefined;
+  displayText?: string | null;
   headers: Header[];
   encoding?: string | null;
   base64Encoded?: boolean | null;
@@ -30,17 +32,42 @@ export function makeBodyPayload(input: {
   const contentType = contentTypeFromHeaders(input.headers);
   const base64Encoded = input.base64Encoded === true || input.encoding?.toLowerCase() === "base64";
   const rawText = input.body;
-  const prettyText = base64Encoded ? null : prettyJsonOrNull(rawText);
+  const displayText = input.displayText ?? rawText;
+  const prettyText = base64Encoded && displayText === rawText ? null : prettyJsonOrNull(displayText);
   return {
     rawText,
+    displayText,
     prettyText,
-    isLikelyJson: prettyText != null || isLikelyJson(rawText, contentType),
+    isLikelyJson: prettyText != null || isLikelyJson(displayText, contentType),
     contentType,
     encoding: base64Encoded ? "base64" : (input.encoding ?? null),
     capturedBytes: bodyByteLength(rawText, base64Encoded),
     totalBytes: input.totalBytes ?? null,
     base64Encoded
   };
+}
+
+export async function decodeRequestBodyForDisplay(input: {
+  body: string;
+  headers: Header[];
+  encoding?: string | null;
+}): Promise<string> {
+  if (input.encoding?.toLowerCase() !== "base64") return input.body;
+  if (!hasGzipContentEncoding(headerValue(input.headers, "content-encoding"))) return input.body;
+
+  const bytes = decodeBase64Bytes(input.body);
+  if (bytes == null || typeof DecompressionStream === "undefined") return input.body;
+
+  try {
+    const decompressed = await decompressGzip(bytes);
+    try {
+      return new TextDecoder("utf-8", { fatal: true }).decode(decompressed);
+    } catch {
+      return `Binary payload after gzip decompression (${formatBytes(decompressed.byteLength)}). Raw payload is shown below as captured.\n\n${input.body}`;
+    }
+  } catch {
+    return input.body;
+  }
 }
 
 export function contentTypeFromHeaders(headers: Header[]): string | null {
@@ -68,6 +95,25 @@ export function bodyMetadata(payload: BodyPayload): string | null {
     parts.push(`Total ${formatBytes(payload.totalBytes)}`);
   }
   return parts.length === 0 ? null : parts.join(" ");
+}
+
+function headerValue(headers: Header[], name: string): string | null {
+  return headers.find((header) => header.name.toLowerCase() === name)?.value ?? null;
+}
+
+function hasGzipContentEncoding(value: string | null): boolean {
+  if (value == null || value.trim().length === 0) return false;
+  return value
+    .split(/[,\n]/u)
+    .map((token) => token.split(";")[0].trim().toLowerCase())
+    .some((token) => token === "gzip" || token === "x-gzip");
+}
+
+async function decompressGzip(bytes: Uint8Array): Promise<Uint8Array> {
+  const copy = new Uint8Array(bytes.byteLength);
+  copy.set(bytes);
+  const stream = new Blob([copy.buffer]).stream().pipeThrough(new DecompressionStream("gzip"));
+  return new Uint8Array(await new Response(stream).arrayBuffer());
 }
 
 export function prettyJsonOrNull(text: string | null | undefined): string | null {
@@ -149,5 +195,16 @@ function bodyByteLength(value: string, base64Encoded: boolean): number {
     return atob(value.replace(/\s+/gu, "")).length;
   } catch {
     return new TextEncoder().encode(value).byteLength;
+  }
+}
+
+function decodeBase64Bytes(value: string): Uint8Array | null {
+  try {
+    const binary = atob(value.replace(/\s+/gu, ""));
+    const bytes = new Uint8Array(binary.length);
+    for (let index = 0; index < binary.length; index += 1) bytes[index] = binary.charCodeAt(index);
+    return bytes;
+  } catch {
+    return null;
   }
 }

--- a/snapo-desktop-electron/src/network/payload.ts
+++ b/snapo-desktop-electron/src/network/payload.ts
@@ -8,11 +8,13 @@ export interface JsonNode {
   children: JsonNode[];
 }
 
+export type JsonFormat = "none" | "single" | "stream" | "invalid";
+
 export interface BodyPayload {
   rawText: string;
   displayText: string;
   prettyText: string | null;
-  isLikelyJson: boolean;
+  jsonFormat: JsonFormat;
   contentType: string | null;
   encoding: string | null;
   capturedBytes: number;
@@ -33,12 +35,12 @@ export function makeBodyPayload(input: {
   const base64Encoded = input.base64Encoded === true || input.encoding?.toLowerCase() === "base64";
   const rawText = input.body;
   const displayText = input.displayText ?? rawText;
-  const prettyText = base64Encoded && displayText === rawText ? null : prettyJsonOrNull(displayText);
+  const json = base64Encoded && displayText === rawText ? noJson : inspectJson(displayText, contentType);
   return {
     rawText,
     displayText,
-    prettyText,
-    isLikelyJson: prettyText != null || isLikelyJson(displayText, contentType),
+    prettyText: json.prettyText,
+    jsonFormat: json.format,
     contentType,
     encoding: base64Encoded ? "base64" : (input.encoding ?? null),
     capturedBytes: bodyByteLength(rawText, base64Encoded),
@@ -123,6 +125,42 @@ export function prettyJsonOrNull(text: string | null | undefined): string | null
   } catch {
     return null;
   }
+}
+
+interface JsonInspection {
+  format: JsonFormat;
+  prettyText: string | null;
+}
+
+const noJson: JsonInspection = {
+  format: "none",
+  prettyText: null
+};
+
+function inspectJson(text: string, contentType: string | null): JsonInspection {
+  const prettyText = prettyJsonOrNull(text);
+  if (prettyText != null) return { format: "single", prettyText };
+
+  const prettyStream = prettyJsonStreamOrNull(text);
+  if (prettyStream != null) return { format: "stream", prettyText: prettyStream };
+
+  return isLikelyJson(text, contentType) ? { format: "invalid", prettyText: null } : noJson;
+}
+
+function prettyJsonStreamOrNull(text: string): string | null {
+  const documents = text
+    .split(/\r?\n/u)
+    .map((document) => document.trim())
+    .filter((document) => document.length > 0);
+  if (documents.length < 2) return null;
+
+  const prettyDocuments: string[] = [];
+  for (const document of documents) {
+    const prettyDocument = prettyJsonOrNull(document);
+    if (prettyDocument == null) return null;
+    prettyDocuments.push(prettyDocument);
+  }
+  return prettyDocuments.join("\n");
 }
 
 export function parseJsonNode(text: string, rootKey = "root"): JsonNode | null {

--- a/snapo-desktop-electron/src/styles.css
+++ b/snapo-desktop-electron/src/styles.css
@@ -916,6 +916,10 @@ body.split-pane-resizing {
   align-items: center;
 }
 
+.json-row-multiline {
+  align-items: flex-start;
+}
+
 .json-row-trailing {
   flex: 0 0 auto;
   display: inline-flex;
@@ -989,6 +993,11 @@ body.split-pane-resizing {
   white-space: nowrap;
 }
 
+.json-line .json-string-multiline {
+  white-space: pre-wrap;
+  overflow-wrap: anywhere;
+}
+
 .json-line > .json-key,
 .json-line > .json-punctuation {
   flex: 0 0 auto;
@@ -1004,6 +1013,23 @@ body.split-pane-resizing {
 
 .json-string {
   color: var(--json-string);
+}
+
+.json-string-expander-row {
+  min-height: 18px;
+  display: flex;
+  align-items: baseline;
+  gap: 4px;
+  width: 100%;
+  color: var(--on-surface-variant);
+  font-size: 12px;
+  line-height: 16px;
+}
+
+.json-string-expander {
+  color: inherit;
+  font-size: inherit;
+  line-height: inherit;
 }
 
 .json-number-bool {


### PR DESCRIPTION
## Summary
- Update the Network Inspector copy to reflect the Electron-based implementation and rename sanitized exports to explicit HAR actions
- Add app version plumbing from Electron to the web client so generated HAR files include the correct creator version
- Improve payload rendering with decoded request-body display text, multiline string expansion, and adaptive timing updates
- Keep the Electron and desktop inspector UI labels aligned

## Testing
- Not run (not requested)
- Validation scope covered by code changes across Electron bridge, HAR generation, and inspector UI rendering