### PR TITLE
[codex] Show initial frame while live preview starts

### DIFF
--- a/snapo-app-mac/Snap-O/LivePreview/LivePreviewSession.swift
+++ b/snapo-app-mac/Snap-O/LivePreview/LivePreviewSession.swift
@@ -1,12 +1,16 @@
 import AppKit
 @preconcurrency import AVFoundation
 import Foundation
+import ImageIO
 import SnapODeviceClient
 
 /// Owns one device-side live-preview process and its decoded frame stream.
 @MainActor
 final class LivePreviewSession {
+  private static let initialFrameTimeout: Duration = .seconds(2)
+
   let deviceID: String
+  private(set) var initialFrame: CGImage?
 
   var media: Media?
   var sampleBufferHandler: ((CMSampleBuffer) -> Void)?
@@ -26,11 +30,43 @@ final class LivePreviewSession {
     self.deviceID = deviceID
 
     let exec = await adb.exec()
-    densityScale = try await CGFloat(exec.displayDensity(deviceID: deviceID))
+    async let densityValue = exec.displayDensity(deviceID: deviceID)
+    async let capturedFrame = Self.captureInitialFrame(deviceID: deviceID, using: exec)
+    densityScale = try await CGFloat(densityValue)
+    initialFrame = try await capturedFrame
+
     screenStream = try await exec.startScreenStream(deviceID: deviceID)
 
     setupDecoder()
     startStreamTask()
+  }
+
+  private static func captureInitialFrame(deviceID: String, using exec: ADBClient) async throws -> CGImage? {
+    let timeout = initialFrameTimeout
+    let data = try await withThrowingTaskGroup(of: Data?.self, returning: Data?.self) { group in
+      group.addTask {
+        do {
+          return try await exec.screencapPNG(deviceID: deviceID)
+        } catch {
+          try Task.checkCancellation()
+          return nil
+        }
+      }
+      group.addTask {
+        try await Task.sleep(for: timeout)
+        return nil
+      }
+
+      defer { group.cancelAll() }
+      guard let result = try await group.next() else { return nil }
+      return result
+    }
+    return data.flatMap(decodeInitialFrame)
+  }
+
+  private static func decodeInitialFrame(from data: Data) -> CGImage? {
+    guard let source = CGImageSourceCreateWithData(data as CFData, nil) else { return nil }
+    return CGImageSourceCreateImageAtIndex(source, 0, nil)
   }
 
   func waitUntilReady() async throws -> Media {
@@ -49,6 +85,10 @@ final class LivePreviewSession {
 
   func cancel() {
     finish(with: nil)
+  }
+
+  func discardInitialFrame() {
+    initialFrame = nil
   }
 
   private func setupDecoder() {

--- a/snapo-app-mac/Snap-O/LivePreview/LivePreviewSession.swift
+++ b/snapo-app-mac/Snap-O/LivePreview/LivePreviewSession.swift
@@ -13,11 +13,20 @@ final class LivePreviewSession {
   private(set) var initialFrame: CGImage?
 
   var media: Media?
+  var initialFrameHandler: ((CGImage) -> Void)? {
+    didSet {
+      if let initialFrame {
+        initialFrameHandler?(initialFrame)
+      }
+    }
+  }
+
   var sampleBufferHandler: ((CMSampleBuffer) -> Void)?
 
   private let densityScale: CGFloat
   private let screenStream: ScreenStreamSession
   private var decoder: H264StreamDecoder?
+  private var initialFrameTask: Task<Void, Never>?
   private var streamTask: Task<Void, Never>?
   private var hasStopped = false
 
@@ -31,14 +40,13 @@ final class LivePreviewSession {
 
     let exec = await adb.exec()
     async let densityValue = exec.displayDensity(deviceID: deviceID)
-    async let capturedFrame = Self.captureInitialFrame(deviceID: deviceID, using: exec)
+    async let startedStream = exec.startScreenStream(deviceID: deviceID)
     densityScale = try await CGFloat(densityValue)
-    initialFrame = try await capturedFrame
-
-    screenStream = try await exec.startScreenStream(deviceID: deviceID)
+    screenStream = try await startedStream
 
     setupDecoder()
     startStreamTask()
+    startInitialFrameTask(using: exec)
   }
 
   private static func captureInitialFrame(deviceID: String, using exec: ADBClient) async throws -> CGImage? {
@@ -89,6 +97,23 @@ final class LivePreviewSession {
 
   func discardInitialFrame() {
     initialFrame = nil
+    initialFrameHandler = nil
+  }
+
+  private func startInitialFrameTask(using exec: ADBClient) {
+    initialFrameTask = Task { [weak self] in
+      guard let self else { return }
+      defer { initialFrameTask = nil }
+
+      do {
+        guard let frame = try await Self.captureInitialFrame(deviceID: deviceID, using: exec),
+              !hasStopped else { return }
+        initialFrame = frame
+        initialFrameHandler?(frame)
+      } catch {
+        // The initial frame is best-effort; live preview continues without it.
+      }
+    }
   }
 
   private func setupDecoder() {
@@ -143,8 +168,12 @@ final class LivePreviewSession {
 
     streamTask?.cancel()
     streamTask = nil
+    initialFrameTask?.cancel()
+    initialFrameTask = nil
     screenStream.close()
     decoder = nil
+    initialFrame = nil
+    initialFrameHandler = nil
     sampleBufferHandler = nil
 
     stopResult = error

--- a/snapo-app-mac/Snap-O/LivePreview/LivePreviewView.swift
+++ b/snapo-app-mac/Snap-O/LivePreview/LivePreviewView.swift
@@ -38,7 +38,9 @@ struct LivePreviewRendererView: NSViewRepresentable {
 final class LivePreviewDisplayView: NSView {
   private var renderer: LivePreviewRenderer?
   private var trackingArea: NSTrackingArea?
+  private var readyForDisplayObserver: NSObjectProtocol?
   private let displayLayer = AVSampleBufferDisplayLayer()
+  private let initialFrameLayer = CALayer()
   private var endedLivePreviewTrace = false
 
   private var pointerState = PointerState()
@@ -73,21 +75,32 @@ final class LivePreviewDisplayView: NSView {
       detachSession()
     }
     self.renderer = renderer
-    attachSession()
+    if shouldDetach {
+      attachSession()
+    }
   }
 
   private func configureLayerIfNeeded() {
     guard displayLayer.superlayer == nil else { return }
     wantsLayer = true
     layer?.addSublayer(displayLayer)
+    layer?.addSublayer(initialFrameLayer)
     displayLayer.videoGravity = .resizeAspect
     displayLayer.backgroundColor = NSColor.black.cgColor
     displayLayer.frame = bounds
     displayLayer.autoresizingMask = [.layerWidthSizable, .layerHeightSizable]
+    initialFrameLayer.contentsGravity = .resizeAspect
+    initialFrameLayer.frame = bounds
+    initialFrameLayer.autoresizingMask = [.layerWidthSizable, .layerHeightSizable]
   }
 
   private func attachSession() {
     guard let session = renderer?.session else { return }
+    let initialFrame = session.initialFrame
+    setInitialFrame(initialFrame)
+    if initialFrame != nil {
+      observeDisplayReadiness()
+    }
     session.sampleBufferHandler = { [weak self] sample in
       self?.enqueue(sample)
     }
@@ -95,10 +108,12 @@ final class LivePreviewDisplayView: NSView {
   }
 
   private func detachSession() {
+    stopObservingDisplayReadiness()
     renderer?.session.sampleBufferHandler = nil
     displayLayer.sampleBufferRenderer.stopRequestingMediaData()
     displayLayer.sampleBufferRenderer.flush(removingDisplayedImage: true, completionHandler: nil)
     displayLayer.sampleBufferRenderer.requestMediaDataWhenReady(on: .main) {}
+    setInitialFrame(nil)
     endedLivePreviewTrace = false
   }
 
@@ -110,6 +125,39 @@ final class LivePreviewDisplayView: NSView {
       Perf.end(.livePreviewStart, finalLabel: "first frame enqueued")
       Perf.end(.appFirstSnapshot, finalLabel: "first media appeared (live)")
     }
+  }
+
+  private func observeDisplayReadiness() {
+    guard let operationID = renderer?.operation.id else { return }
+    stopObservingDisplayReadiness()
+    readyForDisplayObserver = NotificationCenter.default.addObserver(
+      forName: .AVSampleBufferDisplayLayerReadyForDisplayDidChange,
+      object: displayLayer,
+      queue: .main
+    ) { [weak self] _ in
+      Task { @MainActor [weak self] in
+        guard let self,
+              renderer?.operation.id == operationID,
+              displayLayer.isReadyForDisplay else { return }
+        renderer?.session.discardInitialFrame()
+        setInitialFrame(nil)
+        stopObservingDisplayReadiness()
+      }
+    }
+  }
+
+  private func stopObservingDisplayReadiness() {
+    guard let readyForDisplayObserver else { return }
+    NotificationCenter.default.removeObserver(readyForDisplayObserver)
+    self.readyForDisplayObserver = nil
+  }
+
+  private func setInitialFrame(_ image: CGImage?) {
+    if image == nil, initialFrameLayer.contents == nil { return }
+    CATransaction.begin()
+    CATransaction.setDisableActions(true)
+    initialFrameLayer.contents = image
+    CATransaction.commit()
   }
 
   override func updateTrackingAreas() {

--- a/snapo-app-mac/Snap-O/LivePreview/LivePreviewView.swift
+++ b/snapo-app-mac/Snap-O/LivePreview/LivePreviewView.swift
@@ -95,11 +95,11 @@ final class LivePreviewDisplayView: NSView {
   }
 
   private func attachSession() {
-    guard let session = renderer?.session else { return }
-    let initialFrame = session.initialFrame
-    setInitialFrame(initialFrame)
-    if initialFrame != nil {
-      observeDisplayReadiness()
+    guard let renderer else { return }
+    let session = renderer.session
+    let operationID = renderer.operation.id
+    session.initialFrameHandler = { [weak self] frame in
+      self?.displayInitialFrame(frame, operationID: operationID)
     }
     session.sampleBufferHandler = { [weak self] sample in
       self?.enqueue(sample)
@@ -109,6 +109,7 @@ final class LivePreviewDisplayView: NSView {
 
   private func detachSession() {
     stopObservingDisplayReadiness()
+    renderer?.session.initialFrameHandler = nil
     renderer?.session.sampleBufferHandler = nil
     displayLayer.sampleBufferRenderer.stopRequestingMediaData()
     displayLayer.sampleBufferRenderer.flush(removingDisplayedImage: true, completionHandler: nil)
@@ -127,8 +128,18 @@ final class LivePreviewDisplayView: NSView {
     }
   }
 
-  private func observeDisplayReadiness() {
-    guard let operationID = renderer?.operation.id else { return }
+  private func displayInitialFrame(_ image: CGImage, operationID: UUID) {
+    guard renderer?.operation.id == operationID else { return }
+    observeDisplayReadiness(operationID: operationID)
+    guard !displayLayer.isReadyForDisplay else {
+      hideInitialFrameIfReady(operationID: operationID)
+      return
+    }
+    setInitialFrame(image)
+    hideInitialFrameIfReady(operationID: operationID)
+  }
+
+  private func observeDisplayReadiness(operationID: UUID) {
     stopObservingDisplayReadiness()
     readyForDisplayObserver = NotificationCenter.default.addObserver(
       forName: .AVSampleBufferDisplayLayerReadyForDisplayDidChange,
@@ -136,14 +147,17 @@ final class LivePreviewDisplayView: NSView {
       queue: .main
     ) { [weak self] _ in
       Task { @MainActor [weak self] in
-        guard let self,
-              renderer?.operation.id == operationID,
-              displayLayer.isReadyForDisplay else { return }
-        renderer?.session.discardInitialFrame()
-        setInitialFrame(nil)
-        stopObservingDisplayReadiness()
+        self?.hideInitialFrameIfReady(operationID: operationID)
       }
     }
+  }
+
+  private func hideInitialFrameIfReady(operationID: UUID) {
+    guard renderer?.operation.id == operationID,
+          displayLayer.isReadyForDisplay else { return }
+    renderer?.session.discardInitialFrame()
+    setInitialFrame(nil)
+    stopObservingDisplayReadiness()
   }
 
   private func stopObservingDisplayReadiness() {


### PR DESCRIPTION
## Summary

- capture a best-effort device screenshot before starting the H.264 live-preview stream
- display the screenshot as an aspect-fit bootstrap frame until AVFoundation reports live video ready for display
- bound screenshot capture to two seconds and clean up observers and full-resolution image memory after handoff

## Why

Live preview can remain black until enough stream data arrives for AVFoundation to make the first video frame displayable. Showing a fresh screenshot bridges that startup gap without changing persisted capture media.

## Impact

Starting or retrying live preview now shows the device immediately, then hands off to the live stream once a real frame is ready. Screenshot failure remains non-fatal and falls back to the existing black surface.

## Validation

- `xcodebuild -quiet -project Snap-O.xcodeproj -scheme Snap-O CODE_SIGNING_ALLOWED=NO CODE_SIGNING_REQUIRED=NO build`
- `swiftlint lint --strict --no-cache --config .swiftlint.yml Snap-O/LivePreview/LivePreviewSession.swift Snap-O/LivePreview/LivePreviewView.swift`
- SwiftFormat 0.61.1 lint on both changed files