### PR TITLE
[codex] Replace Electron action with Run Snap-O

### DIFF
--- a/.codex/environments/environment.toml
+++ b/.codex/environments/environment.toml
@@ -9,7 +9,7 @@ script = ""
 name = "Electron"
 icon = "run"
 command = '''
-cd $CODEX_WORKTREE_PATH/snapo-desktop-electron
+cd snapo-desktop-electron
 npm install
 npm run dev
 '''

--- a/.codex/environments/environment.toml
+++ b/.codex/environments/environment.toml
@@ -6,15 +6,6 @@ name = "snap-o"
 script = ""
 
 [[actions]]
-name = "Electron"
-icon = "run"
-command = '''
-cd snapo-desktop-electron
-npm install
-npm run dev
-'''
-
-[[actions]]
 name = "Open Xcode"
 icon = "tool"
 command = "open snapo-app-mac/Snap-O.xcodeproj"

--- a/.codex/environments/environment.toml
+++ b/.codex/environments/environment.toml
@@ -6,6 +6,20 @@ name = "snap-o"
 script = ""
 
 [[actions]]
+name = "Run Snap-O"
+icon = "run"
+command = '''
+set -e
+cd snapo-app-mac
+xcodebuild -project Snap-O.xcodeproj \
+  -scheme Snap-O \
+  -configuration Debug \
+  -derivedDataPath DerivedData \
+  build
+open DerivedData/Build/Products/Debug/Snap-O.app
+'''
+
+[[actions]]
 name = "Open Xcode"
 icon = "tool"
 command = "open snapo-app-mac/Snap-O.xcodeproj"


### PR DESCRIPTION
## Summary

Replace the Electron environment action with a native `Run Snap-O` action while preserving the existing `Open Xcode` action.

The new action:

- builds the `Snap-O` Xcode scheme in Debug configuration
- writes build products to the ignored `snapo-app-mac/DerivedData` directory
- stops immediately if the build fails
- opens the resulting Debug `Snap-O.app`

## Why

The environment should launch the native macOS app instead of the obsolete Electron development workflow. This gives contributors a direct build-and-run action without requiring them to open Xcode first.

## Impact

The environment action menu now builds and launches the native Debug app. The separate `Open Xcode` action remains available.

## Validation

- Parsed `.codex/environments/environment.toml` with Python's `tomllib`
- Ran `git diff --check`
- Ran the exact Debug `xcodebuild` command used by the action
- Verified `DerivedData/Build/Products/Debug/Snap-O.app/Contents/MacOS/Snap-O` is executable