### PR TITLE
[codex] Move network inspector controls into the macOS toolbar

### DIFF
--- a/snapo-app-mac/Snap-O/App/SnapOCommands.swift
+++ b/snapo-app-mac/Snap-O/App/SnapOCommands.swift
@@ -101,10 +101,23 @@ struct SnapOCommands: Commands {
     if let captureController {
       CommandGroup(replacing: .pasteboard) {
         Button("Copy") {
-          captureController.copyCurrentImage()
+          let copiedFocusedContent = NSApp.sendAction(
+            #selector(NSText.copy(_:)),
+            to: nil,
+            from: nil
+          )
+          if !copiedFocusedContent {
+            captureController.copyCurrentImage()
+          }
         }
         .keyboardShortcut("c")
-        .disabled(captureController.currentCapture?.media.isImage != true)
+
+        Divider()
+
+        Button("Select All") {
+          NSApp.sendAction(#selector(NSResponder.selectAll(_:)), to: nil, from: nil)
+        }
+        .keyboardShortcut("a")
       }
       CommandGroup(replacing: .undoRedo) {}
     }

--- a/snapo-app-mac/Snap-O/CaptureWindow/CaptureToolbar.swift
+++ b/snapo-app-mac/Snap-O/CaptureWindow/CaptureToolbar.swift
@@ -4,6 +4,7 @@ import SwiftUI
 
 private enum CaptureToolbarStyle {
   static let iconFont = Font.system(size: 17, weight: .medium)
+  static let singleControlSize: CGFloat = 36
 }
 
 struct CaptureToolbar: View {
@@ -18,6 +19,7 @@ struct CaptureToolbar: View {
 
   @Environment(AppSettings.self)
   private var settings
+  @State private var isNetworkSearchPresented = false
 
   var body: some View {
     ZStack {
@@ -55,15 +57,24 @@ struct CaptureToolbar: View {
             captureToggle()
           }
           if let networkModel {
+            NetworkInspectorToolbarControls(
+              model: networkModel,
+              isSearchPresented: $isNetworkSearchPresented
+            )
             NetworkInspectorServerPicker(model: networkModel)
+              .padding(.leading, 4)
           }
           Spacer()
+          if let networkModel {
+            NetworkInspectorExportMenu(model: networkModel)
+          }
         }
         .frame(height: Self.height)
         .padding(.leading, presentedLayout.showsCapture ? capturePaneWidth + 12 : 12)
-        .padding(.trailing, 64)
+        .padding(.trailing, presentedLayout.showsCapture ? 64 : 12)
         .frame(maxWidth: .infinity)
         .offset(y: titlebarHeight / 2)
+        .animation(.easeOut(duration: 0.16), value: isNetworkSearchPresented)
       }
 
       if presentedLayout.showsCapture {
@@ -160,7 +171,7 @@ struct CaptureToolbar: View {
     }
     .help(workspace.showsCapture ? "Hide Capture" : "Show Capture")
     .controlSize(.extraLarge)
-    .snapOToolbarGroupStyle()
+    .snapOToolbarSingleControlStyle()
   }
 
   private func networkToggle() -> some View {
@@ -172,13 +183,16 @@ struct CaptureToolbar: View {
     }
     .help(workspace.showsNetwork ? "Hide Network Inspector (⌘⌥I)" : "Show Network Inspector (⌘⌥I)")
     .controlSize(.extraLarge)
-    .snapOToolbarGroupStyle()
+    .snapOToolbarSingleControlStyle()
   }
 
   private func toggleIcon(_ systemName: String) -> some View {
     Image(systemName: systemName)
       .font(CaptureToolbarStyle.iconFont)
-      .frame(width: 34, height: 32)
+      .frame(
+        width: CaptureToolbarStyle.singleControlSize,
+        height: CaptureToolbarStyle.singleControlSize
+      )
   }
 
   private func captureProgress(_ progress: String) -> some View {
@@ -203,6 +217,286 @@ struct CaptureToolbar: View {
         guard isCaptureInFlight else { return }
         controller.setProgressHovering(false)
       }
+  }
+}
+
+private struct NetworkInspectorExportMenu: View {
+  @Bindable var model: NetworkInspectorWebViewModel
+  @State private var menuPresenter = NetworkInspectorExportMenuPresenter()
+
+  var body: some View {
+    Button {
+      menuPresenter.present(model: model)
+    } label: {
+      Image(systemName: "square.and.arrow.up")
+        .font(CaptureToolbarStyle.iconFont)
+        .frame(
+          width: CaptureToolbarStyle.singleControlSize,
+          height: CaptureToolbarStyle.singleControlSize
+        )
+        .accessibilityLabel("Export")
+        .background {
+          NetworkInspectorExportMenuAnchor(presenter: menuPresenter)
+            .allowsHitTesting(false)
+        }
+    }
+    .help("Export requests")
+    .disabled(!model.isPageReady || (model.selectedRecordKind == nil && !model.hasVisibleRecords))
+    .controlSize(.extraLarge)
+    .snapOToolbarSingleControlStyle()
+  }
+}
+
+private struct NetworkInspectorExportMenuAnchor: NSViewRepresentable {
+  let presenter: NetworkInspectorExportMenuPresenter
+
+  func makeNSView(context: Context) -> NSView {
+    let view = NSView()
+    presenter.anchorView = view
+    return view
+  }
+
+  func updateNSView(_ nsView: NSView, context: Context) {
+    presenter.anchorView = nsView
+  }
+}
+
+@MainActor
+private final class NetworkInspectorExportMenuPresenter: NSObject {
+  weak var anchorView: NSView?
+  private var model: NetworkInspectorWebViewModel?
+
+  func present(model: NetworkInspectorWebViewModel) {
+    guard let anchorView, anchorView.window != nil else { return }
+    self.model = model
+
+    let menu = NSMenu()
+    menu.autoenablesItems = false
+    menu.addItem(
+      menuItem(
+        title: "Export HAR (sanitized)…",
+        systemImage: "doc.badge.arrow.up",
+        action: #selector(exportHar),
+        isEnabled: model.hasVisibleRecords
+      )
+    )
+    menu.addItem(.separator())
+    menu.addItem(
+      menuItem(
+        title: "Copy URL",
+        systemImage: "link",
+        action: #selector(copyURL),
+        isEnabled: model.selectedRecordKind != nil
+      )
+    )
+    menu.addItem(
+      menuItem(
+        title: "Copy as CURL",
+        systemImage: "terminal",
+        action: #selector(copyCurl),
+        isEnabled: model.selectedRecordKind == "request"
+      )
+    )
+
+    menu.popUp(positioning: nil, at: NSPoint(x: 0, y: 0), in: anchorView)
+    self.model = nil
+  }
+
+  private func menuItem(
+    title: String,
+    systemImage: String,
+    action: Selector,
+    isEnabled: Bool
+  ) -> NSMenuItem {
+    let item = NSMenuItem(title: title, action: action, keyEquivalent: "")
+    item.target = self
+    item.image = NSImage(systemSymbolName: systemImage, accessibilityDescription: nil)
+    item.isEnabled = isEnabled
+    return item
+  }
+
+  @objc
+  private func exportHar() {
+    model?.exportVisibleRecordsAsHar()
+  }
+
+  @objc
+  private func copyURL() {
+    model?.copySelectedURL()
+  }
+
+  @objc
+  private func copyCurl() {
+    model?.copySelectedCurl()
+  }
+}
+
+private struct NetworkInspectorToolbarControls: View {
+  @Bindable var model: NetworkInspectorWebViewModel
+  @Binding var isSearchPresented: Bool
+
+  private var sortHelp: String {
+    model.sortNewestFirst
+      ? "Sorted newest first. Show oldest first"
+      : "Sorted oldest first. Show newest first"
+  }
+
+  var body: some View {
+    HStack(spacing: 8) {
+      HStack(spacing: 0) {
+        Button {
+          model.clearCompletedRecords()
+        } label: {
+          Label("Clear Completed Requests", systemImage: "trash")
+            .labelStyle(.iconOnly)
+            .font(.system(size: 15, weight: .medium))
+            .frame(width: 34, height: 32)
+        }
+        .help("Clear completed requests")
+        .disabled(!model.hasClearableItems)
+
+        Button {
+          model.setSortNewestFirst(!model.sortNewestFirst)
+        } label: {
+          Label(
+            model.sortNewestFirst ? "Newest First" : "Oldest First",
+            systemImage: model.sortNewestFirst ? "arrow.down" : "arrow.up"
+          )
+          .labelStyle(.iconOnly)
+          .font(.system(size: 15, weight: .medium))
+          .frame(width: 34, height: 32)
+        }
+        .help(sortHelp)
+
+        if !isSearchPresented {
+          Button {
+            isSearchPresented = true
+          } label: {
+            Label("Filter Requests", systemImage: "magnifyingglass")
+              .labelStyle(.iconOnly)
+              .font(.system(size: 15, weight: .medium))
+              .frame(width: 34, height: 32)
+          }
+          .help("Filter requests (⌘F)")
+          .keyboardShortcut("f", modifiers: .command)
+          .transition(.opacity)
+        }
+      }
+      .snapOToolbarGroupStyle()
+
+      if isSearchPresented {
+        NetworkInspectorSearchField(
+          text: Binding(
+            get: { model.searchText },
+            set: { model.setSearchText($0) }
+          )
+        ) {
+          isSearchPresented = false
+        }
+        .transition(
+          .modifier(
+            active: NetworkInspectorSearchTransition(progress: 0),
+            identity: NetworkInspectorSearchTransition(progress: 1)
+          )
+        )
+      }
+    }
+    .disabled(!model.isPageReady)
+    .onAppear {
+      if !model.searchText.isEmpty {
+        isSearchPresented = true
+      }
+    }
+    .onChange(of: model.searchText) {
+      if !model.searchText.isEmpty {
+        isSearchPresented = true
+      }
+    }
+  }
+}
+
+private struct NetworkInspectorSearchTransition: ViewModifier {
+  let progress: CGFloat
+
+  func body(content: Content) -> some View {
+    content
+      .frame(width: 220 * progress, height: 28, alignment: .leading)
+      .clipped()
+      .opacity(progress)
+  }
+}
+
+private struct NetworkInspectorSearchField: NSViewRepresentable {
+  @Binding var text: String
+  let dismiss: () -> Void
+
+  func makeCoordinator() -> Coordinator {
+    Coordinator(text: $text, dismiss: dismiss)
+  }
+
+  func makeNSView(context: Context) -> FocusedSearchField {
+    let searchField = FocusedSearchField(string: text)
+    searchField.placeholderString = "Filter requests"
+    searchField.sendsSearchStringImmediately = true
+    searchField.sendsWholeSearchString = true
+    searchField.delegate = context.coordinator
+    searchField.bezelStyle = .roundedBezel
+    searchField.controlSize = .large
+    return searchField
+  }
+
+  func updateNSView(_ nsView: FocusedSearchField, context: Context) {
+    context.coordinator.text = $text
+    context.coordinator.dismiss = dismiss
+    if nsView.stringValue != text {
+      nsView.stringValue = text
+    }
+  }
+
+  final class Coordinator: NSObject, NSSearchFieldDelegate {
+    var text: Binding<String>
+    var dismiss: () -> Void
+
+    init(text: Binding<String>, dismiss: @escaping () -> Void) {
+      self.text = text
+      self.dismiss = dismiss
+    }
+
+    func controlTextDidChange(_ notification: Notification) {
+      guard let field = notification.object as? NSSearchField else { return }
+      text.wrappedValue = field.stringValue
+    }
+
+    func control(
+      _ control: NSControl,
+      textView: NSTextView,
+      doCommandBy commandSelector: Selector
+    ) -> Bool {
+      guard commandSelector == #selector(NSResponder.cancelOperation(_:)),
+            let field = control as? NSSearchField
+      else {
+        return false
+      }
+
+      if field.stringValue.isEmpty {
+        dismiss()
+      } else {
+        field.stringValue = ""
+        text.wrappedValue = ""
+      }
+      return true
+    }
+  }
+}
+
+private final class FocusedSearchField: NSSearchField {
+  override func viewDidMoveToWindow() {
+    super.viewDidMoveToWindow()
+    guard window != nil else { return }
+    DispatchQueue.main.async { [weak self] in
+      guard let self else { return }
+      window?.makeFirstResponder(self)
+    }
   }
 }
 
@@ -502,6 +796,18 @@ private extension View {
       buttonStyle(.glass)
     } else {
       buttonStyle(.borderless)
+    }
+  }
+
+  @ViewBuilder
+  func snapOToolbarSingleControlStyle() -> some View {
+    if #available(macOS 26.0, *) {
+      buttonStyle(.borderless)
+        .glassEffect(in: Circle())
+    } else {
+      buttonStyle(.borderless)
+        .background(Color(nsColor: .windowBackgroundColor), in: Circle())
+        .shadow(color: .black.opacity(0.18), radius: 3, y: 1)
     }
   }
 

--- a/snapo-app-mac/Snap-O/NetworkInspector/NetworkInspectorModels.swift
+++ b/snapo-app-mac/Snap-O/NetworkInspector/NetworkInspectorModels.swift
@@ -129,6 +129,11 @@ struct NetworkInspectorServer: Codable {
 struct NetworkInspectorNativeState: Codable {
   let servers: [NetworkInspectorServer]
   let selectedServer: NetworkServerReference?
+  let searchText: String
+  let sortNewestFirst: Bool
+  let hasClearableItems: Bool
+  let selectedRecordKind: String?
+  let hasVisibleRecords: Bool
 }
 
 struct NetworkLoadBodiesInput: Codable {
@@ -169,6 +174,11 @@ struct NetworkSaveFileInput: Codable {
   let data: String
   let mimeType: String?
   let encoding: String?
+  let directoryKind: NetworkSaveDirectoryKind?
+}
+
+enum NetworkSaveDirectoryKind: String, Codable {
+  case har
 }
 
 struct NetworkSaveFileResult: Codable {

--- a/snapo-app-mac/Snap-O/NetworkInspector/NetworkInspectorWebView.swift
+++ b/snapo-app-mac/Snap-O/NetworkInspector/NetworkInspectorWebView.swift
@@ -37,13 +37,18 @@ final class NetworkInspectorWebViewModel: NSObject, WKNavigationDelegate {
   let webView: WKWebView
   private(set) var servers: [NetworkInspectorServer] = []
   private(set) var selectedServer: NetworkInspectorServer?
+  private(set) var searchText = ""
+  private(set) var sortNewestFirst = false
+  private(set) var hasClearableItems = false
+  private(set) var selectedRecordKind: String?
+  private(set) var hasVisibleRecords = false
 
   @ObservationIgnored private let embeddedHTML: String?
   @ObservationIgnored private let developmentURL: URL?
   @ObservationIgnored private let bridge: NetworkInspectorWebBridge
   @ObservationIgnored private var outputTask: Task<Void, Never>?
   @ObservationIgnored private var recoveryTask: Task<Void, Never>?
-  private var isPageReady = false
+  private(set) var isPageReady = false
 
   init(service: NetworkInspectorService) {
     let configuration = WKWebViewConfiguration()
@@ -70,6 +75,11 @@ final class NetworkInspectorWebViewModel: NSObject, WKNavigationDelegate {
           $0.deviceId == selection.deviceId && $0.socketName == selection.socketName
         }
       }
+      self?.searchText = state.searchText
+      self?.sortNewestFirst = state.sortNewestFirst
+      self?.hasClearableItems = state.hasClearableItems
+      self?.selectedRecordKind = state.selectedRecordKind
+      self?.hasVisibleRecords = state.hasVisibleRecords
     }
     webView.navigationDelegate = self
     loadInspector()
@@ -143,6 +153,33 @@ final class NetworkInspectorWebViewModel: NSObject, WKNavigationDelegate {
       eventName: "network:selected-server",
       payload: NetworkServerReference(deviceId: server.deviceId, socketName: server.socketName)
     )
+  }
+
+  func setSearchText(_ searchText: String) {
+    self.searchText = searchText
+    dispatch(eventName: "network:search-text", payload: searchText)
+  }
+
+  func setSortNewestFirst(_ sortNewestFirst: Bool) {
+    self.sortNewestFirst = sortNewestFirst
+    dispatch(eventName: "network:sort-newest-first", payload: sortNewestFirst)
+  }
+
+  func clearCompletedRecords() {
+    hasClearableItems = false
+    dispatch(eventName: "network:clear-completed", payload: true)
+  }
+
+  func copySelectedURL() {
+    dispatch(eventName: "network:copy-selected-url", payload: true)
+  }
+
+  func copySelectedCurl() {
+    dispatch(eventName: "network:copy-selected-curl", payload: true)
+  }
+
+  func exportVisibleRecordsAsHar() {
+    dispatch(eventName: "network:export-visible-har", payload: true)
   }
 
   private func loadInspector() {
@@ -307,6 +344,12 @@ final class NetworkInspectorWebBridge: NSObject, WKScriptMessageHandlerWithReply
       let input = try Self.decode(StreamIdentifier.self, from: payload)
       await service.stopStream(input.streamId)
       return nil
+    case "copyText":
+      let input = try Self.decode(ClipboardText.self, from: payload)
+      let pasteboard = NSPasteboard.general
+      pasteboard.clearContents()
+      pasteboard.setString(input.text, forType: .string)
+      return nil
     case "openExternal":
       let input = try Self.decode(ExternalURL.self, from: payload)
       guard let url = URL(string: input.url),
@@ -347,17 +390,24 @@ final class NetworkInspectorWebBridge: NSObject, WKScriptMessageHandlerWithReply
     }
 
     let panel = NSSavePanel()
+    panel.canCreateDirectories = true
     panel.nameFieldStringValue = input.defaultPath
+    if input.directoryKind == .har {
+      panel.directoryURL = SaveLocation.defaultHARExportDirectory()
+    }
     guard panel.runModal() == .OK, let url = panel.url else {
       return NetworkSaveFileResult(saved: false, path: nil)
     }
     try data.write(to: url, options: .atomic)
+    if input.directoryKind == .har {
+      SaveLocation.setLastHARExportDirectoryURL(url.deletingLastPathComponent())
+    }
     return NetworkSaveFileResult(saved: true, path: url.path)
   }
 
   static func jsonObject(_ value: some Encodable) throws -> Any {
     let data = try JSONEncoder().encode(value)
-    return try JSONSerialization.jsonObject(with: data)
+    return try JSONSerialization.jsonObject(with: data, options: .fragmentsAllowed)
   }
 
   private static func decode<T: Decodable>(_ type: T.Type, from payload: Any?) throws -> T {
@@ -374,5 +424,9 @@ final class NetworkInspectorWebBridge: NSObject, WKScriptMessageHandlerWithReply
 
   private struct ExternalURL: Decodable {
     let url: String
+  }
+
+  private struct ClipboardText: Decodable {
+    let text: String
   }
 }

--- a/snapo-app-mac/Snap-O/Storage/SaveLocation.swift
+++ b/snapo-app-mac/Snap-O/Storage/SaveLocation.swift
@@ -1,6 +1,8 @@
 import Foundation
 
 enum SaveLocation {
+  private static let lastHARExportDirectoryKey = "lastHARExportDirectory"
+
   static func defaultDirectory(for kind: MediaSaveKind) -> URL {
     if let existing = UserDefaults.standard.url(forKey: lastDirectoryKey(for: kind)) {
       return existing
@@ -19,10 +21,29 @@ enum SaveLocation {
     UserDefaults.standard.set(url, forKey: lastDirectoryKey(for: kind))
   }
 
+  static func defaultHARExportDirectory() -> URL {
+    if let existing = UserDefaults.standard.url(forKey: lastHARExportDirectoryKey),
+       isDirectory(existing) {
+      return existing
+    }
+    return FileManager.default.urls(for: .downloadsDirectory, in: .userDomainMask).first
+      ?? FileManager.default.homeDirectoryForCurrentUser
+  }
+
+  static func setLastHARExportDirectoryURL(_ url: URL) {
+    UserDefaults.standard.set(url, forKey: lastHARExportDirectoryKey)
+  }
+
   private static func lastDirectoryKey(for kind: MediaSaveKind) -> String {
     switch kind {
     case .image: "lastImageSaveDir"
     case .video: "lastVideoSaveDir"
     }
+  }
+
+  private static func isDirectory(_ url: URL) -> Bool {
+    var isDirectory: ObjCBool = false
+    return FileManager.default.fileExists(atPath: url.path, isDirectory: &isDirectory)
+      && isDirectory.boolValue
   }
 }

--- a/snapo-network-inspector-web/src/features/network-inspector/NetworkInspectorApp.tsx
+++ b/snapo-network-inspector-web/src/features/network-inspector/NetworkInspectorApp.tsx
@@ -34,6 +34,7 @@ export function NetworkInspectorApp(): JSX.Element {
         selectedRecordId={model.selectedRecordId}
         client={model.client}
         showsServerPicker={!model.client.usesNativeServerPicker}
+        showsInlineToolbar={!model.client.usesNativeServerPicker}
         onServerChange={model.selectServer}
         onReplacementServerClick={model.selectReplacementServer}
         onSearchTextChange={model.setSearchText}

--- a/snapo-network-inspector-web/src/features/network-inspector/components/RecordList.tsx
+++ b/snapo-network-inspector-web/src/features/network-inspector/components/RecordList.tsx
@@ -115,9 +115,7 @@ function sidebarContextMenuItems(
   client: NetworkClient
 ): ContextMenuItem[] {
   const exportRecords = contextMenuExportSelection(clicked, selectedRecordId, allRecords);
-  const items: ContextMenuItem[] = [
-    { label: "Copy URL", action: () => void navigator.clipboard.writeText(clicked.url) }
-  ];
+  const items: ContextMenuItem[] = [{ label: "Copy URL", action: () => void client.copyText(clicked.url) }];
   if (clicked.kind === "request") {
     items.push({ label: "Copy as cURL", action: () => void copyCurl(client, clicked) });
   }

--- a/snapo-network-inspector-web/src/features/network-inspector/components/Sidebar.tsx
+++ b/snapo-network-inspector-web/src/features/network-inspector/components/Sidebar.tsx
@@ -20,6 +20,7 @@ export const Sidebar = memo(function Sidebar({
   selectedRecordId,
   client,
   showsServerPicker,
+  showsInlineToolbar,
   onServerChange,
   onReplacementServerClick,
   onSearchTextChange,
@@ -39,6 +40,7 @@ export const Sidebar = memo(function Sidebar({
   selectedRecordId: string | null;
   client: NetworkClient;
   showsServerPicker: boolean;
+  showsInlineToolbar: boolean;
   onServerChange(server: ServerId | null): void;
   onReplacementServerClick(server: SnapOServer): void;
   onSearchTextChange(value: string): void;
@@ -76,38 +78,40 @@ export const Sidebar = memo(function Sidebar({
 
       {serverHasProtocolWarning(selectedServer) ? <ProtocolWarning server={selectedServer} /> : null}
 
-      <div className="filter-frame">
-        <div className="search-row">
-          <input
-            value={searchText}
-            onChange={(event) => onSearchTextChange(event.target.value)}
-            placeholder="Filter by keyword"
-            aria-label="Filter by keyword"
-          />
-        </div>
+      {showsInlineToolbar ? (
+        <div className="filter-frame">
+          <div className="search-row">
+            <input
+              value={searchText}
+              onChange={(event) => onSearchTextChange(event.target.value)}
+              placeholder="Filter by keyword"
+              aria-label="Filter by keyword"
+            />
+          </div>
 
-        <div className="toolbar-action-group">
-          <button
-            className="toolbar-icon-button"
-            type="button"
-            title={`Sorted ${sortLabel}`}
-            aria-label={`Sorted ${sortLabel}. Toggle sort order`}
-            onClick={onToggleSortOrder}
-          >
-            <SortIcon size={16} />
-          </button>
-          <button
-            className="toolbar-icon-button"
-            type="button"
-            title="Clear completed"
-            aria-label="Clear completed"
-            disabled={!hasClearableItems}
-            onClick={onClearCompleted}
-          >
-            <Trash2 size={16} />
-          </button>
+          <div className="toolbar-action-group">
+            <button
+              className="toolbar-icon-button"
+              type="button"
+              title={`Sorted ${sortLabel}`}
+              aria-label={`Sorted ${sortLabel}. Toggle sort order`}
+              onClick={onToggleSortOrder}
+            >
+              <SortIcon size={16} />
+            </button>
+            <button
+              className="toolbar-icon-button"
+              type="button"
+              title="Clear completed"
+              aria-label="Clear completed"
+              disabled={!hasClearableItems}
+              onClick={onClearCompleted}
+            >
+              <Trash2 size={16} />
+            </button>
+          </div>
         </div>
-      </div>
+      ) : null}
 
       <RecordList
         records={records}

--- a/snapo-network-inspector-web/src/features/network-inspector/hooks/useNetworkInspectorModel.ts
+++ b/snapo-network-inspector-web/src/features/network-inspector/hooks/useNetworkInspectorModel.ts
@@ -13,6 +13,7 @@ import {
 import type { DebugInspectorPreset, SnapOServer } from "../../../network/bridge-types";
 import { useInspectorUiState } from "./useInspectorUiState";
 import { applyDebugInspectorPreset } from "../lib/debug";
+import { copyCurl, exportAsHar } from "../lib/exportActions";
 import {
   clearCompleted,
   countRecordsForServer,
@@ -66,6 +67,8 @@ export function useNetworkInspectorModel(): NetworkInspectorModel {
   const [sortNewestFirst, setSortNewestFirst] = useState(false);
   const [debugPreset, setDebugPreset] = useState<DebugInspectorPreset>("live");
   const uiState = useInspectorUiState();
+  const toggleSortOrder = useCallback(() => setSortNewestFirst((value) => !value), []);
+  const clearCompletedRecords = useCallback(() => setState(clearCompleted), []);
 
   const selectedServer = useMemo(
     () => pickSelectedServer(preferredServer, state.servers),
@@ -91,6 +94,9 @@ export function useNetworkInspectorModel(): NetworkInspectorModel {
   );
 
   useEffect(() => client.onNativeSelectedServer(selectServer), [client, selectServer]);
+  useEffect(() => client.onNativeSearchText(setSearchText), [client]);
+  useEffect(() => client.onNativeSortOrder(setSortNewestFirst), [client]);
+  useEffect(() => client.onNativeClearCompleted(clearCompletedRecords), [clearCompletedRecords, client]);
 
   useEffect(() => {
     const unsubscribeEvent = client.onEvent((event) => {
@@ -145,15 +151,6 @@ export function useNetworkInspectorModel(): NetworkInspectorModel {
     [displayServers, selectedServer]
   );
 
-  useEffect(() => {
-    client.nativeInspectorStateChanged({
-      servers: displayServers,
-      selectedServer:
-        selectedServerModel == null
-          ? null
-          : { deviceId: selectedServerModel.deviceId, socketName: selectedServerModel.socketName }
-    });
-  }, [client, displayServers, selectedServerModel]);
   const selectedServerIsConnected = selectedServerModel?.isConnected === true;
   const selectedServerConnectionKey =
     selectedServerModel == null
@@ -291,14 +288,60 @@ export function useNetworkInspectorModel(): NetworkInspectorModel {
     [allRecords.length, selectedServerModel, serverRecordCount, visibleRecords.length]
   );
   const hasClearableItems = useMemo(() => allRecords.some(isCompletedRecord), [allRecords]);
+  const selectedRecordKind = selectedRecord?.kind ?? null;
+  const hasVisibleRecords = visibleRecords.length > 0;
+
+  useEffect(
+    () =>
+      client.onNativeCopySelectedUrl(() => {
+        if (selectedRecord != null) void client.copyText(selectedRecord.url);
+      }),
+    [client, selectedRecord]
+  );
+  useEffect(
+    () =>
+      client.onNativeCopySelectedCurl(() => {
+        if (selectedRecord?.kind === "request") void copyCurl(client, selectedRecord);
+      }),
+    [client, selectedRecord]
+  );
+  useEffect(
+    () =>
+      client.onNativeExportVisibleHar(() => {
+        void exportAsHar(client, visibleRecords);
+      }),
+    [client, visibleRecords]
+  );
+
+  useEffect(() => {
+    client.nativeInspectorStateChanged({
+      servers: displayServers,
+      selectedServer:
+        selectedServerModel == null
+          ? null
+          : { deviceId: selectedServerModel.deviceId, socketName: selectedServerModel.socketName },
+      searchText,
+      sortNewestFirst,
+      hasClearableItems,
+      selectedRecordKind,
+      hasVisibleRecords
+    });
+  }, [
+    client,
+    displayServers,
+    hasClearableItems,
+    hasVisibleRecords,
+    searchText,
+    selectedRecordKind,
+    selectedServerModel,
+    sortNewestFirst
+  ]);
 
   const selectReplacementServer = useCallback(
     (server: SnapOServer) => selectServer({ deviceId: server.deviceId, socketName: server.socketName }),
     [selectServer]
   );
   const selectRecord = useCallback((id: string) => setPreferredRecordId(id), []);
-  const toggleSortOrder = useCallback(() => setSortNewestFirst((value) => !value), []);
-  const clearCompletedRecords = useCallback(() => setState(clearCompleted), []);
   const openDocs = useCallback(() => void client.openExternal(docsUrl), [client]);
 
   return {

--- a/snapo-network-inspector-web/src/features/network-inspector/lib/exportActions.ts
+++ b/snapo-network-inspector-web/src/features/network-inspector/lib/exportActions.ts
@@ -18,7 +18,7 @@ export async function copyCurl(client: NetworkClient, request: RequestRecord): P
       hydrated = request;
     }
   }
-  await navigator.clipboard.writeText(makeCurlCommand(hydrated));
+  await client.copyText(makeCurlCommand(hydrated));
 }
 
 export async function exportAsHar(client: NetworkClient, records: InspectorRecord[]): Promise<void> {
@@ -42,6 +42,7 @@ export async function exportAsHar(client: NetworkClient, records: InspectorRecor
   await client.saveFile({
     defaultPath: harFileName(hydrated.length),
     data: buildHar(hydrated, appVersion),
-    mimeType: "application/har+json"
+    mimeType: "application/har+json",
+    directoryKind: "har"
   });
 }

--- a/snapo-network-inspector-web/src/network/bridge-types.ts
+++ b/snapo-network-inspector-web/src/network/bridge-types.ts
@@ -18,6 +18,11 @@ export interface SnapOServer {
 export interface NativeInspectorState {
   servers: SnapOServer[];
   selectedServer: StartStreamInput | null;
+  searchText: string;
+  sortNewestFirst: boolean;
+  hasClearableItems: boolean;
+  selectedRecordKind: "request" | "websocket" | null;
+  hasVisibleRecords: boolean;
 }
 
 export interface CdpMessage {
@@ -77,6 +82,7 @@ export interface SaveFileInput {
   data: string;
   mimeType?: string | null;
   encoding?: "utf8" | "base64";
+  directoryKind?: "har";
 }
 
 export interface SaveFileResult {

--- a/snapo-network-inspector-web/src/network/client.ts
+++ b/snapo-network-inspector-web/src/network/client.ts
@@ -21,6 +21,7 @@ export interface NetworkClient {
   stopStream(streamId: string): Promise<void>;
   onEvent(callback: (event: StreamEvent) => void): () => void;
   onStatus(callback: (status: StreamStatus) => void): () => void;
+  copyText(text: string): Promise<void>;
   openExternal(url: string): Promise<void>;
   saveFile(input: SaveFileInput): Promise<SaveFileResult>;
   debugInspectorPreset(): Promise<DebugInspectorPreset>;
@@ -29,6 +30,12 @@ export interface NetworkClient {
   onPreferredDevice(callback: (deviceId: string) => void): () => void;
   nativeInspectorStateChanged(state: NativeInspectorState): void;
   onNativeSelectedServer(callback: (server: StartStreamInput) => void): () => void;
+  onNativeSearchText(callback: (searchText: string) => void): () => void;
+  onNativeSortOrder(callback: (sortNewestFirst: boolean) => void): () => void;
+  onNativeClearCompleted(callback: () => void): () => void;
+  onNativeCopySelectedUrl(callback: () => void): () => void;
+  onNativeCopySelectedCurl(callback: () => void): () => void;
+  onNativeExportVisibleHar(callback: () => void): () => void;
 }
 
 export function createNetworkClient(): NetworkClient {
@@ -78,6 +85,10 @@ class WebKitNetworkClient implements NetworkClient {
     return listenWebKitEvent<StreamStatus>("network:status", callback);
   }
 
+  copyText(text: string): Promise<void> {
+    return this.invoke<void>("copyText", { text });
+  }
+
   openExternal(url: string): Promise<void> {
     return this.invoke<void>("openExternal", { url });
   }
@@ -108,6 +119,30 @@ class WebKitNetworkClient implements NetworkClient {
 
   onNativeSelectedServer(callback: (server: StartStreamInput) => void): () => void {
     return listenWebKitEvent<StartStreamInput>("network:selected-server", callback);
+  }
+
+  onNativeSearchText(callback: (searchText: string) => void): () => void {
+    return listenWebKitEvent<string>("network:search-text", callback);
+  }
+
+  onNativeSortOrder(callback: (sortNewestFirst: boolean) => void): () => void {
+    return listenWebKitEvent<boolean>("network:sort-newest-first", callback);
+  }
+
+  onNativeClearCompleted(callback: () => void): () => void {
+    return listenWebKitEvent<boolean>("network:clear-completed", callback);
+  }
+
+  onNativeCopySelectedUrl(callback: () => void): () => void {
+    return listenWebKitEvent<boolean>("network:copy-selected-url", callback);
+  }
+
+  onNativeCopySelectedCurl(callback: () => void): () => void {
+    return listenWebKitEvent<boolean>("network:copy-selected-curl", callback);
+  }
+
+  onNativeExportVisibleHar(callback: () => void): () => void {
+    return listenWebKitEvent<boolean>("network:export-visible-har", callback);
   }
 
   private async invoke<T>(command: string, payload?: unknown): Promise<T> {
@@ -172,6 +207,10 @@ class HttpNetworkClient implements NetworkClient {
     return () => this.statusCallbacks.delete(callback);
   }
 
+  copyText(text: string): Promise<void> {
+    return navigator.clipboard.writeText(text);
+  }
+
   async openExternal(url: string): Promise<void> {
     window.open(url, "_blank", "noopener,noreferrer");
   }
@@ -224,6 +263,36 @@ class HttpNetworkClient implements NetworkClient {
   }
 
   onNativeSelectedServer(callback: (server: StartStreamInput) => void): () => void {
+    void callback;
+    return () => {};
+  }
+
+  onNativeSearchText(callback: (searchText: string) => void): () => void {
+    void callback;
+    return () => {};
+  }
+
+  onNativeSortOrder(callback: (sortNewestFirst: boolean) => void): () => void {
+    void callback;
+    return () => {};
+  }
+
+  onNativeClearCompleted(callback: () => void): () => void {
+    void callback;
+    return () => {};
+  }
+
+  onNativeCopySelectedUrl(callback: () => void): () => void {
+    void callback;
+    return () => {};
+  }
+
+  onNativeCopySelectedCurl(callback: () => void): () => void {
+    void callback;
+    return () => {};
+  }
+
+  onNativeExportVisibleHar(callback: () => void): () => void {
     void callback;
     return () => {};
   }


### PR DESCRIPTION
## Summary

- move Clear, Sort, and expandable Search controls into the native macOS network inspector toolbar while preserving the web toolbar in headless mode
- add a native Export menu for sanitized HAR export, Copy URL, and Copy as CURL
- match native toolbar sizing, circular single-action controls, spacing, and coordinated search/app-selector animation
- make Edit commands focus-aware so Select All and Copy work with selected text before falling back to screenshot copying
- remember a HAR-specific export directory, defaulting to Downloads

## Why

The network-only macOS view left the native toolbar visually sparse while the primary request controls remained separated inside the web UI. Moving those actions into the toolbar makes the inspector feel native without changing headless web behavior.

## Fixes

- allow top-level JSON fragments in the WebKit bridge so string and Boolean toolbar commands reach React
- route Copy through the macOS responder chain before copying the current screenshot
- present Export from a correctly sized native button and anchored AppKit menu
- keep HAR export-directory persistence separate from image and video save locations

## Validation

- `mise exec -- swiftformat --lint ...`
- `swiftlint lint --strict ...`
- `npm test`
- `npm run lint`
- `npm run format:check`
- `xcodebuild -project Snap-O.xcodeproj -scheme Snap-O -derivedDataPath /tmp/snapo-toolbar-derived-data CODE_SIGNING_ALLOWED=NO CODE_SIGNING_REQUIRED=NO build -quiet`
- live verified Clear, Select All, focus-aware Copy, menu placement, and toolbar sizing/animation