### PR TITLE
[codex] Align Android no-op network APIs

### DIFF
--- a/snapo-link-android/network-httpurlconnection-noop/src/main/java/com/openai/snapo/network/httpurlconnection/SnapOHttpUrlInterceptor.kt
+++ b/snapo-link-android/network-httpurlconnection-noop/src/main/java/com/openai/snapo/network/httpurlconnection/SnapOHttpUrlInterceptor.kt
@@ -9,7 +9,7 @@ import java.net.HttpURLConnection
 import java.net.URL
 
 // No-op implementation for release builds
-class SnapOHttpUrlInterceptor(
+class SnapOHttpUrlInterceptor @JvmOverloads constructor(
     private val responseBodyPreviewBytes: Int = 0,
     private val textBodyMaxBytes: Int = 0,
     private val binaryBodyMaxBytes: Int = 0,

--- a/snapo-link-android/network-okhttp3-noop/src/main/java/com/openai/snapo/network/okhttp3/SnapOInterceptorWebSocketFactory.kt
+++ b/snapo-link-android/network-okhttp3-noop/src/main/java/com/openai/snapo/network/okhttp3/SnapOInterceptorWebSocketFactory.kt
@@ -13,7 +13,7 @@ fun WebSocket.Factory.withSnapOInterceptor(
     dispatcher: CoroutineDispatcher = Dispatchers.Unconfined,
 ): WebSocket.Factory = this
 
-class SnapOInterceptorWebSocketFactory(
+class SnapOInterceptorWebSocketFactory @JvmOverloads constructor(
     private val delegate: WebSocket.Factory,
     textPreviewChars: Int = 0,
     binaryPreviewBytes: Int = 0,

--- a/snapo-link-android/network-okhttp3-noop/src/main/java/com/openai/snapo/network/okhttp3/SnapOOkHttpInterceptor.kt
+++ b/snapo-link-android/network-okhttp3-noop/src/main/java/com/openai/snapo/network/okhttp3/SnapOOkHttpInterceptor.kt
@@ -6,12 +6,16 @@ import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.Dispatchers
 import okhttp3.Interceptor
 import okhttp3.Response
+import java.io.Closeable
 
 // No-op implementation for release builds
-class SnapOOkHttpInterceptor(
-    private val responseBodyPreviewBytes: Long = 0L,
-    private val textBodyMaxBytes: Long = 0L,
+class SnapOOkHttpInterceptor @JvmOverloads constructor(
+    private val responseBodyPreviewBytes: Int = 0,
+    private val textBodyMaxBytes: Int = 0,
+    private val binaryBodyMaxBytes: Int = 0,
     dispatcher: CoroutineDispatcher = Dispatchers.Unconfined,
-) : Interceptor {
+) : Interceptor, Closeable {
     override fun intercept(chain: Interceptor.Chain): Response = chain.proceed(chain.request())
+
+    override fun close() = Unit
 }

--- a/snapo-link-android/network-okhttp3/src/main/java/com/openai/snapo/network/okhttp3/SnapOInterceptorWebSocketFactory.kt
+++ b/snapo-link-android/network-okhttp3/src/main/java/com/openai/snapo/network/okhttp3/SnapOInterceptorWebSocketFactory.kt
@@ -24,6 +24,7 @@ import okhttp3.Response
 import okhttp3.WebSocket
 import okhttp3.WebSocketListener
 import okio.ByteString
+import java.io.Closeable
 import java.util.ArrayList
 import java.util.UUID
 import kotlin.math.min
@@ -47,7 +48,7 @@ class SnapOInterceptorWebSocketFactory @JvmOverloads constructor(
     private val textPreviewChars: Int = DefaultTextPreviewChars,
     private val binaryPreviewBytes: Int = DefaultBinaryPreviewBytes,
     dispatcher: CoroutineDispatcher = DefaultDispatcher,
-) : WebSocket.Factory {
+) : WebSocket.Factory, Closeable {
 
     private val scope = CoroutineScope(SupervisorJob() + dispatcher)
 
@@ -70,6 +71,10 @@ class SnapOInterceptorWebSocketFactory @JvmOverloads constructor(
         val realWebSocket = delegate.newWebSocket(request, interceptingListener)
         return InterceptedWebSocket(webSocketId, realWebSocket)
             .also { interceptingListener.interceptedWebSocket = it }
+    }
+
+    override fun close() {
+        scope.cancel()
     }
 
     private inline fun publish(crossinline builder: () -> NetworkEventRecord) {


### PR DESCRIPTION
## Summary

- align the OkHttp no-op interceptor constructor with the real artifact, including all three `Int` limits
- make the no-op OkHttp interceptor `Closeable`
- add matching Java constructor overloads to the no-op OkHttp, HttpURLConnection, and WebSocket APIs
- restore `Closeable` on the real WebSocket factory so closing it cancels its coroutine scope, matching the no-op lifecycle contract

## Why

The sample apps use real network artifacts in debug builds and no-op artifacts in release builds. Their published JVM APIs had diverged, so shared source could compile in debug and fail in release. The WebSocket factory had also accidentally lost its lifecycle API while its no-op counterpart retained it.

## Validation

- assembled all four affected network library release variants
- assembled debug and release variants of all three Android sample apps
- compared generated JVM constructors, interfaces, and `close()` methods with `javap`
- ran `git diff --check`