### PR TITLE
[codex] Build Electron helper only when needed

### DIFF
--- a/snapo-app-mac/Snap-O.xcodeproj/project.pbxproj
+++ b/snapo-app-mac/Snap-O.xcodeproj/project.pbxproj
@@ -216,13 +216,12 @@
 /* Begin PBXShellScriptBuildPhase section */
 			32F7D8A12F5B123400C0FFEE /* Embed Network Inspector Helper */ = {
 				isa = PBXShellScriptBuildPhase;
-				alwaysOutOfDate = 1;
 				buildActionMask = 2147483647;
 				files = (
 				);
 				inputPaths = (
-					"$(PROJECT_DIR)/../snapo-desktop-electron/build/macos/main/app/Snap-O Network Inspector.app",
-					"$(PROJECT_DIR)/../snapo-desktop-electron/build/macos/main-release/app/Snap-O Network Inspector.app",
+					"$(PROJECT_DIR)/../snapo-desktop-electron/build/macos/$(SNAPO_NETWORK_INSPECTOR_HELPER_VARIANT)/app/Snap-O Network Inspector.app",
+					"$(BUILT_PRODUCTS_DIR)/snapo",
 				);
 				name = "Embed Network Inspector Helper";
 				outputPaths = (
@@ -251,12 +250,11 @@
 				);
 				name = "Build Network Inspector Helper";
 				outputPaths = (
-					"$(PROJECT_DIR)/../snapo-desktop-electron/build/macos/main/app/Snap-O Network Inspector.app",
-					"$(PROJECT_DIR)/../snapo-desktop-electron/build/macos/main-release/app/Snap-O Network Inspector.app",
+					"$(PROJECT_DIR)/../snapo-desktop-electron/build/macos/$(SNAPO_NETWORK_INSPECTOR_HELPER_VARIANT)/app/Snap-O Network Inspector.app",
 				);
 				runOnlyForDeploymentPostprocessing = 0;
 				shellPath = /bin/sh;
-				shellScript = "set -e\n\nELECTRON_DIR=\"${PROJECT_DIR}/../snapo-desktop-electron\"\n\nif [ ! -d \"${ELECTRON_DIR}\" ]; then\n  echo \"error: snapo-desktop-electron not found at ${ELECTRON_DIR}\" >&2\n  exit 1\nfi\n\nif [ -s \"${HOME}/.nvm/nvm.sh\" ]; then\n  . \"${HOME}/.nvm/nvm.sh\"\nfi\nexport PATH=\"/opt/homebrew/bin:/usr/local/bin:${PATH}\"\n\nif ! command -v npm >/dev/null 2>&1; then\n  echo \"error: npm not found. Install Node.js or make npm available to Xcode build scripts.\" >&2\n  exit 1\nfi\n\nTASK=\"package:mac\"\nif [ \"${CONFIGURATION}\" = \"Release\" ]; then\n  TASK=\"package:mac:release\"\nfi\n\n( cd \"${ELECTRON_DIR}\" && npm ci && npm run \"${TASK}\" )\n";
+				shellScript = "set -e\n\nELECTRON_DIR=\"${PROJECT_DIR}/../snapo-desktop-electron\"\n\nif [ ! -d \"${ELECTRON_DIR}\" ]; then\n  echo \"error: snapo-desktop-electron not found at ${ELECTRON_DIR}\" >&2\n  exit 1\nfi\n\nif [ -s \"${HOME}/.nvm/nvm.sh\" ]; then\n  . \"${HOME}/.nvm/nvm.sh\"\nfi\nexport PATH=\"/opt/homebrew/bin:/usr/local/bin:${PATH}\"\n\nif ! command -v npm >/dev/null 2>&1; then\n  echo \"error: npm not found. Install Node.js or make npm available to Xcode build scripts.\" >&2\n  exit 1\nfi\n\nMAKE_TARGET=\"package-mac-if-needed\"\nif [ \"${CONFIGURATION}\" = \"Release\" ]; then\n  MAKE_TARGET=\"package-mac-release-if-needed\"\nfi\n\n( cd \"${ELECTRON_DIR}\" && make \"${MAKE_TARGET}\" )\n";
 			showEnvVarsInLog = 0;
 		};
 /* End PBXShellScriptBuildPhase section */
