### PR TITLE
[codex] Add Android Studio environment action

### DIFF
--- a/.codex/environments/environment.toml
+++ b/.codex/environments/environment.toml
@@ -23,3 +23,11 @@ open DerivedData/Build/Products/Debug/Snap-O.app
 name = "Open Xcode"
 icon = "tool"
 command = "open snapo-app-mac/Snap-O.xcodeproj"
+
+[[actions]]
+name = "Open Android Studio"
+icon = "tool"
+command = '''
+cd snapo-link-android
+open -b com.google.android.studio build.gradle.kts
+'''


### PR DESCRIPTION
## Summary

- Add an **Open Android Studio** Codex environment action.
- Open `snapo-link-android/build.gradle.kts` with Android Studio's macOS bundle ID so the file is not routed to IntelliJ IDEA.

## Why

The existing generic `open` command can select IntelliJ IDEA based on file associations. Targeting `com.google.android.studio` makes the action deterministic.

## Impact

Developers can launch the Android Gradle build script directly in Android Studio from Codex Run Actions.

## Validation

- Parsed `.codex/environments/environment.toml` with Python's `tomllib`.
- Ran `git diff --check origin/main...HEAD`.