### PR TITLE
[codex] Improve Android network interceptor performance

### DIFF
--- a/snapo-app-mac/SnapOCLI/RequestDetailsFetcher.swift
+++ b/snapo-app-mac/SnapOCLI/RequestDetailsFetcher.swift
@@ -126,6 +126,7 @@ struct RequestDetailsFetcher {
 
       if details.requestSeen,
          details.requestHasPostData,
+         details.responseSeen || details.responseTerminal,
          !requestBodyResolved,
          requestBodyAttempts < Self.attemptLimit {
         requestBodyAttempts += 1
@@ -135,8 +136,18 @@ struct RequestDetailsFetcher {
             params: ["requestId": .string(requestID)],
             timeout: .milliseconds(500)
           )
-          requestBody = message.result?["postData"]?.stringValue
-          requestBodyResolved = true
+          if let error = message.error {
+            if error.message.lowercased().contains("no request body captured") {
+              requestBodyResolved = true
+            } else {
+              return .failure(error.message)
+            }
+          } else if let postData = message.result?["postData"]?.stringValue {
+            requestBody = postData
+            requestBodyResolved = true
+          } else {
+            return .failure("Malformed response for Network.getRequestPostData")
+          }
         } catch NetworkSessionError.commandTimedOut {
           if requestBodyAttempts >= Self.attemptLimit {
             requestBodyResolved = true

--- a/snapo-link-android/network-httpurlconnection/build.gradle.kts
+++ b/snapo-link-android/network-httpurlconnection/build.gradle.kts
@@ -13,4 +13,5 @@ android {
 dependencies {
     implementation(project(":network"))
     api(libs.kotlinx.coroutines.core)
+    testImplementation(libs.junit4)
 }

--- a/snapo-link-android/network-httpurlconnection/src/main/java/com/openai/snapo/network/httpurlconnection/SnapOHttpUrlInterceptor.kt
+++ b/snapo-link-android/network-httpurlconnection/src/main/java/com/openai/snapo/network/httpurlconnection/SnapOHttpUrlInterceptor.kt
@@ -16,6 +16,7 @@ import com.openai.snapo.network.Timings
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.Job
 import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.cancel
 import kotlinx.coroutines.launch
@@ -35,33 +36,39 @@ import java.security.Permission
 import java.util.UUID
 import java.util.concurrent.TimeUnit
 import java.util.concurrent.atomic.AtomicBoolean
-import kotlin.math.max
 
 /** HttpURLConnection interceptor that mirrors traffic to the active SnapO link if present. */
 class SnapOHttpUrlInterceptor @JvmOverloads constructor(
-    internal val responseBodyPreviewBytes: Int = DefaultBodyPreviewBytes,
-    internal val textBodyMaxBytes: Int = DefaultTextBodyMaxBytes,
-    internal val binaryBodyMaxBytes: Int = DefaultBinaryBodyMaxBytes,
+    responseBodyPreviewBytes: Int = DefaultBodyPreviewBytes,
+    textBodyMaxBytes: Int = DefaultTextBodyMaxBytes,
+    binaryBodyMaxBytes: Int = DefaultBinaryBodyMaxBytes,
     dispatcher: CoroutineDispatcher = DefaultDispatcher,
 ) : Closeable {
 
+    internal val responseBodyPreviewBytes = responseBodyPreviewBytes.coerceAtLeast(0)
+    internal val textBodyMaxBytes = resolveEffectiveMaxBytes(textBodyMaxBytes, contentLength = null)
+    internal val binaryBodyMaxBytes = resolveEffectiveMaxBytes(binaryBodyMaxBytes, contentLength = null)
     private val scope = CoroutineScope(SupervisorJob() + dispatcher)
 
     fun open(url: URL): HttpURLConnection = intercept(url.openConnection() as HttpURLConnection)
 
     fun intercept(connection: HttpURLConnection): HttpURLConnection =
-        InterceptingHttpURLConnection(connection, this)
+        if (NetworkInspector.getOrNull() == null) {
+            connection
+        } else {
+            InterceptingHttpURLConnection(connection, this)
+        }
 
     override fun close() {
         scope.cancel()
     }
 
-    internal fun publish(builder: () -> NetworkEventRecord) {
-        val server = NetworkInspector.getOrNull() ?: return
-        val record = builder()
-        scope.launch {
+    internal fun publish(after: Job? = null, builder: () -> NetworkEventRecord): Job? {
+        val server = NetworkInspector.getOrNull() ?: return null
+        return scope.launch {
             try {
-                server.publish(record)
+                after?.join()
+                server.publish(builder())
             } catch (_: Throwable) {
             }
         }
@@ -69,20 +76,45 @@ class SnapOHttpUrlInterceptor @JvmOverloads constructor(
 
     internal fun updateLatestResponseBody(
         requestId: String,
-        bodyPreview: String?,
-        body: String?,
-        bodyEncoding: String?,
+        bodyValues: () -> CapturedBodyValues,
         bodyTruncatedBytes: Long?,
         bodySize: Long?,
-    ) {
-        val server = NetworkInspector.getOrNull() ?: return
-        scope.launch {
+        after: Job? = null,
+    ): Job? {
+        val server = NetworkInspector.getOrNull() ?: return null
+        return scope.launch {
             try {
+                after?.join()
+                val body = bodyValues()
                 server.updateLatestResponseBody(
                     requestId = requestId,
-                    bodyPreview = bodyPreview,
-                    body = body,
-                    bodyEncoding = bodyEncoding,
+                    bodyPreview = body.bodyPreview,
+                    body = body.body,
+                    bodyEncoding = body.bodyEncoding,
+                    bodyTruncatedBytes = bodyTruncatedBytes,
+                    bodySize = bodySize,
+                )
+            } catch (_: Throwable) {
+            }
+        }
+    }
+
+    internal fun updateLatestRequestBody(
+        requestId: String,
+        bodyValues: () -> RequestBodyValues,
+        bodyTruncatedBytes: Long?,
+        bodySize: Long?,
+        after: Job? = null,
+    ): Job? {
+        val server = NetworkInspector.getOrNull() ?: return null
+        return scope.launch {
+            try {
+                after?.join()
+                val body = bodyValues()
+                server.updateLatestRequestBody(
+                    requestId = requestId,
+                    body = body.body,
+                    bodyEncoding = body.encoding,
                     bodyTruncatedBytes = bodyTruncatedBytes,
                     bodySize = bodySize,
                 )
@@ -116,8 +148,11 @@ private class InterceptingHttpURLConnection(
     private val requestHeaders = snapshotHeaders(delegate)
     private var context: InterceptContext? = null
     private var requestPublished: Boolean = false
+    private var requestPublication: Job? = null
+    private var publishedRequestBodyBytes: Long = 0L
     private var responseMeta: ResponseMeta? = null
     private var responsePublished: Boolean = false
+    private var responsePublication: Job? = null
     private var responseFinishedPublished: Boolean = false
     private var requestBodyCapture: BodyCaptureSink? = null
 
@@ -136,7 +171,7 @@ private class InterceptingHttpURLConnection(
         ensureRequestContext()
         val output = delegate.outputStream
         val capture = ensureRequestBodyCapture() ?: return output
-        return CapturingOutputStream(output, capture)
+        return CapturingOutputStream(output, capture, ::updatePublishedRequestBody)
     }
 
     override fun getInputStream(): InputStream {
@@ -318,7 +353,10 @@ private class InterceptingHttpURLConnection(
 
     private fun ensureRequestPublished() {
         ensureRequestContext()
-        if (requestPublished) return
+        if (requestPublished) {
+            updatePublishedRequestBody()
+            return
+        }
         requestPublished = true
         val currentContext = context ?: return
         val capture = requestBodyCapture?.snapshot()
@@ -329,30 +367,15 @@ private class InterceptingHttpURLConnection(
         val bodySize = capture?.totalBytes ?: requestContentLength()
         val truncatedBytes = capture?.truncatedBytes
         val hasBody = delegate.doOutput || requestBodyCapture != null || (bodySize?.let { it > 0L } == true)
+        publishedRequestBodyBytes = capture?.totalBytes ?: 0L
 
-        interceptor.publish {
-            val bodyEncoding: String?
-            val body = when {
-                requestBodyBytes == null || requestBodyBytes.isEmpty() -> {
-                    bodyEncoding = null
-                    null
-                }
-
-                hasNonIdentityContentEncoding(contentEncoding) -> {
-                    bodyEncoding = "base64"
-                    encodeToString(requestBodyBytes, NO_WRAP)
-                }
-
-                mediaType?.isTextLike() == true -> {
-                    bodyEncoding = null
-                    String(requestBodyBytes, mediaType.charsetOrUtf8())
-                }
-
-                else -> {
-                    bodyEncoding = "base64"
-                    encodeToString(requestBodyBytes, NO_WRAP)
-                }
-            }
+        requestPublication = interceptor.publish {
+            val bodyValues = resolveRequestBodyValues(
+                bytes = requestBodyBytes,
+                mediaType = mediaType,
+                contentEncoding = contentEncoding,
+                hasBody = hasBody,
+            )
             RequestWillBeSent(
                 id = currentContext.requestId,
                 tWallMs = currentContext.startWall,
@@ -361,12 +384,35 @@ private class InterceptingHttpURLConnection(
                 url = delegate.url.toString(),
                 headers = requestHeaders.toMapCopy().toHeaderList(),
                 hasBody = hasBody,
-                body = body,
-                bodyEncoding = bodyEncoding,
+                body = bodyValues.body,
+                bodyEncoding = bodyValues.encoding,
                 bodyTruncatedBytes = truncatedBytes,
                 bodySize = bodySize,
             )
         }
+    }
+
+    private fun updatePublishedRequestBody() {
+        if (!requestPublished) return
+        val currentContext = context ?: return
+        val capture = requestBodyCapture?.snapshot() ?: return
+        if (capture.totalBytes == publishedRequestBodyBytes) return
+        publishedRequestBodyBytes = capture.totalBytes
+        val mediaType = parseMediaType(requestContentType())
+        val contentEncoding = requestContentEncoding()
+        requestPublication = interceptor.updateLatestRequestBody(
+            requestId = currentContext.requestId,
+            bodyValues = {
+                resolveRequestBodyValues(
+                    bytes = capture.bytes,
+                    mediaType = mediaType,
+                    contentEncoding = contentEncoding,
+                )
+            },
+            bodyTruncatedBytes = capture.truncatedBytes,
+            bodySize = maxOf(requestContentLength() ?: 0L, capture.totalBytes),
+            after = requestPublication,
+        ) ?: requestPublication
     }
 
     private fun ensureResponseStarted(code: Int? = null): ResponseMeta? {
@@ -390,7 +436,7 @@ private class InterceptingHttpURLConnection(
 
         if (!responsePublished) {
             responsePublished = true
-            interceptor.publish {
+            responsePublication = interceptor.publish(after = requestPublication) {
                 ResponseReceived(
                     id = currentContext.requestId,
                     tWallMs = responseWall,
@@ -429,6 +475,7 @@ private class InterceptingHttpURLConnection(
                 interceptor = interceptor,
                 context = context,
                 charset = mediaType.charsetOrUtf8(),
+                initialPublication = responsePublication,
             )
         }
         val effectiveMax = resolveEffectiveMaxBytes(
@@ -444,15 +491,26 @@ private class InterceptingHttpURLConnection(
             delegate = stream,
             capture = capture,
             interceptor = interceptor,
-            context = context,
             mediaType = mediaType,
-            responseMeta = meta,
+            captureContext = ResponseCaptureContext(
+                request = context,
+                response = meta,
+                publication = responsePublication,
+            ),
         )
     }
 
     private fun ensureRequestBodyCapture(): BodyCaptureSink? {
-        if (interceptor.textBodyMaxBytes <= 0) return null
-        return requestBodyCapture ?: BodyCaptureSink(interceptor.textBodyMaxBytes).also {
+        val mediaType = parseMediaType(requestContentType())
+        val captureLimit = if (
+            hasNonIdentityContentEncoding(requestContentEncoding()) || mediaType?.isTextLike() != true
+        ) {
+            interceptor.binaryBodyMaxBytes
+        } else {
+            interceptor.textBodyMaxBytes
+        }
+        if (captureLimit <= 0) return null
+        return requestBodyCapture ?: BodyCaptureSink(captureLimit).also {
             requestBodyCapture = it
         }
     }
@@ -461,7 +519,7 @@ private class InterceptingHttpURLConnection(
         val currentContext = context ?: return
         val failWall = System.currentTimeMillis()
         val failMono = SystemClock.elapsedRealtimeNanos()
-        interceptor.publish {
+        interceptor.publish(after = requestPublication) {
             RequestFailed(
                 id = currentContext.requestId,
                 tWallMs = failWall,
@@ -479,7 +537,7 @@ private class InterceptingHttpURLConnection(
         responseFinishedPublished = true
         val nowWall = System.currentTimeMillis()
         val nowMono = SystemClock.elapsedRealtimeNanos()
-        interceptor.publish {
+        interceptor.publish(after = responsePublication) {
             ResponseFinished(
                 id = currentContext.requestId,
                 tWallMs = nowWall,
@@ -592,10 +650,38 @@ private data class BodyCaptureSnapshot(
     val truncatedBytes: Long?,
 )
 
+internal data class RequestBodyValues(
+    val body: String?,
+    val encoding: String?,
+)
+
+private fun resolveRequestBodyValues(
+    bytes: ByteArray?,
+    mediaType: ParsedMediaType?,
+    contentEncoding: String?,
+    hasBody: Boolean = true,
+): RequestBodyValues {
+    val usesBase64 = hasNonIdentityContentEncoding(contentEncoding) || mediaType?.isTextLike() != true
+    if (bytes == null || bytes.isEmpty()) {
+        return RequestBodyValues(
+            body = null,
+            encoding = "base64".takeIf { hasBody && usesBase64 },
+        )
+    }
+    return when {
+        usesBase64 ->
+            RequestBodyValues(body = encodeToString(bytes, NO_WRAP), encoding = "base64")
+        else -> RequestBodyValues(body = String(bytes, mediaType.charsetOrUtf8()), encoding = null)
+    }
+}
+
 private class CapturingOutputStream(
     delegate: OutputStream,
     private val capture: BodyCaptureSink,
+    private val onClosed: () -> Unit,
 ) : FilterOutputStream(delegate) {
+
+    private val closed = AtomicBoolean(false)
 
     override fun write(b: Int) {
         out.write(b)
@@ -606,15 +692,33 @@ private class CapturingOutputStream(
         out.write(b, off, len)
         capture.append(b, off, len)
     }
+
+    override fun close() {
+        try {
+            super.close()
+        } finally {
+            if (closed.compareAndSet(false, true)) {
+                try {
+                    onClosed()
+                } catch (_: Throwable) {
+                }
+            }
+        }
+    }
 }
+
+private data class ResponseCaptureContext(
+    val request: InterceptContext?,
+    val response: ResponseMeta?,
+    val publication: Job?,
+)
 
 private class ResponseCapturingInputStream(
     delegate: InputStream,
     private val capture: BodyCaptureSink,
     private val interceptor: SnapOHttpUrlInterceptor,
-    private val context: InterceptContext?,
     private val mediaType: ParsedMediaType?,
-    private val responseMeta: ResponseMeta?,
+    private val captureContext: ResponseCaptureContext,
 ) : FilterInputStream(delegate) {
 
     private val completed = AtomicBoolean(false)
@@ -659,29 +763,30 @@ private class ResponseCapturingInputStream(
 
     private fun complete(error: Throwable?) {
         if (!completed.compareAndSet(false, true)) return
-        val currentContext = context ?: return
+        val currentContext = captureContext.request ?: return
         val snapshot = capture.snapshot()
-        val meta = responseMeta
-        val bytes = snapshot.bytes
-        val bodyValues = resolveCapturedBodyValues(
-            bytes = bytes,
-            mediaType = mediaType,
-            previewBytes = interceptor.responseBodyPreviewBytes,
-        )
+        val meta = captureContext.response
         val totalBytes = snapshot.totalBytes.takeIf { it > 0L } ?: meta?.contentLength
-        updateResponseBodyIfNeeded(
+        val bodyUpdate = interceptor.updateLatestResponseBody(
             requestId = currentContext.requestId,
-            bodyValues = bodyValues,
-            truncatedBytes = snapshot.truncatedBytes,
-            totalBytes = totalBytes,
-            error = error,
+            bodyValues = {
+                resolveCapturedBodyValues(
+                    bytes = snapshot.bytes,
+                    mediaType = mediaType,
+                    previewBytes = interceptor.responseBodyPreviewBytes,
+                )
+            },
+            bodyTruncatedBytes = snapshot.truncatedBytes,
+            bodySize = totalBytes,
+            after = captureContext.publication,
         )
         publishLoadingFinishedIfNeeded(
             requestId = currentContext.requestId,
             totalBytes = totalBytes,
             error = error,
+            after = bodyUpdate,
         )
-        publishFailureIfNeeded(currentContext, error)
+        publishFailureIfNeeded(currentContext, error, after = bodyUpdate)
     }
 
     private fun resolveCapturedBodyValues(
@@ -733,36 +838,16 @@ private class ResponseCapturingInputStream(
         }
     }
 
-    private fun updateResponseBodyIfNeeded(
-        requestId: String,
-        bodyValues: CapturedBodyValues,
-        truncatedBytes: Long?,
-        totalBytes: Long?,
-        error: Throwable?,
-    ) {
-        val bodyPreview = bodyValues.bodyPreview
-        val body = bodyValues.body
-        val hasPayload = !body.isNullOrEmpty() || !bodyPreview.isNullOrEmpty() || truncatedBytes != null
-        if (!hasPayload && error == null) return
-        interceptor.updateLatestResponseBody(
-            requestId = requestId,
-            bodyPreview = bodyPreview,
-            body = body,
-            bodyEncoding = bodyValues.bodyEncoding,
-            bodyTruncatedBytes = truncatedBytes,
-            bodySize = totalBytes,
-        )
-    }
-
     private fun publishLoadingFinishedIfNeeded(
         requestId: String,
         totalBytes: Long?,
         error: Throwable?,
+        after: Job?,
     ) {
         if (error != null) return
         val nowWall = System.currentTimeMillis()
         val nowMono = SystemClock.elapsedRealtimeNanos()
-        interceptor.publish {
+        interceptor.publish(after = after) {
             ResponseFinished(
                 id = requestId,
                 tWallMs = nowWall,
@@ -772,11 +857,11 @@ private class ResponseCapturingInputStream(
         }
     }
 
-    private fun publishFailureIfNeeded(currentContext: InterceptContext, error: Throwable?) {
+    private fun publishFailureIfNeeded(currentContext: InterceptContext, error: Throwable?, after: Job?) {
         if (error == null) return
         val failWall = System.currentTimeMillis()
         val failMono = SystemClock.elapsedRealtimeNanos()
-        interceptor.publish {
+        interceptor.publish(after = after) {
             RequestFailed(
                 id = currentContext.requestId,
                 tWallMs = failWall,
@@ -789,7 +874,7 @@ private class ResponseCapturingInputStream(
     }
 }
 
-private data class CapturedBodyValues(
+internal data class CapturedBodyValues(
     val bodyPreview: String?,
     val body: String?,
     val bodyEncoding: String?,
@@ -818,10 +903,13 @@ private class SseCapturingInputStream(
     private val interceptor: SnapOHttpUrlInterceptor,
     private val context: InterceptContext?,
     private val charset: java.nio.charset.Charset,
+    initialPublication: Job?,
 ) : FilterInputStream(delegate) {
 
     private val parser = SseBuffer(charset)
     private val closed = AtomicBoolean(false)
+    private val publicationLock = Any()
+    private var previousPublication = initialPublication
     private var totalBytes: Long = 0L
     private var nextSequence: Long = 0L
 
@@ -872,7 +960,7 @@ private class SseCapturingInputStream(
             val sequence = ++nextSequence
             val nowWall = System.currentTimeMillis()
             val nowMono = SystemClock.elapsedRealtimeNanos()
-            interceptor.publish {
+            publish {
                 ResponseStreamEvent(
                     id = currentContext.requestId,
                     tWallMs = nowWall,
@@ -892,7 +980,7 @@ private class SseCapturingInputStream(
             val sequence = ++nextSequence
             val nowWall = System.currentTimeMillis()
             val nowMono = SystemClock.elapsedRealtimeNanos()
-            interceptor.publish {
+            publish {
                 ResponseStreamEvent(
                     id = currentContext.requestId,
                     tWallMs = nowWall,
@@ -905,7 +993,7 @@ private class SseCapturingInputStream(
 
         val nowWall = System.currentTimeMillis()
         val nowMono = SystemClock.elapsedRealtimeNanos()
-        interceptor.publish {
+        publish {
             ResponseStreamClosed(
                 id = currentContext.requestId,
                 tWallMs = nowWall,
@@ -915,6 +1003,15 @@ private class SseCapturingInputStream(
                 totalEvents = nextSequence,
                 totalBytes = totalBytes,
             )
+        }
+    }
+
+    private fun publish(builder: () -> NetworkEventRecord) {
+        synchronized(publicationLock) {
+            previousPublication = interceptor.publish(
+                after = previousPublication,
+                builder = builder,
+            ) ?: previousPublication
         }
     }
 }
@@ -974,11 +1071,11 @@ private fun extractCharset(param: String): String? {
     return param.substring(valueStart).trim().trim('"')
 }
 
-private fun resolveEffectiveMaxBytes(maxBytes: Int, contentLength: Long?): Int {
+internal fun resolveEffectiveMaxBytes(maxBytes: Int, contentLength: Long?): Int {
     if (maxBytes <= 0) return 0
-    if (contentLength == null) return maxBytes
-    return if (contentLength in 0 until AbsoluteBodyTextMaxBytes) {
-        max(maxBytes, contentLength.toInt())
+    val knownLength = contentLength?.takeIf { it >= 0L } ?: return maxBytes
+    return if (knownLength < CompleteBodyCaptureThresholdBytes) {
+        maxOf(maxBytes.toLong(), knownLength).toInt()
     } else {
         maxBytes
     }
@@ -1038,4 +1135,4 @@ private const val DefaultBodyPreviewBytes: Int = 4096
 private const val DefaultTextBodyMaxBytes: Int = 5 * 1024 * 1024
 private const val DefaultBinaryBodyMaxBytes: Int = DefaultTextBodyMaxBytes
 private const val MinLikelyTextRatio: Double = 0.85
-private const val AbsoluteBodyTextMaxBytes: Long = 8L * 1024L * 1024L
+private const val CompleteBodyCaptureThresholdBytes: Long = 8L * 1024L * 1024L

--- a/snapo-link-android/network-httpurlconnection/src/test/java/com/openai/snapo/network/httpurlconnection/SnapOHttpUrlInterceptorTest.kt
+++ b/snapo-link-android/network-httpurlconnection/src/test/java/com/openai/snapo/network/httpurlconnection/SnapOHttpUrlInterceptorTest.kt
@@ -1,0 +1,47 @@
+package com.openai.snapo.network.httpurlconnection
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertSame
+import org.junit.Test
+import java.net.HttpURLConnection
+import java.net.URL
+
+class SnapOHttpUrlInterceptorTest {
+
+    @Test
+    fun `small known bodies can expand the configured capture limit`() {
+        assertEquals(7_000_000, resolveEffectiveMaxBytes(maxBytes = 1_024, contentLength = 7_000_000L))
+        assertEquals(1_024, resolveEffectiveMaxBytes(maxBytes = 1_024, contentLength = 512L))
+        assertEquals(12 * 1024 * 1024, resolveEffectiveMaxBytes(12 * 1024 * 1024, contentLength = null))
+        assertEquals(1_024, resolveEffectiveMaxBytes(maxBytes = 1_024, contentLength = 9L * 1024L * 1024L))
+        assertEquals(0, resolveEffectiveMaxBytes(-1, contentLength = null))
+    }
+
+    @Test
+    fun `capture defaults preserve full body limits`() {
+        val interceptor = SnapOHttpUrlInterceptor()
+        try {
+            assertEquals(5 * 1024 * 1024, interceptor.textBodyMaxBytes)
+            assertEquals(interceptor.textBodyMaxBytes, interceptor.binaryBodyMaxBytes)
+        } finally {
+            interceptor.close()
+        }
+    }
+
+    @Test
+    fun `inactive interceptor returns the original connection`() {
+        val connection = FakeHttpURLConnection()
+        val interceptor = SnapOHttpUrlInterceptor()
+        try {
+            assertSame(connection, interceptor.intercept(connection))
+        } finally {
+            interceptor.close()
+        }
+    }
+
+    private class FakeHttpURLConnection : HttpURLConnection(URL("https://example.com")) {
+        override fun connect() = Unit
+        override fun disconnect() = Unit
+        override fun usingProxy(): Boolean = false
+    }
+}

--- a/snapo-link-android/network-okhttp3/build.gradle.kts
+++ b/snapo-link-android/network-okhttp3/build.gradle.kts
@@ -15,4 +15,6 @@ dependencies {
     api(platform(libs.okhttp3.bom))
     api(libs.okhttp3.okhttp)
     api(libs.kotlinx.coroutines.core)
+    testImplementation(libs.junit4)
+    testImplementation(libs.okhttp3.mockwebserver3)
 }

--- a/snapo-link-android/network-okhttp3/src/main/java/com/openai/snapo/network/okhttp3/OkhttpEventFactory.kt
+++ b/snapo-link-android/network-okhttp3/src/main/java/com/openai/snapo/network/okhttp3/OkhttpEventFactory.kt
@@ -6,9 +6,7 @@ import com.openai.snapo.network.ResponseReceived
 import com.openai.snapo.network.Timings
 import okhttp3.Headers
 import okhttp3.Request
-import okhttp3.RequestBody
 import okhttp3.Response
-import java.io.IOException
 
 internal object OkhttpEventFactory {
 
@@ -19,6 +17,7 @@ internal object OkhttpEventFactory {
         body: String?,
         bodyEncoding: String?,
         truncatedBytes: Long?,
+        bodySize: Long?,
     ): RequestWillBeSent =
         RequestWillBeSent(
             id = context.requestId,
@@ -31,7 +30,7 @@ internal object OkhttpEventFactory {
             body = body,
             bodyEncoding = bodyEncoding,
             bodyTruncatedBytes = truncatedBytes,
-            bodySize = request.body.safeContentLength(),
+            bodySize = bodySize,
         )
 
     fun createResponseReceived(
@@ -67,13 +66,5 @@ private fun Headers.toHeaderList(): List<Header> {
         for (index in 0 until headerCount) {
             add(Header(name(index), value(index)))
         }
-    }
-}
-
-private fun RequestBody?.safeContentLength(): Long? = this?.let {
-    try {
-        it.contentLength().takeIf { len -> len >= 0L }
-    } catch (_: IOException) {
-        null
     }
 }

--- a/snapo-link-android/network-okhttp3/src/main/java/com/openai/snapo/network/okhttp3/SnapOInterceptorWebSocketFactory.kt
+++ b/snapo-link-android/network-okhttp3/src/main/java/com/openai/snapo/network/okhttp3/SnapOInterceptorWebSocketFactory.kt
@@ -53,6 +53,10 @@ class SnapOInterceptorWebSocketFactory @JvmOverloads constructor(
     private val scope = CoroutineScope(SupervisorJob() + dispatcher)
 
     override fun newWebSocket(request: Request, listener: WebSocketListener): WebSocket {
+        if (NetworkInspector.getOrNull() == null) {
+            return delegate.newWebSocket(request, listener)
+        }
+
         val webSocketId = UUID.randomUUID().toString()
         val nowWall = System.currentTimeMillis()
         val nowMono = SystemClock.elapsedRealtimeNanos()

--- a/snapo-link-android/network-okhttp3/src/main/java/com/openai/snapo/network/okhttp3/SnapOOkHttpInterceptor.kt
+++ b/snapo-link-android/network-okhttp3/src/main/java/com/openai/snapo/network/okhttp3/SnapOOkHttpInterceptor.kt
@@ -10,22 +10,24 @@ import com.openai.snapo.network.ResponseFinished
 import com.openai.snapo.network.Timings
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Job
 import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.cancel
 import kotlinx.coroutines.launch
+import okhttp3.Headers
 import okhttp3.Interceptor
 import okhttp3.MediaType
 import okhttp3.MediaType.Companion.toMediaTypeOrNull
 import okhttp3.Request
 import okhttp3.Response
 import okhttp3.ResponseBody
+import okhttp3.TrailersSource
 import okio.Buffer
 import okio.BufferedSink
 import okio.BufferedSource
+import okio.ByteString.Companion.toByteString
 import okio.ForwardingSink
 import okio.ForwardingSource
-import okio.Sink
-import okio.Timeout
 import okio.buffer
 import java.io.Closeable
 import java.io.IOException
@@ -35,19 +37,26 @@ import java.nio.charset.CodingErrorAction
 import java.util.UUID
 import java.util.concurrent.TimeUnit
 import java.util.concurrent.atomic.AtomicBoolean
-import kotlin.math.max
 
 /** OkHttp interceptor that mirrors traffic to the active SnapO link if present. */
 class SnapOOkHttpInterceptor @JvmOverloads constructor(
-    private val responseBodyPreviewBytes: Int = DefaultBodyPreviewBytes,
-    private val textBodyMaxBytes: Int = DefaultTextBodyMaxBytes,
-    private val binaryBodyMaxBytes: Int = DefaultBinaryBodyMaxBytes,
+    responseBodyPreviewBytes: Int = DefaultBodyPreviewBytes,
+    textBodyMaxBytes: Int = DefaultTextBodyMaxBytes,
+    binaryBodyMaxBytes: Int = DefaultBinaryBodyMaxBytes,
     dispatcher: CoroutineDispatcher = DefaultDispatcher,
 ) : Interceptor, Closeable {
 
+    private val responseBodyPreviewBytes = responseBodyPreviewBytes.coerceAtLeast(0)
+    private val textBodyMaxBytes = resolveEffectiveMaxBytes(textBodyMaxBytes, contentLength = null)
+    private val binaryBodyMaxBytes = resolveEffectiveMaxBytes(binaryBodyMaxBytes, contentLength = null)
     private val scope = CoroutineScope(SupervisorJob() + dispatcher)
 
+    @Suppress("TooGenericExceptionCaught")
     override fun intercept(chain: Interceptor.Chain): Response {
+        if (NetworkInspector.getOrNull() == null) {
+            return chain.proceed(chain.request())
+        }
+
         val context = InterceptContext(
             requestId = UUID.randomUUID().toString(),
             startWall = System.currentTimeMillis(),
@@ -56,40 +65,39 @@ class SnapOOkHttpInterceptor @JvmOverloads constructor(
 
         val request = chain.request()
         val requestBody = request.body
-        if (requestBody != null && requestBody.isOneShot()) {
-            val capturingBody = CapturingRequestBody(requestBody, textBodyMaxBytes)
-            val requestWithCapture = request.newBuilder()
-                .method(request.method, capturingBody)
-                .build()
-            var didPublish = false
-            fun publishOnce() {
-                if (didPublish) return
-                didPublish = true
-                publishRequest(
-                    context = context,
-                    request = requestWithCapture,
-                    capturedBody = capturingBody.snapshot(),
-                    skipFallback = true,
-                )
-            }
-
-            return runCatching {
-                val response = chain.proceed(requestWithCapture)
-                publishOnce()
-                handleResponse(context, response)
-            }.onFailure { error ->
-                publishOnce()
-                handleFailure(context, error)
-            }.getOrThrow()
+        val declaredRequestBodySize = requestBody.safeContentLength()
+        val requestPublication = publishRequest(context, request, declaredRequestBodySize)
+        val requestCapture = RequestCaptureTracker(requestPublication) { capture, after ->
+            updateRequestBody(
+                context = context,
+                after = after,
+                request = request,
+                declaredBodySize = declaredRequestBodySize,
+                capture = capture,
+            )
         }
+        val interceptedRequest = request.withCapturingBody(
+            maxBytes = requestCaptureLimit(request),
+            onComplete = requestCapture::captured,
+        )
 
-        publishRequest(context, request)
-        return runCatching {
-            val response = chain.proceed(request)
-            handleResponse(context, response)
-        }.onFailure { error ->
-            handleFailure(context, error)
-        }.getOrThrow()
+        return try {
+            val response = chain.proceed(interceptedRequest)
+            handleResponse(context, response, after = requestCapture.completion())
+        } catch (error: IOException) {
+            rethrowAfterRequestFailure(context, requestCapture.completion(), error)
+        } catch (error: RuntimeException) {
+            rethrowAfterRequestFailure(context, requestCapture.completion(), error)
+        }
+    }
+
+    private fun rethrowAfterRequestFailure(
+        context: InterceptContext,
+        requestCompletion: Job?,
+        error: Throwable,
+    ): Nothing {
+        handleFailure(context, error, after = requestCompletion)
+        throw error
     }
 
     override fun close() {
@@ -99,96 +107,140 @@ class SnapOOkHttpInterceptor @JvmOverloads constructor(
     private fun publishRequest(
         context: InterceptContext,
         request: Request,
-        capturedBody: RequestBodyCapture? = null,
-        skipFallback: Boolean = false,
-    ) {
-        val requestBody = if (skipFallback) capturedBody else capturedBody ?: request.captureBody(textBodyMaxBytes)
-        val contentType = resolveRequestContentType(requestBody?.contentType, request)
-        val contentEncoding = request.header("Content-Encoding")
-        val hasCapturedBody = (requestBody?.body?.isNotEmpty() == true) || (requestBody?.truncatedBytes ?: 0L) > 0L
-        val hasBody = request.body != null || hasCapturedBody
-        publish {
-            var encoding: String? = null
-            val encodedBody: String? = when {
-                requestBody == null -> null
+        declaredBodySize: Long?,
+    ): Job? = publish {
+        OkhttpEventFactory.createRequestWillBeSent(
+            context,
+            request,
+            hasBody = request.body != null,
+            body = null,
+            bodyEncoding = requestBodyEncoding(request),
+            truncatedBytes = null,
+            bodySize = declaredBodySize,
+        )
+    }
 
-                hasNonIdentityContentEncoding(contentEncoding) -> {
-                    encoding = "base64"
-                    encodeToString(requestBody.body, NO_WRAP)
-                }
-
-                contentType.isMultipartFormData() -> {
-                    formatMultipartBody(requestBody.body, contentType)
-                }
-
-                contentType.isTextLike() -> {
-                    val charset = contentType.resolveCharset()
-                    String(requestBody.body, charset)
-                }
-
-                else -> {
-                    encoding = "base64"
-                    encodeToString(requestBody.body, NO_WRAP)
-                }
+    private fun updateRequestBody(
+        context: InterceptContext,
+        after: Job?,
+        request: Request,
+        declaredBodySize: Long?,
+        capture: RequestBodyCapture?,
+    ): Job? {
+        if (capture == null) return after
+        val server = NetworkInspector.getOrNull() ?: return null
+        return scope.launch {
+            try {
+                after?.join()
+                val encoded = encodeRequestBody(capture, request)
+                server.updateLatestRequestBody(
+                    requestId = context.requestId,
+                    body = encoded.body,
+                    bodyEncoding = encoded.encoding,
+                    bodyTruncatedBytes = capture.truncatedBytes,
+                    bodySize = maxOf(declaredBodySize ?: 0L, capture.totalBytes),
+                )
+            } catch (_: Throwable) {
             }
-            OkhttpEventFactory.createRequestWillBeSent(
+        }
+    }
+
+    private fun handleResponse(context: InterceptContext, response: Response, after: Job?): Response {
+        val endWall = System.currentTimeMillis()
+        val endMono = SystemClock.elapsedRealtimeNanos()
+        val responseBody = response.body
+        val bodySize = responseBody.safeContentLength()
+        if (response.hasNoBodyByProtocol()) {
+            val responsePublication = publishResponseMetadata(
                 context,
-                request,
-                hasBody = hasBody,
-                body = encodedBody,
-                bodyEncoding = encoding,
-                truncatedBytes = requestBody?.truncatedBytes,
+                response,
+                bodySize,
+                endWall = endWall,
+                endMono = endMono,
+                after = after,
+            )
+            publishLoadingFinished(context, bodySize = 0L, after = responsePublication)
+            return response
+        }
+        val contentType = responseBody.contentType()
+        return if (contentType.isEventStream()) {
+            handleStreamingResponse(
+                context,
+                response,
+                responseBody,
+                contentType = contentType,
+                bodySize = bodySize,
+                endWall = endWall,
+                endMono = endMono,
+                after = after,
+            )
+        } else {
+            handleStandardResponse(
+                context = context,
+                response = response,
+                body = responseBody,
+                contentType = contentType,
+                bodySize = bodySize,
+                endWall = endWall,
+                endMono = endMono,
+                after = after,
             )
         }
     }
 
-    private fun handleResponse(context: InterceptContext, response: Response): Response {
-        val endWall = System.currentTimeMillis()
-        val endMono = SystemClock.elapsedRealtimeNanos()
-        val responseBody = response.body
-        if (response.hasNoBodyByProtocol()) {
-            publishStandardResponse(context, response, responseBody, endWall = endWall, endMono = endMono)
-            publishLoadingFinished(context, bodySize = 0L)
+    private fun handleStandardResponse(
+        context: InterceptContext,
+        response: Response,
+        body: ResponseBody,
+        contentType: MediaType?,
+        bodySize: Long?,
+        endWall: Long,
+        endMono: Long,
+        after: Job?,
+    ): Response {
+        val responsePublication = publishResponseMetadata(
+            context = context,
+            response = response,
+            bodySize = bodySize,
+            endWall = endWall,
+            endMono = endMono,
+            after = after,
+        )
+        if (bodySize == 0L) {
+            publishLoadingFinished(context, bodySize = 0L, after = responsePublication)
             return response
         }
-        return if (responseBody.contentType().isEventStream()) {
-            handleStreamingResponse(context, response, responseBody, endWall = endWall, endMono = endMono)
-        } else {
-            val completeBodySize = publishStandardResponse(
-                context = context,
-                response = response,
-                body = responseBody,
-                endWall = endWall,
-                endMono = endMono,
-            )
-            if (completeBodySize != null) {
-                publishLoadingFinished(context, completeBodySize)
-                return response
-            }
-            response.newBuilder()
-                .body(
-                    CompletionTrackingResponseBody(
-                        delegate = responseBody,
-                        onFinished = { totalBytes ->
-                            publishLoadingFinished(context, totalBytes)
-                        },
-                        onFailed = { error ->
-                            handleFailure(context, error)
-                        },
-                    ),
+        val capturingBody = CapturingResponseBody(
+            delegate = body,
+            maxBytes = responseCaptureLimit(contentType, bodySize),
+            onComplete = { capture, error ->
+                completeResponseCapture(
+                    context = context,
+                    contentType = contentType,
+                    declaredBodySize = bodySize,
+                    responsePublication = responsePublication,
+                    capture = capture,
+                    error = error,
                 )
-                .build()
-        }
+            },
+        )
+        return response.newBuilder()
+            .body(capturingBody)
+            .trailers(capturingTrailersSource(response, capturingBody))
+            .build()
     }
 
     private fun handleStreamingResponse(
         context: InterceptContext,
         response: Response,
         body: ResponseBody,
+        contentType: MediaType?,
+        bodySize: Long?,
         endWall: Long,
         endMono: Long,
+        after: Job?,
     ): Response {
-        publish {
+        val responsePublication = publish(after = after) {
             OkhttpEventFactory.createResponseReceived(
                 context = context,
                 response = response,
@@ -198,64 +250,136 @@ class SnapOOkHttpInterceptor @JvmOverloads constructor(
                 bodyText = null,
                 bodyEncoding = null,
                 truncatedBytes = null,
-                bodySize = body.safeContentLength(),
+                bodySize = bodySize,
             )
         }
+        val publicationLock = Any()
+        var previousPublication = responsePublication
         val streamingBody = StreamingResponseRelayBody(
             delegate = body,
             requestId = context.requestId,
-            charset = body.contentType().resolveCharset(),
-            onRecord = { publish(it) },
+            charset = contentType.resolveCharset(),
+            onRecord = { recordBuilder ->
+                synchronized(publicationLock) {
+                    previousPublication = publish(
+                        after = previousPublication,
+                        builder = recordBuilder,
+                    ) ?: previousPublication
+                }
+            },
         )
         return response.newBuilder().body(streamingBody).build()
     }
 
-    private fun publishStandardResponse(
+    private fun publishResponseMetadata(
         context: InterceptContext,
         response: Response,
-        body: ResponseBody,
+        bodySize: Long?,
         endWall: Long,
         endMono: Long,
-    ): Long? {
-        val bodySize = body.safeContentLength()
-        var completeBodySize = bodySize.takeIf { it == 0L }
-        publish {
-            val textBody = response.captureTextBody(textBodyMaxBytes, responseBodyPreviewBytes)
-            val binaryBody = if (textBody == null) {
-                response.captureBinaryBody(binaryBodyMaxBytes, responseBodyPreviewBytes)
-            } else {
-                null
-            }
-            completeBodySize = completeCapturedBodySize(
-                textBody = textBody,
-                binaryBody = binaryBody,
-                bodySize = bodySize,
-            )
-            val bodyPreview = textBody?.preview
-                ?: binaryBody?.preview
-                ?: response.bodyPreview(responseBodyPreviewBytes)
-            val truncatedBytes = textBody?.truncatedBytes(bodySize)
-                ?: binaryBody?.truncatedBytes(bodySize)
-            val bodyEncoding = if (binaryBody != null) "base64" else null
+        after: Job?,
+    ): Job? {
+        return publish(after = after) {
             OkhttpEventFactory.createResponseReceived(
                 context = context,
                 response = response,
                 endWall = endWall,
                 endMono = endMono,
-                bodyPreview = bodyPreview,
-                bodyText = textBody?.body ?: binaryBody?.base64,
-                bodyEncoding = bodyEncoding,
-                truncatedBytes = truncatedBytes,
+                bodyPreview = null,
+                bodyText = null,
+                bodyEncoding = null,
+                truncatedBytes = null,
                 bodySize = bodySize,
             )
         }
-        return completeBodySize
     }
 
-    private fun handleFailure(context: InterceptContext, error: Throwable) {
+    private fun requestCaptureLimit(request: Request): Int {
+        return resolveRequestCaptureLimit(
+            request = request,
+            textBodyMaxBytes = textBodyMaxBytes,
+            binaryBodyMaxBytes = binaryBodyMaxBytes,
+        )
+    }
+
+    private fun responseCaptureLimit(contentType: MediaType?, contentLength: Long?): Int {
+        val bodyLimit = when {
+            contentType == null -> maxOf(textBodyMaxBytes, binaryBodyMaxBytes)
+            contentType.isTextLike() -> textBodyMaxBytes
+            else -> binaryBodyMaxBytes
+        }
+        return resolveEffectiveMaxBytes(
+            maxBytes = maxOf(bodyLimit, responseBodyPreviewBytes),
+            contentLength = contentLength,
+        )
+    }
+
+    private fun completeResponseCapture(
+        context: InterceptContext,
+        contentType: MediaType?,
+        declaredBodySize: Long?,
+        responsePublication: Job?,
+        capture: ResponseBodyCapture,
+        error: Throwable?,
+    ) {
+        val completionWall = System.currentTimeMillis()
+        val completionMono = SystemClock.elapsedRealtimeNanos()
+        val server = NetworkInspector.getOrNull() ?: return
+        scope.launch {
+            try {
+                responsePublication?.join()
+                val body = runCatching {
+                    resolveResponseBodyCapture(
+                        capture = capture,
+                        contentType = contentType,
+                        textBodyMaxBytes = textBodyMaxBytes,
+                        binaryBodyMaxBytes = binaryBodyMaxBytes,
+                        previewBytes = responseBodyPreviewBytes,
+                        declaredBodySize = declaredBodySize,
+                    )
+                }.getOrNull()
+                if (body != null) {
+                    runCatching {
+                        server.updateLatestResponseBody(
+                            requestId = context.requestId,
+                            bodyPreview = body.preview,
+                            body = body.body,
+                            bodyEncoding = body.encoding,
+                            bodyTruncatedBytes = body.truncatedBytes,
+                            bodySize = body.bodySize,
+                        )
+                    }
+                }
+                val completedBodySize = body?.bodySize
+                    ?: declaredBodySize
+                    ?: capture.totalBytes
+                val completionRecord = if (error == null) {
+                    ResponseFinished(
+                        id = context.requestId,
+                        tWallMs = completionWall,
+                        tMonoNs = completionMono,
+                        bodySize = completedBodySize,
+                    )
+                } else {
+                    RequestFailed(
+                        id = context.requestId,
+                        tWallMs = completionWall,
+                        tMonoNs = completionMono,
+                        errorKind = error.javaClass.simpleName.ifEmpty { error.javaClass.name },
+                        message = error.message,
+                        timings = Timings(totalMs = nanosToMillis(completionMono - context.startMono)),
+                    )
+                }
+                server.publish(completionRecord)
+            } catch (_: Throwable) {
+            }
+        }
+    }
+
+    private fun handleFailure(context: InterceptContext, error: Throwable, after: Job? = null) {
         val failWall = System.currentTimeMillis()
         val failMono = SystemClock.elapsedRealtimeNanos()
-        publish {
+        publish(after = after) {
             RequestFailed(
                 id = context.requestId,
                 tWallMs = failWall,
@@ -267,10 +391,10 @@ class SnapOOkHttpInterceptor @JvmOverloads constructor(
         }
     }
 
-    private fun publishLoadingFinished(context: InterceptContext, bodySize: Long?) {
+    private fun publishLoadingFinished(context: InterceptContext, bodySize: Long?, after: Job? = null) {
         val finishWall = System.currentTimeMillis()
         val finishMono = SystemClock.elapsedRealtimeNanos()
-        publish {
+        publish(after = after) {
             ResponseFinished(
                 id = context.requestId,
                 tWallMs = finishWall,
@@ -280,12 +404,15 @@ class SnapOOkHttpInterceptor @JvmOverloads constructor(
         }
     }
 
-    private inline fun publish(crossinline builder: () -> NetworkEventRecord) {
-        val server = NetworkInspector.getOrNull() ?: return
-        val record = builder()
-        scope.launch {
+    private inline fun publish(
+        after: Job? = null,
+        crossinline builder: () -> NetworkEventRecord,
+    ): Job? {
+        val server = NetworkInspector.getOrNull() ?: return null
+        return scope.launch {
             try {
-                server.publish(record)
+                after?.join()
+                server.publish(builder())
             } catch (_: Throwable) {
             }
         }
@@ -298,63 +425,83 @@ internal data class InterceptContext(
     val startMono: Long,
 )
 
-private data class TextBodyCapture(
-    val body: String,
-    val preview: String?,
-    val truncated: Boolean,
-    val capturedBytes: Long,
-    val originalBytes: Long,
-)
-
-private data class BinaryBodyCapture(
-    val base64: String,
-    val preview: String?,
-    val truncated: Boolean,
-    val capturedBytes: Long,
-    val originalBytes: Long,
-)
-
 internal data class RequestBodyCapture(
     val contentType: MediaType?,
     val body: ByteArray,
+    val totalBytes: Long,
     val truncatedBytes: Long,
 )
 
-private class RequestBodyCaptureBuffer(private val maxBytes: Int) {
+internal data class ResponseBodyCapture(
+    val body: ByteArray,
+    val totalBytes: Long,
+    val reachedEof: Boolean,
+)
+
+private class RequestCaptureTracker(
+    initialCompletion: Job?,
+    private val update: (RequestBodyCapture, Job?) -> Job?,
+) {
+    private val lock = Any()
+    private var latestCompletion = initialCompletion
+
+    fun captured(capture: RequestBodyCapture) {
+        synchronized(lock) {
+            latestCompletion = update(capture, latestCompletion) ?: latestCompletion
+        }
+    }
+
+    fun completion(): Job? = synchronized(lock) { latestCompletion }
+}
+
+private fun Request.withCapturingBody(
+    maxBytes: Int,
+    onComplete: (RequestBodyCapture) -> Unit,
+): Request {
+    val requestBody = body ?: return this
+    if (requestBody.isDuplex() || maxBytes <= 0) return this
+    return newBuilder()
+        .method(
+            method,
+            CapturingRequestBody(
+                delegate = requestBody,
+                maxBytes = maxBytes,
+                onComplete = onComplete,
+            ),
+        )
+        .build()
+}
+
+private data class CapturedBytes(
+    val body: ByteArray,
+    val totalBytes: Long,
+)
+
+private class BodyCaptureBuffer(private val maxBytes: Int) {
     private val buffer = Buffer()
     private var totalBytes: Long = 0
 
-    fun append(source: Buffer, byteCount: Long) {
+    fun append(source: Buffer, offset: Long, byteCount: Long) {
         if (byteCount <= 0L) return
         totalBytes += byteCount
         if (maxBytes <= 0) return
         val remaining = maxBytes.toLong() - buffer.size
         if (remaining <= 0L) return
         val toCopy = minOf(byteCount, remaining)
-        source.copyTo(buffer, 0, toCopy)
+        source.copyTo(buffer, offset, toCopy)
     }
 
-    fun snapshot(contentType: MediaType?): RequestBodyCapture? {
-        if (maxBytes <= 0) return null
-        val captured = buffer.readByteArray()
-        val truncatedBytes = (totalBytes - captured.size.toLong()).coerceAtLeast(0L)
-        return RequestBodyCapture(
-            contentType = contentType,
-            body = captured,
-            truncatedBytes = truncatedBytes,
-        )
-    }
+    fun snapshot(): CapturedBytes = CapturedBytes(
+        body = buffer.readByteArray(),
+        totalBytes = totalBytes,
+    )
 }
 
-private class CapturingRequestBody(
+internal class CapturingRequestBody(
     private val delegate: okhttp3.RequestBody,
     private val maxBytes: Int,
+    private val onComplete: (RequestBodyCapture) -> Unit,
 ) : okhttp3.RequestBody() {
-    @Volatile
-    private var captured: RequestBodyCapture? = null
-
-    fun snapshot(): RequestBodyCapture? = captured
-
     override fun contentType(): MediaType? = delegate.contentType()
 
     override fun contentLength(): Long = delegate.contentLength()
@@ -364,31 +511,41 @@ private class CapturingRequestBody(
     override fun isDuplex(): Boolean = delegate.isDuplex()
 
     override fun writeTo(sink: BufferedSink) {
-        val capture = RequestBodyCaptureBuffer(maxBytes)
+        val capture = BodyCaptureBuffer(maxBytes)
         val capturingSink = object : ForwardingSink(sink) {
             override fun write(source: Buffer, byteCount: Long) {
-                capture.append(source, byteCount)
+                capture.append(source, offset = 0L, byteCount = byteCount)
                 super.write(source, byteCount)
             }
         }
         val buffered = capturingSink.buffer()
         try {
             delegate.writeTo(buffered)
-            buffered.flush()
+            buffered.emit()
         } finally {
-            captured = capture.snapshot(contentType())
+            val snapshot = capture.snapshot()
+            val completedCapture = RequestBodyCapture(
+                contentType = runCatching { contentType() }.getOrNull(),
+                body = snapshot.body,
+                totalBytes = snapshot.totalBytes,
+                truncatedBytes = (snapshot.totalBytes - snapshot.body.size.toLong()).coerceAtLeast(0L),
+            )
+            try {
+                onComplete(completedCapture)
+            } catch (_: Throwable) {
+            }
         }
     }
 }
 
-private class CompletionTrackingResponseBody(
+internal class CapturingResponseBody(
     private val delegate: ResponseBody,
-    private val onFinished: (Long?) -> Unit,
-    private val onFailed: (Throwable) -> Unit,
+    maxBytes: Int,
+    private val onComplete: (ResponseBodyCapture, Throwable?) -> Unit,
 ) : ResponseBody() {
     private val closed = AtomicBoolean(false)
     private val completionNotified = AtomicBoolean(false)
-    private var totalBytes: Long = 0L
+    private val capture = BodyCaptureBuffer(maxBytes)
 
     private val bufferedSource: BufferedSource by lazy {
         object : ForwardingSource(delegate.source()) {
@@ -396,22 +553,19 @@ private class CompletionTrackingResponseBody(
                 return runCatching {
                     val read = super.read(sink, byteCount)
                     if (read > 0L) {
-                        totalBytes += read
+                        capture.append(sink, offset = sink.size - read, byteCount = read)
                     } else if (read == -1L) {
-                        completeSuccessfully()
+                        complete(error = null, reachedEof = true)
                     }
                     read
                 }.onFailure { error ->
-                    completeWithError(error)
+                    complete(error = error, reachedEof = false)
                 }.getOrThrow()
             }
 
             override fun close() {
                 val result = runCatching { super.close() }
-                result.onFailure { error -> completeWithError(error) }
-                if (result.isSuccess) {
-                    completeSuccessfully()
-                }
+                complete(error = result.exceptionOrNull(), reachedEof = false)
                 result.getOrThrow()
             }
         }.buffer()
@@ -429,23 +583,47 @@ private class CompletionTrackingResponseBody(
         }
     }
 
-    private fun completeSuccessfully() {
+    private fun complete(error: Throwable?, reachedEof: Boolean) {
         if (!completionNotified.compareAndSet(false, true)) return
-        val total = if (totalBytes > 0L) {
-            totalBytes
-        } else {
-            delegate.safeContentLength()
+        val snapshot = capture.snapshot()
+        try {
+            onComplete(
+                ResponseBodyCapture(
+                    body = snapshot.body,
+                    totalBytes = snapshot.totalBytes,
+                    reachedEof = reachedEof,
+                ),
+                error,
+            )
+        } catch (_: Throwable) {
         }
-        onFinished(total)
     }
+}
 
-    private fun completeWithError(error: Throwable) {
-        if (!completionNotified.compareAndSet(false, true)) return
-        onFailed(error)
+internal fun capturingTrailersSource(response: Response, body: ResponseBody): TrailersSource {
+    return object : TrailersSource {
+        override fun peek(): Headers? = response.peekTrailers()
+
+        override fun get(): Headers {
+            val source = body.source()
+            val discard = Buffer()
+            while (source.read(discard, SegmentByteCount) != -1L) {
+                discard.clear()
+            }
+            return response.trailers()
+        }
     }
 }
 
 private fun ResponseBody?.safeContentLength(): Long? = this?.let {
+    try {
+        it.contentLength().takeIf { len -> len >= 0L }
+    } catch (_: IOException) {
+        null
+    }
+}
+
+private fun okhttp3.RequestBody?.safeContentLength(): Long? = this?.let {
     try {
         it.contentLength().takeIf { len -> len >= 0L }
     } catch (_: IOException) {
@@ -459,23 +637,6 @@ private fun Response.hasNoBodyByProtocol(): Boolean {
         code == 204 ||
         code == 205 ||
         code == 304
-}
-
-private fun Response.bodyPreview(maxBytes: Int): String? {
-    return if (maxBytes <= 0L) {
-        null
-    } else {
-        try {
-            val peek: ResponseBody = peekBody(maxBytes.toLong())
-            val bytes = peek.bytes()
-            val charset: Charset = peek.contentType().resolveCharset()
-            String(bytes, charset)
-        } catch (_: IOException) {
-            null
-        } catch (_: RuntimeException) {
-            null
-        }
-    }
 }
 
 private fun MediaType?.isTextLike(): Boolean = when {
@@ -506,133 +667,124 @@ private fun MediaType?.isEventStream(): Boolean {
         mediaType.subtype.equals("event-stream", ignoreCase = true)
 }
 
-private fun Response.captureTextBody(maxBytes: Int, previewBytes: Int): TextBodyCapture? {
-    val responseBody = body
-    val mediaType = responseBody.contentType()
-    val isKnownText = mediaType?.isTextLike() == true
-    return when {
-        maxBytes <= 0L -> null
-        mediaType != null && !isKnownText -> null
-        else -> try {
-            val contentLength = responseBody.contentLength()
-            val effectiveMax = when {
-                contentLength in 0 until AbsoluteBodyTextMaxBytes -> max(maxBytes, contentLength.toInt())
-                else -> maxBytes
-            }
-            val peek = peekBody(effectiveMax.toLong() + 1L)
-            val bytes = peek.bytes()
-            val truncated = bytes.size > effectiveMax
-            val effective = if (truncated) bytes.copyOf(effectiveMax) else bytes
-            val charset = mediaType.resolveCharset()
-            val text = if (isKnownText) {
-                String(effective, charset)
-            } else {
-                effective.decodeUtf8TextIfLikely() ?: return null
-            }
-            val previewLimit = previewBytes
-                .coerceAtMost(effective.size)
-            val preview = if (previewLimit > 0) {
-                String(effective, 0, previewLimit, charset)
-            } else {
-                null
-            }
-            TextBodyCapture(
-                body = text,
-                preview = preview,
-                truncated = truncated,
-                capturedBytes = effective.size.toLong(),
-                originalBytes = bytes.size.toLong(),
-            )
-        } catch (_: IOException) {
-            null
-        } catch (_: RuntimeException) {
-            null
-        }
+private data class EncodedBody(
+    val body: String?,
+    val encoding: String?,
+)
+
+internal fun resolveRequestCaptureLimit(
+    request: Request,
+    textBodyMaxBytes: Int,
+    binaryBodyMaxBytes: Int,
+): Int {
+    val requestBody = request.body ?: return 0
+    val contentType = resolveRequestContentType(
+        captureContentType = runCatching { requestBody.contentType() }.getOrNull(),
+        request = request,
+    )
+    return if (requestBodyUsesBase64(request, contentType)) {
+        binaryBodyMaxBytes
+    } else {
+        textBodyMaxBytes
     }
 }
 
-private fun Response.captureBinaryBody(maxBytes: Int, previewBytes: Int): BinaryBodyCapture? {
-    val responseBody = body
-    val mediaType = responseBody.contentType()
+private fun requestBodyEncoding(request: Request): String? {
+    val requestBody = request.body ?: return null
+    val contentType = resolveRequestContentType(
+        captureContentType = runCatching { requestBody.contentType() }.getOrNull(),
+        request = request,
+    )
+    return "base64".takeIf { requestBodyUsesBase64(request, contentType) }
+}
+
+private fun encodeRequestBody(capture: RequestBodyCapture, request: Request): EncodedBody {
+    val contentType = resolveRequestContentType(capture.contentType, request)
     return when {
-        maxBytes <= 0L -> null
-        mediaType?.isTextLike() == true -> null
-        mediaType.isEventStream() -> null
-        else -> try {
-            val contentLength = responseBody.contentLength()
-            val effectiveMax = when {
-                contentLength in 0 until AbsoluteBodyTextMaxBytes ->
-                    max(maxBytes, contentLength.toInt())
-                else -> maxBytes
-            }
-            val peek = peekBody(effectiveMax.toLong() + 1L)
-            val bytes = peek.bytes()
-            val truncated = bytes.size > effectiveMax
-            val effective = if (truncated) bytes.copyOf(effectiveMax) else bytes
-            val previewLimit = previewBytes.coerceAtMost(effective.size)
-            val preview = if (previewLimit > 0) {
-                encodeToString(effective, 0, previewLimit, NO_WRAP)
-            } else {
-                null
-            }
-            BinaryBodyCapture(
-                base64 = encodeToString(effective, NO_WRAP),
-                preview = preview,
-                truncated = truncated,
-                capturedBytes = effective.size.toLong(),
-                originalBytes = bytes.size.toLong(),
-            )
-        } catch (_: IOException) {
-            null
-        } catch (_: RuntimeException) {
-            null
-        }
+        requestBodyUsesBase64(request, contentType) ->
+            EncodedBody(encodeToString(capture.body, NO_WRAP), "base64")
+
+        contentType.isMultipartFormData() ->
+            EncodedBody(formatMultipartBody(capture.body, contentType), null)
+
+        else -> EncodedBody(String(capture.body, contentType.resolveCharset()), null)
     }
 }
 
-private fun completeCapturedBodySize(
-    textBody: TextBodyCapture?,
-    binaryBody: BinaryBodyCapture?,
-    bodySize: Long?,
+private fun requestBodyUsesBase64(request: Request, contentType: MediaType?): Boolean {
+    return hasNonIdentityContentEncoding(request.header("Content-Encoding")) ||
+        (!contentType.isTextLike() && !contentType.isMultipartFormData())
+}
+
+internal data class ResolvedResponseBodyCapture(
+    val preview: String?,
+    val body: String?,
+    val encoding: String?,
+    val truncatedBytes: Long?,
+    val bodySize: Long,
+)
+
+internal fun resolveResponseBodyCapture(
+    capture: ResponseBodyCapture,
+    contentType: MediaType?,
+    textBodyMaxBytes: Int,
+    binaryBodyMaxBytes: Int,
+    previewBytes: Int,
+    declaredBodySize: Long?,
+): ResolvedResponseBodyCapture {
+    val likelyText = capture.isLikelyText(contentType)
+    val bodyLimit = if (likelyText) textBodyMaxBytes else binaryBodyMaxBytes
+    val retainedBodyBytes = capture.body.prefix(bodyLimit)
+    val previewSource = capture.body.prefix(previewBytes)
+    val charset = contentType.resolveCharset()
+    val body = retainedBodyBytes.encodeForInspector(likelyText, charset)
+    val preview = previewSource.encodeForInspector(likelyText, charset)
+    val bodySize = capture.resolvedBodySize(declaredBodySize)
+    val truncatedBytes = capture.resolvedTruncatedBytes(
+        bodySize = bodySize,
+        retainedBytes = retainedBodyBytes.size,
+        hasDeclaredBodySize = declaredBodySize != null,
+    )
+    return ResolvedResponseBodyCapture(
+        preview = preview,
+        body = body,
+        encoding = "base64".takeIf { body != null && !likelyText },
+        truncatedBytes = truncatedBytes,
+        bodySize = bodySize,
+    )
+}
+
+private fun ResponseBodyCapture.isLikelyText(contentType: MediaType?): Boolean = when {
+    contentType?.isTextLike() == true -> true
+    contentType != null -> false
+    else -> body.decodeUtf8TextIfLikely() != null
+}
+
+private fun ByteArray.encodeForInspector(likelyText: Boolean, charset: Charset): String? = when {
+    isEmpty() -> null
+    likelyText -> String(this, charset)
+    else -> toByteString().base64()
+}
+
+private fun ResponseBodyCapture.resolvedBodySize(declaredBodySize: Long?): Long = when {
+    reachedEof -> totalBytes
+    declaredBodySize != null -> maxOf(declaredBodySize, totalBytes)
+    else -> totalBytes
+}
+
+private fun ResponseBodyCapture.resolvedTruncatedBytes(
+    bodySize: Long,
+    retainedBytes: Int,
+    hasDeclaredBodySize: Boolean,
 ): Long? {
-    if (bodySize == 0L) return 0L
-    val capturedBytes = textBody?.capturedBytes ?: binaryBody?.capturedBytes ?: return null
-    val truncated = textBody?.truncated ?: binaryBody?.truncated ?: return null
-    if (truncated) return null
-    if (bodySize != null && capturedBytes < bodySize) return null
-    return bodySize ?: capturedBytes
+    val truncatedBytes = (bodySize - retainedBytes.toLong()).coerceAtLeast(0L)
+    val truncationIsKnown = reachedEof || hasDeclaredBodySize || totalBytes > retainedBytes
+    return truncatedBytes.takeIf { it > 0L && truncationIsKnown }
 }
 
-private fun Request.captureBody(maxBytes: Int): RequestBodyCapture? {
-    if (maxBytes <= 0) return null
-    val requestBody = body ?: return null
-    if (requestBody.isDuplex() || requestBody.isOneShot()) return null
-    return try {
-        val capture = RequestBodyCaptureBuffer(maxBytes)
-        val sink = CapturingBlackholeSink(capture).buffer()
-        requestBody.writeTo(sink)
-        sink.flush()
-        capture.snapshot(requestBody.contentType())
-    } catch (_: IOException) {
-        null
-    } catch (_: RuntimeException) {
-        null
-    }
-}
-
-private class CapturingBlackholeSink(
-    private val capture: RequestBodyCaptureBuffer,
-) : Sink {
-    override fun write(source: Buffer, byteCount: Long) {
-        capture.append(source, byteCount)
-        source.skip(byteCount)
-    }
-
-    override fun flush() = Unit
-
-    override fun timeout(): Timeout = Timeout.NONE
-
-    override fun close() = Unit
+private fun ByteArray.prefix(maxBytes: Int): ByteArray {
+    if (maxBytes <= 0 || isEmpty()) return ByteArray(0)
+    return if (size <= maxBytes) this else copyOf(maxBytes)
 }
 
 private fun hasNonIdentityContentEncoding(contentEncoding: String?): Boolean {
@@ -642,22 +794,6 @@ private fun hasNonIdentityContentEncoding(contentEncoding: String?): Boolean {
         ?.filter { token -> token.isNotEmpty() }
         .orEmpty()
     return encodings.any { token -> token != "identity" }
-}
-
-private fun TextBodyCapture.truncatedBytes(totalBytes: Long?): Long? {
-    return when {
-        totalBytes != null -> max(totalBytes - capturedBytes, 0L)
-        truncated -> max(originalBytes - capturedBytes, 0L)
-        else -> null
-    }
-}
-
-private fun BinaryBodyCapture.truncatedBytes(totalBytes: Long?): Long? {
-    return when {
-        totalBytes != null -> max(totalBytes - capturedBytes, 0L)
-        truncated -> max(originalBytes - capturedBytes, 0L)
-        else -> null
-    }
 }
 
 private fun MediaType?.resolveCharset(): Charset {
@@ -944,5 +1080,16 @@ internal fun nanosToMillis(deltaNs: Long): Long? {
     return TimeUnit.NANOSECONDS.toMillis(deltaNs)
 }
 
+internal fun resolveEffectiveMaxBytes(maxBytes: Int, contentLength: Long?): Int {
+    if (maxBytes <= 0) return 0
+    val knownLength = contentLength?.takeIf { it >= 0L } ?: return maxBytes
+    return if (knownLength < CompleteBodyCaptureThresholdBytes) {
+        maxOf(maxBytes.toLong(), knownLength).toInt()
+    } else {
+        maxBytes
+    }
+}
+
 private const val MinLikelyTextRatio: Double = 0.85
-private const val AbsoluteBodyTextMaxBytes: Long = 8L * 1024L * 1024L
+private const val SegmentByteCount: Long = 8L * 1024L
+private const val CompleteBodyCaptureThresholdBytes: Long = 8L * 1024L * 1024L

--- a/snapo-link-android/network-okhttp3/src/test/java/com/openai/snapo/network/okhttp3/BodyCaptureTest.kt
+++ b/snapo-link-android/network-okhttp3/src/test/java/com/openai/snapo/network/okhttp3/BodyCaptureTest.kt
@@ -1,0 +1,287 @@
+package com.openai.snapo.network.okhttp3
+
+import okhttp3.Headers
+import okhttp3.MediaType
+import okhttp3.MediaType.Companion.toMediaType
+import okhttp3.Protocol
+import okhttp3.Request
+import okhttp3.RequestBody
+import okhttp3.Response
+import okhttp3.ResponseBody
+import okhttp3.TrailersSource
+import okio.Buffer
+import okio.BufferedSink
+import okio.BufferedSource
+import okio.ForwardingSource
+import okio.Source
+import okio.Timeout
+import okio.buffer
+import org.junit.Assert.assertArrayEquals
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertSame
+import org.junit.Assert.assertTrue
+import org.junit.Assert.fail
+import org.junit.Test
+import java.io.IOException
+
+class BodyCaptureTest {
+
+    @Test
+    fun `request body is serialized once and captured from the real write`() {
+        val delegate = CountingRequestBody("request body")
+        var capture: RequestBodyCapture? = null
+        val body = CapturingRequestBody(delegate = delegate, maxBytes = 4) { value ->
+            capture = value
+        }
+        val sink = Buffer()
+
+        body.writeTo(sink)
+
+        assertEquals("request body", sink.readUtf8())
+        assertEquals(1, delegate.writeCount)
+        val captured = checkNotNull(capture)
+        assertArrayEquals("requ".encodeToByteArray(), captured.body)
+        assertEquals(12L, captured.totalBytes)
+        assertEquals(8L, captured.truncatedBytes)
+    }
+
+    @Test
+    fun `request capture does not add a network flush`() {
+        val upstream = FlushCountingSink()
+        val networkSink = upstream.buffer()
+        val body = CapturingRequestBody(CountingRequestBody("request body"), maxBytes = 4) { }
+
+        body.writeTo(networkSink)
+
+        assertEquals(0, upstream.flushCount)
+        networkSink.emit()
+        assertEquals("request body", upstream.received.readUtf8())
+    }
+
+    @Test
+    fun `request observer failure cannot break the network write`() {
+        val sink = Buffer()
+        val body = CapturingRequestBody(CountingRequestBody("request body"), maxBytes = 4) {
+            error("observer failed")
+        }
+
+        body.writeTo(sink)
+
+        assertEquals("request body", sink.readUtf8())
+    }
+
+    @Test
+    fun `response body is not read until the caller consumes it`() {
+        val delegate = TrackingResponseBody("response body")
+        val captures = mutableListOf<ResponseBodyCapture>()
+        val body = CapturingResponseBody(delegate = delegate, maxBytes = 4) { capture, error ->
+            assertNull(error)
+            captures += capture
+        }
+
+        val firstSource = body.source()
+
+        assertEquals(0, delegate.readCount)
+        assertSame(firstSource, body.source())
+        assertEquals("response body", body.string())
+        assertTrue(delegate.readCount > 0)
+        assertEquals(1, captures.size)
+        assertArrayEquals("resp".encodeToByteArray(), captures.single().body)
+        assertEquals(13L, captures.single().totalBytes)
+        assertTrue(captures.single().reachedEof)
+    }
+
+    @Test
+    fun `reading trailers first still passes the response through the capture tee`() {
+        val captures = mutableListOf<ResponseBodyCapture>()
+        val body = CapturingResponseBody(TrackingResponseBody("response body"), maxBytes = 4) { capture, _ ->
+            captures += capture
+        }
+        val trailers = Headers.Builder().add("X-Trailer", "done").build()
+        val response = Response.Builder()
+            .request(Request.Builder().url("https://example.com/response").build())
+            .protocol(Protocol.HTTP_1_1)
+            .code(200)
+            .message("OK")
+            .body(body)
+            .trailers(
+                object : TrailersSource {
+                    override fun get(): Headers = trailers
+                },
+            )
+            .build()
+        val wrapped = response.newBuilder()
+            .trailers(capturingTrailersSource(response, body))
+            .build()
+
+        assertEquals(trailers, wrapped.trailers())
+        assertEquals(1, captures.size)
+        assertEquals(13L, captures.single().totalBytes)
+        assertTrue(captures.single().reachedEof)
+    }
+
+    @Test
+    fun `zero response capture limit still preserves the caller body`() {
+        var capture: ResponseBodyCapture? = null
+        val body = CapturingResponseBody(TrackingResponseBody("complete"), maxBytes = 0) { value, _ ->
+            capture = value
+        }
+
+        assertEquals("complete", body.string())
+        val captured = checkNotNull(capture)
+        assertArrayEquals(ByteArray(0), captured.body)
+        assertEquals(8L, captured.totalBytes)
+    }
+
+    @Test
+    fun `observer failure cannot break a successful response read`() {
+        val body = CapturingResponseBody(TrackingResponseBody("complete"), maxBytes = 4) { _, _ ->
+            error("observer failed")
+        }
+
+        assertEquals("complete", body.string())
+    }
+
+    @Test
+    fun `observer failure cannot replace the upstream response failure`() {
+        val expected = IOException("upstream failed")
+        val body = CapturingResponseBody(FailingResponseBody(expected), maxBytes = 4) { _, _ ->
+            error("observer failed")
+        }
+
+        try {
+            body.source().read(Buffer(), 1L)
+            fail("Expected the upstream failure")
+        } catch (error: IOException) {
+            assertSame(expected, error)
+        }
+    }
+
+    @Test
+    fun `response formatter applies body and preview limits after capture`() {
+        val capture = ResponseBodyCapture(
+            body = "0123456789".encodeToByteArray(),
+            totalBytes = 10L,
+            reachedEof = true,
+        )
+
+        val text = resolveResponseBodyCapture(
+            capture = capture,
+            contentType = "text/plain; charset=utf-8".toMediaType(),
+            textBodyMaxBytes = 4,
+            binaryBodyMaxBytes = 6,
+            previewBytes = 2,
+            declaredBodySize = 10L,
+        )
+        val binary = resolveResponseBodyCapture(
+            capture = capture,
+            contentType = "application/octet-stream".toMediaType(),
+            textBodyMaxBytes = 4,
+            binaryBodyMaxBytes = 4,
+            previewBytes = 2,
+            declaredBodySize = 10L,
+        )
+        val omitted = resolveResponseBodyCapture(
+            capture = capture,
+            contentType = "text/plain".toMediaType(),
+            textBodyMaxBytes = 0,
+            binaryBodyMaxBytes = 0,
+            previewBytes = 2,
+            declaredBodySize = 10L,
+        )
+
+        assertEquals("0123", text.body)
+        assertEquals("01", text.preview)
+        assertEquals(null, text.encoding)
+        assertEquals(6L, text.truncatedBytes)
+        assertEquals("MDEyMw==", binary.body)
+        assertEquals("MDE=", binary.preview)
+        assertEquals("base64", binary.encoding)
+        assertEquals(6L, binary.truncatedBytes)
+        assertNull(omitted.body)
+        assertEquals("01", omitted.preview)
+        assertEquals(10L, omitted.truncatedBytes)
+    }
+
+    @Test
+    fun `closing a partially consumed response completes once without claiming eof`() {
+        val captures = mutableListOf<ResponseBodyCapture>()
+        val body = CapturingResponseBody(TrackingResponseBody("response body"), maxBytes = 4) { capture, _ ->
+            captures += capture
+        }
+        val sink = Buffer()
+
+        body.source().read(sink, 2L)
+        body.close()
+        body.close()
+
+        assertEquals(1, captures.size)
+        assertFalse(captures.single().reachedEof)
+    }
+
+    private class CountingRequestBody(private val value: String) : RequestBody() {
+        var writeCount: Int = 0
+            private set
+
+        override fun contentType(): MediaType? = null
+
+        override fun writeTo(sink: BufferedSink) {
+            writeCount += 1
+            sink.writeUtf8(value)
+        }
+    }
+
+    private class TrackingResponseBody(value: String) : ResponseBody() {
+        private val contentLength = value.encodeToByteArray().size.toLong()
+        private val upstream = Buffer().writeUtf8(value)
+        private val trackedSource: BufferedSource = object : ForwardingSource(upstream) {
+            override fun read(sink: Buffer, byteCount: Long): Long {
+                readCount += 1
+                return super.read(sink, byteCount)
+            }
+        }.buffer()
+
+        var readCount: Int = 0
+            private set
+
+        override fun contentType(): MediaType = "text/plain; charset=utf-8".toMediaType()
+
+        override fun contentLength(): Long = contentLength
+
+        override fun source(): BufferedSource = trackedSource
+    }
+
+    private class FailingResponseBody(private val failure: IOException) : ResponseBody() {
+        private val failingSource: BufferedSource = object : Source {
+            override fun read(sink: Buffer, byteCount: Long): Long = throw failure
+            override fun timeout(): Timeout = Timeout.NONE
+            override fun close() = Unit
+        }.buffer()
+
+        override fun contentType(): MediaType = "text/plain".toMediaType()
+
+        override fun contentLength(): Long = -1L
+
+        override fun source(): BufferedSource = failingSource
+    }
+
+    private class FlushCountingSink : okio.Sink {
+        val received = Buffer()
+        var flushCount: Int = 0
+            private set
+
+        override fun write(source: Buffer, byteCount: Long) {
+            received.write(source, byteCount)
+        }
+
+        override fun flush() {
+            flushCount += 1
+        }
+
+        override fun timeout(): Timeout = Timeout.NONE
+
+        override fun close() = Unit
+    }
+}

--- a/snapo-link-android/network-okhttp3/src/test/java/com/openai/snapo/network/okhttp3/SnapOOkHttpInterceptorTest.kt
+++ b/snapo-link-android/network-okhttp3/src/test/java/com/openai/snapo/network/okhttp3/SnapOOkHttpInterceptorTest.kt
@@ -1,0 +1,132 @@
+package com.openai.snapo.network.okhttp3
+
+import mockwebserver3.MockResponse
+import mockwebserver3.MockWebServer
+import okhttp3.MediaType
+import okhttp3.MediaType.Companion.toMediaType
+import okhttp3.OkHttpClient
+import okhttp3.Request
+import okhttp3.RequestBody
+import okhttp3.RequestBody.Companion.toRequestBody
+import okhttp3.WebSocket
+import okhttp3.WebSocketListener
+import okio.BufferedSink
+import okio.ByteString
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertSame
+import org.junit.Test
+
+class SnapOOkHttpInterceptorTest {
+
+    @Test
+    fun `small known bodies can expand the configured capture limit`() {
+        assertEquals(7_000_000, resolveEffectiveMaxBytes(maxBytes = 1_024, contentLength = 7_000_000L))
+        assertEquals(1_024, resolveEffectiveMaxBytes(maxBytes = 1_024, contentLength = 512L))
+        assertEquals(12 * 1024 * 1024, resolveEffectiveMaxBytes(12 * 1024 * 1024, contentLength = null))
+        assertEquals(1_024, resolveEffectiveMaxBytes(maxBytes = 1_024, contentLength = 9L * 1024L * 1024L))
+        assertEquals(0, resolveEffectiveMaxBytes(-1, contentLength = null))
+    }
+
+    @Test
+    fun `capture defaults preserve full body and websocket preview limits`() {
+        assertEquals(5 * 1024 * 1024, DefaultTextBodyMaxBytes)
+        assertEquals(DefaultTextBodyMaxBytes, DefaultBinaryBodyMaxBytes)
+        assertEquals(DefaultTextBodyMaxBytes, DefaultTextPreviewChars)
+    }
+
+    @Test
+    fun `request capture uses the limit for its encoded representation`() {
+        val textRequest = requestWithBody("text/plain".toMediaType())
+        val binaryRequest = requestWithBody("application/octet-stream".toMediaType())
+        val compressedTextRequest = textRequest.newBuilder()
+            .header("Content-Encoding", "gzip")
+            .build()
+
+        assertEquals(100, resolveRequestCaptureLimit(textRequest, 100, 20))
+        assertEquals(20, resolveRequestCaptureLimit(binaryRequest, 100, 20))
+        assertEquals(20, resolveRequestCaptureLimit(compressedTextRequest, 100, 20))
+    }
+
+    @Test
+    fun `inactive interceptor passes traffic through without serializing the request twice`() {
+        val server = MockWebServer()
+        val interceptor = SnapOOkHttpInterceptor()
+        try {
+            server.enqueue(MockResponse.Builder().body("response body").build())
+            server.start()
+            val requestBody = CountingRequestBody("request body")
+            val client = OkHttpClient.Builder()
+                .addInterceptor(interceptor)
+                .build()
+            val request = Request.Builder()
+                .url(server.url("/pass-through"))
+                .post(requestBody)
+                .build()
+
+            client.newCall(request).execute().use { response ->
+                assertEquals("response body", response.body.string())
+            }
+
+            assertEquals(1, requestBody.writeCount)
+        } finally {
+            interceptor.close()
+            server.close()
+        }
+    }
+
+    @Test
+    fun `inactive websocket factory preserves the delegate socket and listener`() {
+        val delegate = RecordingWebSocketFactory()
+        val factory = SnapOInterceptorWebSocketFactory(delegate)
+        val listener = object : WebSocketListener() {}
+        val request = Request.Builder().url("https://example.com/socket").build()
+        try {
+            val socket = factory.newWebSocket(request, listener)
+
+            assertSame(delegate.socket, socket)
+            assertSame(request, delegate.request)
+            assertSame(listener, delegate.listener)
+        } finally {
+            factory.close()
+        }
+    }
+
+    private class CountingRequestBody(private val value: String) : RequestBody() {
+        var writeCount: Int = 0
+            private set
+
+        override fun contentType(): MediaType? = null
+
+        override fun writeTo(sink: BufferedSink) {
+            writeCount += 1
+            sink.writeUtf8(value)
+        }
+    }
+
+    private fun requestWithBody(contentType: MediaType): Request = Request.Builder()
+        .url("https://example.com/request")
+        .post("body".toRequestBody(contentType))
+        .build()
+
+    private class RecordingWebSocketFactory : WebSocket.Factory {
+        var request: Request? = null
+            private set
+        var listener: WebSocketListener? = null
+            private set
+
+        val socket = object : WebSocket {
+            override fun request(): Request = checkNotNull(request)
+            override fun queueSize(): Long = 0L
+            override fun send(text: String): Boolean = true
+            override fun send(bytes: ByteString): Boolean = true
+            override fun close(code: Int, reason: String?): Boolean = true
+            override fun cancel() = Unit
+        }
+
+        override fun newWebSocket(request: Request, listener: WebSocketListener): WebSocket {
+            this.request = request
+            this.listener = listener
+            return socket
+        }
+    }
+}

--- a/snapo-link-android/network/src/main/java/com/openai/snapo/network/EventBuffer.kt
+++ b/snapo-link-android/network/src/main/java/com/openai/snapo/network/EventBuffer.kt
@@ -29,7 +29,6 @@ internal class EventBuffer(
     private val requestBodiesById: MutableMap<String, CapturedBody> = mutableMapOf()
     private val responseBodiesById: MutableMap<String, CapturedBody> = mutableMapOf()
     private val openWebSockets: MutableSet<String> = mutableSetOf()
-    private val activeResponseStreams: MutableSet<String> = mutableSetOf()
 
     fun append(record: NetworkEventRecord): Long {
         val normalizedRecord = normalizeRecord(record)
@@ -38,7 +37,6 @@ internal class EventBuffer(
         insertSorted(normalizedRecord)
         approxBytes += estimateSize(normalizedRecord)
         updateWebSocketStateOnAdd(normalizedRecord)
-        updateStreamStateOnAdd(normalizedRecord)
         evictExpiredIfNeeded(normalizedRecord)
         trimToByteLimit()
         trimToCountLimit()
@@ -239,34 +237,13 @@ internal class EventBuffer(
         }
     }
 
-    private fun updateStreamStateOnAdd(record: NetworkEventRecord) {
-        when (record) {
-            is ResponseStreamEvent -> activeResponseStreams.add(record.id)
-            is ResponseStreamClosed -> activeResponseStreams.remove(record.id)
-            is ResponseFinished -> activeResponseStreams.remove(record.id)
-            is RequestFailed -> activeResponseStreams.remove(record.id)
-            else -> Unit
-        }
-    }
-
     private fun updateConversationStateOnRemove(record: NetworkEventRecord) {
-        when (record) {
-            is PerRequestRecord -> {
-                val hasRemainingRecords = records.any { candidate ->
-                    (candidate as? PerRequestRecord)?.id == record.id
-                }
-                if (!hasRemainingRecords) {
-                    activeResponseStreams.remove(record.id)
-                }
+        if (record is PerWebSocketRecord) {
+            val hasRemainingRecords = records.any { candidate ->
+                candidate.perWebSocketRecord()?.id == record.id
             }
-
-            is PerWebSocketRecord -> {
-                val hasRemainingRecords = records.any { candidate ->
-                    candidate.perWebSocketRecord()?.id == record.id
-                }
-                if (!hasRemainingRecords) {
-                    openWebSockets.remove(record.id)
-                }
+            if (!hasRemainingRecords) {
+                openWebSockets.remove(record.id)
             }
         }
     }
@@ -274,9 +251,6 @@ internal class EventBuffer(
     private fun completedRequestIds(): Set<String> {
         return records.mapNotNullTo(mutableSetOf()) { candidate ->
             when (candidate) {
-                is ResponseReceived ->
-                    candidate.id.takeUnless(activeResponseStreams::contains)
-
                 is ResponseFinished -> candidate.id
                 is RequestFailed -> candidate.id
                 is ResponseStreamClosed -> candidate.id

--- a/snapo-link-android/network/src/main/java/com/openai/snapo/network/EventBuffer.kt
+++ b/snapo-link-android/network/src/main/java/com/openai/snapo/network/EventBuffer.kt
@@ -61,6 +61,32 @@ internal class EventBuffer(
 
     fun findResponseBody(requestId: String): CapturedBody? = responseBodiesById[requestId]
 
+    fun updateLatestRequestBody(
+        requestId: String,
+        body: String?,
+        bodyEncoding: String?,
+        bodyTruncatedBytes: Long?,
+        bodySize: Long?,
+    ): Boolean {
+        val index = records.indexOfLast { candidate ->
+            (candidate as? RequestWillBeSent)?.id == requestId
+        }
+        if (index < 0) return false
+        if (!body.isNullOrEmpty()) {
+            upsertRequestBody(requestId, body, bodyEncoding)
+        }
+        val existing = records[index] as? RequestWillBeSent ?: return false
+        val updated = existing.copy(
+            body = null,
+            bodyEncoding = bodyEncoding,
+            bodyTruncatedBytes = bodyTruncatedBytes,
+            bodySize = bodySize ?: existing.bodySize,
+        )
+        replaceRecord(index, existing, updated)
+        trimToByteLimit()
+        return true
+    }
+
     fun updateLatestResponseBody(
         requestId: String,
         bodyPreview: String?,
@@ -90,13 +116,21 @@ internal class EventBuffer(
             bodyTruncatedBytes = bodyTruncatedBytes,
             bodySize = bodySize ?: existing.bodySize,
         )
+        replaceRecord(index, existing, updated)
+        trimToByteLimit()
+        return true
+    }
+
+    private fun replaceRecord(
+        index: Int,
+        existing: NetworkEventRecord,
+        updated: NetworkEventRecord,
+    ) {
         val sequence = checkNotNull(sequenceByRecord.remove(existing))
         records[index] = updated
         sequenceByRecord[updated] = sequence
         subtractApproxBytes(existing)
         approxBytes += estimateSize(updated)
-        trimToByteLimit()
-        return true
     }
 
     private fun normalizeRecord(record: NetworkEventRecord): NetworkEventRecord {

--- a/snapo-link-android/network/src/main/java/com/openai/snapo/network/NetworkInspector.kt
+++ b/snapo-link-android/network/src/main/java/com/openai/snapo/network/NetworkInspector.kt
@@ -92,6 +92,24 @@ class NetworkInspectorServer internal constructor(
         }
     }
 
+    suspend fun updateLatestRequestBody(
+        requestId: String,
+        body: String?,
+        bodyEncoding: String?,
+        bodyTruncatedBytes: Long?,
+        bodySize: Long?,
+    ) {
+        bufferLock.withLock {
+            eventBuffer.updateLatestRequestBody(
+                requestId = requestId,
+                body = body,
+                bodyEncoding = bodyEncoding,
+                bodyTruncatedBytes = bodyTruncatedBytes,
+                bodySize = bodySize,
+            )
+        }
+    }
+
     private suspend fun snapshotMessages(): NetworkReplaySnapshot {
         val snapshot = bufferLock.withLock { eventBuffer.sequencedSnapshot() }
         val requestUrls = HashMap<String, String>()

--- a/snapo-link-android/network/src/main/java/com/openai/snapo/network/NetworkInspectorTransport.kt
+++ b/snapo-link-android/network/src/main/java/com/openai/snapo/network/NetworkInspectorTransport.kt
@@ -52,8 +52,9 @@ internal class NetworkInspectorTransport(
     private val sessionsGuard = Any()
     private val sessions = LinkedHashSet<NetworkInspectorSession>()
 
-    @Volatile
-    private var latestAppIcon: SnapOAppIcon? = null
+    private val appIcon: SnapOAppIcon? by lazy(LazyThreadSafetyMode.SYNCHRONIZED) {
+        appIconProvider.loadAppIcon()
+    }
 
     fun start(): Boolean {
         if (server != null) return true
@@ -64,7 +65,6 @@ internal class NetworkInspectorTransport(
             )
         }.getOrNull() ?: return false
 
-        latestAppIcon = appIconProvider.loadAppIcon()
         server = boundServer
         acceptJob = scope.launch(Dispatchers.IO) { acceptLoop(boundServer) }
         return true
@@ -129,7 +129,7 @@ internal class NetworkInspectorTransport(
             serverStartWallMs = serverStartWallMs,
             serverStartMonoNs = serverStartMonoNs,
             mode = config.modeLabel,
-            icon = latestAppIcon,
+            icon = appIcon,
         )
         return CdpMessage(
             method = SnapOMethod.AppInfo,

--- a/snapo-link-android/network/src/test/java/com/openai/snapo/network/EventBufferEvictionTest.kt
+++ b/snapo-link-android/network/src/test/java/com/openai/snapo/network/EventBufferEvictionTest.kt
@@ -94,7 +94,7 @@ class EventBufferEvictionTest {
         buffer.append(responseFinished(id = "sentinel-2", wallTimeMs = 13L))
 
         assertEquals(
-            listOf("sentinel-1", "sentinel-2"),
+            listOf(STREAM_ID, STREAM_ID, "sentinel-2"),
             buffer.snapshot().mapNotNull(::recordId),
         )
     }
@@ -132,6 +132,21 @@ class EventBufferEvictionTest {
     }
 
     @Test
+    fun `response headers alone do not mark a conversation complete`() {
+        val buffer = EventBuffer(NetworkInspectorConfig(maxBufferedEvents = 5))
+        buffer.append(request(id = "active", wallTimeMs = 1L))
+        buffer.append(response(id = "active", wallTimeMs = 2L))
+        httpConversation(wallTimeOffsetMs = 10L).forEach(buffer::append)
+
+        buffer.append(responseFinished(id = SENTINEL_ID, wallTimeMs = 20L))
+
+        assertEquals(
+            listOf("active", "active", SENTINEL_ID),
+            buffer.snapshot().mapNotNull(::recordId),
+        )
+    }
+
+    @Test
     fun `expiring the last response stream record clears active state`() {
         val buffer = EventBuffer(
             NetworkInspectorConfig(
@@ -150,7 +165,7 @@ class EventBufferEvictionTest {
         buffer.append(webSocketMessage(id = TRIGGER_ID, wallTimeMs = 13L))
 
         assertEquals(
-            listOf(TRIGGER_ID, TRIGGER_ID),
+            listOf(STREAM_ID, STREAM_ID),
             buffer.snapshot().mapNotNull(::recordId),
         )
     }

--- a/snapo-link-android/network/src/test/java/com/openai/snapo/network/EventBufferSequenceTest.kt
+++ b/snapo-link-android/network/src/test/java/com/openai/snapo/network/EventBufferSequenceTest.kt
@@ -50,6 +50,25 @@ class EventBufferSequenceTest {
     }
 
     @Test
+    fun `request body updates preserve the event sequence`() {
+        val buffer = EventBuffer(NetworkInspectorConfig())
+        val sequence = buffer.append(request(id = "request", wallTimeMs = 100L))
+
+        buffer.updateLatestRequestBody(
+            requestId = "request",
+            body = "updated body",
+            bodyEncoding = null,
+            bodyTruncatedBytes = 2L,
+            bodySize = 14L,
+        )
+
+        val event = buffer.sequencedSnapshot().records.single()
+        assertEquals(sequence, event.snapoSequence)
+        assertEquals(14L, (event.record as RequestWillBeSent).bodySize)
+        assertEquals("updated body", buffer.findRequestBody("request")?.body)
+    }
+
+    @Test
     fun `watermark advances when older events are evicted`() {
         val buffer = EventBuffer(
             NetworkInspectorConfig(maxBufferedEvents = 1),

--- a/snapo-link-android/samples/demo-okhttp/src/main/java/com/openai/snapo/demo/MainActivity.kt
+++ b/snapo-link-android/samples/demo-okhttp/src/main/java/com/openai/snapo/demo/MainActivity.kt
@@ -9,6 +9,8 @@ import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.Button
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
@@ -70,6 +72,7 @@ class MainActivity : ComponentActivity() {
                         onPostRequestClick = { runPostRequest(scope) },
                         onUnknownLengthGzipPostRequestClick = { runUnknownLengthGzipPostRequest(scope) },
                         onNoContentTypeTextResponseClick = { runNoContentTypeTextResponseRequest(scope) },
+                        onSlowResponseClick = { runSlowResponseRequest(scope) },
                         onWebSocketDemoClick = { startWebSocketDemo(scope) },
                         modifier = Modifier.padding(innerPadding)
                     )
@@ -146,13 +149,31 @@ class MainActivity : ComponentActivity() {
         }
     }
 
-    private fun executeRequest(scope: CoroutineScope, request: Request) {
+    private fun runSlowResponseRequest(scope: CoroutineScope) {
+        scope.launch {
+            val url = resolveMockHttpUrl("/slow-response") ?: return@launch
+            val request = Request.Builder()
+                .url(url)
+                .header("X-SnapO-Demo", "okhttp-slow-body")
+                .build()
+            executeRequest(scope, request, printResponseBody = false)
+        }
+    }
+
+    private fun executeRequest(
+        scope: CoroutineScope,
+        request: Request,
+        printResponseBody: Boolean = true,
+    ) {
         val call = client.newCall(request)
         scope.launch {
             try {
                 call.executeAsync().use { response ->
                     withContext(Dispatchers.IO) {
-                        println(response.body.string())
+                        val responseBody = response.body.string()
+                        if (printResponseBody) {
+                            println(responseBody)
+                        }
                     }
                 }
             } catch (error: IOException) {
@@ -222,12 +243,15 @@ fun Greeting(
     onPostRequestClick: () -> Unit,
     onUnknownLengthGzipPostRequestClick: () -> Unit,
     onNoContentTypeTextResponseClick: () -> Unit,
+    onSlowResponseClick: () -> Unit,
     onWebSocketDemoClick: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
     Column(
         verticalArrangement = Arrangement.spacedBy(16.dp),
-        modifier = modifier.padding(16.dp),
+        modifier = modifier
+            .verticalScroll(rememberScrollState())
+            .padding(16.dp),
     ) {
         Button(onClick = onNetworkRequestClick) {
             Text("Network Request")
@@ -240,6 +264,9 @@ fun Greeting(
         }
         Button(onClick = onNoContentTypeTextResponseClick) {
             Text("GET text (no Content-Type)")
+        }
+        Button(onClick = onSlowResponseClick) {
+            Text("Slow response")
         }
         Button(onClick = onWebSocketDemoClick) {
             Text("WebSocket Echo")
@@ -256,6 +283,7 @@ private fun GreetingPreview() {
             onPostRequestClick = {},
             onUnknownLengthGzipPostRequestClick = {},
             onNoContentTypeTextResponseClick = {},
+            onSlowResponseClick = {},
             onWebSocketDemoClick = {},
         )
     }

--- a/snapo-link-android/samples/demo-shared/src/main/java/com/openai/snapo/demo/shared/DemoMockServer.kt
+++ b/snapo-link-android/samples/demo-shared/src/main/java/com/openai/snapo/demo/shared/DemoMockServer.kt
@@ -9,6 +9,7 @@ import okhttp3.WebSocket
 import okhttp3.WebSocketListener
 import okio.ByteString
 import java.net.InetAddress
+import java.util.concurrent.TimeUnit
 
 class DemoMockServer {
     private var server: MockWebServer? = null
@@ -39,6 +40,7 @@ private fun createServer(): MockWebServer {
     val gzipPostBody = """{"ok":true,"endpoint":"post-gzip-unknown-length","source":"mockwebserver"}"""
     val noTypeBody = """{"message":"Hello from Snap-O without Content-Type","source":"okhttp-demo"}"""
     val formBody = """{"ok":true,"endpoint":"form-post","source":"mockwebserver"}"""
+    val slowBody = """{"message":"${"x".repeat(SlowBodyPayloadCharacters)}","source":"okhttp-demo"}"""
     return MockWebServer().apply {
         dispatcher = object : Dispatcher() {
             override fun dispatch(request: RecordedRequest): MockResponse {
@@ -78,6 +80,7 @@ private fun createServer(): MockWebServer {
                         .setHeader("Connection", "close")
                         .body(noTypeBody)
                         .build()
+                    "/slow-response" -> slowResponse(slowBody)
                     "/ws-echo" -> MockResponse.Builder()
                         .webSocketUpgrade(
                             object : WebSocketListener() {
@@ -100,6 +103,20 @@ private fun createServer(): MockWebServer {
     }
 }
 
+private fun slowResponse(body: String): MockResponse = MockResponse.Builder()
+    .code(200)
+    .setHeader("Content-Type", "application/json; charset=utf-8")
+    .setHeader("X-SnapO-Demo", "headers-before-body")
+    .setHeader("Connection", "close")
+    .body(body)
+    .bodyDelay(SlowBodyInitialDelayMs, TimeUnit.MILLISECONDS)
+    .throttleBody(
+        bytesPerPeriod = SlowBodyChunkBytes,
+        period = SlowBodyChunkDelayMs,
+        unit = TimeUnit.MILLISECONDS,
+    )
+    .build()
+
 fun String.toWebSocketUrl(): String {
     return when {
         startsWith("http://") -> "ws://${removePrefix("http://")}"
@@ -110,3 +127,7 @@ fun String.toWebSocketUrl(): String {
 
 private const val DemoLogTag: String = "SnapODemo"
 private const val MockHost: String = "127.0.0.1"
+private const val SlowBodyPayloadCharacters: Int = 1024 * 1024
+private const val SlowBodyInitialDelayMs: Long = 2_000L
+private const val SlowBodyChunkBytes: Long = 128L * 1024L
+private const val SlowBodyChunkDelayMs: Long = 250L

--- a/snapo-network-inspector-web/src/features/network-inspector/lib/exportActions.test.ts
+++ b/snapo-network-inspector-web/src/features/network-inspector/lib/exportActions.test.ts
@@ -2,7 +2,29 @@ import { describe, expect, it, vi } from "vitest";
 import type { NetworkClient } from "../../../network/client";
 import type { RequestBodies, SaveFileInput } from "../../../network/bridge-types";
 import type { InspectorRecord, RequestRecord, StreamEventRecord } from "../../../network/cdp";
-import { exportAsHar, hydrateRecordsForHar } from "./exportActions";
+import { copyCurl, exportAsHar, hydrateRecordsForHar } from "./exportActions";
+
+describe("export body readiness", () => {
+  it("does not query a request body before its upload is known to be complete", async () => {
+    const client = {
+      loadBodies: vi.fn(),
+      copyText: vi.fn(async () => undefined)
+    } as unknown as NetworkClient;
+    const pending = request("pending", {
+      method: "POST",
+      status: { kind: "pending" },
+      endedAt: undefined,
+      requestHasPostData: true,
+      requestBodySize: 4,
+      hasReceivedResponse: false
+    });
+
+    await copyCurl(client, pending);
+
+    expect(client.loadBodies).not.toHaveBeenCalled();
+    expect(client.copyText).toHaveBeenCalledOnce();
+  });
+});
 
 describe("HAR body hydration budget", () => {
   it("counts existing cached bodies before hydrating missing bodies", async () => {

--- a/snapo-network-inspector-web/src/features/network-inspector/lib/exportActions.test.ts
+++ b/snapo-network-inspector-web/src/features/network-inspector/lib/exportActions.test.ts
@@ -24,6 +24,25 @@ describe("export body readiness", () => {
     expect(client.loadBodies).not.toHaveBeenCalled();
     expect(client.copyText).toHaveBeenCalledOnce();
   });
+
+  it("loads only the request body when copying a completed request as curl", async () => {
+    const client = {
+      loadBodies: vi.fn(async () => ({ requestId: "complete", requestBody: "body" })),
+      copyText: vi.fn(async () => undefined)
+    } as unknown as NetworkClient;
+    const complete = request("complete", {
+      method: "POST",
+      requestHasPostData: true,
+      requestBodySize: 4,
+      hasReceivedResponse: true
+    });
+
+    await copyCurl(client, complete);
+
+    expect(client.loadBodies).toHaveBeenCalledWith(
+      expect.objectContaining({ includeRequestBody: true, includeResponseBody: false })
+    );
+  });
 });
 
 describe("HAR body hydration budget", () => {

--- a/snapo-network-inspector-web/src/features/network-inspector/lib/exportActions.ts
+++ b/snapo-network-inspector-web/src/features/network-inspector/lib/exportActions.ts
@@ -3,7 +3,7 @@ import type { RequestBodies } from "../../../network/bridge-types";
 import { estimatedStringStorageBytes, hydratedBodyRetentionLimitBytes } from "../../../network/body-retention";
 import { applyRequestBodies, type InspectorRecord, type RequestRecord } from "../../../network/cdp";
 import { buildHar, harFileName, makeCurlCommand, streamEventsRaw } from "../../../network/exporters";
-import { shouldRequestRequestBody } from "./records";
+import { shouldRequestRequestBody, shouldRequestResponseBody } from "./records";
 
 const exportBodyLoadConcurrency = 3;
 
@@ -17,7 +17,9 @@ export async function copyCurl(client: NetworkClient, request: RequestRecord): P
           deviceId: request.server.deviceId,
           socketName: request.server.socketName,
           serverInstanceId: request.server.instanceId,
-          requestId: request.requestId
+          requestId: request.requestId,
+          includeRequestBody: true,
+          includeResponseBody: false
         })
       );
     } catch {
@@ -109,12 +111,17 @@ async function loadBodiesForHar(
   record: InspectorRecord
 ): Promise<RequestBodies | null> {
   if (record.kind !== "request") return null;
+  const includeRequestBody = shouldRequestRequestBody(record);
+  const includeResponseBody = shouldRequestResponseBody(record);
+  if (!includeRequestBody && !includeResponseBody) return null;
   try {
     return await client.loadBodies({
       deviceId: record.server.deviceId,
       socketName: record.server.socketName,
       serverInstanceId: record.server.instanceId,
-      requestId: record.requestId
+      requestId: record.requestId,
+      includeRequestBody,
+      includeResponseBody
     });
   } catch {
     // A completed request may no longer expose its body. Keep its metadata in the HAR.

--- a/snapo-network-inspector-web/src/features/network-inspector/lib/exportActions.ts
+++ b/snapo-network-inspector-web/src/features/network-inspector/lib/exportActions.ts
@@ -3,12 +3,13 @@ import type { RequestBodies } from "../../../network/bridge-types";
 import { estimatedStringStorageBytes, hydratedBodyRetentionLimitBytes } from "../../../network/body-retention";
 import { applyRequestBodies, type InspectorRecord, type RequestRecord } from "../../../network/cdp";
 import { buildHar, harFileName, makeCurlCommand, streamEventsRaw } from "../../../network/exporters";
+import { shouldRequestRequestBody } from "./records";
 
 const exportBodyLoadConcurrency = 3;
 
 export async function copyCurl(client: NetworkClient, request: RequestRecord): Promise<void> {
   let hydrated = request;
-  if (request.requestBody == null) {
+  if (shouldRequestRequestBody(request)) {
     try {
       hydrated = applyRequestBodies(
         request,

--- a/snapo-network-inspector-web/src/features/network-inspector/lib/records.test.ts
+++ b/snapo-network-inspector-web/src/features/network-inspector/lib/records.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it } from "vitest";
+import type { RequestRecord } from "../../../network/cdp";
+import { shouldRequestRequestBody } from "./records";
+
+describe("request body loading", () => {
+  it("waits until request transmission has completed", () => {
+    expect(shouldRequestRequestBody(request())).toBe(false);
+    expect(shouldRequestRequestBody(request({ hasReceivedResponse: true }))).toBe(true);
+    expect(shouldRequestRequestBody(request({ status: { kind: "failure", message: "failed" } }))).toBe(true);
+  });
+
+  it("skips requests without a fetchable body", () => {
+    expect(shouldRequestRequestBody(request({ requestHasPostData: false, hasReceivedResponse: true }))).toBe(false);
+    expect(shouldRequestRequestBody(request({ requestBodySize: 0, hasReceivedResponse: true }))).toBe(false);
+    expect(shouldRequestRequestBody(request({ requestBody: "cached", hasReceivedResponse: true }))).toBe(false);
+  });
+});
+
+const server = { deviceId: "device", socketName: "socket", instanceId: "instance" };
+
+function request(overrides: Partial<RequestRecord> = {}): RequestRecord {
+  return {
+    kind: "request",
+    server,
+    requestId: "request",
+    method: "POST",
+    url: "https://example.com/request",
+    requestHeaders: [],
+    responseHeaders: [],
+    status: { kind: "pending" },
+    startedAt: 1,
+    requestHasPostData: true,
+    requestBodySize: 8,
+    streamEvents: [],
+    streamEventCount: 0,
+    updatedAt: 1,
+    ...overrides
+  };
+}

--- a/snapo-network-inspector-web/src/features/network-inspector/lib/records.ts
+++ b/snapo-network-inspector-web/src/features/network-inspector/lib/records.ts
@@ -57,6 +57,7 @@ export function isCompletedRecord(record: InspectorRecord): boolean {
 export function shouldRequestRequestBody(request: RequestRecord): boolean {
   if (request.requestBody != null) return false;
   if (request.requestHasPostData === false) return false;
+  if (!request.hasReceivedResponse && request.status.kind !== "failure") return false;
   return request.requestBodySize == null || request.requestBodySize !== 0;
 }
 


### PR DESCRIPTION
## Summary
- Capture OkHttp and HttpURLConnection request bodies during the real network write instead of serializing or writing them a second time.
- Publish in-flight requests and response headers as soon as they are observed, then capture response bodies as callers consume or close them.
- Keep bodies deferred through the event buffer, desktop export paths, and `snapo` CLI so they are loaded only when needed; load Android app icons on demand.
- Add a protocol-realistic slow-response case to the OkHttp demo app for inspecting headers while the body is still arriving.

## Why
The Android interceptors could duplicate upload work and delay the app's access to a response while Snap-O inspected its body. The surrounding event, export, and CLI paths also assumed bodies were always available inline. This change preserves normal client semantics while reducing CPU, memory, and transport work. Existing 5 MiB capture defaults remain unchanged.

## Performance
Controlled device benchmarks compared the same harness at the pre-change base and this branch:

- Repeatable 5 MiB uploads perform one body write instead of two, reduce caller CPU p50 by 48–54%, and improve upload wall-time p95 by 14–16%.
- A throttled 5 MiB response returns headers in roughly 3.6 ms p50 instead of 128 ms (about 35× faster); full-read CPU p50 improves by 32–36%.
- Empty 204 responses add only 0.01–0.19 ms median overhead.

## Testing
- [x] Built and ran Snap-O locally
- [x] Added or updated tests
- [x] `JAVA_HOME=/opt/homebrew/Cellar/openjdk@17/17.0.19/libexec/openjdk.jdk/Contents/Home ./gradlew --no-daemon --max-workers=2 -Dorg.gradle.jvmargs=-Xmx4096m build` (744 tasks)
- [x] `xcodebuild -project Snap-O.xcodeproj -scheme Snap-O CODE_SIGNING_ALLOWED=NO CODE_SIGNING_REQUIRED=NO build`
- [x] `mise run lint`
- [x] `npm test -- --run src/features/network-inspector/lib/exportActions.test.ts src/features/network-inspector/lib/records.test.ts`
- [x] `npm run typecheck`
- [x] Installed and exercised the slow-response demo on an Android emulator

## Checklist
- [x] I have read the [Contributing guidelines](https://github.com/openai/snap-o?tab=contributing-ov-file#contributing-to-snap-o)
- [x] Documentation has been updated (not needed; no public API or setup changes)
