### PR TITLE
[codex] Package macOS Electron app with @electron/packager

### DIFF
--- a/.github/workflows/electron.yml
+++ b/.github/workflows/electron.yml
@@ -33,6 +33,11 @@ jobs:
       - name: Install dependencies
         working-directory: snapo-desktop-electron
         run: |
+          if grep -q 'socket-firewall-registry\.gateway\.' package-lock.json; then
+            echo "::error::package-lock.json contains an internal npm registry URL"
+            exit 1
+          fi
+
           set +e
           set -o pipefail
           npm ci --foreground-scripts --timing --loglevel verbose 2>&1 | tee "${RUNNER_TEMP}/npm-ci.log"

--- a/.github/workflows/electron.yml
+++ b/.github/workflows/electron.yml
@@ -37,25 +37,7 @@ jobs:
             echo "::error::package-lock.json contains an internal npm registry URL"
             exit 1
           fi
-
-          set +e
-          set -o pipefail
-          npm ci --foreground-scripts --timing --loglevel verbose 2>&1 | tee "${RUNNER_TEMP}/npm-ci.log"
-          status=${PIPESTATUS[0]}
-          set -e
-
-          if (( status != 0 )); then
-            echo "::group::npm debug logs"
-            for log in "${HOME}"/.npm/_logs/*-debug-0.log; do
-              if [[ -f "${log}" ]]; then
-                echo "===== ${log} ====="
-                cat "${log}"
-              fi
-            done
-            echo "::endgroup::"
-          fi
-
-          exit "${status}"
+          npm ci
       - name: Check formatting
         working-directory: snapo-desktop-electron
         run: npm run format:check

--- a/.github/workflows/electron.yml
+++ b/.github/workflows/electron.yml
@@ -32,7 +32,25 @@ jobs:
           cache-dependency-path: snapo-desktop-electron/package-lock.json
       - name: Install dependencies
         working-directory: snapo-desktop-electron
-        run: npm ci
+        run: |
+          set +e
+          set -o pipefail
+          npm ci --foreground-scripts --timing --loglevel verbose 2>&1 | tee "${RUNNER_TEMP}/npm-ci.log"
+          status=${PIPESTATUS[0]}
+          set -e
+
+          if (( status != 0 )); then
+            echo "::group::npm debug logs"
+            for log in "${HOME}"/.npm/_logs/*-debug-0.log; do
+              if [[ -f "${log}" ]]; then
+                echo "===== ${log} ====="
+                cat "${log}"
+              fi
+            done
+            echo "::endgroup::"
+          fi
+
+          exit "${status}"
       - name: Check formatting
         working-directory: snapo-desktop-electron
         run: npm run format:check

--- a/snapo-desktop-electron/AGENTS.md
+++ b/snapo-desktop-electron/AGENTS.md
@@ -1,0 +1,7 @@
+# Electron Project Instructions
+
+## npm Registry
+
+- Use the repository registry from `.npmrc`: `https://openai.firewall.socket.dev/npm/`.
+- Environment-level `NPM_CONFIG_REGISTRY` values may override `.npmrc`. Pass the repository registry explicitly when adding dependencies or regenerating `package-lock.json`.
+- Before committing lockfile changes, verify that `package-lock.json` contains no URLs under `socket-firewall-registry.gateway.*`.

--- a/snapo-desktop-electron/README.md
+++ b/snapo-desktop-electron/README.md
@@ -6,7 +6,7 @@ The Electron backend talks directly to the local ADB server and Snap-O network s
 
 ## Requirements
 
-- Node.js 20+
+- Node.js 22.12+
 - A running local ADB server
 - A connected Android app with the Snap-O network dependencies
 

--- a/snapo-desktop-electron/package-lock.json
+++ b/snapo-desktop-electron/package-lock.json
@@ -12,6 +12,7 @@
         "fast-xml-parser": "^5.7.2"
       },
       "devDependencies": {
+        "@electron/packager": "^20.0.0",
         "@eslint/js": "^10.0.1",
         "@types/node": "^20.10.6",
         "@types/react": "^18.2.46",
@@ -32,6 +33,9 @@
         "typescript": "^5.3.3",
         "typescript-eslint": "^8.59.1",
         "vite": "^8.0.9"
+      },
+      "engines": {
+        "node": ">=22.12.0"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -500,6 +504,34 @@
         "url": "https://github.com/sponsors/JounQin"
       }
     },
+    "node_modules/@electron/asar": {
+      "version": "4.2.0",
+      "resolved": "https://socket-firewall-registry.gateway.unified-30.internal.api.openai.org/npm/@electron/asar/-/asar-4.2.0.tgz",
+      "integrity": "sha512-npW1NW5yy8EB9XY/vEw9sUdgmq0sJEhmSBb6bqyFOAw1CSkrhvAvO6QWlW8CdIMo8VN1lkdF345l/MeW0LrY0Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "commander": "^13.1.0",
+        "glob": "^13.0.2",
+        "minimatch": "^10.0.1"
+      },
+      "bin": {
+        "asar": "bin/asar.mjs"
+      },
+      "engines": {
+        "node": ">=22.12.0"
+      }
+    },
+    "node_modules/@electron/asar/node_modules/commander": {
+      "version": "13.1.0",
+      "resolved": "https://socket-firewall-registry.gateway.unified-30.internal.api.openai.org/npm/commander/-/commander-13.1.0.tgz",
+      "integrity": "sha512-/rFeCpNJQbhSZjGVwO9RFV3xPqbnERS8MmIQzCtD/zl6gpJuV/bMLuN92oG3F7d8oDEHHRrujSXNUr8fpjntKw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/@electron/get": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/@electron/get/-/get-2.0.3.tgz",
@@ -520,6 +552,205 @@
       },
       "optionalDependencies": {
         "global-agent": "^3.0.0"
+      }
+    },
+    "node_modules/@electron/notarize": {
+      "version": "3.1.1",
+      "resolved": "https://socket-firewall-registry.gateway.unified-30.internal.api.openai.org/npm/@electron/notarize/-/notarize-3.1.1.tgz",
+      "integrity": "sha512-uQQSlOiJnqRkTL1wlEBAxe90nVN/Fc/hEmk0bqpKk8nKjV1if/tXLHKUPePtv9Xsx90PtZU8aidx5lAiOpjkQQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.0",
+        "promise-retry": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 22.12.0"
+      }
+    },
+    "node_modules/@electron/notarize/node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://socket-firewall-registry.gateway.unified-30.internal.api.openai.org/npm/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@electron/osx-sign": {
+      "version": "2.4.0",
+      "resolved": "https://socket-firewall-registry.gateway.unified-30.internal.api.openai.org/npm/@electron/osx-sign/-/osx-sign-2.4.0.tgz",
+      "integrity": "sha512-9mJiKF/yrn2FYt1Pd9hIN8bUWs6w6uhm8DJJ/tZtTPMVmqv9/NO1JvRh+NyOJp8kE2bfffK4YkU3ZyM+rHipUw==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "debug": "^4.3.4",
+        "isbinaryfile": "^4.0.8",
+        "plist": "^3.0.5",
+        "semver": "^7.7.1"
+      },
+      "bin": {
+        "electron-osx-flat": "bin/electron-osx-flat.mjs",
+        "electron-osx-sign": "bin/electron-osx-sign.mjs"
+      },
+      "engines": {
+        "node": ">=22.12.0"
+      }
+    },
+    "node_modules/@electron/osx-sign/node_modules/semver": {
+      "version": "7.8.2",
+      "resolved": "https://socket-firewall-registry.gateway.unified-30.internal.api.openai.org/npm/semver/-/semver-7.8.2.tgz",
+      "integrity": "sha512-c8jsqUZm3omBOI66G90z1Dyw5z622G8oLG+omfsHBJf3CWQTlOcwOjvOG6wtiNfW6anKm/eA39LMwMtMez2TiQ==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@electron/packager": {
+      "version": "20.0.0",
+      "resolved": "https://socket-firewall-registry.gateway.unified-30.internal.api.openai.org/npm/@electron/packager/-/packager-20.0.0.tgz",
+      "integrity": "sha512-kl4c4LcsrQflg0wAi3mqpmmZFRdTYoZFLZPBP9YeEIvWwQR1NmkZphwT7558UeLOdhr6Ac5l83r8W69KaJBedg==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "@electron/asar": "^4.0.1",
+        "@electron/get": "^5.0.0",
+        "@electron/notarize": "^3.1.0",
+        "@electron/osx-sign": "^2.2.0",
+        "@electron/universal": "^3.0.1",
+        "@electron/windows-sign": "^2.0.2",
+        "@malept/cross-spawn-promise": "^2.0.0",
+        "debug": "^4.4.1",
+        "extract-zip": "^2.0.1",
+        "filenamify": "^6.0.0",
+        "galactus": "^2.0.2",
+        "graceful-fs": "^4.2.11",
+        "junk": "^4.0.1",
+        "parse-author": "^2.0.0",
+        "plist": "^3.1.0",
+        "resedit": "^2.0.3",
+        "semver": "^7.7.2",
+        "yargs-parser": "^22.0.0"
+      },
+      "bin": {
+        "electron-packager": "bin/electron-packager.mjs"
+      },
+      "engines": {
+        "node": ">= 22.12.0"
+      },
+      "funding": {
+        "url": "https://github.com/electron/packager?sponsor=1"
+      }
+    },
+    "node_modules/@electron/packager/node_modules/@electron/get": {
+      "version": "5.0.0",
+      "resolved": "https://socket-firewall-registry.gateway.unified-30.internal.api.openai.org/npm/@electron/get/-/get-5.0.0.tgz",
+      "integrity": "sha512-pjoBpru1KdEtcExBnuHAP1cAc/5faoedw0hzJkL3o4/IJp7HNF1+fbrdxT3gMYRX2oJfvnA/WXeCTVQpYYxyJA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.1.1",
+        "env-paths": "^3.0.0",
+        "graceful-fs": "^4.2.11",
+        "progress": "^2.0.3",
+        "semver": "^7.6.3",
+        "sumchecker": "^3.0.1"
+      },
+      "engines": {
+        "node": ">=22.12.0"
+      },
+      "optionalDependencies": {
+        "undici": "^7.24.4"
+      }
+    },
+    "node_modules/@electron/packager/node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://socket-firewall-registry.gateway.unified-30.internal.api.openai.org/npm/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@electron/packager/node_modules/env-paths": {
+      "version": "3.0.0",
+      "resolved": "https://socket-firewall-registry.gateway.unified-30.internal.api.openai.org/npm/env-paths/-/env-paths-3.0.0.tgz",
+      "integrity": "sha512-dtJUTepzMW3Lm/NPxRf3wP4642UWhjL2sQxc+ym2YMj1m/H2zDNQOlezafzkHwn6sMstjHTwG6iQQsctDW/b1A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@electron/packager/node_modules/semver": {
+      "version": "7.8.2",
+      "resolved": "https://socket-firewall-registry.gateway.unified-30.internal.api.openai.org/npm/semver/-/semver-7.8.2.tgz",
+      "integrity": "sha512-c8jsqUZm3omBOI66G90z1Dyw5z622G8oLG+omfsHBJf3CWQTlOcwOjvOG6wtiNfW6anKm/eA39LMwMtMez2TiQ==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@electron/universal": {
+      "version": "3.0.4",
+      "resolved": "https://socket-firewall-registry.gateway.unified-30.internal.api.openai.org/npm/@electron/universal/-/universal-3.0.4.tgz",
+      "integrity": "sha512-G7mNdfZIdPbx54dTorGlV7SN7nHAKlbJU1NjjeuEo7RzEMYBG62+tKpA2VrzocGcvFLxqJI5XYIknca9EijwOw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@electron/asar": "^4.0.0",
+        "debug": "^4.3.1",
+        "plist": "^3.1.0"
+      },
+      "engines": {
+        "node": ">=22.12.0"
+      }
+    },
+    "node_modules/@electron/windows-sign": {
+      "version": "2.0.3",
+      "resolved": "https://socket-firewall-registry.gateway.unified-30.internal.api.openai.org/npm/@electron/windows-sign/-/windows-sign-2.0.3.tgz",
+      "integrity": "sha512-lJGpt2artEZNiOsQtU1JmcLr4Ow/AGskwjTTNaxL2+R2wLN7G2BHL4Z9unOoW321N69kBP1nzObSMdDbQydjbA==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "debug": "^4.3.4",
+        "graceful-fs": "^4.2.11",
+        "postject": "^1.0.0-alpha.6"
+      },
+      "bin": {
+        "electron-windows-sign": "bin/electron-windows-sign.mjs"
+      },
+      "engines": {
+        "node": ">=22.12.0"
       }
     },
     "node_modules/@emnapi/core": {
@@ -806,6 +1037,29 @@
       "integrity": "sha512-dXn3FZhPv0US+7dtJsIi2R+c7qWYiReoEh5zUntWCf4oSpMNib8FDhSoed6m3QyZdx5hK7iLFkYk3rNxwt8vTA==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@malept/cross-spawn-promise": {
+      "version": "2.0.0",
+      "resolved": "https://socket-firewall-registry.gateway.unified-30.internal.api.openai.org/npm/@malept/cross-spawn-promise/-/cross-spawn-promise-2.0.0.tgz",
+      "integrity": "sha512-1DpKU0Z5ThltBwjNySMC14g0CkbyhCaz9FkhxqNsZI6uAPJXFS8cMXlBKo26FJ8ZuW6S9GCMcR9IO5k2X5/9Fg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/malept"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/subscription/pkg/npm-.malept-cross-spawn-promise?utm_medium=referral&utm_source=npm_fund"
+        }
+      ],
+      "license": "Apache-2.0",
+      "dependencies": {
+        "cross-spawn": "^7.0.1"
+      },
+      "engines": {
+        "node": ">= 12.13.0"
+      }
     },
     "node_modules/@napi-rs/wasm-runtime": {
       "version": "1.1.4",
@@ -1638,6 +1892,16 @@
         }
       }
     },
+    "node_modules/@xmldom/xmldom": {
+      "version": "0.9.10",
+      "resolved": "https://socket-firewall-registry.gateway.unified-30.internal.api.openai.org/npm/@xmldom/xmldom/-/xmldom-0.9.10.tgz",
+      "integrity": "sha512-A9gOqLdi6cV4ibazAjcQufGj0B1y/vDqYrcuP6d/6x8P27gRS8643Dj9o1dEKtB6O7fwxb2FgBmJS2mX7gpvdw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.6"
+      }
+    },
     "node_modules/acorn": {
       "version": "8.16.0",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.16.0.tgz",
@@ -1731,6 +1995,16 @@
         "node": ">=8"
       }
     },
+    "node_modules/author-regex": {
+      "version": "1.0.0",
+      "resolved": "https://socket-firewall-registry.gateway.unified-30.internal.api.openai.org/npm/author-regex/-/author-regex-1.0.0.tgz",
+      "integrity": "sha512-KbWgR8wOYRAPekEmMXrYYdc7BRyhn2Ftk7KWfMUnQ43hFdojWEFRxhhRUm3/OFEdPa1r0KAvTTg9YQK57xTe0g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.8"
+      }
+    },
     "node_modules/balanced-match": {
       "version": "4.0.4",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
@@ -1740,6 +2014,27 @@
       "engines": {
         "node": "18 || 20 || >=22"
       }
+    },
+    "node_modules/base64-js": {
+      "version": "1.5.1",
+      "resolved": "https://socket-firewall-registry.gateway.unified-30.internal.api.openai.org/npm/base64-js/-/base64-js-1.5.1.tgz",
+      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
     },
     "node_modules/baseline-browser-mapping": {
       "version": "2.10.24",
@@ -2274,6 +2569,13 @@
         "node": ">=6"
       }
     },
+    "node_modules/err-code": {
+      "version": "2.0.3",
+      "resolved": "https://socket-firewall-registry.gateway.unified-30.internal.api.openai.org/npm/err-code/-/err-code-2.0.3.tgz",
+      "integrity": "sha512-2bmlRpNKBxT/CRmPOlyISQpNj+qSeYvcym/uT0Jx2bMOlKLtSy1ZmLuVxSEKKyor/N5yhvp/ZiG1oE3DEYMSFA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/error-ex": {
       "version": "1.3.4",
       "resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.4.tgz",
@@ -2711,6 +3013,35 @@
         "node": ">=16.0.0"
       }
     },
+    "node_modules/filename-reserved-regex": {
+      "version": "3.0.0",
+      "resolved": "https://socket-firewall-registry.gateway.unified-30.internal.api.openai.org/npm/filename-reserved-regex/-/filename-reserved-regex-3.0.0.tgz",
+      "integrity": "sha512-hn4cQfU6GOT/7cFHXBqeBg2TbrMBgdD0kcjLhvSQYYwm3s4B6cjvBfb7nBALJLAXqmU5xajSa7X2NnUud/VCdw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/filenamify": {
+      "version": "6.0.0",
+      "resolved": "https://socket-firewall-registry.gateway.unified-30.internal.api.openai.org/npm/filenamify/-/filenamify-6.0.0.tgz",
+      "integrity": "sha512-vqIlNogKeyD3yzrm0yhRMQg8hOVwYcYRfjEoODd49iCprMn4HL85gK3HcykQE53EPIpX3HcAbGA5ELQv216dAQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "filename-reserved-regex": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/fill-range": {
       "version": "7.1.1",
       "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz",
@@ -2762,6 +3093,37 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/flora-colossus": {
+      "version": "3.0.2",
+      "resolved": "https://socket-firewall-registry.gateway.unified-30.internal.api.openai.org/npm/flora-colossus/-/flora-colossus-3.0.2.tgz",
+      "integrity": "sha512-Jk78K/Tzt6saxQPGChlJw69xuFGpWyTSAS8EdU0h/FyXwD2K46yNOXmo6nRHcZ9ooekyBAzMkwmiGNt7wOC5zg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.1"
+      },
+      "engines": {
+        "node": ">=22.12.0"
+      }
+    },
+    "node_modules/flora-colossus/node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://socket-firewall-registry.gateway.unified-30.internal.api.openai.org/npm/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/fs-extra": {
       "version": "8.1.0",
       "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-8.1.0.tgz",
@@ -2792,6 +3154,38 @@
         "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
+    "node_modules/galactus": {
+      "version": "2.0.2",
+      "resolved": "https://socket-firewall-registry.gateway.unified-30.internal.api.openai.org/npm/galactus/-/galactus-2.0.2.tgz",
+      "integrity": "sha512-HmKyTFGomdAchz4umx8MwBnrnfFmdpwiTyGA4ZOF7rya2Lmgbc9qate4yweInL+0gUBVImhaz12SBGpW3SY4Yg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.1",
+        "flora-colossus": "^3.0.2"
+      },
+      "engines": {
+        "node": ">=22.12.0"
+      }
+    },
+    "node_modules/galactus/node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://socket-firewall-registry.gateway.unified-30.internal.api.openai.org/npm/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/gensync": {
       "version": "1.0.0-beta.2",
       "resolved": "https://registry.npmjs.org/gensync/-/gensync-1.0.0-beta.2.tgz",
@@ -2816,6 +3210,24 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/glob": {
+      "version": "13.0.6",
+      "resolved": "https://socket-firewall-registry.gateway.unified-30.internal.api.openai.org/npm/glob/-/glob-13.0.6.tgz",
+      "integrity": "sha512-Wjlyrolmm8uDpm/ogGyXZXb1Z+Ca2B8NbJwqBVg0axK9GbBeoS7yGV6vjXnYdGm6X53iehEuxxbyiKp8QmN4Vw==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "minimatch": "^10.2.2",
+        "minipass": "^7.1.3",
+        "path-scurry": "^2.0.2"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/glob-parent": {
@@ -3220,6 +3632,19 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/isbinaryfile": {
+      "version": "4.0.10",
+      "resolved": "https://socket-firewall-registry.gateway.unified-30.internal.api.openai.org/npm/isbinaryfile/-/isbinaryfile-4.0.10.tgz",
+      "integrity": "sha512-iHrqe5shvBUcFbmZq9zOQHBoeOhZJu6RQGrDpBgenUm/Am+F3JM2MgQj+rK3Z601fzrL5gLZWtAPH2OBaSVcyw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 8.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/gjtorikian/"
+      }
+    },
     "node_modules/isexe": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
@@ -3317,6 +3742,19 @@
       "license": "MIT",
       "optionalDependencies": {
         "graceful-fs": "^4.1.6"
+      }
+    },
+    "node_modules/junk": {
+      "version": "4.0.1",
+      "resolved": "https://socket-firewall-registry.gateway.unified-30.internal.api.openai.org/npm/junk/-/junk-4.0.1.tgz",
+      "integrity": "sha512-Qush0uP+G8ZScpGMZvHUiRfI0YBWuB3gVBYlI0v0vvOJt5FLicco+IkP0a50LqTTQhmts/m6tP5SWE+USyIvcQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/keyv": {
@@ -3802,6 +4240,16 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
+    "node_modules/minipass": {
+      "version": "7.1.3",
+      "resolved": "https://socket-firewall-registry.gateway.unified-30.internal.api.openai.org/npm/minipass/-/minipass-7.1.3.tgz",
+      "integrity": "sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      }
+    },
     "node_modules/ms": {
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
@@ -3967,6 +4415,19 @@
         "node": ">=6"
       }
     },
+    "node_modules/parse-author": {
+      "version": "2.0.0",
+      "resolved": "https://socket-firewall-registry.gateway.unified-30.internal.api.openai.org/npm/parse-author/-/parse-author-2.0.0.tgz",
+      "integrity": "sha512-yx5DfvkN8JsHL2xk2Os9oTia467qnvRgey4ahSm2X8epehBLx/gWLcy5KI+Y36ful5DzGbCS6RazqZGgy1gHNw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "author-regex": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/parse-json": {
       "version": "5.2.0",
       "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-5.2.0.tgz",
@@ -4021,6 +4482,33 @@
         "node": ">=8"
       }
     },
+    "node_modules/path-scurry": {
+      "version": "2.0.2",
+      "resolved": "https://socket-firewall-registry.gateway.unified-30.internal.api.openai.org/npm/path-scurry/-/path-scurry-2.0.2.tgz",
+      "integrity": "sha512-3O/iVVsJAPsOnpwWIeD+d6z/7PmqApyQePUtCndjatj/9I5LylHvt5qluFaBT3I5h3r1ejfR056c+FCv+NnNXg==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "lru-cache": "^11.0.0",
+        "minipass": "^7.1.2"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/path-scurry/node_modules/lru-cache": {
+      "version": "11.5.1",
+      "resolved": "https://socket-firewall-registry.gateway.unified-30.internal.api.openai.org/npm/lru-cache/-/lru-cache-11.5.1.tgz",
+      "integrity": "sha512-RPimw/7aMdv2oqRrxKwvZXcPfwBrn/JZ2xYcY9Hus/6LaS3VOAKVWKWgNLCFSiOm1ESXinjsDlidVU7JlnCN2A==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": "20 || >=22"
+      }
+    },
     "node_modules/path-type": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/path-type/-/path-type-4.0.0.tgz",
@@ -4029,6 +4517,21 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/pe-library": {
+      "version": "1.0.1",
+      "resolved": "https://socket-firewall-registry.gateway.unified-30.internal.api.openai.org/npm/pe-library/-/pe-library-1.0.1.tgz",
+      "integrity": "sha512-nh39Mo1eGWmZS7y+mK/dQIqg7S1lp38DpRxkyoHf0ZcUs/HDc+yyTjuOtTvSMZHmfSLuSQaX945u05Y2Q6UWZg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14",
+        "npm": ">=7"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/jet2jet"
       }
     },
     "node_modules/pend": {
@@ -4056,6 +4559,21 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/plist": {
+      "version": "3.1.1",
+      "resolved": "https://socket-firewall-registry.gateway.unified-30.internal.api.openai.org/npm/plist/-/plist-3.1.1.tgz",
+      "integrity": "sha512-ZIfcLJC+7E7FBFnDxm9MPmt7D+DidyQ26lewieO75AdhA2ayMtsJSES0iWzqJQbcVRSrTufQoy0DR94xHue0oA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@xmldom/xmldom": "^0.9.10",
+        "base64-js": "^1.5.1",
+        "xmlbuilder": "^15.1.1"
+      },
+      "engines": {
+        "node": ">=10.4.0"
       }
     },
     "node_modules/postcss": {
@@ -4142,6 +4660,22 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/postject": {
+      "version": "1.0.0-alpha.6",
+      "resolved": "https://socket-firewall-registry.gateway.unified-30.internal.api.openai.org/npm/postject/-/postject-1.0.0-alpha.6.tgz",
+      "integrity": "sha512-b9Eb8h2eVqNE8edvKdwqkrY6O7kAwmI8kcnBv1NScolYJbo59XUF0noFq+lxbC1yN20bmC0WBEbDC5H/7ASb0A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "commander": "^9.4.0"
+      },
+      "bin": {
+        "postject": "dist/cli.js"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
     "node_modules/prelude-ls": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz",
@@ -4176,6 +4710,20 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.4.0"
+      }
+    },
+    "node_modules/promise-retry": {
+      "version": "2.0.1",
+      "resolved": "https://socket-firewall-registry.gateway.unified-30.internal.api.openai.org/npm/promise-retry/-/promise-retry-2.0.1.tgz",
+      "integrity": "sha512-y+WKFlBR8BGXnsNlIHFGPZmyDf3DFMoLhaflAnyZgV6rG6xu+JwesTo2Q9R6XwYmtmwAFCkAk3e35jEdoeh/3g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "err-code": "^2.0.2",
+        "retry": "^0.12.0"
+      },
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/pump": {
@@ -4290,6 +4838,24 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/resedit": {
+      "version": "2.0.3",
+      "resolved": "https://socket-firewall-registry.gateway.unified-30.internal.api.openai.org/npm/resedit/-/resedit-2.0.3.tgz",
+      "integrity": "sha512-oTeemxwoMuxxTYxXUwjkrOPfngTQehlv0/HoYFNkB4uzsP1Un1A9nI8JQKGOFkxpqkC7qkMs0lUsGrvUlbLNUA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "pe-library": "^1.0.1"
+      },
+      "engines": {
+        "node": ">=14",
+        "npm": ">=7"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/jet2jet"
+      }
+    },
     "node_modules/resolve-alpn": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/resolve-alpn/-/resolve-alpn-1.2.1.tgz",
@@ -4318,6 +4884,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/retry": {
+      "version": "0.12.0",
+      "resolved": "https://socket-firewall-registry.gateway.unified-30.internal.api.openai.org/npm/retry/-/retry-0.12.0.tgz",
+      "integrity": "sha512-9LkiTwjUh6rT555DtE9rTX+BKByPfrMzEAtnlEtdEwr3Nkffwiihqe2bWADg+OQRjt9gl6ICdmB/ZFDCGAtSow==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4"
       }
     },
     "node_modules/reusify": {
@@ -4976,6 +5552,17 @@
         "typescript": ">=4.8.4 <6.1.0"
       }
     },
+    "node_modules/undici": {
+      "version": "7.27.1",
+      "resolved": "https://socket-firewall-registry.gateway.unified-30.internal.api.openai.org/npm/undici/-/undici-7.27.1.tgz",
+      "integrity": "sha512-UDdpiex+mzigiyrXrGbiUaF4HzTNhKbh2vRNFaTMzcqmLIPrZxaCtwo/1TMSuWoM1Xz3WiTo9KdgI3kRqYzJGg==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=20.18.1"
+      }
+    },
     "node_modules/undici-types": {
       "version": "6.21.0",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
@@ -5166,12 +5753,32 @@
         "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
       }
     },
+    "node_modules/xmlbuilder": {
+      "version": "15.1.1",
+      "resolved": "https://socket-firewall-registry.gateway.unified-30.internal.api.openai.org/npm/xmlbuilder/-/xmlbuilder-15.1.1.tgz",
+      "integrity": "sha512-yMqGBqtXyeN1e3TGYvgNgDVZ3j84W4cwkOXQswghol6APgZWaff9lnbvN7MHYJOiXsvGPXtjTYJEiC9J2wv9Eg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8.0"
+      }
+    },
     "node_modules/yallist": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
       "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/yargs-parser": {
+      "version": "22.0.0",
+      "resolved": "https://socket-firewall-registry.gateway.unified-30.internal.api.openai.org/npm/yargs-parser/-/yargs-parser-22.0.0.tgz",
+      "integrity": "sha512-rwu/ClNdSMpkSrUb+d6BRsSkLUq1fmfsY6TOpYzTwvwkg1/NRG85KBy3kq++A8LKQwX6lsu+aWad+2khvuXrqw==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=23"
+      }
     },
     "node_modules/yauzl": {
       "version": "2.10.0",

--- a/snapo-desktop-electron/package-lock.json
+++ b/snapo-desktop-electron/package-lock.json
@@ -506,7 +506,7 @@
     },
     "node_modules/@electron/asar": {
       "version": "4.2.0",
-      "resolved": "https://socket-firewall-registry.gateway.unified-30.internal.api.openai.org/npm/@electron/asar/-/asar-4.2.0.tgz",
+      "resolved": "https://openai.firewall.socket.dev/npm/@electron/asar/-/asar-4.2.0.tgz",
       "integrity": "sha512-npW1NW5yy8EB9XY/vEw9sUdgmq0sJEhmSBb6bqyFOAw1CSkrhvAvO6QWlW8CdIMo8VN1lkdF345l/MeW0LrY0Q==",
       "dev": true,
       "license": "MIT",
@@ -524,7 +524,7 @@
     },
     "node_modules/@electron/asar/node_modules/commander": {
       "version": "13.1.0",
-      "resolved": "https://socket-firewall-registry.gateway.unified-30.internal.api.openai.org/npm/commander/-/commander-13.1.0.tgz",
+      "resolved": "https://openai.firewall.socket.dev/npm/commander/-/commander-13.1.0.tgz",
       "integrity": "sha512-/rFeCpNJQbhSZjGVwO9RFV3xPqbnERS8MmIQzCtD/zl6gpJuV/bMLuN92oG3F7d8oDEHHRrujSXNUr8fpjntKw==",
       "dev": true,
       "license": "MIT",
@@ -556,7 +556,7 @@
     },
     "node_modules/@electron/notarize": {
       "version": "3.1.1",
-      "resolved": "https://socket-firewall-registry.gateway.unified-30.internal.api.openai.org/npm/@electron/notarize/-/notarize-3.1.1.tgz",
+      "resolved": "https://openai.firewall.socket.dev/npm/@electron/notarize/-/notarize-3.1.1.tgz",
       "integrity": "sha512-uQQSlOiJnqRkTL1wlEBAxe90nVN/Fc/hEmk0bqpKk8nKjV1if/tXLHKUPePtv9Xsx90PtZU8aidx5lAiOpjkQQ==",
       "dev": true,
       "license": "MIT",
@@ -570,7 +570,7 @@
     },
     "node_modules/@electron/notarize/node_modules/debug": {
       "version": "4.4.3",
-      "resolved": "https://socket-firewall-registry.gateway.unified-30.internal.api.openai.org/npm/debug/-/debug-4.4.3.tgz",
+      "resolved": "https://openai.firewall.socket.dev/npm/debug/-/debug-4.4.3.tgz",
       "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
       "dev": true,
       "license": "MIT",
@@ -588,7 +588,7 @@
     },
     "node_modules/@electron/osx-sign": {
       "version": "2.4.0",
-      "resolved": "https://socket-firewall-registry.gateway.unified-30.internal.api.openai.org/npm/@electron/osx-sign/-/osx-sign-2.4.0.tgz",
+      "resolved": "https://openai.firewall.socket.dev/npm/@electron/osx-sign/-/osx-sign-2.4.0.tgz",
       "integrity": "sha512-9mJiKF/yrn2FYt1Pd9hIN8bUWs6w6uhm8DJJ/tZtTPMVmqv9/NO1JvRh+NyOJp8kE2bfffK4YkU3ZyM+rHipUw==",
       "dev": true,
       "license": "BSD-2-Clause",
@@ -608,7 +608,7 @@
     },
     "node_modules/@electron/osx-sign/node_modules/semver": {
       "version": "7.8.2",
-      "resolved": "https://socket-firewall-registry.gateway.unified-30.internal.api.openai.org/npm/semver/-/semver-7.8.2.tgz",
+      "resolved": "https://openai.firewall.socket.dev/npm/semver/-/semver-7.8.2.tgz",
       "integrity": "sha512-c8jsqUZm3omBOI66G90z1Dyw5z622G8oLG+omfsHBJf3CWQTlOcwOjvOG6wtiNfW6anKm/eA39LMwMtMez2TiQ==",
       "dev": true,
       "license": "ISC",
@@ -621,7 +621,7 @@
     },
     "node_modules/@electron/packager": {
       "version": "20.0.0",
-      "resolved": "https://socket-firewall-registry.gateway.unified-30.internal.api.openai.org/npm/@electron/packager/-/packager-20.0.0.tgz",
+      "resolved": "https://openai.firewall.socket.dev/npm/@electron/packager/-/packager-20.0.0.tgz",
       "integrity": "sha512-kl4c4LcsrQflg0wAi3mqpmmZFRdTYoZFLZPBP9YeEIvWwQR1NmkZphwT7558UeLOdhr6Ac5l83r8W69KaJBedg==",
       "dev": true,
       "license": "BSD-2-Clause",
@@ -657,7 +657,7 @@
     },
     "node_modules/@electron/packager/node_modules/@electron/get": {
       "version": "5.0.0",
-      "resolved": "https://socket-firewall-registry.gateway.unified-30.internal.api.openai.org/npm/@electron/get/-/get-5.0.0.tgz",
+      "resolved": "https://openai.firewall.socket.dev/npm/@electron/get/-/get-5.0.0.tgz",
       "integrity": "sha512-pjoBpru1KdEtcExBnuHAP1cAc/5faoedw0hzJkL3o4/IJp7HNF1+fbrdxT3gMYRX2oJfvnA/WXeCTVQpYYxyJA==",
       "dev": true,
       "license": "MIT",
@@ -678,7 +678,7 @@
     },
     "node_modules/@electron/packager/node_modules/debug": {
       "version": "4.4.3",
-      "resolved": "https://socket-firewall-registry.gateway.unified-30.internal.api.openai.org/npm/debug/-/debug-4.4.3.tgz",
+      "resolved": "https://openai.firewall.socket.dev/npm/debug/-/debug-4.4.3.tgz",
       "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
       "dev": true,
       "license": "MIT",
@@ -696,7 +696,7 @@
     },
     "node_modules/@electron/packager/node_modules/env-paths": {
       "version": "3.0.0",
-      "resolved": "https://socket-firewall-registry.gateway.unified-30.internal.api.openai.org/npm/env-paths/-/env-paths-3.0.0.tgz",
+      "resolved": "https://openai.firewall.socket.dev/npm/env-paths/-/env-paths-3.0.0.tgz",
       "integrity": "sha512-dtJUTepzMW3Lm/NPxRf3wP4642UWhjL2sQxc+ym2YMj1m/H2zDNQOlezafzkHwn6sMstjHTwG6iQQsctDW/b1A==",
       "dev": true,
       "license": "MIT",
@@ -709,7 +709,7 @@
     },
     "node_modules/@electron/packager/node_modules/semver": {
       "version": "7.8.2",
-      "resolved": "https://socket-firewall-registry.gateway.unified-30.internal.api.openai.org/npm/semver/-/semver-7.8.2.tgz",
+      "resolved": "https://openai.firewall.socket.dev/npm/semver/-/semver-7.8.2.tgz",
       "integrity": "sha512-c8jsqUZm3omBOI66G90z1Dyw5z622G8oLG+omfsHBJf3CWQTlOcwOjvOG6wtiNfW6anKm/eA39LMwMtMez2TiQ==",
       "dev": true,
       "license": "ISC",
@@ -722,7 +722,7 @@
     },
     "node_modules/@electron/universal": {
       "version": "3.0.4",
-      "resolved": "https://socket-firewall-registry.gateway.unified-30.internal.api.openai.org/npm/@electron/universal/-/universal-3.0.4.tgz",
+      "resolved": "https://openai.firewall.socket.dev/npm/@electron/universal/-/universal-3.0.4.tgz",
       "integrity": "sha512-G7mNdfZIdPbx54dTorGlV7SN7nHAKlbJU1NjjeuEo7RzEMYBG62+tKpA2VrzocGcvFLxqJI5XYIknca9EijwOw==",
       "dev": true,
       "license": "MIT",
@@ -737,7 +737,7 @@
     },
     "node_modules/@electron/windows-sign": {
       "version": "2.0.3",
-      "resolved": "https://socket-firewall-registry.gateway.unified-30.internal.api.openai.org/npm/@electron/windows-sign/-/windows-sign-2.0.3.tgz",
+      "resolved": "https://openai.firewall.socket.dev/npm/@electron/windows-sign/-/windows-sign-2.0.3.tgz",
       "integrity": "sha512-lJGpt2artEZNiOsQtU1JmcLr4Ow/AGskwjTTNaxL2+R2wLN7G2BHL4Z9unOoW321N69kBP1nzObSMdDbQydjbA==",
       "dev": true,
       "license": "BSD-2-Clause",
@@ -1040,7 +1040,7 @@
     },
     "node_modules/@malept/cross-spawn-promise": {
       "version": "2.0.0",
-      "resolved": "https://socket-firewall-registry.gateway.unified-30.internal.api.openai.org/npm/@malept/cross-spawn-promise/-/cross-spawn-promise-2.0.0.tgz",
+      "resolved": "https://openai.firewall.socket.dev/npm/@malept/cross-spawn-promise/-/cross-spawn-promise-2.0.0.tgz",
       "integrity": "sha512-1DpKU0Z5ThltBwjNySMC14g0CkbyhCaz9FkhxqNsZI6uAPJXFS8cMXlBKo26FJ8ZuW6S9GCMcR9IO5k2X5/9Fg==",
       "dev": true,
       "funding": [
@@ -1894,7 +1894,7 @@
     },
     "node_modules/@xmldom/xmldom": {
       "version": "0.9.10",
-      "resolved": "https://socket-firewall-registry.gateway.unified-30.internal.api.openai.org/npm/@xmldom/xmldom/-/xmldom-0.9.10.tgz",
+      "resolved": "https://openai.firewall.socket.dev/npm/@xmldom/xmldom/-/xmldom-0.9.10.tgz",
       "integrity": "sha512-A9gOqLdi6cV4ibazAjcQufGj0B1y/vDqYrcuP6d/6x8P27gRS8643Dj9o1dEKtB6O7fwxb2FgBmJS2mX7gpvdw==",
       "dev": true,
       "license": "MIT",
@@ -1997,7 +1997,7 @@
     },
     "node_modules/author-regex": {
       "version": "1.0.0",
-      "resolved": "https://socket-firewall-registry.gateway.unified-30.internal.api.openai.org/npm/author-regex/-/author-regex-1.0.0.tgz",
+      "resolved": "https://openai.firewall.socket.dev/npm/author-regex/-/author-regex-1.0.0.tgz",
       "integrity": "sha512-KbWgR8wOYRAPekEmMXrYYdc7BRyhn2Ftk7KWfMUnQ43hFdojWEFRxhhRUm3/OFEdPa1r0KAvTTg9YQK57xTe0g==",
       "dev": true,
       "license": "MIT",
@@ -2017,7 +2017,7 @@
     },
     "node_modules/base64-js": {
       "version": "1.5.1",
-      "resolved": "https://socket-firewall-registry.gateway.unified-30.internal.api.openai.org/npm/base64-js/-/base64-js-1.5.1.tgz",
+      "resolved": "https://openai.firewall.socket.dev/npm/base64-js/-/base64-js-1.5.1.tgz",
       "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
       "dev": true,
       "funding": [
@@ -2571,7 +2571,7 @@
     },
     "node_modules/err-code": {
       "version": "2.0.3",
-      "resolved": "https://socket-firewall-registry.gateway.unified-30.internal.api.openai.org/npm/err-code/-/err-code-2.0.3.tgz",
+      "resolved": "https://openai.firewall.socket.dev/npm/err-code/-/err-code-2.0.3.tgz",
       "integrity": "sha512-2bmlRpNKBxT/CRmPOlyISQpNj+qSeYvcym/uT0Jx2bMOlKLtSy1ZmLuVxSEKKyor/N5yhvp/ZiG1oE3DEYMSFA==",
       "dev": true,
       "license": "MIT"
@@ -3015,7 +3015,7 @@
     },
     "node_modules/filename-reserved-regex": {
       "version": "3.0.0",
-      "resolved": "https://socket-firewall-registry.gateway.unified-30.internal.api.openai.org/npm/filename-reserved-regex/-/filename-reserved-regex-3.0.0.tgz",
+      "resolved": "https://openai.firewall.socket.dev/npm/filename-reserved-regex/-/filename-reserved-regex-3.0.0.tgz",
       "integrity": "sha512-hn4cQfU6GOT/7cFHXBqeBg2TbrMBgdD0kcjLhvSQYYwm3s4B6cjvBfb7nBALJLAXqmU5xajSa7X2NnUud/VCdw==",
       "dev": true,
       "license": "MIT",
@@ -3028,7 +3028,7 @@
     },
     "node_modules/filenamify": {
       "version": "6.0.0",
-      "resolved": "https://socket-firewall-registry.gateway.unified-30.internal.api.openai.org/npm/filenamify/-/filenamify-6.0.0.tgz",
+      "resolved": "https://openai.firewall.socket.dev/npm/filenamify/-/filenamify-6.0.0.tgz",
       "integrity": "sha512-vqIlNogKeyD3yzrm0yhRMQg8hOVwYcYRfjEoODd49iCprMn4HL85gK3HcykQE53EPIpX3HcAbGA5ELQv216dAQ==",
       "dev": true,
       "license": "MIT",
@@ -3095,7 +3095,7 @@
     },
     "node_modules/flora-colossus": {
       "version": "3.0.2",
-      "resolved": "https://socket-firewall-registry.gateway.unified-30.internal.api.openai.org/npm/flora-colossus/-/flora-colossus-3.0.2.tgz",
+      "resolved": "https://openai.firewall.socket.dev/npm/flora-colossus/-/flora-colossus-3.0.2.tgz",
       "integrity": "sha512-Jk78K/Tzt6saxQPGChlJw69xuFGpWyTSAS8EdU0h/FyXwD2K46yNOXmo6nRHcZ9ooekyBAzMkwmiGNt7wOC5zg==",
       "dev": true,
       "license": "MIT",
@@ -3108,7 +3108,7 @@
     },
     "node_modules/flora-colossus/node_modules/debug": {
       "version": "4.4.3",
-      "resolved": "https://socket-firewall-registry.gateway.unified-30.internal.api.openai.org/npm/debug/-/debug-4.4.3.tgz",
+      "resolved": "https://openai.firewall.socket.dev/npm/debug/-/debug-4.4.3.tgz",
       "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
       "dev": true,
       "license": "MIT",
@@ -3156,7 +3156,7 @@
     },
     "node_modules/galactus": {
       "version": "2.0.2",
-      "resolved": "https://socket-firewall-registry.gateway.unified-30.internal.api.openai.org/npm/galactus/-/galactus-2.0.2.tgz",
+      "resolved": "https://openai.firewall.socket.dev/npm/galactus/-/galactus-2.0.2.tgz",
       "integrity": "sha512-HmKyTFGomdAchz4umx8MwBnrnfFmdpwiTyGA4ZOF7rya2Lmgbc9qate4yweInL+0gUBVImhaz12SBGpW3SY4Yg==",
       "dev": true,
       "license": "MIT",
@@ -3170,7 +3170,7 @@
     },
     "node_modules/galactus/node_modules/debug": {
       "version": "4.4.3",
-      "resolved": "https://socket-firewall-registry.gateway.unified-30.internal.api.openai.org/npm/debug/-/debug-4.4.3.tgz",
+      "resolved": "https://openai.firewall.socket.dev/npm/debug/-/debug-4.4.3.tgz",
       "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
       "dev": true,
       "license": "MIT",
@@ -3214,7 +3214,7 @@
     },
     "node_modules/glob": {
       "version": "13.0.6",
-      "resolved": "https://socket-firewall-registry.gateway.unified-30.internal.api.openai.org/npm/glob/-/glob-13.0.6.tgz",
+      "resolved": "https://openai.firewall.socket.dev/npm/glob/-/glob-13.0.6.tgz",
       "integrity": "sha512-Wjlyrolmm8uDpm/ogGyXZXb1Z+Ca2B8NbJwqBVg0axK9GbBeoS7yGV6vjXnYdGm6X53iehEuxxbyiKp8QmN4Vw==",
       "dev": true,
       "license": "BlueOak-1.0.0",
@@ -3634,7 +3634,7 @@
     },
     "node_modules/isbinaryfile": {
       "version": "4.0.10",
-      "resolved": "https://socket-firewall-registry.gateway.unified-30.internal.api.openai.org/npm/isbinaryfile/-/isbinaryfile-4.0.10.tgz",
+      "resolved": "https://openai.firewall.socket.dev/npm/isbinaryfile/-/isbinaryfile-4.0.10.tgz",
       "integrity": "sha512-iHrqe5shvBUcFbmZq9zOQHBoeOhZJu6RQGrDpBgenUm/Am+F3JM2MgQj+rK3Z601fzrL5gLZWtAPH2OBaSVcyw==",
       "dev": true,
       "license": "MIT",
@@ -3746,7 +3746,7 @@
     },
     "node_modules/junk": {
       "version": "4.0.1",
-      "resolved": "https://socket-firewall-registry.gateway.unified-30.internal.api.openai.org/npm/junk/-/junk-4.0.1.tgz",
+      "resolved": "https://openai.firewall.socket.dev/npm/junk/-/junk-4.0.1.tgz",
       "integrity": "sha512-Qush0uP+G8ZScpGMZvHUiRfI0YBWuB3gVBYlI0v0vvOJt5FLicco+IkP0a50LqTTQhmts/m6tP5SWE+USyIvcQ==",
       "dev": true,
       "license": "MIT",
@@ -4242,7 +4242,7 @@
     },
     "node_modules/minipass": {
       "version": "7.1.3",
-      "resolved": "https://socket-firewall-registry.gateway.unified-30.internal.api.openai.org/npm/minipass/-/minipass-7.1.3.tgz",
+      "resolved": "https://openai.firewall.socket.dev/npm/minipass/-/minipass-7.1.3.tgz",
       "integrity": "sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==",
       "dev": true,
       "license": "BlueOak-1.0.0",
@@ -4417,7 +4417,7 @@
     },
     "node_modules/parse-author": {
       "version": "2.0.0",
-      "resolved": "https://socket-firewall-registry.gateway.unified-30.internal.api.openai.org/npm/parse-author/-/parse-author-2.0.0.tgz",
+      "resolved": "https://openai.firewall.socket.dev/npm/parse-author/-/parse-author-2.0.0.tgz",
       "integrity": "sha512-yx5DfvkN8JsHL2xk2Os9oTia467qnvRgey4ahSm2X8epehBLx/gWLcy5KI+Y36ful5DzGbCS6RazqZGgy1gHNw==",
       "dev": true,
       "license": "MIT",
@@ -4484,7 +4484,7 @@
     },
     "node_modules/path-scurry": {
       "version": "2.0.2",
-      "resolved": "https://socket-firewall-registry.gateway.unified-30.internal.api.openai.org/npm/path-scurry/-/path-scurry-2.0.2.tgz",
+      "resolved": "https://openai.firewall.socket.dev/npm/path-scurry/-/path-scurry-2.0.2.tgz",
       "integrity": "sha512-3O/iVVsJAPsOnpwWIeD+d6z/7PmqApyQePUtCndjatj/9I5LylHvt5qluFaBT3I5h3r1ejfR056c+FCv+NnNXg==",
       "dev": true,
       "license": "BlueOak-1.0.0",
@@ -4501,7 +4501,7 @@
     },
     "node_modules/path-scurry/node_modules/lru-cache": {
       "version": "11.5.1",
-      "resolved": "https://socket-firewall-registry.gateway.unified-30.internal.api.openai.org/npm/lru-cache/-/lru-cache-11.5.1.tgz",
+      "resolved": "https://openai.firewall.socket.dev/npm/lru-cache/-/lru-cache-11.5.1.tgz",
       "integrity": "sha512-RPimw/7aMdv2oqRrxKwvZXcPfwBrn/JZ2xYcY9Hus/6LaS3VOAKVWKWgNLCFSiOm1ESXinjsDlidVU7JlnCN2A==",
       "dev": true,
       "license": "BlueOak-1.0.0",
@@ -4521,7 +4521,7 @@
     },
     "node_modules/pe-library": {
       "version": "1.0.1",
-      "resolved": "https://socket-firewall-registry.gateway.unified-30.internal.api.openai.org/npm/pe-library/-/pe-library-1.0.1.tgz",
+      "resolved": "https://openai.firewall.socket.dev/npm/pe-library/-/pe-library-1.0.1.tgz",
       "integrity": "sha512-nh39Mo1eGWmZS7y+mK/dQIqg7S1lp38DpRxkyoHf0ZcUs/HDc+yyTjuOtTvSMZHmfSLuSQaX945u05Y2Q6UWZg==",
       "dev": true,
       "license": "MIT",
@@ -4563,7 +4563,7 @@
     },
     "node_modules/plist": {
       "version": "3.1.1",
-      "resolved": "https://socket-firewall-registry.gateway.unified-30.internal.api.openai.org/npm/plist/-/plist-3.1.1.tgz",
+      "resolved": "https://openai.firewall.socket.dev/npm/plist/-/plist-3.1.1.tgz",
       "integrity": "sha512-ZIfcLJC+7E7FBFnDxm9MPmt7D+DidyQ26lewieO75AdhA2ayMtsJSES0iWzqJQbcVRSrTufQoy0DR94xHue0oA==",
       "dev": true,
       "license": "MIT",
@@ -4662,7 +4662,7 @@
     },
     "node_modules/postject": {
       "version": "1.0.0-alpha.6",
-      "resolved": "https://socket-firewall-registry.gateway.unified-30.internal.api.openai.org/npm/postject/-/postject-1.0.0-alpha.6.tgz",
+      "resolved": "https://openai.firewall.socket.dev/npm/postject/-/postject-1.0.0-alpha.6.tgz",
       "integrity": "sha512-b9Eb8h2eVqNE8edvKdwqkrY6O7kAwmI8kcnBv1NScolYJbo59XUF0noFq+lxbC1yN20bmC0WBEbDC5H/7ASb0A==",
       "dev": true,
       "license": "MIT",
@@ -4714,7 +4714,7 @@
     },
     "node_modules/promise-retry": {
       "version": "2.0.1",
-      "resolved": "https://socket-firewall-registry.gateway.unified-30.internal.api.openai.org/npm/promise-retry/-/promise-retry-2.0.1.tgz",
+      "resolved": "https://openai.firewall.socket.dev/npm/promise-retry/-/promise-retry-2.0.1.tgz",
       "integrity": "sha512-y+WKFlBR8BGXnsNlIHFGPZmyDf3DFMoLhaflAnyZgV6rG6xu+JwesTo2Q9R6XwYmtmwAFCkAk3e35jEdoeh/3g==",
       "dev": true,
       "license": "MIT",
@@ -4840,7 +4840,7 @@
     },
     "node_modules/resedit": {
       "version": "2.0.3",
-      "resolved": "https://socket-firewall-registry.gateway.unified-30.internal.api.openai.org/npm/resedit/-/resedit-2.0.3.tgz",
+      "resolved": "https://openai.firewall.socket.dev/npm/resedit/-/resedit-2.0.3.tgz",
       "integrity": "sha512-oTeemxwoMuxxTYxXUwjkrOPfngTQehlv0/HoYFNkB4uzsP1Un1A9nI8JQKGOFkxpqkC7qkMs0lUsGrvUlbLNUA==",
       "dev": true,
       "license": "MIT",
@@ -4888,7 +4888,7 @@
     },
     "node_modules/retry": {
       "version": "0.12.0",
-      "resolved": "https://socket-firewall-registry.gateway.unified-30.internal.api.openai.org/npm/retry/-/retry-0.12.0.tgz",
+      "resolved": "https://openai.firewall.socket.dev/npm/retry/-/retry-0.12.0.tgz",
       "integrity": "sha512-9LkiTwjUh6rT555DtE9rTX+BKByPfrMzEAtnlEtdEwr3Nkffwiihqe2bWADg+OQRjt9gl6ICdmB/ZFDCGAtSow==",
       "dev": true,
       "license": "MIT",
@@ -5554,7 +5554,7 @@
     },
     "node_modules/undici": {
       "version": "7.27.1",
-      "resolved": "https://socket-firewall-registry.gateway.unified-30.internal.api.openai.org/npm/undici/-/undici-7.27.1.tgz",
+      "resolved": "https://openai.firewall.socket.dev/npm/undici/-/undici-7.27.1.tgz",
       "integrity": "sha512-UDdpiex+mzigiyrXrGbiUaF4HzTNhKbh2vRNFaTMzcqmLIPrZxaCtwo/1TMSuWoM1Xz3WiTo9KdgI3kRqYzJGg==",
       "dev": true,
       "license": "MIT",
@@ -5755,7 +5755,7 @@
     },
     "node_modules/xmlbuilder": {
       "version": "15.1.1",
-      "resolved": "https://socket-firewall-registry.gateway.unified-30.internal.api.openai.org/npm/xmlbuilder/-/xmlbuilder-15.1.1.tgz",
+      "resolved": "https://openai.firewall.socket.dev/npm/xmlbuilder/-/xmlbuilder-15.1.1.tgz",
       "integrity": "sha512-yMqGBqtXyeN1e3TGYvgNgDVZ3j84W4cwkOXQswghol6APgZWaff9lnbvN7MHYJOiXsvGPXtjTYJEiC9J2wv9Eg==",
       "dev": true,
       "license": "MIT",
@@ -5772,7 +5772,7 @@
     },
     "node_modules/yargs-parser": {
       "version": "22.0.0",
-      "resolved": "https://socket-firewall-registry.gateway.unified-30.internal.api.openai.org/npm/yargs-parser/-/yargs-parser-22.0.0.tgz",
+      "resolved": "https://openai.firewall.socket.dev/npm/yargs-parser/-/yargs-parser-22.0.0.tgz",
       "integrity": "sha512-rwu/ClNdSMpkSrUb+d6BRsSkLUq1fmfsY6TOpYzTwvwkg1/NRG85KBy3kq++A8LKQwX6lsu+aWad+2khvuXrqw==",
       "dev": true,
       "license": "ISC",

--- a/snapo-desktop-electron/package.json
+++ b/snapo-desktop-electron/package.json
@@ -4,6 +4,9 @@
   "private": true,
   "type": "module",
   "main": "dist-electron/electron/main.js",
+  "engines": {
+    "node": ">=22.12.0"
+  },
   "scripts": {
     "dev": "node scripts/dev.mjs",
     "build": "tsc -p tsconfig.electron.json && vite build",
@@ -13,7 +16,7 @@
     "lint:fix": "eslint . --fix && npm run lint:css:fix",
     "lint:css": "stylelint \"src/**/*.css\"",
     "lint:css:fix": "stylelint \"src/**/*.css\" --fix",
