### PR TITLE
[codex] Refine workspace pane controls

### DIFF
--- a/snapo-app-mac/Snap-O/App/AppDelegate.swift
+++ b/snapo-app-mac/Snap-O/App/AppDelegate.swift
@@ -4,6 +4,7 @@ import Foundation
 @MainActor
 class AppDelegate: NSObject, NSApplicationDelegate {
   func applicationWillFinishLaunching(_ notification: Notification) {
+    NSWindow.allowsAutomaticWindowTabbing = false
     UserDefaults.standard.register(defaults: [
       "NSInitialToolTipDelay": 500
     ])

--- a/snapo-app-mac/Snap-O/App/SnapOCommands.swift
+++ b/snapo-app-mac/Snap-O/App/SnapOCommands.swift
@@ -145,10 +145,13 @@ struct SnapOCommands: Commands {
         workspaceController?.toggleNetwork()
       }
       .keyboardShortcut("i", modifiers: [.command, .option])
+      .disabled(workspaceController?.canToggleNetwork != true)
 
       Button(workspaceController?.showsCapture == true ? "Hide Capture" : "Show Capture") {
         workspaceController?.toggleCapture()
       }
+      .keyboardShortcut("c", modifiers: [.command, .option])
+      .disabled(workspaceController?.canToggleCapture != true)
 
       Button("Logcat Viewer") {
         openWindow(id: LogcatWindowID.main)

--- a/snapo-app-mac/Snap-O/CaptureWindow/CaptureToolbar.swift
+++ b/snapo-app-mac/Snap-O/CaptureWindow/CaptureToolbar.swift
@@ -271,6 +271,7 @@ struct CaptureToolbar: View {
     .help(workspace.showsCapture ? "Hide Capture" : "Show Capture")
     .controlSize(.extraLarge)
     .snapOToolbarSingleControlStyle()
+    .disabled(!workspace.canToggleCapture)
   }
 
   private func networkToggle() -> some View {
@@ -283,6 +284,7 @@ struct CaptureToolbar: View {
     .help(workspace.showsNetwork ? "Hide Network Inspector (⌘⌥I)" : "Show Network Inspector (⌘⌥I)")
     .controlSize(.extraLarge)
     .snapOToolbarSingleControlStyle()
+    .disabled(!workspace.canToggleNetwork)
   }
 
   private func toggleIcon(_ systemName: String) -> some View {

--- a/snapo-app-mac/Snap-O/CaptureWindow/WindowTitleController.swift
+++ b/snapo-app-mac/Snap-O/CaptureWindow/WindowTitleController.swift
@@ -78,6 +78,7 @@ struct WindowChromeController: NSViewRepresentable {
 
     private func applyChrome(to window: NSWindow) {
       window.title = title
+      window.tabbingMode = .disallowed
       window.isMovableByWindowBackground = false
       window.collectionBehavior.insert(.fullScreenPrimary)
     }

--- a/snapo-app-mac/Snap-O/CaptureWindow/WorkspaceLayoutController.swift
+++ b/snapo-app-mac/Snap-O/CaptureWindow/WorkspaceLayoutController.swift
@@ -71,6 +71,14 @@ final class WorkspaceLayoutController {
     return showsNetwork ? .network : .capture
   }
 
+  var canToggleCapture: Bool {
+    !showsCapture || showsNetwork
+  }
+
+  var canToggleNetwork: Bool {
+    !showsNetwork || showsCapture
+  }
+
   init(snapshot: WorkspaceLayoutSnapshot? = nil) {
     let snapshot = snapshot ?? .persisted()
     showsCapture = snapshot.showsCapture || !snapshot.showsNetwork
@@ -107,14 +115,14 @@ final class WorkspaceLayoutController {
   }
 
   func setCaptureVisible(_ visible: Bool) {
+    guard visible || showsNetwork else { return }
     showsCapture = visible
-    if !showsCapture, !showsNetwork { showsNetwork = true }
     persistVisibility()
   }
 
   func setNetworkVisible(_ visible: Bool) {
+    guard visible || showsCapture else { return }
     showsNetwork = visible
-    if !showsCapture, !showsNetwork { showsCapture = true }
     persistVisibility()
   }
 


### PR DESCRIPTION
## Summary

- add `Cmd-Opt-C` for toggling the Capture pane
- prevent Capture or Network Inspector from being hidden when it is the only visible pane
- disable unavailable toolbar and Tools menu actions, including their keyboard shortcuts
- disable native macOS window tabbing for Snap-O workspace windows

## Why

Snap-O workspace windows resize according to whether Capture, Network Inspector, or both panes are visible. Native window tabs share an outer frame, which makes those layout-specific resize transitions ambiguous and inconsistent. Separate windows already provide independent workspaces, so this change explicitly opts out of tabbing.

The pane controller also previously preserved the at-least-one-pane invariant by hiding the requested pane and revealing the other one. That made a Hide action behave like a pane switch. The controller now rejects hiding the last visible pane, and the UI communicates that state by disabling the action.

## Impact

Users can toggle Capture with `Cmd-Opt-C` and Network Inspector with `Cmd-Opt-I`. Either pane can still be shown or hidden while both are available, but the only visible pane cannot be hidden. Workspace windows remain independent rather than being grouped into native tabs.

## Validation

- `xcodebuild -project Snap-O.xcodeproj -scheme Snap-O CODE_SIGNING_ALLOWED=NO CODE_SIGNING_REQUIRED=NO build`
- SwiftLint on all changed Swift files with zero violations
- staged diff whitespace check