### PR TITLE
Show SSE error bodies when response is not event-stream

### DIFF
--- a/snapo-desktop-electron/electron/network-tools.test.ts
+++ b/snapo-desktop-electron/electron/network-tools.test.ts
@@ -1,6 +1,7 @@
 import assert from "node:assert/strict";
 import test from "node:test";
 import { NetworkEventFilter } from "./network-event-filter.js";
+import { isLikelyStreamingRequest } from "../src/network/request-classification.js";
 import { matchesUrlFilterText } from "../src/network/url-filter.js";
 
 test("matchesUrlFilterText uses the Network Inspector search syntax", () => {
@@ -35,4 +36,32 @@ test("NetworkEventFilter keeps lifecycle events for matched request IDs", () => 
     false
   );
   assert.equal(filter.matches({ method: "Network.loadingFinished", params: { requestId: "sentinel" } }), false);
+});
+
+test("observed non-SSE responses override request-side SSE hints", () => {
+  const hintedRequest = {
+    requestHeaders: [{ name: "Accept", value: "text/event-stream,application/json" }],
+    responseHeaders: [],
+    streamEvents: []
+  };
+
+  assert.equal(isLikelyStreamingRequest(hintedRequest), true);
+  assert.equal(
+    isLikelyStreamingRequest({
+      ...hintedRequest,
+      responseHeaders: [{ name: "Content-Type", value: "application/json" }],
+      responseType: "XHR",
+      hasReceivedResponse: true
+    }),
+    false
+  );
+  assert.equal(
+    isLikelyStreamingRequest({
+      ...hintedRequest,
+      responseHeaders: [{ name: "Content-Type", value: "text/event-stream" }],
+      responseType: "EventSource",
+      hasReceivedResponse: true
+    }),
+    true
+  );
 });

--- a/snapo-desktop-electron/src/features/network-inspector/components/RequestDetail.tsx
+++ b/snapo-desktop-electron/src/features/network-inspector/components/RequestDetail.tsx
@@ -1,6 +1,7 @@
 import { memo, useEffect, useState } from "react";
 import { recordId, type Header, type RequestRecord } from "../../../network/cdp";
 import { decodeRequestBodyForDisplay, makeBodyPayload } from "../../../network/payload";
+import { isLikelyStreamingRequest } from "../../../network/request-classification";
 import type { InspectorUiState } from "../hooks/useInspectorUiState";
 import { useAdaptiveTimingText } from "../hooks/useAdaptiveTimingText";
 import { BodySection, payloadMetadata } from "./PayloadView";