@@ -447,6 +445,7 @@
 				RUNTIME_EXCEPTION_DEBUGGING_TOOL = NO;
 				RUNTIME_EXCEPTION_DISABLE_EXECUTABLE_PAGE_PROTECTION = NO;
 				RUNTIME_EXCEPTION_DISABLE_LIBRARY_VALIDATION = NO;
+				SNAPO_NETWORK_INSPECTOR_HELPER_VARIANT = main;
 				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "DEBUG $(inherited) PERF_TRACING";
 				SWIFT_EMIT_LOC_STRINGS = YES;
 				SWIFT_VERSION = 6.0;
@@ -491,6 +490,7 @@
 				RUNTIME_EXCEPTION_DEBUGGING_TOOL = NO;
 				RUNTIME_EXCEPTION_DISABLE_EXECUTABLE_PAGE_PROTECTION = NO;
 				RUNTIME_EXCEPTION_DISABLE_LIBRARY_VALIDATION = NO;
+				SNAPO_NETWORK_INSPECTOR_HELPER_VARIANT = "main-release";
 				SWIFT_EMIT_LOC_STRINGS = YES;
 				SWIFT_VERSION = 6.0;
 			};

--- a/snapo-desktop-electron/Makefile
+++ b/snapo-desktop-electron/Makefile
@@ -1,0 +1,35 @@
+APP_BUNDLE_NAME := Snap-O\ Network\ Inspector.app
+DEBUG_APP := build/macos/main/app/$(APP_BUNDLE_NAME)
+RELEASE_APP := build/macos/main-release/app/$(APP_BUNDLE_NAME)
+NODE_MODULES_STAMP := node_modules/.package-lock.json
+NODE_MODULES_TOOLS := node_modules/.bin/tsc node_modules/electron/package.json
+PACKAGE_SOURCE_PATHS := $(shell find electron resources scripts src -type d -o -type f)
+PACKAGE_INPUTS := \
+	Makefile \
+	../VERSION \
+	.npmrc \
+	index.html \
+	package-lock.json \
+	package.json \
+	tsconfig.electron.json \
+	tsconfig.json \
+	vite.config.ts \
+	$(PACKAGE_SOURCE_PATHS)
+
+.PHONY: package-mac-if-needed package-mac-release-if-needed
+
+package-mac-if-needed: $(DEBUG_APP)
+
+package-mac-release-if-needed: $(RELEASE_APP)
+
+$(DEBUG_APP): $(PACKAGE_INPUTS) $(NODE_MODULES_TOOLS)
+	npm run package:mac
+
+$(RELEASE_APP): $(PACKAGE_INPUTS) $(NODE_MODULES_TOOLS)
+	npm run package:mac:release
+
+$(NODE_MODULES_STAMP): .npmrc package-lock.json package.json
+	npm ci --include=dev
+
+$(NODE_MODULES_TOOLS): $(NODE_MODULES_STAMP)
+	@test -e "$@" || npm ci --include=dev

--- a/snapo-desktop-electron/README.md
+++ b/snapo-desktop-electron/README.md
@@ -36,6 +36,8 @@ npm run package:mac:release
 
 Those commands emit helper app bundles under `build/macos/main/app/` and `build/macos/main-release/app/`, matching the shape consumed by the host macOS app build.
 
+The host macOS Xcode target invokes a Makefile target on each build and reruns packaging only when the helper is missing or Electron/package inputs are newer. Dependency install is also timestamp-based, so unchanged local Run builds do not rerun `npm ci`.
+
 ## CLI
 
 The packaged helper app can also run the existing Snap-O CLI commands instead of opening a window:

--- a/snapo-desktop-electron/scripts/package-macos.mjs
+++ b/snapo-desktop-electron/scripts/package-macos.mjs
@@ -65,11 +65,12 @@ if (packagedPaths.length !== 1) {
   throw new Error(`Expected one packaged app directory, received ${packagedPaths.length}`);
 }
 
+const stagedAppBundle = path.join(packagedPaths[0], appBundleName);
+await restoreElectronHelperNames(stagedAppBundle);
+await validatePackagedBundle(stagedAppBundle);
 await fs.mkdir(outputDir, { recursive: true });
-await fs.rename(path.join(packagedPaths[0], appBundleName), appBundle);
+await fs.rename(stagedAppBundle, appBundle);
 await fs.rm(packagerOutputDir, { recursive: true, force: true });
-await restoreElectronHelperNames();
-await validatePackagedBundle();
 
 console.log(appBundle);
 