-    "test": "tsc -p tsconfig.electron.json && node --test dist-electron/electron/*.test.js",
+    "test": "tsc -p tsconfig.electron.json && node --test dist-electron/electron/*.test.js scripts/version-info.test.mjs",
     "typecheck": "tsc --noEmit -p tsconfig.json && tsc --noEmit -p tsconfig.electron.json",
     "start": "npm run build && electron .",
     "cli": "npm run build && ELECTRON_RUN_AS_NODE=1 electron dist-electron/electron/cli-entry.js",
@@ -25,6 +28,7 @@
     "fast-xml-parser": "^5.7.2"
   },
   "devDependencies": {
+    "@electron/packager": "^20.0.0",
     "@eslint/js": "^10.0.1",
     "@types/node": "^20.10.6",
     "@types/react": "^18.2.46",

--- a/snapo-desktop-electron/scripts/package-macos.mjs
+++ b/snapo-desktop-electron/scripts/package-macos.mjs
@@ -1,37 +1,75 @@
-import { createRequire } from "node:module";
 import { execFileSync } from "node:child_process";
+import { constants } from "node:fs";
 import fs from "node:fs/promises";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
+import { packager } from "@electron/packager";
+import { parseVersionInfo } from "./version-info.mjs";
 
-const require = createRequire(import.meta.url);
 const scriptDir = path.dirname(fileURLToPath(import.meta.url));
 const projectDir = path.resolve(scriptDir, "..");
 const repoRoot = path.resolve(projectDir, "..");
 const buildVariant = process.argv[2] === "release" ? "main-release" : "main";
-const outputDir = path.join(projectDir, "build/macos", buildVariant, "app");
+const variantDir = path.join(projectDir, "build/macos", buildVariant);
+const packagerOutputDir = path.join(variantDir, ".packager");
+const outputDir = path.join(variantDir, "app");
 const appName = "Snap-O Network Inspector";
 const appBundleName = `${appName}.app`;
-const sourceElectronApp = path.join(projectDir, "node_modules/electron/dist/Electron.app");
 const appBundle = path.join(outputDir, appBundleName);
-const contentsDir = path.join(appBundle, "Contents");
-const resourcesDir = path.join(contentsDir, "Resources");
-const bundledAppDir = path.join(resourcesDir, "app");
+const versionFile = path.join(repoRoot, "VERSION");
 const packageJson = JSON.parse(await fs.readFile(path.join(projectDir, "package.json"), "utf8"));
-const versionInfo = await readVersionInfo(path.join(repoRoot, "VERSION"));
+const electronPackageJson = JSON.parse(
+  await fs.readFile(path.join(projectDir, "node_modules/electron/package.json"), "utf8")
+);
+const versionInfo = parseVersionInfo(await fs.readFile(versionFile, "utf8"), versionFile);
+const packagedPackageJson = {
+  name: packageJson.name,
+  productName: appName,
+  version: versionInfo.version,
+  private: true,
+  type: packageJson.type,
+  main: packageJson.main
+};
 
 await ensureBuiltArtifacts();
+await fs.rm(packagerOutputDir, { recursive: true, force: true });
 await fs.rm(outputDir, { recursive: true, force: true });
-await fs.mkdir(outputDir, { recursive: true });
-await fs.cp(sourceElectronApp, appBundle, {
-  recursive: true,
-  dereference: false,
-  verbatimSymlinks: true
+
+const packagedPaths = await packager({
+  dir: projectDir,
+  out: packagerOutputDir,
+  overwrite: true,
+  platform: "darwin",
+  arch: process.arch,
+  electronVersion: electronPackageJson.version,
+  name: appName,
+  executableName: appName,
+  appBundleId: "com.openai.snapo.network-inspector",
+  extendInfo: { CFBundleIconFile: "network.icns" },
+  appVersion: versionInfo.version,
+  buildVersion: versionInfo.buildNumber ?? versionInfo.version,
+  icon: path.join(projectDir, "resources/icons/network.icns"),
+  extraResource: versionFile,
+  asar: false,
+  prune: true,
+  derefSymlinks: false,
+  quiet: true,
+  ignore: [
+    /^\/(?!package\.json$|dist-electron(?:\/|$)|dist-renderer(?:\/|$)|resources(?:\/|$)|node_modules(?:\/|$))/u,
+    /^\/node_modules\/(?:\.package-lock\.json|\.vite-temp(?:\/|$))/u
+  ],
+  afterCopy: [writePackagedPackageJson]
 });
 
-await rebrandBundle();
-await copyAppPayload();
-await copyRuntimeDependencies();
+if (packagedPaths.length !== 1) {
+  throw new Error(`Expected one packaged app directory, received ${packagedPaths.length}`);
+}
+
+await fs.mkdir(outputDir, { recursive: true });
+await fs.rename(path.join(packagedPaths[0], appBundleName), appBundle);
+await fs.rm(packagerOutputDir, { recursive: true, force: true });
+await restoreElectronHelperNames();
+await validatePackagedBundle();
 
 console.log(appBundle);
 
@@ -49,119 +87,76 @@ async function ensureBuiltArtifacts() {
   }
 }
 
-async function rebrandBundle() {
-  const infoPlist = path.join(contentsDir, "Info.plist");
-  await fs.rename(path.join(contentsDir, "MacOS/Electron"), path.join(contentsDir, `MacOS/${appName}`));
-  await fs.rm(path.join(resourcesDir, "default_app.asar"), { force: true });
-  await fs.copyFile(path.join(projectDir, "resources/icons/network.icns"), path.join(resourcesDir, "network.icns"));
-  await fs.copyFile(path.join(repoRoot, "VERSION"), path.join(resourcesDir, "VERSION"));
-
-  replacePlistString(infoPlist, "CFBundleDisplayName", appName);
-  replacePlistString(infoPlist, "CFBundleExecutable", appName);
-  replacePlistString(infoPlist, "CFBundleIconFile", "network.icns");
-  replacePlistString(infoPlist, "CFBundleIdentifier", "com.openai.snapo.network-inspector");
-  replacePlistString(infoPlist, "CFBundleName", appName);
-  replacePlistString(infoPlist, "CFBundleShortVersionString", versionInfo.version);
-  replacePlistString(infoPlist, "CFBundleVersion", versionInfo.buildNumber ?? versionInfo.version);
-  removePlistKey(infoPlist, "ElectronAsarIntegrity");
+async function writePackagedPackageJson({ buildPath }) {
+  await fs.writeFile(path.join(buildPath, "package.json"), `${JSON.stringify(packagedPackageJson, null, 2)}\n`, "utf8");
 }
 
-async function copyAppPayload() {
-  await fs.mkdir(bundledAppDir, { recursive: true });
-  await fs.writeFile(
-    path.join(bundledAppDir, "package.json"),
-    `${JSON.stringify(
-      {
-        name: packageJson.name,
-        productName: appName,
-        version: versionInfo.version,
-        private: true,
-        type: packageJson.type,
-        main: packageJson.main
-      },
-      null,
-      2
-    )}\n`,
-    "utf8"
-  );
-  await fs.cp(path.join(projectDir, "dist-electron"), path.join(bundledAppDir, "dist-electron"), { recursive: true });
-  await fs.cp(path.join(projectDir, "dist-renderer"), path.join(bundledAppDir, "dist-renderer"), { recursive: true });
-  await fs.cp(path.join(projectDir, "resources"), path.join(bundledAppDir, "resources"), { recursive: true });
-}
+async function restoreElectronHelperNames() {
+  const frameworksDir = path.join(appBundle, "Contents", "Frameworks");
+  for (const suffix of ["", " (GPU)", " (Plugin)", " (Renderer)"]) {
+    const packagedName = `${appName} Helper${suffix}`;
+    const electronName = `Electron Helper${suffix}`;
+    const packagedHelper = path.join(frameworksDir, `${packagedName}.app`);
+    const electronHelper = path.join(frameworksDir, `${electronName}.app`);
 
-async function copyRuntimeDependencies() {
-  const copied = new Set();
-  for (const dependency of ["@devicefarmer/adbkit", "fast-xml-parser"]) {
-    await copyDependencyClosure(dependency, projectDir, copied);
+    await fs.rename(
+      path.join(packagedHelper, "Contents", "MacOS", packagedName),
+      path.join(packagedHelper, "Contents", "MacOS", electronName)
+    );
+    await fs.rename(packagedHelper, electronHelper);
+
+    const infoPlist = path.join(electronHelper, "Contents", "Info.plist");
+    replacePlistString(infoPlist, "CFBundleExecutable", electronName);
+    replacePlistString(infoPlist, "CFBundleDisplayName", electronName);
+    replacePlistString(infoPlist, "CFBundleName", electronName);
   }
 }
 
-async function copyDependencyClosure(name, fromDir, copied) {
-  const packageDir = await findPackageDir(name, fromDir);
-  if (copied.has(packageDir)) return;
-  copied.add(packageDir);
+async function validatePackagedBundle() {
+  const frameworksDir = path.join(appBundle, "Contents", "Frameworks");
+  const helperApps = (await fs.readdir(frameworksDir, { withFileTypes: true }))
+    .filter((entry) => entry.isDirectory() && entry.name.endsWith(".app"))
+    .map((entry) => path.join(frameworksDir, entry.name));
+  if (helperApps.length === 0) throw new Error(`No helper app bundles found in ${frameworksDir}`);
 
-  const relativePackageDir = path.relative(projectDir, packageDir);
-  await fs.cp(packageDir, path.join(bundledAppDir, relativePackageDir), {
-    recursive: true,
-    dereference: false,
-    verbatimSymlinks: true
-  });
-
-  const packageJsonPath = path.join(packageDir, "package.json");
-  const dependencyPackageJson = JSON.parse(await fs.readFile(packageJsonPath, "utf8"));
-  const dependencies = {
-    ...dependencyPackageJson.dependencies,
-    ...dependencyPackageJson.optionalDependencies
-  };
-  for (const dependencyName of Object.keys(dependencies)) {
-    await copyDependencyClosure(dependencyName, packageDir, copied);
-  }
-}
-
-async function findPackageDir(name, fromDir) {
-  let currentDir = path.dirname(require.resolve(name, { paths: [fromDir] }));
-  while (currentDir !== path.dirname(currentDir)) {
-    const packageJsonPath = path.join(currentDir, "package.json");
-    try {
-      const dependencyPackageJson = JSON.parse(await fs.readFile(packageJsonPath, "utf8"));
-      if (dependencyPackageJson.name === name && isNamedPackageDir(currentDir, name)) return currentDir;
-    } catch {
-      // Walk upward until we find the package root for the resolved entrypoint.
+  for (const bundle of [appBundle, ...helperApps]) {
+    const executable = readPlistValue(bundle, "CFBundleExecutable");
+    if (executable.length === 0 || path.basename(executable) !== executable) {
+      throw new Error(`Invalid CFBundleExecutable in ${bundle}`);
     }
-    currentDir = path.dirname(currentDir);
+    const executablePath = path.join(bundle, "Contents", "MacOS", executable);
+    if (!(await fs.stat(executablePath)).isFile()) {
+      throw new Error(`CFBundleExecutable does not resolve to a file: ${executablePath}`);
+    }
+    await fs.access(executablePath, constants.X_OK);
+
+    const appVersion = readPlistValue(bundle, "CFBundleShortVersionString");
+    const buildVersion = readPlistValue(bundle, "CFBundleVersion");
+    if (appVersion !== versionInfo.version || buildVersion !== (versionInfo.buildNumber ?? versionInfo.version)) {
+      throw new Error(`Bundle versions do not match ${versionFile}: ${bundle}`);
+    }
   }
-  throw new Error(`Unable to find package root for ${name}`);
-}
 
-function isNamedPackageDir(packageDir, name) {
-  return packageDir.endsWith(path.join("node_modules", ...name.split("/")));
-}
-
-async function readVersionInfo(versionFile) {
-  const entries = Object.fromEntries(
-    (await fs.readFile(versionFile, "utf8"))
-      .split(/\r?\n/u)
-      .map((line) => line.trim())
-      .filter((line) => line.length > 0 && !line.startsWith("#"))
-      .map((line) => line.split("=", 2).map((part) => part.trim()))
-      .filter((parts) => parts.length === 2)
+  const bundledPackageJson = JSON.parse(
+    await fs.readFile(path.join(appBundle, "Contents/Resources/app/package.json"), "utf8")
   );
-  if (entries.VERSION == null) throw new Error(`Missing VERSION in ${versionFile}`);
-  return {
-    version: entries.VERSION,
-    buildNumber: entries.BUILD_NUMBER ?? null
-  };
+  if (bundledPackageJson.version !== versionInfo.version) {
+    throw new Error(`Packaged app version does not match ${versionFile}`);
+  }
+
+  for (const dependency of ["@devicefarmer/adbkit", "fast-xml-parser"]) {
+    await fs.access(path.join(appBundle, "Contents/Resources/app/node_modules", dependency, "package.json"));
+  }
+}
+
+function readPlistValue(bundle, key) {
+  return execFileSync(
+    "/usr/bin/plutil",
+    ["-extract", key, "raw", "-o", "-", path.join(bundle, "Contents", "Info.plist")],
+    { encoding: "utf8" }
+  ).trim();
 }
 
 function replacePlistString(plistPath, key, value) {
-  execFileSync("/usr/bin/plutil", ["-replace", key, "-string", value, plistPath], { stdio: "inherit" });
-}
-
-function removePlistKey(plistPath, key) {
-  try {
-    execFileSync("/usr/bin/plutil", ["-remove", key, plistPath], { stdio: "ignore" });
-  } catch {
-    // Source Electron app bundles have this today, but older releases may not.
-  }
+  execFileSync("/usr/bin/plutil", ["-replace", key, "-string", value, plistPath]);
 }

--- a/snapo-desktop-electron/scripts/version-info.mjs
+++ b/snapo-desktop-electron/scripts/version-info.mjs
@@ -1,0 +1,15 @@
+export function parseVersionInfo(contents, source = "VERSION") {
+  const entries = Object.fromEntries(
+    contents
+      .split(/\r?\n/u)
+      .map((line) => line.trim())
+      .filter((line) => line.length > 0 && !line.startsWith("#"))
+      .map((line) => line.split("=", 2).map((part) => part.trim()))
+      .filter((parts) => parts.length === 2)
+  );
+  if (entries.VERSION == null) throw new Error(`Missing VERSION in ${source}`);
+  return {
+    version: entries.VERSION,
+    buildNumber: entries.BUILD_NUMBER ?? null
+  };
+}

--- a/snapo-desktop-electron/scripts/version-info.test.mjs
+++ b/snapo-desktop-electron/scripts/version-info.test.mjs
@@ -1,0 +1,15 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { parseVersionInfo } from "./version-info.mjs";
+
+test("reads the app and build versions from VERSION contents", () => {
+  assert.deepEqual(parseVersionInfo("VERSION = 2.3.4\nBUILD_NUMBER = 20260611.1\n"), {
+    version: "2.3.4",
+    buildNumber: "20260611.1"
+  });
+});
+
+test("requires VERSION and permits an omitted build number", () => {
+  assert.deepEqual(parseVersionInfo("VERSION=2.3.4\n"), { version: "2.3.4", buildNumber: null });
+  assert.throws(() => parseVersionInfo("BUILD_NUMBER=1\n", "test-version"), /Missing VERSION in test-version/u);
+});


### PR DESCRIPTION
## Summary

- replace the hand-written Electron bundle assembly with `@electron/packager`
- preserve the existing Xcode output path, unarchived app payload, icon name, and `Electron Helper*.app` paths
- source the app version and build number from the repository `VERSION` file for the outer app, helper apps, and packaged metadata
- validate bundle executables, versions, and required runtime dependencies after packaging
- use the repository Socket firewall registry for the new Packager lockfile entries and reject internal gateway URLs in CI

## Why

Electron's copied helper app plists omit `CFBundleExecutable`. Native codesign can infer those executables, but rcodesign cannot, which leads to incomplete signatures and invalid sealed-resource verification. Electron Packager supplies the standard macOS plist and helper handling while removing the custom dependency-copy implementation.

The compatibility step restores the existing helper filenames after Packager runs and explicitly keeps each helper plist executable aligned with its binary.

The initial Packager lockfile entries inherited an environment-level internal registry override. Those absolute URLs bypassed the repository `.npmrc` and timed out in GitHub Actions. The lockfile now uses `https://openai.firewall.socket.dev/npm/`; CI rejects internal gateway URLs before installation, and scoped `AGENTS.md` guidance documents the requirement for future dependency changes.

## Impact

- macOS packaging now requires Node.js 22.12 or newer, matching `@electron/packager` 20.
- signing, AKV, notarization, and release workflow behavior are unchanged.

## Validation

- cold-cache `npm ci` fetched all dependencies through `openai.firewall.socket.dev` in 7 seconds
- `npm run typecheck`
- `npm test`
- `npm run lint`
- `npm run format:check`
- `npm run package:mac:release`
- packaged GUI launch through `windowReadyToShow` with clean shutdown
- isolated packaged CLI smoke test
- `plutil` inspection of the outer app and all four helper app executable/version fields
- [Electron verification workflow](https://github.com/openai/snap-o/actions/runs/27372412321) passed in 28 seconds
