### PR TITLE
[codex] Use ditto to package macOS Electron helper

### DIFF
--- a/snapo-desktop-electron/scripts/package-macos.mjs
+++ b/snapo-desktop-electron/scripts/package-macos.mjs
@@ -23,11 +23,7 @@ const versionInfo = await readVersionInfo(path.join(repoRoot, "VERSION"));
 await ensureBuiltArtifacts();
 await fs.rm(outputDir, { recursive: true, force: true });
 await fs.mkdir(outputDir, { recursive: true });
-await fs.cp(sourceElectronApp, appBundle, {
-  recursive: true,
-  dereference: false,
-  verbatimSymlinks: true
-});
+execFileSync("/usr/bin/ditto", [sourceElectronApp, appBundle], { stdio: "inherit" });
 
 await rebrandBundle();
 await copyAppPayload();


### PR DESCRIPTION
## Summary
- copy the source Electron `.app` bundle with macOS `/usr/bin/ditto`
- keep the existing rebranding and payload-copy flow unchanged

## Why
The `2.0.0` macOS release workflow failed while packaging the Electron Network Inspector helper. The Node `fs.cp()` call returned, but the copied bundle was incomplete on the hosted runner: `Contents/Info.plist` was missing when `plutil` attempted to update it.

`ditto` is the macOS-native bundle copy tool and is already used later in the Xcode embed phase for this helper app.

## Impact
This hardens macOS release packaging against partial Electron app-bundle copies in GitHub Actions.

## Validation
- `npm run package:mac:release`
- `/tmp/node-v24.16.0-darwin-arm64/bin/node scripts/package-macos.mjs release`
- `xcodebuild -project snapo-app-mac/Snap-O.xcodeproj -scheme Snap-O -configuration Release -archivePath /tmp/Snap-O-ditto.xcarchive -derivedDataPath /tmp/snapo-ditto-archive-derived-data -sdk macosx CODE_SIGNING_ALLOWED=NO archive`
- verified generated and embedded helper `Contents/Info.plist` files exist and contain `CFBundleDisplayName = Snap-O Network Inspector`