### PR TITLE
[codex] Unify capture placeholder styling

### DIFF
--- a/snapo-app-mac/Snap-O/CaptureWindow/CaptureWindow.swift
+++ b/snapo-app-mac/Snap-O/CaptureWindow/CaptureWindow.swift
@@ -389,7 +389,7 @@ struct CaptureWindow: View {
           fileStore: controller.fileStore,
           livePreviewHost: controller
         )
-      } else if controller.isLivePreviewActive {
+      } else if controller.isLivePreviewActive, controller.hasDevices {
         EmptyView()
       } else if controller.isDeviceListInitialized {
         IdleOverlayView(

--- a/snapo-app-mac/Snap-O/CaptureWindow/CaptureWindow.swift
+++ b/snapo-app-mac/Snap-O/CaptureWindow/CaptureWindow.swift
@@ -381,7 +381,7 @@ struct CaptureWindow: View {
 
   private func captureContent(controller: CaptureWindowController) -> some View {
     ZStack {
-      Color.black
+      captureLetterboxBackground
 
       if controller.currentCapture != nil {
         CaptureSnapshotView(
@@ -389,6 +389,8 @@ struct CaptureWindow: View {
           fileStore: controller.fileStore,
           livePreviewHost: controller
         )
+      } else if controller.isLivePreviewActive {
+        EmptyView()
       } else if controller.isDeviceListInitialized {
         IdleOverlayView(
           hasDevices: controller.hasDevices,

--- a/snapo-app-mac/Snap-O/CaptureWindow/IdleOverlayView.swift
+++ b/snapo-app-mac/Snap-O/CaptureWindow/IdleOverlayView.swift
@@ -11,9 +11,11 @@ struct IdleOverlayView: View {
   var body: some View {
     VStack(spacing: 12) {
       Image("Aperture")
+        .renderingMode(.template)
         .resizable()
+        .foregroundStyle(.secondary)
         .frame(width: 64, height: 64)
-        .infiniteRotate(animated: isProcessing)
+        .infiniteRotate(animated: isProcessing || isRecording)
 
       if isRecording, !isProcessing {
         Button {
@@ -23,22 +25,14 @@ struct IdleOverlayView: View {
             Text("Stop Recording")
             Text("⎋")
               .font(.subheadline)
-              .foregroundStyle(.white.opacity(0.7))
+              .foregroundStyle(.secondary)
           }
-          .padding(.horizontal, 16)
-          .padding(.vertical, 10)
-          .background(
-            RoundedRectangle(cornerRadius: 10)
-              .fill(Color.gray.opacity(0.3))
-          )
-          .foregroundStyle(Color.white)
         }
-        .buttonStyle(.plain)
         .keyboardShortcut(.cancelAction)
       } else if isRecording {
         ProgressView()
           .progressViewStyle(.circular)
-          .tint(.white)
+          .tint(.primary)
           .controlSize(.large)
       } else if !hasDevices, isDeviceListInitialized {
         Text("Waiting for device…")

--- a/snapo-app-mac/Snap-O/CaptureWindow/LiveCaptureView.swift
+++ b/snapo-app-mac/Snap-O/CaptureWindow/LiveCaptureView.swift
@@ -1,3 +1,4 @@
+import AppKit
 import Foundation
 import SwiftUI
 
@@ -20,7 +21,7 @@ struct LiveCaptureView<Host: LivePreviewHosting>: View {
       if let renderer {
         LivePreviewRendererView(renderer: renderer)
       } else {
-        Color.black
+        Color(nsColor: .unemphasizedSelectedContentBackgroundColor)
       }
     }
     .frame(maxWidth: .infinity, maxHeight: .infinity)

--- a/snapo-app-mac/Snap-O/CaptureWindow/WaitingForDeviceView.swift
+++ b/snapo-app-mac/Snap-O/CaptureWindow/WaitingForDeviceView.swift
@@ -6,7 +6,9 @@ struct WaitingForDeviceView: View {
   var body: some View {
     VStack(spacing: 12) {
       Image("Aperture")
+        .renderingMode(.template)
         .resizable()
+        .foregroundStyle(.secondary)
         .frame(width: 64, height: 64)
         .infiniteRotate(animated: true)
 

--- a/snapo-app-mac/Snap-O/LivePreview/LivePreviewView.swift
+++ b/snapo-app-mac/Snap-O/LivePreview/LivePreviewView.swift
@@ -81,9 +81,20 @@ final class LivePreviewDisplayView: NSView {
     wantsLayer = true
     layer?.addSublayer(displayLayer)
     displayLayer.videoGravity = .resizeAspect
-    displayLayer.backgroundColor = NSColor.black.cgColor
+    updateDisplayLayerBackgroundColor()
     displayLayer.frame = bounds
     displayLayer.autoresizingMask = [.layerWidthSizable, .layerHeightSizable]
+  }
+
+  override func viewDidChangeEffectiveAppearance() {
+    super.viewDidChangeEffectiveAppearance()
+    updateDisplayLayerBackgroundColor()
+  }
+
+  private func updateDisplayLayerBackgroundColor() {
+    effectiveAppearance.performAsCurrentDrawingAppearance {
+      displayLayer.backgroundColor = NSColor.unemphasizedSelectedContentBackgroundColor.cgColor
+    }
   }
 
   private func attachSession() {


### PR DESCRIPTION
## Summary
- Use the existing adaptive letterbox color across capture placeholders and live preview, including the wait for the first preview frame.
- Render the Snap-O aperture as a neutral template icon in startup and capture states.
- Keep the aperture rotating throughout recording and return Stop Recording to the standard macOS button treatment.
- Refresh the live-preview display-layer background when the effective appearance changes.

## Why
The capture experience mixed a hard-coded black canvas with the source asset's green icon. Recording also stopped the aperture animation once setup cleared `isProcessing`, even though recording remained active. Live preview retained a separate hard-coded black display-layer fallback.

## Impact
Capture, startup, recording, and live-preview waiting states now share one light/dark-adaptive letterbox treatment. Snap-O no longer paints the live-preview surface black before the first frame.

## Testing
- [x] Built Snap-O with `xcodebuild -project Snap-O.xcodeproj -scheme Snap-O CODE_SIGNING_ALLOWED=NO CODE_SIGNING_REQUIRED=NO build`
- [x] SwiftFormat lint
- [x] SwiftLint strict
- [ ] Ran Snap-O locally
- [ ] Added or updated tests (not applicable: the app has no capture UI test target)

## Checklist
- [x] I have read the [Contributing guidelines](https://github.com/openai/snap-o?tab=contributing-ov-file#contributing-to-snap-o)
- [x] Documentation has been updated (not needed for this UI-only change)