### PR TITLE
[codex] Add Open Xcode environment action

### DIFF
--- a/.codex/environments/environment.toml
+++ b/.codex/environments/environment.toml
@@ -13,3 +13,8 @@ cd $CODEX_WORKTREE_PATH/snapo-desktop-electron
 npm install
 npm run dev
 '''
+
+[[actions]]
+name = "Open Xcode"
+icon = "tool"
+command = "open snapo-app-mac/Snap-O.xcodeproj"


### PR DESCRIPTION
## Summary
- add an `Open Xcode` Codex environment action
- open `snapo-app-mac/Snap-O.xcodeproj` from the workspace

## Why
The environment already exposes an Electron dev action, but opening the native macOS project still requires a manual shell step. This adds the matching one-click action for the Xcode workflow.

## Impact
Codex users can launch the Snap-O Xcode project directly from the environment actions menu. No app runtime behavior changes.

## Validation
- `git diff --check -- .codex/environments/environment.toml`