### PR TITLE
[codex] Enforce minimum workspace width

### DIFF
--- a/snapo-app-mac/Snap-O/CaptureWindow/WindowSizingController.swift
+++ b/snapo-app-mac/Snap-O/CaptureWindow/WindowSizingController.swift
@@ -187,11 +187,14 @@ struct WindowSizingController: NSViewRepresentable {
     }
 
     func windowWillResize(_ sender: NSWindow, to frameSize: NSSize) -> NSSize {
-      guard currentLayout == .capture else { return frameSize }
+      let width = max(frameSize.width, sender.minSize.width)
+      guard currentLayout == .capture else {
+        return NSSize(width: width, height: frameSize.height)
+      }
       let aspect = max(currentAspect, 0.0001)
       return NSSize(
-        width: frameSize.width,
-        height: (WindowChromeMetrics.totalToolbarHeight + (frameSize.width / aspect)).rounded()
+        width: width,
+        height: (WindowChromeMetrics.totalToolbarHeight + (width / aspect)).rounded()
       )
     }
 
@@ -506,7 +509,7 @@ struct WindowSizingController: NSViewRepresentable {
     private func constrained(_ frame: NSRect, for window: NSWindow) -> NSRect {
       guard let screen = window.screen ?? NSScreen.main else { return frame }
       let visibleFrame = screen.visibleFrame
-      let width = min(frame.width, visibleFrame.width)
+      let width = min(max(frame.width, window.minSize.width), visibleFrame.width)
       let height = min(frame.height, visibleFrame.height)
       let x = min(max(frame.minX, visibleFrame.minX), visibleFrame.maxX - width)
       let y = min(max(frame.minY, visibleFrame.minY), visibleFrame.maxY - height)


### PR DESCRIPTION
## Summary

- enforce the configured `NSWindow.minSize` during live resizing
- clamp restored workspace frames to the same minimum width
- preserve capture-only aspect-ratio sizing

## Why

The window sizing delegate returned resize proposals unchanged when the network inspector was visible, and restored frames were only constrained to the screen bounds. Those paths could bypass the configured minimum size and compress the capture and network inspector UI into an unusable layout.

## Impact

Windows that show the network inspector can no longer be resized or restored below the layout's configured minimum width. Capture-only behavior remains unchanged.

## Validation

- `xcodebuild -project Snap-O.xcodeproj -scheme Snap-O -configuration Debug -derivedDataPath /tmp/snap-o-derived CODE_SIGNING_ALLOWED=NO CODE_SIGNING_REQUIRED=NO build`
- `swiftlint lint --strict --no-cache`
- SwiftFormat 0.61.1 lint