### PR TITLE
Remove root package-lock.json

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,0 @@
-{
-  "name": "snap-o",
-  "lockfileVersion": 3,
-  "requires": true,
-  "packages": {}
-}


### PR DESCRIPTION
## Summary
- Delete the empty root `package-lock.json` file
- Keep the repository from tracking an unused lockfile at the top level

## Testing
- Not run (not requested)