### PR TITLE
[codex] Pause hidden looping video playback

### DIFF
--- a/snapo-app-mac/Snap-O/UI/VideoLoopingView.swift
+++ b/snapo-app-mac/Snap-O/UI/VideoLoopingView.swift
@@ -6,30 +6,64 @@ struct VideoLoopingView: View {
 
   @State private var player: AVQueuePlayer?
   @State private var looper: AVPlayerLooper?
+  @State private var isViewVisible = false
+  @State private var isWindowVisible = false
+  @State private var shouldResumeWhenVisible = true
 
   var body: some View {
     Group {
       if let player {
         VideoPlayer(player: player)
-          .onAppear { player.play() }
-          .onDisappear { player.pause() }
       } else {
         // very brief fallback while preparing
         Color.black
       }
     }
-    .task {
-      await setupPlayer()
+    .background {
+      WindowVisibilityReader { isVisible in
+        updateWindowVisibility(isVisible)
+      }
+      .frame(width: 0, height: 0)
+    }
+    .onAppear {
+      isViewVisible = true
+      if player == nil {
+        setupPlayer()
+      }
+      updatePlayback()
+    }
+    .onDisappear {
+      isViewVisible = false
+      player?.pause()
     }
   }
 
-  private func setupPlayer() async {
-    // Build looping playback
+  private func setupPlayer() {
     let item = AVPlayerItem(url: url)
     let queue = AVQueuePlayer()
     let looper = AVPlayerLooper(player: queue, templateItem: item)
     player = queue
     self.looper = looper
-    queue.play()
+  }
+
+  private func updateWindowVisibility(_ isVisible: Bool) {
+    guard isVisible != isWindowVisible else { return }
+
+    if !isVisible, let player {
+      shouldResumeWhenVisible = player.timeControlStatus != .paused
+    }
+
+    isWindowVisible = isVisible
+    updatePlayback()
+  }
+
+  private func updatePlayback() {
+    guard let player else { return }
+
+    if isViewVisible, isWindowVisible, shouldResumeWhenVisible {
+      player.play()
+    } else {
+      player.pause()
+    }
   }
 }

--- a/snapo-app-mac/Snap-O/UI/WindowVisibilityReader.swift
+++ b/snapo-app-mac/Snap-O/UI/WindowVisibilityReader.swift
@@ -1,0 +1,59 @@
+import AppKit
+import Combine
+import SwiftUI
+
+struct WindowVisibilityReader: View {
+  let visibilityDidChange: (Bool) -> Void
+
+  @State private var windowID: ObjectIdentifier?
+
+  var body: some View {
+    WindowReader { window in
+      windowID = window.map(ObjectIdentifier.init)
+      visibilityDidChange(window.map(isVisible) ?? false)
+    }
+    .onReceive(NotificationCenter.default.publisher(for: NSWindow.didChangeOcclusionStateNotification)) {
+      guard let window = $0.object as? NSWindow,
+            ObjectIdentifier(window) == windowID else { return }
+      visibilityDidChange(isVisible(window))
+    }
+  }
+
+  private func isVisible(_ window: NSWindow) -> Bool {
+    window.isVisible
+      && !window.isMiniaturized
+      && window.occlusionState.contains(.visible)
+  }
+}
+
+private struct WindowReader: NSViewRepresentable {
+  let windowDidChange: (NSWindow?) -> Void
+
+  func makeNSView(context: Context) -> WindowReaderView {
+    WindowReaderView(windowDidChange: windowDidChange)
+  }
+
+  func updateNSView(_ nsView: WindowReaderView, context: Context) {
+    nsView.windowDidChange = windowDidChange
+  }
+}
+
+@MainActor
+private final class WindowReaderView: NSView {
+  var windowDidChange: (NSWindow?) -> Void
+
+  init(windowDidChange: @escaping (NSWindow?) -> Void) {
+    self.windowDidChange = windowDidChange
+    super.init(frame: .zero)
+  }
+
+  @available(*, unavailable)
+  required init?(coder: NSCoder) {
+    fatalError("init(coder:) has not been implemented")
+  }
+
+  override func viewDidMoveToWindow() {
+    super.viewDidMoveToWindow()
+    windowDidChange(window)
+  }
+}


### PR DESCRIPTION
## Summary

- pause looping video playback when the Snap-O window is fully occluded, hidden, or minimized
- resume only when playback was active before the window became hidden
- keep playback running when the window remains visible, even if Snap-O is not focused
- extract AppKit window visibility tracking into a reusable `WindowVisibilityReader`

## Why

`VideoLoopingView` previously paused only when SwiftUI removed the view. A live player could therefore continue decoding a looping recording while its window was completely hidden, consuming energy without producing visible output.

## Validation

- `xcodebuild -project Snap-O.xcodeproj -scheme Snap-O -configuration Debug -destination 'platform=macOS' CODE_SIGNING_ALLOWED=NO build`
- `git diff --cached --check`