@@ -91,8 +92,8 @@ async function writePackagedPackageJson({ buildPath }) {
   await fs.writeFile(path.join(buildPath, "package.json"), `${JSON.stringify(packagedPackageJson, null, 2)}\n`, "utf8");
 }
 
-async function restoreElectronHelperNames() {
-  const frameworksDir = path.join(appBundle, "Contents", "Frameworks");
+async function restoreElectronHelperNames(bundlePath) {
+  const frameworksDir = path.join(bundlePath, "Contents", "Frameworks");
   for (const suffix of ["", " (GPU)", " (Plugin)", " (Renderer)"]) {
     const packagedName = `${appName} Helper${suffix}`;
     const electronName = `Electron Helper${suffix}`;
@@ -112,14 +113,14 @@ async function restoreElectronHelperNames() {
   }
 }
 
-async function validatePackagedBundle() {
-  const frameworksDir = path.join(appBundle, "Contents", "Frameworks");
+async function validatePackagedBundle(bundlePath) {
+  const frameworksDir = path.join(bundlePath, "Contents", "Frameworks");
   const helperApps = (await fs.readdir(frameworksDir, { withFileTypes: true }))
     .filter((entry) => entry.isDirectory() && entry.name.endsWith(".app"))
     .map((entry) => path.join(frameworksDir, entry.name));
   if (helperApps.length === 0) throw new Error(`No helper app bundles found in ${frameworksDir}`);
 
-  for (const bundle of [appBundle, ...helperApps]) {
+  for (const bundle of [bundlePath, ...helperApps]) {
     const executable = readPlistValue(bundle, "CFBundleExecutable");
     if (executable.length === 0 || path.basename(executable) !== executable) {
       throw new Error(`Invalid CFBundleExecutable in ${bundle}`);
@@ -138,14 +139,14 @@ async function validatePackagedBundle() {
   }
 
   const bundledPackageJson = JSON.parse(
-    await fs.readFile(path.join(appBundle, "Contents/Resources/app/package.json"), "utf8")
+    await fs.readFile(path.join(bundlePath, "Contents/Resources/app/package.json"), "utf8")
   );
   if (bundledPackageJson.version !== versionInfo.version) {
     throw new Error(`Packaged app version does not match ${versionFile}`);
   }
 
   for (const dependency of ["@devicefarmer/adbkit", "fast-xml-parser"]) {
-    await fs.access(path.join(appBundle, "Contents/Resources/app/node_modules", dependency, "package.json"));
+    await fs.access(path.join(bundlePath, "Contents/Resources/app/node_modules", dependency, "package.json"));
   }
 }
 

--- a/snapo-desktop-electron/scripts/package-macos.mjs
+++ b/snapo-desktop-electron/scripts/package-macos.mjs
@@ -40,7 +40,7 @@ const packagedPaths = await packager({
   out: packagerOutputDir,
   overwrite: true,
   platform: "darwin",
-  arch: process.arch,
+  arch: "universal",
   electronVersion: electronPackageJson.version,
   name: appName,
   executableName: appName,


### PR DESCRIPTION
## Summary

- keep the Xcode helper build phase running on every host build
- use Make prerequisites to rebuild the Electron helper only when its inputs change
- include the Makefile itself as an input so build-logic changes invalidate existing bundles
- install Node dependencies only when package metadata changes or required tools are missing
- publish the final helper bundle only after staged helper renaming and validation succeed
- make helper embedding configuration-specific and dependency-aware

## Why

The host app needs to detect Electron changes automatically, but unchanged local Run builds should not rerun `npm ci` and repackage the helper. The same path also needs to work from a clean CI checkout and recover correctly after packaging failures.

## Impact

Unchanged local builds now skip Electron installation and packaging. Clean builds, changed Electron inputs, and Makefile changes still produce the appropriate debug or release helper before embedding it. Failed post-processing or validation cannot leave a partial bundle that Make considers complete.

## Validation

- `npm run format:check`
- `npm run lint`
- `npm test`
- `make package-mac-if-needed` rebuilt the debug helper once, then completed with no output on an unchanged second run
- `make package-mac-release-if-needed` rebuilt the release helper once, then completed with no output on an unchanged second run
- unsigned `xcodebuild` for the Snap-O scheme succeeded after rebasing onto latest `origin/main`
- `git diff --check`