### PR TITLE
[codex] Limit workspace splitter to content area

### DIFF
--- a/snapo-app-mac/Snap-O/CaptureWindow/CaptureWindow.swift
+++ b/snapo-app-mac/Snap-O/CaptureWindow/CaptureWindow.swift
@@ -213,10 +213,9 @@ struct CaptureWindow: View {
             previewHeight: metrics.previewHeight,
             aspectRatio: controller.displayInfoForSizing?.aspectRatio
           )
-          .frame(width: 1)
-          .frame(maxHeight: .infinity)
+          .frame(width: 1, height: metrics.previewHeight)
           .offset(x: captureWidth - 0.5)
-          .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
+          .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .bottomLeading)
         }
       }
       .background(


### PR DESCRIPTION
## Summary

- constrain the workspace splitter hit area to the content region below the toolbar
- keep split dragging and the horizontal resize cursor available on the content divider

## Root cause

The splitter overlay expanded to the full window height, so its AppKit cursor rect and mouse handling also covered the divider drawn through the toolbar.

## Impact

Hovering or dragging the divider in the toolbar no longer presents or activates split resizing. The divider below the toolbar retains its existing drag and double-click behavior.

## Validation

- `xcodebuild -project Snap-O.xcodeproj -scheme Snap-O -configuration Debug -destination 'platform=macOS' build`
