### PR TITLE
[codex] Fix native network inspector header spacing

### DIFF
--- a/snapo-network-inspector-web/src/features/network-inspector/components/Sidebar.tsx
+++ b/snapo-network-inspector-web/src/features/network-inspector/components/Sidebar.tsx
@@ -52,7 +52,7 @@ export const Sidebar = memo(function Sidebar({
   const sortLabel = sortNewestFirst ? "newest first" : "oldest first";
 
   return (
-    <aside className="sidebar">
+    <aside className={showsInlineToolbar ? "sidebar" : "sidebar sidebar-without-inline-toolbar"}>
       {showsServerPicker || replacementServer != null ? (
         <div className="server-picker-frame">
           {showsServerPicker ? (

--- a/snapo-network-inspector-web/src/styles.css
+++ b/snapo-network-inspector-web/src/styles.css
@@ -465,6 +465,11 @@ body.split-pane-resizing {
   min-height: 0;
 }
 
+.sidebar-without-inline-toolbar > .server-picker-frame + .record-list-frame,
+.sidebar-without-inline-toolbar > .protocol-warning + .record-list-frame {
+  margin-top: 8px;
+}
+
 .record-list {
   height: 100%;
   overflow: auto;


### PR DESCRIPTION
## Summary

- restore an 8px gap between native-mode sidebar header content and the request list
- apply the spacing only when a server banner or protocol warning directly precedes the list
- preserve the existing web inspector layout and avoid adding space when requests start at the top

## Root cause

Moving the Network Inspector controls into the macOS toolbar removed the inline web filter row in native mode. That row previously supplied the top padding before the request list, so remaining header content such as the **New process available** banner and protocol warnings became flush with the list.

## Impact

Native macOS users see the intended separation below transient banners and warnings without changes to inspector behavior or web-mode spacing.

## Validation

- `npm test`
- `npm run lint`
- `npm run format:check`
- `npm run build:frontend`
- `xcodebuild -project Snap-O.xcodeproj -scheme Snap-O -configuration Debug build CODE_SIGNING_ALLOWED=NO`