### PR TITLE
Disable automatic DevTools on Electron startup

### DIFF
--- a/snapo-desktop-electron/README.md
+++ b/snapo-desktop-electron/README.md
@@ -25,6 +25,8 @@ npm run build
 npm run start
 ```
 
+Local `npm run start` and `npm run dev` builds expose **View > Toggle Developer Tools**.
+
 ## Package macOS helper
 
 ```bash

--- a/snapo-desktop-electron/electron/main.ts
+++ b/snapo-desktop-electron/electron/main.ts
@@ -32,7 +32,7 @@ const updateController = new UpdateController(() => {
 
 const NewWindowOffsetPx = 100;
 const DockIconPath = path.join(app.getAppPath(), "resources/icons/network.png");
-const IsDevelopment = (process.env.SNAPO_ELECTRON_DEV_SERVER_URL?.length ?? 0) > 0;
+const IsDevelopment = !app.isPackaged;
 let debugInspectorPreset: DebugInspectorPreset = "live";
 let logFilePath: string | null = null;
 
@@ -95,9 +95,6 @@ function createWindow(parentWindow?: BrowserWindow): BrowserWindow {
   const devServerUrl = process.env.SNAPO_ELECTRON_DEV_SERVER_URL;
   if (devServerUrl != null && devServerUrl.length > 0) {
     void window.loadURL(devServerUrl);
-    window.webContents.once("did-finish-load", () => {
-      window.webContents.openDevTools({ mode: "detach" });
-    });
   } else {
     void window.loadFile(path.join(__dirname, "../../dist-renderer/index.html"));
   }


### PR DESCRIPTION
## Summary
- Stop opening DevTools automatically when the Electron dev server starts
- Keep DevTools available through **View > Toggle Developer Tools** for local runs
- Document the manual DevTools path in the Electron README

## Testing
- Not run (not requested)