### PR TITLE
[codex] Fix capture window title layout and updates

### DIFF
--- a/snapo-app-mac/Snap-O/ADB/DeviceTracker.swift
+++ b/snapo-app-mac/Snap-O/ADB/DeviceTracker.swift
@@ -113,7 +113,7 @@ final class DeviceTracker: @unchecked Sendable {
       .split(separator: "\n", omittingEmptySubsequences: true)
       .compactMap(parseDeviceRow)
 
-    let activeDeviceIDs = Set(parsed.map { $0.id })
+    let activeDeviceIDs = Set(parsed.map(\.id))
     await infoCache.retain(deviceIDs: activeDeviceIDs)
 
     return await withTaskGroup(of: Device?.self) { group in
@@ -220,7 +220,7 @@ final class DeviceTracker: @unchecked Sendable {
   }
 
   private actor DeviceInfoCache {
-    // ADB can reuse an emulator serial, but each connection gets a new transport ID.
+    /// ADB can reuse an emulator serial, but each connection gets a new transport ID.
     private struct Entry {
       let transportID: String?
       let info: DeviceInfo

--- a/snapo-app-mac/Snap-O/ADB/DeviceTracker.swift
+++ b/snapo-app-mac/Snap-O/ADB/DeviceTracker.swift
@@ -105,10 +105,18 @@ final class DeviceTracker: @unchecked Sendable {
       .split(separator: "\n", omittingEmptySubsequences: true)
       .compactMap(parseDeviceRow)
 
+    let activeDeviceIDs = Set(parsed.map { $0.id })
+    await infoCache.retain(deviceIDs: activeDeviceIDs)
+
     return await withTaskGroup(of: Device?.self) { group in
       for (id, fields) in parsed {
         group.addTask {
-          let info = await self.deviceInfo(for: id, fallbackModel: fields["model"], exec: exec)
+          let info = await self.deviceInfo(
+            for: id,
+            transportID: fields["transport_id"],
+            fallbackModel: fields["model"],
+            exec: exec
+          )
           return Device(
             id: id,
             model: info.model,
@@ -159,8 +167,13 @@ final class DeviceTracker: @unchecked Sendable {
     return (id, fields)
   }
 
-  private func deviceInfo(for id: String, fallbackModel: String?, exec: ADBExec) async -> DeviceInfo {
-    if let cached = await infoCache.value(for: id) {
+  private func deviceInfo(
+    for id: String,
+    transportID: String?,
+    fallbackModel: String?,
+    exec: ADBExec
+  ) async -> DeviceInfo {
+    if let cached = await infoCache.value(for: id, transportID: transportID) {
       return cached
     }
 
@@ -184,7 +197,7 @@ final class DeviceTracker: @unchecked Sendable {
       manufacturer: manufacturer,
       avdName: avdName
     )
-    await infoCache.set(info, for: id)
+    await infoCache.set(info, for: id, transportID: transportID)
     return info
   }
 
@@ -199,14 +212,27 @@ final class DeviceTracker: @unchecked Sendable {
   }
 
   private actor DeviceInfoCache {
-    private var storage: [String: DeviceInfo] = [:]
-
-    func value(for deviceID: String) -> DeviceInfo? {
-      storage[deviceID]
+    // ADB can reuse an emulator serial, but each connection gets a new transport ID.
+    private struct Entry {
+      let transportID: String?
+      let info: DeviceInfo
     }
 
-    func set(_ info: DeviceInfo, for deviceID: String) {
-      storage[deviceID] = info
+    private var storage: [String: Entry] = [:]
+
+    func value(for deviceID: String, transportID: String?) -> DeviceInfo? {
+      guard let entry = storage[deviceID], entry.transportID == transportID else {
+        return nil
+      }
+      return entry.info
+    }
+
+    func set(_ info: DeviceInfo, for deviceID: String, transportID: String?) {
+      storage[deviceID] = Entry(transportID: transportID, info: info)
+    }
+
+    func retain(deviceIDs: Set<String>) {
+      storage = storage.filter { deviceIDs.contains($0.key) }
     }
   }
 

--- a/snapo-app-mac/Snap-O/ADB/DeviceTracker.swift
+++ b/snapo-app-mac/Snap-O/ADB/DeviceTracker.swift
@@ -75,7 +75,8 @@ final class DeviceTracker: @unchecked Sendable {
     while !Task.isCancelled {
       let exec = await adbService.exec()
       guard let (handle, stream) = try? await exec.trackDevices() else {
-        if hasSeenFirstMessage { broadcast([]) }
+        if Task.isCancelled { break }
+        await handleTrackingInterruption()
         await pause()
         continue
       }
@@ -88,14 +89,21 @@ final class DeviceTracker: @unchecked Sendable {
           let devices = await parseDevices(from: payload, exec: exec)
           broadcast(devices)
         }
+        if Task.isCancelled { break }
+        await handleTrackingInterruption()
         await pause()
       } catch is CancellationError {
         break
       } catch {
-        if hasSeenFirstMessage { broadcast([]) }
+        await handleTrackingInterruption()
         await pause()
       }
     }
+  }
+
+  private func handleTrackingInterruption() async {
+    await infoCache.removeAll()
+    if hasSeenFirstMessage { broadcast([]) }
   }
 
   // MARK: - Device parsing
@@ -233,6 +241,10 @@ final class DeviceTracker: @unchecked Sendable {
 
     func retain(deviceIDs: Set<String>) {
       storage = storage.filter { deviceIDs.contains($0.key) }
+    }
+
+    func removeAll() {
+      storage.removeAll()
     }
   }
 

--- a/snapo-app-mac/Snap-O/CaptureWindow/WindowTitleController.swift
+++ b/snapo-app-mac/Snap-O/CaptureWindow/WindowTitleController.swift
@@ -124,6 +124,8 @@ struct WindowChromeController: NSViewRepresentable {
 }
 
 private final class WindowTitleOverlayView: NSView {
+  private static let horizontalPadding: CGFloat = 8
+
   var title = "" {
     didSet {
       needsDisplay = true
@@ -154,23 +156,45 @@ private final class WindowTitleOverlayView: NSView {
 
     let contentLeft = overlayX(forContentX: contentView.bounds.minX, contentView: contentView)
     let contentRight = overlayX(forContentX: contentView.bounds.maxX, contentView: contentView)
-    let centerX = networkLeadingX.map {
-      (overlayX(forContentX: $0, contentView: contentView) + contentRight) / 2
-    } ?? ((contentLeft + contentRight) / 2)
+    let leadingX: CGFloat
+    let centerX: CGFloat
+    if let networkLeadingX {
+      let networkLeft = overlayX(forContentX: networkLeadingX, contentView: contentView)
+      leadingX = networkLeft + Self.horizontalPadding
+      centerX = (networkLeft + contentRight) / 2
+    } else {
+      leadingX = max(contentLeft, windowControlsTrailingX) + Self.horizontalPadding
+      centerX = (contentLeft + contentRight) / 2
+    }
+
+    let trailingX = contentRight - Self.horizontalPadding
+    let availableWidth = trailingX - leadingX
+    guard availableWidth > 0 else { return }
+
+    let paragraphStyle = NSMutableParagraphStyle()
+    paragraphStyle.alignment = .center
+    paragraphStyle.lineBreakMode = .byTruncatingTail
 
     let attributedTitle = NSAttributedString(
       string: title,
       attributes: [
         .font: NSFont.systemFont(ofSize: NSFont.systemFontSize, weight: .semibold),
-        .foregroundColor: NSColor.labelColor
+        .foregroundColor: NSColor.labelColor,
+        .paragraphStyle: paragraphStyle
       ]
     )
     let titleSize = attributedTitle.size()
+    let titleWidth = min(titleSize.width, availableWidth)
+    let centeredX = centerX - (titleWidth / 2)
+    let titleX = min(max(centeredX, leadingX), trailingX - titleWidth)
     attributedTitle.draw(
-      at: NSPoint(
-        x: centerX - (titleSize.width / 2),
-        y: (WindowChromeMetrics.titlebarHeight - titleSize.height) / 2
-      )
+      with: NSRect(
+        x: titleX,
+        y: (WindowChromeMetrics.titlebarHeight - titleSize.height) / 2,
+        width: titleWidth,
+        height: titleSize.height
+      ),
+      options: [.usesLineFragmentOrigin, .truncatesLastVisibleLine]
     )
   }
 
@@ -181,6 +205,19 @@ private final class WindowTitleOverlayView: NSView {
   private func overlayX(forContentX contentX: CGFloat, contentView: NSView) -> CGFloat {
     let pointInWindow = contentView.convert(NSPoint(x: contentX, y: 0), to: nil)
     return convert(pointInWindow, from: nil).x
+  }
+
+  private var windowControlsTrailingX: CGFloat {
+    guard let zoomButton = window?.standardWindowButton(.zoomButton),
+          let buttonContainer = zoomButton.superview
+    else {
+      return bounds.minX
+    }
+
+    return convert(
+      NSPoint(x: zoomButton.frame.maxX, y: zoomButton.frame.midY),
+      from: buttonContainer
+    ).x
   }
 }
 


### PR DESCRIPTION
## Summary

- Keep capture-window titles centered when possible while clamping them clear of the macOS traffic-light controls.
- Let long titles use the remaining space to the right and truncate only when the full safe width is exhausted.
- Refresh cached device metadata when an ADB transport changes and evict metadata for disconnected devices.

## Why

The custom title renderer drew the full title around the window center without accounting for the window controls. Separately, device metadata was cached only by ADB serial, but emulator serials are commonly reused, allowing a new emulator to inherit the previous emulator's display name.

## Impact

Long device names no longer overlap the window controls, and recordings from a newly connected device or emulator show the current device name in the title.

## Validation

- `swiftlint lint --no-cache Snap-O/CaptureWindow/WindowTitleController.swift Snap-O/ADB/DeviceTracker.swift`
- `xcodebuild -project Snap-O.xcodeproj -scheme Snap-O CODE_SIGNING_ALLOWED=NO CODE_SIGNING_REQUIRED=NO build`