### PR TITLE
[codex] Timeout stalled screenshot captures

### DIFF
--- a/snapo-app-mac/Snap-O/ADB/ADBExec.swift
+++ b/snapo-app-mac/Snap-O/ADB/ADBExec.swift
@@ -20,6 +20,7 @@ struct ADBExec {
   private let notifyServerAvailable: ServerObserver
 
   private static let serverLauncher = ADBServerLauncher()
+  private static let screenshotTimeout: TimeInterval = 10
 
   // MARK: - Public entry points
 
@@ -29,7 +30,17 @@ struct ADBExec {
   }
 
   func screencapPNG(deviceID: String) async throws -> Data {
-    try await runShellData(deviceID: deviceID, command: "screencap -p 2>/dev/null")
+    do {
+      return try await runShellData(
+        deviceID: deviceID,
+        command: "screencap -p 2>/dev/null",
+        ioTimeout: Self.screenshotTimeout
+      )
+    } catch ADBError.requestTimedOut {
+      throw ADBError.requestTimedOut(
+        "Screenshot capture timed out after \(Int(Self.screenshotTimeout)) seconds"
+      )
+    }
   }
 
   func startScreenrecord(
@@ -266,8 +277,12 @@ struct ADBExec {
 
   // MARK: - Private helpers
 
-  private func runShellData(deviceID: String, command: String) async throws -> Data {
-    try await withConnection { connection in
+  private func runShellData(
+    deviceID: String,
+    command: String,
+    ioTimeout: TimeInterval? = nil
+  ) async throws -> Data {
+    try await withConnection(ioTimeout: ioTimeout) { connection in
       try connection.sendTransport(to: deviceID)
       try connection.sendShell(command)
       return try connection.readToEnd()
@@ -284,9 +299,10 @@ struct ADBExec {
 
   private func withConnection<T: Sendable>(
     maxAttempts: Int = 3,
+    ioTimeout: TimeInterval? = nil,
     _ body: @escaping @Sendable (ADBSocketConnection) throws -> T
   ) async throws -> T {
-    try await runWithRetry(maxAttempts: maxAttempts) { connection in
+    try await runWithRetry(maxAttempts: maxAttempts, ioTimeout: ioTimeout) { connection in
       defer { connection.close() }
       return try body(connection)
     }
@@ -294,6 +310,7 @@ struct ADBExec {
 
   private func runWithRetry<T: Sendable>(
     maxAttempts: Int,
+    ioTimeout: TimeInterval? = nil,
     _ operation: @escaping @Sendable (ADBSocketConnection) async throws -> T
   ) async throws -> T {
     var lastError: Error?
@@ -303,7 +320,7 @@ struct ADBExec {
       try await ADBExec.serverLauncher.waitForOngoingRestart()
 
       do {
-        let connection = try ADBSocketConnection()
+        let connection = try ADBSocketConnection(ioTimeout: ioTimeout)
         do {
           let value = try await operation(connection)
           await notifyServerAvailable()

--- a/snapo-app-mac/Snap-O/ADB/ADBExec.swift
+++ b/snapo-app-mac/Snap-O/ADB/ADBExec.swift
@@ -20,7 +20,6 @@ struct ADBExec {
   private let notifyServerAvailable: ServerObserver
 
   private static let serverLauncher = ADBServerLauncher()
-  private static let screenshotTimeout: TimeInterval = 10
 
   // MARK: - Public entry points
 
@@ -30,17 +29,7 @@ struct ADBExec {
   }
 
   func screencapPNG(deviceID: String) async throws -> Data {
-    do {
-      return try await runShellData(
-        deviceID: deviceID,
-        command: "screencap -p 2>/dev/null",
-        ioTimeout: Self.screenshotTimeout
-      )
-    } catch ADBError.requestTimedOut {
-      throw ADBError.requestTimedOut(
-        "Screenshot capture timed out after \(Int(Self.screenshotTimeout)) seconds"
-      )
-    }
+    try await runShellData(deviceID: deviceID, command: "screencap -p 2>/dev/null")
   }
 
   func startScreenrecord(
@@ -277,12 +266,8 @@ struct ADBExec {
 
   // MARK: - Private helpers
 
-  private func runShellData(
-    deviceID: String,
-    command: String,
-    ioTimeout: TimeInterval? = nil
-  ) async throws -> Data {
-    try await withConnection(ioTimeout: ioTimeout) { connection in
+  private func runShellData(deviceID: String, command: String) async throws -> Data {
+    try await withConnection { connection in
       try connection.sendTransport(to: deviceID)
       try connection.sendShell(command)
       return try connection.readToEnd()
@@ -299,10 +284,9 @@ struct ADBExec {
 
   private func withConnection<T: Sendable>(
     maxAttempts: Int = 3,
-    ioTimeout: TimeInterval? = nil,
     _ body: @escaping @Sendable (ADBSocketConnection) throws -> T
   ) async throws -> T {
-    try await runWithRetry(maxAttempts: maxAttempts, ioTimeout: ioTimeout) { connection in
+    try await runWithRetry(maxAttempts: maxAttempts) { connection in
       defer { connection.close() }
       return try body(connection)
     }
@@ -310,7 +294,6 @@ struct ADBExec {
 
   private func runWithRetry<T: Sendable>(
     maxAttempts: Int,
-    ioTimeout: TimeInterval? = nil,
     _ operation: @escaping @Sendable (ADBSocketConnection) async throws -> T
   ) async throws -> T {
     var lastError: Error?
@@ -320,9 +303,13 @@ struct ADBExec {
       try await ADBExec.serverLauncher.waitForOngoingRestart()
 
       do {
-        let connection = try ADBSocketConnection(ioTimeout: ioTimeout)
+        let connection = try ADBSocketConnection()
         do {
-          let value = try await operation(connection)
+          let value = try await withTaskCancellationHandler {
+            try await operation(connection)
+          } onCancel: {
+            connection.close()
+          }
           await notifyServerAvailable()
           return value
         } catch {
@@ -330,6 +317,7 @@ struct ADBExec {
           throw error
         }
       } catch {
+        if Task.isCancelled { throw CancellationError() }
         let normalized = normalize(error)
         lastError = normalized
 

--- a/snapo-app-mac/Snap-O/ADB/ADBSocketConnection.swift
+++ b/snapo-app-mac/Snap-O/ADB/ADBSocketConnection.swift
@@ -37,8 +37,17 @@ final class ADBSocketConnection {
   private let socketDescriptor: Int32
   private var isClosed = false
 
-  init() throws {
-    socketDescriptor = try Self.openSocket()
+  init(ioTimeout: TimeInterval? = nil) throws {
+    let descriptor = try Self.openSocket()
+    do {
+      if let ioTimeout {
+        try Self.setIOTimeout(ioTimeout, on: descriptor)
+      }
+      socketDescriptor = descriptor
+    } catch {
+      Darwin.close(descriptor)
+      throw error
+    }
   }
 
   deinit {
@@ -317,6 +326,9 @@ final class ADBSocketConnection {
   }
 
   private static func makeSocketError(_ code: Int32, context: String) -> ADBError {
+    if code == EAGAIN || code == EWOULDBLOCK {
+      return ADBError.requestTimedOut("ADB request timed out while waiting to \(context)")
+    }
     let message = String(cString: strerror(code))
     return ADBError.serverUnavailable("\(context) failed: \(message)")
   }
@@ -353,6 +365,29 @@ private extension ADBSocketConnection {
     }
 
     return descriptor
+  }
+
+  static func setIOTimeout(_ timeout: TimeInterval, on descriptor: Int32) throws {
+    let seconds = floor(timeout)
+    var value = timeval(
+      tv_sec: Int(seconds),
+      tv_usec: Int32((timeout - seconds) * 1_000_000)
+    )
+
+    for option in [SO_RCVTIMEO, SO_SNDTIMEO] {
+      let result = withUnsafePointer(to: &value) {
+        setsockopt(
+          descriptor,
+          SOL_SOCKET,
+          option,
+          $0,
+          socklen_t(MemoryLayout<timeval>.size)
+        )
+      }
+      guard result == 0 else {
+        throw makeSocketError(errno, context: "configure socket timeout")
+      }
+    }
   }
 
   static func asciiData(_ value: String, label: String) throws -> Data {

--- a/snapo-app-mac/Snap-O/ADB/ADBSocketConnection.swift
+++ b/snapo-app-mac/Snap-O/ADB/ADBSocketConnection.swift
@@ -35,19 +35,11 @@ final class ADBSocketConnection {
   }
 
   private let socketDescriptor: Int32
+  private let closeLock = NSLock()
   private var isClosed = false
 
-  init(ioTimeout: TimeInterval? = nil) throws {
-    let descriptor = try Self.openSocket()
-    do {
-      if let ioTimeout {
-        try Self.setIOTimeout(ioTimeout, on: descriptor)
-      }
-      socketDescriptor = descriptor
-    } catch {
-      Darwin.close(descriptor)
-      throw error
-    }
+  init() throws {
+    socketDescriptor = try Self.openSocket()
   }
 
   deinit {
@@ -55,8 +47,12 @@ final class ADBSocketConnection {
   }
 
   func close() {
-    guard !isClosed else { return }
+    closeLock.lock()
+    let shouldClose = !isClosed
     isClosed = true
+    closeLock.unlock()
+
+    guard shouldClose else { return }
     shutdown(socketDescriptor, SHUT_RDWR)
     Darwin.close(socketDescriptor)
   }
@@ -326,9 +322,6 @@ final class ADBSocketConnection {
   }
 
   private static func makeSocketError(_ code: Int32, context: String) -> ADBError {
-    if code == EAGAIN || code == EWOULDBLOCK {
-      return ADBError.requestTimedOut("ADB request timed out while waiting to \(context)")
-    }
     let message = String(cString: strerror(code))
     return ADBError.serverUnavailable("\(context) failed: \(message)")
   }
@@ -365,29 +358,6 @@ private extension ADBSocketConnection {
     }
 
     return descriptor
-  }
-
-  static func setIOTimeout(_ timeout: TimeInterval, on descriptor: Int32) throws {
-    let seconds = floor(timeout)
-    var value = timeval(
-      tv_sec: Int(seconds),
-      tv_usec: Int32((timeout - seconds) * 1_000_000)
-    )
-
-    for option in [SO_RCVTIMEO, SO_SNDTIMEO] {
-      let result = withUnsafePointer(to: &value) {
-        setsockopt(
-          descriptor,
-          SOL_SOCKET,
-          option,
-          $0,
-          socklen_t(MemoryLayout<timeval>.size)
-        )
-      }
-      guard result == 0 else {
-        throw makeSocketError(errno, context: "configure socket timeout")
-      }
-    }
   }
 
   static func asciiData(_ value: String, label: String) throws -> Data {

--- a/snapo-app-mac/Snap-O/App/CaptureService.swift
+++ b/snapo-app-mac/Snap-O/App/CaptureService.swift
@@ -7,7 +7,7 @@ actor CaptureService {
   private let fileStore: FileStore
   private let deviceTracker: DeviceTracker
 
-  private var preloadedTask: Task<([CaptureMedia], Error?), Error>?
+  private var preloadedTask: Task<ScreenshotCaptureResult, Error>?
   private var didLogPreloadStart = false
   private var lastCaptureTimestamp: Date? // Keeps filenames unique when captures share a real timestamp.
   private var showTouchesOverrides: [String: Task<Bool?, Never>] = [:]
@@ -22,10 +22,32 @@ actor CaptureService {
     self.deviceTracker = deviceTracker
   }
 
-  func captureScreenshots() async -> ([CaptureMedia], Error?) {
-    await collectMedia(for: deviceTracker.latestDevices) { device in
-      try await self.captureScreenshot(for: device)
+  func captureScreenshots() async -> ScreenshotCaptureResult {
+    var media: [CaptureMedia] = []
+    var failures: [CaptureFailure] = []
+
+    await withTaskGroup(of: (Device, Result<CaptureMedia, Error>).self) { group in
+      for device in deviceTracker.latestDevices {
+        group.addTask {
+          do {
+            return (device, try await .success(self.captureScreenshot(for: device)))
+          } catch {
+            return (device, .failure(error))
+          }
+        }
+      }
+
+      for await (device, result) in group {
+        switch result {
+        case .success(let capture):
+          media.append(capture)
+        case .failure(let error):
+          failures.append(CaptureFailure(device: device, error: error))
+        }
+      }
     }
+
+    return ScreenshotCaptureResult(media: media, failures: failures)
   }
 
   private func captureScreenshot(for device: Device) async throws -> CaptureMedia {
@@ -191,8 +213,8 @@ actor CaptureService {
     guard let task = preloadedTask else { return [] }
     preloadedTask = nil
     do {
-      let (media, _) = try await task.value
-      let fresh = media.filter { Date().timeIntervalSince($0.media.capturedAt) <= 1 }
+      let result = try await task.value
+      let fresh = result.media.filter { Date().timeIntervalSince($0.media.capturedAt) <= 1 }
       if fresh.isEmpty { return [] }
       Perf.step(.appFirstSnapshot, "return media")
       return fresh

--- a/snapo-app-mac/Snap-O/App/CaptureService.swift
+++ b/snapo-app-mac/Snap-O/App/CaptureService.swift
@@ -3,6 +3,8 @@ import CoreGraphics
 import Foundation
 
 actor CaptureService {
+  private static let screenshotTimeoutSeconds = 10
+
   private let adb: ADBService
   private let fileStore: FileStore
   private let deviceTracker: DeviceTracker
@@ -30,7 +32,7 @@ actor CaptureService {
       for device in deviceTracker.latestDevices {
         group.addTask {
           do {
-            let capture = try await self.captureScreenshot(for: device)
+            let capture = try await self.captureScreenshotWithTimeout(for: device)
             return (device, .success(capture))
           } catch {
             return (device, .failure(error))
@@ -49,6 +51,26 @@ actor CaptureService {
     }
 
     return ScreenshotCaptureResult(media: media, failures: failures)
+  }
+
+  private func captureScreenshotWithTimeout(for device: Device) async throws -> CaptureMedia {
+    try await withThrowingTaskGroup(of: CaptureMedia.self) { group in
+      group.addTask {
+        try await self.captureScreenshot(for: device)
+      }
+      group.addTask {
+        try await Task.sleep(for: .seconds(Self.screenshotTimeoutSeconds))
+        throw ADBError.requestTimedOut(
+          "Screenshot capture timed out after \(Self.screenshotTimeoutSeconds) seconds"
+        )
+      }
+
+      defer { group.cancelAll() }
+      guard let capture = try await group.next() else {
+        throw CancellationError()
+      }
+      return capture
+    }
   }
 
   private func captureScreenshot(for device: Device) async throws -> CaptureMedia {

--- a/snapo-app-mac/Snap-O/App/CaptureService.swift
+++ b/snapo-app-mac/Snap-O/App/CaptureService.swift
@@ -30,7 +30,8 @@ actor CaptureService {
       for device in deviceTracker.latestDevices {
         group.addTask {
           do {
-            return (device, try await .success(self.captureScreenshot(for: device)))
+            let capture = try await self.captureScreenshot(for: device)
+            return (device, .success(capture))
           } catch {
             return (device, .failure(error))
           }

--- a/snapo-app-mac/Snap-O/CaptureWindow/CaptureMedia.swift
+++ b/snapo-app-mac/Snap-O/CaptureWindow/CaptureMedia.swift
@@ -12,6 +12,20 @@ struct CaptureMedia: Identifiable, Equatable {
   }
 }
 
+struct CaptureFailure {
+  let device: Device
+  let error: Error
+
+  var message: String {
+    "\(device.displayTitle): \(error.localizedDescription)"
+  }
+}
+
+struct ScreenshotCaptureResult {
+  let media: [CaptureMedia]
+  let failures: [CaptureFailure]
+}
+
 extension [CaptureMedia] {
   func media(forDeviceID id: String) -> CaptureMedia? {
     first { $0.device.id == id }

--- a/snapo-app-mac/Snap-O/CaptureWindow/CaptureWindow.swift
+++ b/snapo-app-mac/Snap-O/CaptureWindow/CaptureWindow.swift
@@ -55,6 +55,19 @@ struct CaptureWindow: View {
       } else {
         WaitingForDeviceView(isDeviceListInitialized: controller.isDeviceListInitialized)
       }
+
+      if controller.currentCapture != nil, !controller.screenshotFailures.isEmpty {
+        VStack {
+          ScreenshotFailureBanner(
+            failures: controller.screenshotFailures,
+            successfulCaptureCount: controller.mediaList.count,
+            onDismiss: controller.dismissScreenshotFailures
+          )
+          Spacer()
+        }
+        .padding(.horizontal, 12)
+        .padding(.top, 12)
+      }
     }
     .task { await controller.start() }
     .onDisappear { controller.tearDown() }
@@ -128,5 +141,62 @@ struct CaptureWindow: View {
       guard controller.canStartLivePreviewNow else { return }
       await controller.startLivePreview()
     }
+  }
+}
+
+private struct ScreenshotFailureBanner: View {
+  let failures: [CaptureFailure]
+  let successfulCaptureCount: Int
+  let onDismiss: () -> Void
+
+  private var title: String {
+    let total = successfulCaptureCount + failures.count
+    if total == 1 { return "Screenshot failed" }
+    return "\(failures.count) of \(total) screenshots failed"
+  }
+
+  var body: some View {
+    HStack(alignment: .top, spacing: 8) {
+      Image(systemName: "exclamationmark.triangle.fill")
+        .font(.system(size: 14))
+        .foregroundStyle(.orange)
+        .padding(.top, 1)
+
+      VStack(alignment: .leading, spacing: 3) {
+        Text(title)
+          .font(.subheadline.weight(.semibold))
+
+        ForEach(failures, id: \.device.id) { failure in
+          Text(failure.message)
+            .font(.caption)
+            .foregroundStyle(.secondary)
+            .fixedSize(horizontal: false, vertical: true)
+        }
+      }
+
+      Spacer(minLength: 0)
+
+      Button(action: onDismiss) {
+        Image(systemName: "xmark.circle.fill")
+          .font(.system(size: 14))
+          .symbolRenderingMode(.hierarchical)
+          .frame(width: 18, height: 18)
+          .contentShape(Rectangle())
+      }
+      .buttonStyle(.plain)
+      .foregroundStyle(.secondary)
+      .help("Dismiss")
+    }
+    .padding(12)
+    .frame(maxWidth: 460, alignment: .leading)
+    .background(
+      Color(nsColor: .controlBackgroundColor),
+      in: RoundedRectangle(cornerRadius: 8, style: .continuous)
+    )
+    .overlay {
+      RoundedRectangle(cornerRadius: 8, style: .continuous)
+        .stroke(Color(nsColor: .separatorColor), lineWidth: 1)
+    }
+    .shadow(color: .black.opacity(0.18), radius: 5, y: 2)
   }
 }

--- a/snapo-app-mac/Snap-O/CaptureWindow/CaptureWindowController.swift
+++ b/snapo-app-mac/Snap-O/CaptureWindow/CaptureWindowController.swift
@@ -17,6 +17,7 @@ final class CaptureWindowController {
   private(set) var isDeviceListInitialized: Bool = false
   private(set) var isProcessing: Bool = false
   private(set) var lastError: String?
+  private(set) var screenshotFailures: [CaptureFailure] = []
   private(set) var mode: CaptureWindowMode
 
   private var knownDevices: [Device] = []
@@ -74,6 +75,11 @@ final class CaptureWindowController {
 
   func hasAlternativeMedia() -> Bool {
     snapshotController.hasAlternativeMedia
+  }
+
+  func dismissScreenshotFailures() {
+    screenshotFailures = []
+    lastError = nil
   }
 
   var hasDevices: Bool {
@@ -170,6 +176,7 @@ final class CaptureWindowController {
     guard canCaptureNow else { return }
     isProcessing = true
     lastError = nil
+    screenshotFailures = []
     if pendingPreferredDeviceID == nil {
       pendingPreferredDeviceID = currentCapture?.device.id ?? lastViewedDeviceID
     }
@@ -181,9 +188,9 @@ final class CaptureWindowController {
 
     let screenshotMode = PreparingScreenshotMode(
       captureService: captureService
-    ) { [weak self] media, error in
+    ) { [weak self] result in
       guard let self else { return }
-      applyCaptureResults(newMedia: media, encounteredError: error)
+      applyScreenshotCaptureResult(result)
     }
     mode = .preparingScreenshot(screenshotMode)
     screenshotMode.start()
@@ -194,6 +201,7 @@ final class CaptureWindowController {
     let devices = knownDevices
     isProcessing = true
     lastError = nil
+    screenshotFailures = []
     pendingPreferredDeviceID = currentCapture?.device.id
     mediaDisplayMode.updateMediaList(
       [],
@@ -238,6 +246,7 @@ final class CaptureWindowController {
 
     isProcessing = true
     lastError = nil
+    screenshotFailures = []
 
     await recordingMode.finish(using: devices)
   }
@@ -246,6 +255,7 @@ final class CaptureWindowController {
     guard canStartLivePreviewNow else { return }
     isProcessing = true
     lastError = nil
+    screenshotFailures = []
     let preferredDeviceID = currentCapture?.device.id ?? lastViewedDeviceID ?? knownDevices.first?.id
     pendingPreferredDeviceID = preferredDeviceID
 
@@ -368,6 +378,17 @@ final class CaptureWindowController {
       shouldSort: false
     )
     mode = .displaying(mediaDisplayMode)
+  }
+
+  private func applyScreenshotCaptureResult(_ result: ScreenshotCaptureResult) {
+    screenshotFailures = result.failures.sorted {
+      $0.device.displayTitle.localizedCaseInsensitiveCompare($1.device.displayTitle) == .orderedAscending
+    }
+    let error = result.failures.first?.error
+    applyCaptureResults(newMedia: result.media, encounteredError: error)
+    if !result.failures.isEmpty {
+      lastError = result.failures.map(\.message).joined(separator: "\n")
+    }
   }
 
   private func applyCaptureResults(

--- a/snapo-app-mac/Snap-O/CaptureWindow/PreparingScreenshotMode.swift
+++ b/snapo-app-mac/Snap-O/CaptureWindow/PreparingScreenshotMode.swift
@@ -6,11 +6,11 @@ import Observation
 final class PreparingScreenshotMode {
   @ObservationIgnored private var task: Task<Void, Never>?
   private let captureService: CaptureService
-  private let completion: @MainActor ([CaptureMedia], Error?) -> Void
+  private let completion: @MainActor (ScreenshotCaptureResult) -> Void
 
   init(
     captureService: CaptureService,
-    completion: @escaping @MainActor ([CaptureMedia], Error?) -> Void
+    completion: @escaping @MainActor (ScreenshotCaptureResult) -> Void
   ) {
     self.captureService = captureService
     self.completion = completion
@@ -19,8 +19,8 @@ final class PreparingScreenshotMode {
   func start() {
     task = Task { [weak self] in
       guard let self else { return }
-      let (media, error) = await captureService.captureScreenshots()
-      completion(media, error)
+      let result = await captureService.captureScreenshots()
+      completion(result)
     }
   }
 

--- a/snapo-app-mac/Snap-O/Models/Models.swift
+++ b/snapo-app-mac/Snap-O/Models/Models.swift
@@ -22,6 +22,7 @@ public enum ADBError: Error, LocalizedError {
   case notRecording
   case serverUnavailable(String?)
   case protocolFailure(String)
+  case requestTimedOut(String)
 
   public var errorDescription: String? {
     switch self {
@@ -35,6 +36,8 @@ public enum ADBError: Error, LocalizedError {
       "Could not connect to the adb server: \(message ?? "<unknown>")"
     case .protocolFailure(let message):
       "ADB protocol error: \(message)"
+    case .requestTimedOut(let message):
+      message
     }
   }
 }


### PR DESCRIPTION

<img width="1120" height="439" alt="CleanShot 2026-06-18 at 15 57 11@2x" src="https://github.com/user-attachments/assets/bc660548-421d-42c9-bc50-b2e35276e99f" />


## Summary

- add a 10-second ADB socket timeout for screenshot capture requests
- preserve successful screenshots when another device fails or times out
- surface every per-device screenshot failure in a dismissible macOS notice

## Root cause

Screenshot requests run concurrently for all attached devices, but the task group waits for every request to finish. A stalled ADB socket read therefore prevented the entire capture operation from completing, even when another device had already returned a screenshot.

## Impact

Responsive devices now remain usable when another attached device stops responding. After the timeout, Snap-O displays the successful captures and identifies each failed device instead of hanging indefinitely.

## Validation

- `git diff --cached --check`
- `xcodebuild -project Snap-O.xcodeproj -scheme Snap-O -derivedDataPath /private/tmp/snap-o-derived CODE_SIGNING_ALLOWED=NO CODE_SIGNING_REQUIRED=NO build`
