### PR TITLE
docs: clarify Xcode archive step

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,7 +132,7 @@ If you need to notarize the app yourself:
 
 1. Copy `Config/Signing.xcconfig.sample` → `Config/Signing.xcconfig`.
 2. Edit the new file with your Apple Developer Team ID and signing certificate name.
-3. Archive (⌘B) or upload as usual. The file is ignored by Git, so your credentials remain private.
+3. Use Xcode's Product → Archive flow, then distribute or upload as usual. The file is ignored by Git, so your credentials remain private.
 
 ## Community
 


### PR DESCRIPTION
## Summary
- replace the misleading `Archive (⌘B)` wording with Xcode’s Product > Archive flow
- keep the notarization/signing guidance otherwise unchanged

## Validation
- `git diff --check`