### PR TITLE
[codex] Add aggregate Maven release validation task

### DIFF
--- a/snapo-link-android/build-logic/build.gradle.kts
+++ b/snapo-link-android/build-logic/build.gradle.kts
@@ -26,6 +26,10 @@ gradlePlugin {
             id = "snapo.maven.publish"
             implementationClass = "com.openai.snapo.buildlogic.publishing.MavenPublishConventionPlugin"
         }
+        register("snapoMavenReleaseValidation") {
+            id = "snapo.maven.release-validation"
+            implementationClass = "com.openai.snapo.buildlogic.publishing.MavenCentralReleaseValidationPlugin"
+        }
         register("snapoDetekt") {
             id = "snapo.detekt"
             implementationClass = "com.openai.snapo.buildlogic.quality.DetektConventionPlugin"

--- a/snapo-link-android/build-logic/src/main/kotlin/com/openai/snapo/buildlogic/publishing/MavenCentralReleaseValidationPlugin.kt
+++ b/snapo-link-android/build-logic/src/main/kotlin/com/openai/snapo/buildlogic/publishing/MavenCentralReleaseValidationPlugin.kt
@@ -1,0 +1,84 @@
+package com.openai.snapo.buildlogic.publishing
+
+import org.gradle.api.DefaultTask
+import org.gradle.api.GradleException
+import org.gradle.api.Plugin
+import org.gradle.api.Project
+import org.gradle.api.file.RegularFileProperty
+import org.gradle.api.provider.ListProperty
+import org.gradle.api.tasks.CacheableTask
+import org.gradle.api.tasks.Input
+import org.gradle.api.tasks.OutputFile
+import org.gradle.api.tasks.TaskAction
+import org.gradle.language.base.plugins.LifecycleBasePlugin
+import org.gradle.kotlin.dsl.register
+
+private const val SAMPLE_PROJECT_PREFIX = ":samples:"
+private const val PUBLICATION_ASSEMBLY_TASK = "assembleMavenCentralPublication"
+
+class MavenCentralReleaseValidationPlugin : Plugin<Project> {
+    override fun apply(target: Project) {
+        if (target != target.rootProject) {
+            throw GradleException("snapo.maven.release-validation must be applied to the root project")
+        }
+
+        val validation = target.tasks.register<ValidateMavenCentralReleaseTask>(
+            "validateMavenCentralRelease",
+        ) {
+            group = LifecycleBasePlugin.VERIFICATION_GROUP
+            description = "Builds Maven Central release artifacts and debug sample applications."
+            publicationManifest.set(
+                target.layout.buildDirectory.file("reports/maven-central/publications.tsv"),
+            )
+        }
+
+        target.subprojects.forEach { project ->
+            project.pluginManager.withPlugin("snapo.maven.publish") {
+                if (project.path.startsWith(SAMPLE_PROJECT_PREFIX)) {
+                    throw GradleException("Sample project ${project.path} must not publish to Maven Central")
+                }
+
+                validation.configure {
+                    dependsOn("${project.path}:$PUBLICATION_ASSEMBLY_TASK")
+                    publications.add(
+                        project.provider {
+                            "${project.path}\t${project.group}:${project.name}:${project.version}"
+                        },
+                    )
+                }
+            }
+
+            listOf("com.android.application", "com.android.library").forEach { pluginId ->
+                project.pluginManager.withPlugin(pluginId) {
+                    if (project.path.startsWith(SAMPLE_PROJECT_PREFIX)) {
+                        validation.configure {
+                            dependsOn("${project.path}:assembleDebug")
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+
+@CacheableTask
+abstract class ValidateMavenCentralReleaseTask : DefaultTask() {
+    @get:Input
+    abstract val publications: ListProperty<String>
+
+    @get:OutputFile
+    abstract val publicationManifest: RegularFileProperty
+
+    @TaskAction
+    fun writePublicationManifest() {
+        val entries = publications.get().distinct().sorted()
+        if (entries.isEmpty()) {
+            throw GradleException("No Maven Central publications were discovered")
+        }
+
+        val manifest = publicationManifest.get().asFile
+        manifest.parentFile.mkdirs()
+        manifest.writeText(entries.joinToString(separator = "\n", postfix = "\n"))
+        logger.lifecycle("Validated ${entries.size} Maven Central publications; manifest: $manifest")
+    }
+}

--- a/snapo-link-android/build-logic/src/main/kotlin/com/openai/snapo/buildlogic/publishing/MavenPublishConventionPlugin.kt
+++ b/snapo-link-android/build-logic/src/main/kotlin/com/openai/snapo/buildlogic/publishing/MavenPublishConventionPlugin.kt
@@ -7,6 +7,7 @@ import com.vanniktech.maven.publish.SourcesJar
 import org.gradle.api.Plugin
 import org.gradle.api.Project
 import org.gradle.kotlin.dsl.configure
+import org.gradle.kotlin.dsl.register
 
 class MavenPublishConventionPlugin : Plugin<Project> {
     override fun apply(target: Project) {
@@ -55,6 +56,18 @@ class MavenPublishConventionPlugin : Plugin<Project> {
                         developerConnection.set("scm:git:ssh://git@github.com/openai/snap-o.git")
                     }
                 }
+            }
+
+            target.tasks.register("assembleMavenCentralPublication") {
+                group = "publishing"
+                description = "Assembles the release artifacts and metadata published to Maven Central."
+                dependsOn(
+                    "bundleReleaseAar",
+                    "emptyJavadocJar",
+                    "sourceReleaseJar",
+                    "generateMetadataFileForMavenPublication",
+                    "generatePomFileForMavenPublication",
+                )
             }
         }
     }

--- a/snapo-link-android/build.gradle.kts
+++ b/snapo-link-android/build.gradle.kts
@@ -1,5 +1,6 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 plugins {
+    id("snapo.maven.release-validation")
     alias(libs.plugins.android.application) apply false
     alias(libs.plugins.kotlin.android) apply false
     alias(libs.plugins.android.library) apply false


### PR DESCRIPTION
## Summary

- add a root `validateMavenCentralRelease` Gradle task
- discover Maven Central publications through the existing `snapo.maven.publish` convention
- build release AARs, sources, javadocs, module metadata, and POMs for every publication
- build debug variants for Android projects under `samples`
- reject sample projects that opt into Maven publishing
- emit a deterministic project-path and coordinate manifest for release automation

## Why

The release workflow previously invoked the root `build` task, which built debug and release variants, lint, tests, and packaging for every sample project. The aggregate task makes Snap-O's Gradle model the source of truth for the correct release artifacts and sample validation configurations, without duplicating module lists in release automation.

## Impact

New publishable libraries are automatically included after applying `snapo.maven.publish`. New Android sample projects are automatically validated through `assembleDebug`.

## Validation

- `./gradlew :build-logic:check`
- `./gradlew validateMavenCentralRelease --parallel --build-cache`
- Java 17 task-graph validation
- generated manifest contains the five expected `com.openai.snapo` publications
- optimized graph executes 326 tasks versus 755 in the previous root build
