### PR TITLE
[codex] Harden macOS lint tool installation

### DIFF
--- a/.github/workflows/mac.yml
+++ b/.github/workflows/mac.yml
@@ -18,6 +18,9 @@ on:
       - '.github/workflows/mac.yml'
       - 'VERSION'
 
+permissions:
+  contents: read
+
 jobs:
   build:
     runs-on: macos-26
@@ -81,6 +84,8 @@ jobs:
         run: ./scripts/ci-install-mise.sh
       - name: Install tools
         working-directory: snapo-app-mac
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           mise trust --quiet
           mise install

--- a/snapo-app-mac/mise.toml
+++ b/snapo-app-mac/mise.toml
@@ -1,3 +1,7 @@
+[plugins]
+# Pin the executable asdf installer independently from the SwiftFormat release.
+"asdf:swiftformat" = "https://github.com/mise-plugins/mise-swiftformat.git#f958ffabfe286d5f350e712cc55441cc9587483c"
+
 [tools]
 # SwiftFormat 0.61.x installs as an app bundle through mise's default macOS backend,
 # which does not expose a CLI binary for shims. Use the asdf backend for the CLI install.


### PR DESCRIPTION
## Summary

- authenticate mise's GitHub release lookups with the workflow's read-only `GITHUB_TOKEN`
- explicitly limit workflow permissions to `contents: read`
- pin the SwiftFormat asdf installer plugin to a full verified commit SHA

## Root cause

The macOS style job installed SwiftLint through mise's Aqua backend without authentication. Aqua queried GitHub's releases API using the runner's unauthenticated, IP-scoped quota and intermittently received HTTP 403 rate-limit failures even though SwiftLint itself was version-pinned.

## Impact

CI keeps the existing local mise workflow and pinned SwiftLint/SwiftFormat versions while avoiding the low unauthenticated GitHub API limit. The workflow token is ephemeral and read-only.

## Validation

- parsed `.github/workflows/mac.yml` successfully
- installed SwiftFormat from a fresh mise data directory using the exact CI mise version
- confirmed the installer plugin checked out `f958ffabfe286d5f350e712cc55441cc9587483c`
- SwiftFormat 0.61.1 lint
- SwiftLint 0.63.2 strict lint
- required macOS `xcodebuild` build