### PR TITLE
[codex] Refine capture window toolbar layout

### DIFF
--- a/snapo-app-mac/Snap-O/App/AppDelegate.swift
+++ b/snapo-app-mac/Snap-O/App/AppDelegate.swift
@@ -3,6 +3,12 @@ import Foundation
 
 @MainActor
 class AppDelegate: NSObject, NSApplicationDelegate {
+  func applicationWillFinishLaunching(_ notification: Notification) {
+    UserDefaults.standard.register(defaults: [
+      "NSInitialToolTipDelay": 500
+    ])
+  }
+
   func applicationShouldTerminateAfterLastWindowClosed(_ sender: NSApplication) -> Bool {
     true
   }

--- a/snapo-app-mac/Snap-O/App/SnapOApp.swift
+++ b/snapo-app-mac/Snap-O/App/SnapOApp.swift
@@ -57,6 +57,7 @@ struct SnapOApp: App {
     }
     .environment(settings)
     .defaultSize(width: 480, height: 480)
+    .windowToolbarStyle(.expanded)
     .handlesExternalEvents(matching: Set(["record", "capture", "livepreview"]))
     .commands {
       SnapOCommands(

--- a/snapo-app-mac/Snap-O/CaptureWindow/CaptureToolbar.swift
+++ b/snapo-app-mac/Snap-O/CaptureWindow/CaptureToolbar.swift
@@ -5,8 +5,6 @@ struct CaptureToolbar: ToolbarContent {
   @Bindable var controller: CaptureWindowController
   @Environment(AppSettings.self)
   private var settings
-  @Environment(\.openWindow)
-  private var openWindow
 
   var body: some ToolbarContent {
     if controller.isRecording {
@@ -27,7 +25,10 @@ struct CaptureToolbar: ToolbarContent {
         canStartLivePreviewNow: controller.canStartLivePreviewNow
       )
     }
-    ToolbarItemGroup(placement: .primaryAction) {
+    ToolbarItem(placement: .automatic) {
+      Spacer()
+    }
+    ToolbarItemGroup(placement: .automatic) {
       toolControls()
     }
   }
@@ -70,7 +71,6 @@ struct CaptureToolbar: ToolbarContent {
     .disabled(controller.isStoppingLivePreview)
   }
 
-  @ViewBuilder
   private func toolControls() -> some View {
     Button {
       NetworkInspectorHelperLauncher.open()
@@ -80,14 +80,6 @@ struct CaptureToolbar: ToolbarContent {
     }
     .controlSize(.large)
     .help("Network Inspector (⌘⌥I)")
-    Button {
-      openWindow(id: LogcatWindowID.main)
-    } label: {
-      Label("Logcat Viewer", systemImage: "list.bullet.rectangle")
-        .labelStyle(.iconOnly)
-    }
-    .controlSize(.large)
-    .help("Logcat Viewer (⌘⌥L)")
   }
 }
 

--- a/snapo-app-mac/Snap-O/CaptureWindow/CaptureWindow.swift
+++ b/snapo-app-mac/Snap-O/CaptureWindow/CaptureWindow.swift
@@ -63,9 +63,12 @@ struct CaptureWindow: View {
       Task { await handle(command, controller: controller) }
     }
     .focusedSceneValue(\.captureController, controller)
-    .navigationTitle(controller.navigationTitle)
     .background(
       WindowSizingController(displayInfo: controller.displayInfoForSizing)
+        .frame(width: 0, height: 0)
+    )
+    .background(
+      WindowTitleController(title: controller.navigationTitle)
         .frame(width: 0, height: 0)
     )
     .background(
@@ -80,15 +83,21 @@ struct CaptureWindow: View {
       if !controller.isRecording, let progress = controller.captureProgressText {
         let isCaptureInFlight = controller.isProcessing || controller.isRecording
 
-        ToolbarItem(placement: .status) {
+        if #available(macOS 26.0, *) {
+          ToolbarSpacer(.fixed, placement: .principal)
+        } else {
+          ToolbarItem(placement: .principal) {
+            Spacer()
+              .frame(width: 8)
+          }
+        }
+
+        ToolbarItemGroup(placement: .principal) {
           Text(progress)
             .font(.system(size: 12, weight: .semibold, design: .rounded))
-            .padding(.vertical, 4)
-            .padding(.horizontal, 6)
-            .background(
-              Capsule()
-                .fill(.ultraThinMaterial)
-            )
+            .padding(.horizontal, 10)
+            .padding(.vertical, 5)
+            .fixedSize()
             .opacity(isCaptureInFlight ? 0.45 : 1)
             .allowsHitTesting(!isCaptureInFlight)
             .onHover { hovering in

--- a/snapo-app-mac/Snap-O/CaptureWindow/WindowTitleController.swift
+++ b/snapo-app-mac/Snap-O/CaptureWindow/WindowTitleController.swift
@@ -1,0 +1,116 @@
+import AppKit
+import SwiftUI
+
+/// Keeps the capture window title centered against the full titlebar instead
+/// of AppKit's remaining title slot after toolbar items are laid out.
+struct WindowTitleController: NSViewRepresentable {
+  let title: String
+
+  func makeCoordinator() -> Coordinator {
+    Coordinator()
+  }
+
+  func makeNSView(context: Context) -> NSView {
+    let view = NSView()
+    DispatchQueue.main.async {
+      context.coordinator.configure(window: view.window, title: title)
+    }
+    return view
+  }
+
+  func updateNSView(_ nsView: NSView, context: Context) {
+    context.coordinator.configure(window: nsView.window, title: title)
+  }
+
+  @MainActor
+  final class Coordinator: NSObject {
+    private weak var window: NSWindow?
+    private let titleLabel = NSTextField(labelWithString: "")
+
+    override init() {
+      super.init()
+      titleLabel.translatesAutoresizingMaskIntoConstraints = false
+      titleLabel.font = .systemFont(ofSize: NSFont.systemFontSize, weight: .semibold)
+      titleLabel.lineBreakMode = .byTruncatingMiddle
+      titleLabel.maximumNumberOfLines = 1
+      titleLabel.alignment = .center
+      titleLabel.isSelectable = false
+    }
+
+    func configure(window: NSWindow?, title: String) {
+      guard let window else { return }
+
+      if self.window !== window {
+        attach(to: window)
+      }
+
+      window.title = title
+      titleLabel.stringValue = title
+      installTitleLabel(in: window)
+    }
+
+    private func attach(to window: NSWindow) {
+      if let currentWindow = self.window {
+        stopObservingTitlebarChanges(for: currentWindow)
+      }
+
+      self.window = window
+      window.titleVisibility = .hidden
+      observeTitlebarChanges(for: window)
+    }
+
+    private func installTitleLabel(in window: NSWindow) {
+      guard
+        let closeButton = window.standardWindowButton(.closeButton),
+        let titlebarView = closeButton.superview
+      else {
+        return
+      }
+
+      guard titleLabel.superview !== titlebarView else { return }
+      titleLabel.removeFromSuperview()
+      titlebarView.addSubview(titleLabel)
+
+      NSLayoutConstraint.activate([
+        titleLabel.centerXAnchor.constraint(equalTo: titlebarView.centerXAnchor),
+        titleLabel.centerYAnchor.constraint(equalTo: closeButton.centerYAnchor),
+        titleLabel.leadingAnchor.constraint(greaterThanOrEqualTo: titlebarView.leadingAnchor, constant: 76),
+        titleLabel.trailingAnchor.constraint(lessThanOrEqualTo: titlebarView.trailingAnchor, constant: -76)
+      ])
+    }
+
+    private func observeTitlebarChanges(for window: NSWindow) {
+      NotificationCenter.default.addObserver(
+        self,
+        selector: #selector(titlebarHierarchyDidChange(_:)),
+        name: NSWindow.didEnterFullScreenNotification,
+        object: window
+      )
+      NotificationCenter.default.addObserver(
+        self,
+        selector: #selector(titlebarHierarchyDidChange(_:)),
+        name: NSWindow.didExitFullScreenNotification,
+        object: window
+      )
+    }
+
+    private func stopObservingTitlebarChanges(for window: NSWindow) {
+      NotificationCenter.default.removeObserver(
+        self,
+        name: NSWindow.didEnterFullScreenNotification,
+        object: window
+      )
+      NotificationCenter.default.removeObserver(
+        self,
+        name: NSWindow.didExitFullScreenNotification,
+        object: window
+      )
+    }
+
+    @objc
+    private func titlebarHierarchyDidChange(_ notification: Notification) {
+      guard let window = notification.object as? NSWindow else { return }
+      installTitleLabel(in: window)
+    }
+  }
+}


### PR DESCRIPTION
<img width="944" height="333" alt="CleanShot 2026-06-17 at 13 20 00@2x" src="https://github.com/user-attachments/assets/358499a1-9404-493b-9c48-03b93c8773db" />

## Summary

- use the expanded macOS toolbar style so the title and controls occupy separate rows
- center the capture controls and place capture progress in a distinct adjacent group
- keep Network Inspector aligned on the right and remove the Logcat toolbar button
- center the window title against the full titlebar, including after fullscreen transitions
- shorten the initial native tooltip delay

## Why

The unified toolbar made the capture icons feel cramped and visually inconsistent. The title also shifted according to the surrounding toolbar content rather than staying centered in the window.

## Impact

The capture window now has a clearer title row and a balanced control row. Capture actions remain centered, the optional capture index is visually separate, and the Network Inspector action stays at the trailing edge.

## Validation

- `mise exec -- swiftformat . --lint --config .swiftformat --reporter github-actions-log`
- `mise exec -- swiftlint lint --strict --no-cache --reporter github-actions-logging`
- `xcodebuild -project Snap-O.xcodeproj -scheme Snap-O -derivedDataPath /private/tmp/Snap-O-UI-DerivedData -clonedSourcePackagesDirPath /private/tmp/Snap-O-Packages -packageCachePath /private/tmp/Snap-O-PackageCache CODE_SIGNING_ALLOWED=NO CODE_SIGNING_REQUIRED=NO build`
- `git diff --check`