@@ -15,7 +16,7 @@ export const RequestDetail = memo(function RequestDetail({
   record: RequestRecord;
   uiState: InspectorUiState;
 }): JSX.Element {
-  const isSseResponse = isLikelySseResponse(record);
+  const isSseResponse = isLikelyStreamingRequest(record);
   const requestBodyDisplayText = useRequestBodyDisplayText(record);
   const requestBody = makeBodyPayload({
     body: record.requestBody,
@@ -147,20 +148,6 @@ function useRequestBodyDisplayText(record: RequestRecord): string | null {
     return decodedBody.displayText;
   }
   return record.requestBody;
-}
-
-function isLikelySseResponse(record: RequestRecord): boolean {
-  if (record.streamEvents.length > 0) return true;
-  if (record.responseType?.toLowerCase() === "eventsource") return true;
-  return hasEventStreamHeader(record.responseHeaders) || hasEventStreamHeader(record.requestHeaders);
-}
-
-function hasEventStreamHeader(headers: Header[]): boolean {
-  return headers.some((header) => {
-    const name = header.name.toLowerCase();
-    const value = header.value.toLowerCase();
-    return (name === "content-type" || name === "accept") && value.includes("text/event-stream");
-  });
 }
 
 function requestHeaderValue(headers: Header[], name: string): string | null {

--- a/snapo-desktop-electron/src/features/network-inspector/lib/records.ts
+++ b/snapo-desktop-electron/src/features/network-inspector/lib/records.ts
@@ -8,6 +8,7 @@ import {
   type WebSocketRecord
 } from "../../../network/cdp";
 import type { SnapOServer } from "../../../network/bridge-types";
+import { isLikelyStreamingRequest } from "../../../network/request-classification";
 import { matchesUrlFilterText } from "../../../network/url-filter";
 
 export function collectRecords(
@@ -154,12 +155,6 @@ export function recordShowsActiveIndicator(record: InspectorRecord): boolean {
   return record.streamEvents.length > 0 && record.streamClosed == null;
 }
 
-function isLikelyStreamingRequest(request: RequestRecord): boolean {
-  if (request.streamEvents.length > 0) return true;
-  if (request.responseType?.toLowerCase() === "eventsource") return true;
-  return hasEventStreamHeader(request.responseHeaders) || hasEventStreamHeader(request.requestHeaders);
-}
-
 function responseHasNoBody(request: RequestRecord): boolean {
   if (request.method.toUpperCase() === "HEAD") return true;
   const status = request.status.kind === "success" ? request.status.code : null;
@@ -168,14 +163,6 @@ function responseHasNoBody(request: RequestRecord): boolean {
     if (status === 204 || status === 205 || status === 304) return true;
   }
   return contentLength(request.responseHeaders) === 0;
-}
-
-function hasEventStreamHeader(headers: RequestRecord["requestHeaders"]): boolean {
-  return headers.some((header) => {
-    const name = header.name.toLowerCase();
-    const value = header.value.toLowerCase();
-    return (name === "content-type" || name === "accept") && value.includes("text/event-stream");
-  });
 }
 
 function contentLength(headers: RequestRecord["responseHeaders"]): number | null {

--- a/snapo-desktop-electron/src/network/cdp.ts
+++ b/snapo-desktop-electron/src/network/cdp.ts
@@ -1,5 +1,6 @@
 import type { CdpMessage, RequestBodies, SnapOServer } from "./bridge-types";
 import type { Protocol } from "devtools-protocol";
+import { isLikelyStreamingRequest } from "./request-classification";
 
 type RequestWillBeSentEvent = Partial<Protocol.Network.RequestWillBeSentEvent> & Record<string, unknown>;
 type ResponseReceivedEvent = Partial<Protocol.Network.ResponseReceivedEvent> & Record<string, unknown>;
@@ -45,6 +46,7 @@ export interface RequestRecord {
   responseBody?: string | null;
   responseBodyBase64Encoded?: boolean | null;
   responseType?: string | null;
+  hasReceivedResponse?: boolean;
   streamEvents: StreamEventRecord[];
   streamClosed?: StreamClosedRecord;
   updatedAt: number;
@@ -225,6 +227,7 @@ function reduceResponseReceived(
       endedAt: existing?.endedAt,
       encodedDataLength: params.response?.encodedDataLength ?? existing?.encodedDataLength,
       responseType: stringAt(params, "type") ?? existing?.responseType,
+      hasReceivedResponse: true,
       updatedAt: now
     };
   });
@@ -585,20 +588,6 @@ function headersFrom(headers: Record<string, unknown> | null): Header[] {
       .split("\n")
       .map((line) => ({ name, value: line }))
   );
-}
-
-function isLikelyStreamingRequest(record: RequestRecord): boolean {
-  if (record.streamEvents.length > 0) return true;
-  if (record.responseType?.toLowerCase() === "eventsource") return true;
-  return hasEventStreamHeader(record.responseHeaders) || hasEventStreamHeader(record.requestHeaders);
-}
-
-function hasEventStreamHeader(headers: Header[]): boolean {
-  return headers.some((header) => {
-    const name = header.name.toLowerCase();
-    const value = header.value.toLowerCase();
-    return (name === "content-type" || name === "accept") && value.includes("text/event-stream");
-  });
 }
 
 function recordFromProtocolHeaders(headers: unknown): Record<string, unknown> | null {

--- a/snapo-desktop-electron/src/network/request-classification.ts
+++ b/snapo-desktop-electron/src/network/request-classification.ts
@@ -1,0 +1,31 @@
+interface Header {
+  name: string;
+  value: string;
+}
+
+interface StreamingRequestEvidence {
+  requestHeaders: Header[];
+  responseHeaders: Header[];
+  responseType?: string | null;
+  hasReceivedResponse?: boolean;
+  streamEvents: unknown[];
+}
+
+export function isLikelyStreamingRequest(request: StreamingRequestEvidence): boolean {
+  if (request.streamEvents.length > 0) return true;
+  if (request.responseType?.toLowerCase() === "eventsource") return true;
+  if (request.hasReceivedResponse === true) return hasEventStreamContentType(request.responseHeaders);
+  return hasEventStreamContentType(request.responseHeaders) || acceptsEventStream(request.requestHeaders);
+}
+
+function hasEventStreamContentType(headers: Header[]): boolean {
+  return headers.some((header) => {
+    return header.name.toLowerCase() === "content-type" && header.value.toLowerCase().includes("text/event-stream");
+  });
+}
+
+function acceptsEventStream(headers: Header[]): boolean {
+  return headers.some((header) => {
+    return header.name.toLowerCase() === "accept" && header.value.toLowerCase().includes("text/event-stream");
+  });
+}


### PR DESCRIPTION
## Summary
- centralize Electron network request streaming classification
- treat request-side `Accept: text/event-stream` as a hint only until response metadata arrives
- show JSON error response bodies for SSE-style requests while preserving the SSE viewer for real event streams
- add regression coverage for non-SSE responses overriding request-side SSE hints

## Validation
- `npm run format:check`
- `npm run lint`
- `npm run typecheck`
- `npm test`
- `npm run build`
- `git diff --check`