### PR TITLE
[codex] Port URL filter semantics to Electron inspector

### DIFF
--- a/snapo-desktop-electron/src/features/network-inspector/lib/records.ts
+++ b/snapo-desktop-electron/src/features/network-inspector/lib/records.ts
@@ -29,13 +29,81 @@ export function filterRecords(
   searchText: string,
   newestFirst: boolean
 ): InspectorRecord[] {
-  const query = searchText.trim().toLowerCase();
+  const search = parseUrlFilterTokens(searchText);
   const filteredRecords = records
     .filter((record) => serverMatches(selectedServer, record.server))
-    .filter((record) => (query.length === 0 ? true : record.url.toLowerCase().includes(query)))
+    .filter((record) => matchesUrlFilter(record.url, search))
     .sort((a, b) => a.startedAt - b.startedAt);
   if (newestFirst) filteredRecords.reverse();
   return filteredRecords;
+}
+
+interface UrlFilterTokens {
+  includes: string[];
+  excludes: string[];
+}
+
+function matchesUrlFilter(url: string, tokens: UrlFilterTokens): boolean {
+  if (tokens.includes.length === 0 && tokens.excludes.length === 0) return true;
+  const normalizedUrl = url.toLowerCase();
+  return (
+    tokens.includes.every((token) => normalizedUrl.includes(token)) &&
+    !tokens.excludes.some((token) => normalizedUrl.includes(token))
+  );
+}
+
+function parseUrlFilterTokens(searchText: string): UrlFilterTokens {
+  const includes: string[] = [];
+  const excludes: string[] = [];
+  let index = 0;
+
+  while (index < searchText.length) {
+    while (index < searchText.length && isWhitespace(searchText[index])) index += 1;
+    if (index >= searchText.length) break;
+
+    const isExcluded = searchText[index] === "-";
+    if (isExcluded) index += 1;
+    if (index >= searchText.length) break;
+
+    const quoted = searchText[index] === '"';
+    if (quoted) index += 1;
+
+    let value = "";
+    while (index < searchText.length) {
+      const current = searchText[index];
+      if (quoted && current === '"') {
+        index += 1;
+        break;
+      }
+      if (!quoted && isWhitespace(current)) break;
+
+      const escaped = escapedUrlFilterCharacter(searchText, index, quoted);
+      if (escaped != null) {
+        value += escaped;
+        index += 2;
+      } else {
+        value += current;
+        index += 1;
+      }
+    }
+
+    if (value.trim().length === 0) continue;
+    (isExcluded ? excludes : includes).push(value.toLowerCase());
+  }
+
+  return { includes, excludes };
+}
+
+function escapedUrlFilterCharacter(text: string, index: number, quoted: boolean): string | null {
+  if (text[index] !== "\\") return null;
+  const next = text[index + 1];
+  if (next == null) return null;
+  if (next === '"' || next === "\\") return next;
+  return !quoted && isWhitespace(next) ? next : null;
+}
+
+function isWhitespace(value: string): boolean {
+  return /\s/u.test(value);
 }
 
 export function countRecordsForServer(records: InspectorRecord[], selectedServer: ServerId | null): number {


### PR DESCRIPTION
## Summary
- port the Compose URL filter grammar into the Electron inspector
- support multiple include terms, `-exclude` terms, quoted phrases, and escaped characters

## Why
The Electron inspector still used a single substring search while the Compose implementation supported richer URL filtering. That left one remaining parity gap before deleting the old Compose implementation.

## Validation
- `npm run format`
- `npm run format:check`
- `npm run lint`
- `npm run typecheck`
- `npm run build`