### PR TITLE
[codex] Improve Maven package descriptions

### DIFF
--- a/snapo-link-android/build-logic/src/main/kotlin/com/openai/snapo/buildlogic/publishing/MavenPublishConventionPlugin.kt
+++ b/snapo-link-android/build-logic/src/main/kotlin/com/openai/snapo/buildlogic/publishing/MavenPublishConventionPlugin.kt
@@ -31,7 +31,7 @@ class MavenPublishConventionPlugin : Plugin<Project> {
 
                 pom {
                     name.set("Snap-O ${target.name}")
-                    description.set("Android network inspection integration for Snap-O.")
+                    description.set(target.provider { target.description })
                     inceptionYear.set("2025")
                     url.set("https://github.com/openai/snap-o")
 

--- a/snapo-link-android/network-httpurlconnection-noop/build.gradle.kts
+++ b/snapo-link-android/network-httpurlconnection-noop/build.gradle.kts
@@ -4,6 +4,8 @@ plugins {
     id("snapo.detekt")
 }
 
+description = "No-op HttpURLConnection integration for disabling Snap-O network interception in release builds."
+
 android {
     namespace = "com.openai.snapo.network.httpurlconnection"
 }

--- a/snapo-link-android/network-httpurlconnection/build.gradle.kts
+++ b/snapo-link-android/network-httpurlconnection/build.gradle.kts
@@ -4,6 +4,8 @@ plugins {
     id("snapo.detekt")
 }
 
+description = "HttpURLConnection integration for intercepting network requests with Snap-O."
+
 android {
     namespace = "com.openai.snapo.network.httpurlconnection"
 }

--- a/snapo-link-android/network-okhttp3-noop/build.gradle.kts
+++ b/snapo-link-android/network-okhttp3-noop/build.gradle.kts
@@ -4,6 +4,8 @@ plugins {
     id("snapo.detekt")
 }
 
+description = "No-op OkHttp integration for disabling Snap-O network interception in release builds."
+
 android {
     namespace = "com.openai.snapo.network.okhttp3"
 }

--- a/snapo-link-android/network-okhttp3/build.gradle.kts
+++ b/snapo-link-android/network-okhttp3/build.gradle.kts
@@ -4,6 +4,8 @@ plugins {
     id("snapo.detekt")
 }
 
+description = "OkHttp integration for intercepting network requests with Snap-O."
+
 android {
     namespace = "com.openai.snapo.network.okhttp3"
 }

--- a/snapo-link-android/network/build.gradle.kts
+++ b/snapo-link-android/network/build.gradle.kts
@@ -5,6 +5,8 @@ plugins {
     alias(libs.plugins.kotlinx.serialization)
 }
 
+description = "Shared Android components used by Snap-O network inspection integrations."
+
 android {
     namespace = "com.openai.snapo.network"
 }


### PR DESCRIPTION
## Summary

- read Maven POM descriptions from each Android module's Gradle metadata
- add concise, artifact-specific descriptions for the shared, OkHttp, HttpURLConnection, and release no-op packages

## Why

All five Maven Central artifacts currently use the same generic description, which makes their distinct purposes unclear. Per-module descriptions make the package listings easier to understand and maintain.

## Impact

Future published versions will show descriptions specific to each artifact. Runtime behavior is unchanged.

## Validation

- `./gradlew assemble generatePomFileForMavenPublication`
- inspected the generated POM descriptions for all five published modules
