### PR TITLE
[codex] uinput for Live Preview touch injection, for "Show pointer tap" support

### DIFF
--- a/snapo-app-mac/Snap-O/CaptureWindow/LivePreviewManager.swift
+++ b/snapo-app-mac/Snap-O/CaptureWindow/LivePreviewManager.swift
@@ -82,11 +82,20 @@ final class LivePreviewManager {
       throw CancellationError()
     }
     activeOperations[operation.id] = operation
+    await pointerInjector.prepare(deviceID: deviceID)
 
     let renderer = LivePreviewRenderer(
       operation: operation
-    ) { [weak self] action, source, location in
-      Task { await self?.sendPointerEvent(deviceID: deviceID, action: action, source: source, location: location) }
+    ) { [weak self] action, source, location, displaySize in
+      Task {
+        await self?.sendPointerEvent(
+          deviceID: deviceID,
+          action: action,
+          source: source,
+          location: location,
+          displaySize: displaySize
+        )
+      }
     }
 
     let session = operation.session
@@ -116,6 +125,9 @@ final class LivePreviewManager {
   func stopRenderer(_ renderer: LivePreviewRenderer) async {
     activeOperations.removeValue(forKey: renderer.operation.id)
     _ = await livePreviewService.stop(renderer.operation)
+    if !activeOperations.values.contains(where: { $0.deviceID == renderer.deviceID }) {
+      await pointerInjector.stopDevice(renderer.deviceID)
+    }
   }
 
   func stop() async {
@@ -127,6 +139,7 @@ final class LivePreviewManager {
     captureIDs.removeAll()
     lastDisplayInfo.removeAll()
     notifyMediaChanged()
+    await pointerInjector.stopAll()
 
     for operation in operations {
       _ = await livePreviewService.stop(operation)
@@ -140,10 +153,14 @@ final class LivePreviewManager {
 
   private func syncDevices(with devices: [Device], requireRefresh: Bool) async {
     let currentIDs = Set(devices.map(\.id))
+    let removedDeviceIDs = Set(deviceInfo.keys).subtracting(currentIDs)
     let removedOperations = activeOperations.values.filter { !currentIDs.contains($0.deviceID) }
     for operation in removedOperations {
       activeOperations.removeValue(forKey: operation.id)
       _ = await livePreviewService.stop(operation)
+    }
+    for deviceID in removedDeviceIDs {
+      await pointerInjector.stopDevice(deviceID)
     }
 
     guard !isStopped else { return }
@@ -283,13 +300,15 @@ final class LivePreviewManager {
     deviceID: String,
     action: LivePreviewPointerAction,
     source: LivePreviewPointerSource,
-    location: CGPoint
+    location: CGPoint,
+    displaySize: CGSize
   ) async {
     let event = LivePreviewPointerEvent(
       deviceID: deviceID,
       action: action,
       source: source,
-      location: location
+      location: location,
+      displaySize: displaySize
     )
     await pointerInjector.enqueue(event)
   }

--- a/snapo-app-mac/Snap-O/LivePreview/LivePreviewPointerBackend.swift
+++ b/snapo-app-mac/Snap-O/LivePreview/LivePreviewPointerBackend.swift
@@ -1,0 +1,31 @@
+import CoreGraphics
+
+/// Input source reported by the live-preview surface.
+enum LivePreviewPointerSource: String {
+  case touchscreen
+  case mouse
+}
+
+enum LivePreviewPointerAction: String {
+  case down = "DOWN"
+  case up = "UP"
+  case move = "MOVE"
+  case cancel = "CANCEL"
+}
+
+struct LivePreviewPointerEvent {
+  let deviceID: String
+  let action: LivePreviewPointerAction
+  let source: LivePreviewPointerSource
+  let location: CGPoint
+  let displaySize: CGSize
+}
+
+protocol LivePreviewPointerBackend: Sendable {
+  func send(_ event: LivePreviewPointerEvent) async throws
+  func stop() async
+}
+
+extension LivePreviewPointerBackend {
+  func stop() async {}
+}

--- a/snapo-app-mac/Snap-O/LivePreview/LivePreviewPointerInjector.swift
+++ b/snapo-app-mac/Snap-O/LivePreview/LivePreviewPointerInjector.swift
@@ -65,7 +65,7 @@ actor LivePreviewPointerInjector {
           await backend.stop()
           return
         }
-        await self.finishPreparation(
+        await finishPreparation(
           backend,
           deviceID: deviceID,
           generation: generation

--- a/snapo-app-mac/Snap-O/LivePreview/LivePreviewPointerInjector.swift
+++ b/snapo-app-mac/Snap-O/LivePreview/LivePreviewPointerInjector.swift
@@ -1,63 +1,153 @@
-import AppKit
 import Foundation
-import SnapODeviceClient
 
-/// Input source reported by the live-preview surface.
-enum LivePreviewPointerSource: String {
-  case touchscreen
-  case mouse
-}
-
-enum LivePreviewPointerAction: String {
-  case down = "DOWN"
-  case up = "UP"
-  case move = "MOVE"
-  case cancel = "CANCEL"
-}
-
-struct LivePreviewPointerEvent {
-  let deviceID: String
-  let action: LivePreviewPointerAction
-  let source: LivePreviewPointerSource
-  let location: CGPoint
-
-  func shellCommand() -> String {
-    let roundedX = Int(location.x.rounded())
-    let roundedY = Int(location.y.rounded())
-
-    let components: [String] = [
-      "input",
-      source.rawValue,
-      "motionevent",
-      action.rawValue,
-      "\(roundedX)",
-      "\(roundedY)"
-    ]
-
-    return components.joined(separator: " ")
-  }
-}
-
+/// Serializes pointer events, selects a backend, and keeps each gesture on one backend.
 actor LivePreviewPointerInjector {
-  private static let maximumSendAttempts = 2
+  private typealias PreferredBackendFactory = @Sendable (String) async throws -> any LivePreviewPointerBackend
 
-  private let adb: ADBService
+  private enum DeviceState {
+    case preparing(generation: UUID, task: Task<Void, Never>)
+    case ready(generation: UUID, backend: any LivePreviewPointerBackend)
+    case fallback(generation: UUID)
+
+    var generation: UUID {
+      switch self {
+      case .preparing(let generation, _),
+           .ready(let generation, _),
+           .fallback(let generation):
+        generation
+      }
+    }
+  }
+
+  private enum TouchRoute {
+    case preferred(generation: UUID, backend: any LivePreviewPointerBackend)
+    case fallback(generation: UUID)
+    case discarded(generation: UUID)
+
+    var generation: UUID {
+      switch self {
+      case .preferred(let generation, _),
+           .fallback(let generation),
+           .discarded(let generation):
+        generation
+      }
+    }
+  }
+
+  private let makePreferredBackend: PreferredBackendFactory
+  private let fallbackBackend: any LivePreviewPointerBackend
+  private var deviceStates: [String: DeviceState] = [:]
+  private var touchRoutes: [String: TouchRoute] = [:]
   private var pendingEvents: [LivePreviewPointerEvent] = []
   private var isFlushing = false
 
   init(adb: ADBService) {
-    self.adb = adb
+    makePreferredBackend = { deviceID in
+      try await UInputLivePreviewPointerBackend.start(
+        adb: adb,
+        deviceID: deviceID
+      )
+    }
+    fallbackBackend = ShellLivePreviewPointerBackend(adb: adb)
+  }
+
+  func prepare(deviceID: String) {
+    guard deviceStates[deviceID] == nil else { return }
+
+    let generation = UUID()
+    let makePreferredBackend = makePreferredBackend
+    let task = Task { [weak self] in
+      do {
+        let backend = try await makePreferredBackend(deviceID)
+        guard let self else {
+          await backend.stop()
+          return
+        }
+        await self.finishPreparation(
+          backend,
+          deviceID: deviceID,
+          generation: generation
+        )
+      } catch {
+        await self?.failPreparation(
+          error,
+          deviceID: deviceID,
+          generation: generation
+        )
+      }
+    }
+    deviceStates[deviceID] = .preparing(generation: generation, task: task)
   }
 
   func enqueue(_ event: LivePreviewPointerEvent) async {
-    if event.action == .move {
-      pendingEvents.removeAll { $0.deviceID == event.deviceID && $0.action == .move }
+    if event.action == .move,
+       let index = pendingEvents.lastIndex(where: {
+         $0.deviceID == event.deviceID && $0.source == event.source
+       }),
+       pendingEvents[index].action == .move {
+      pendingEvents[index] = event
+    } else {
+      pendingEvents.append(event)
     }
-    pendingEvents.append(event)
 
     guard !isFlushing else { return }
     isFlushing = true
     Task { await flushQueue() }
+  }
+
+  func stopDevice(_ deviceID: String) async {
+    pendingEvents.removeAll { $0.deviceID == deviceID }
+    touchRoutes.removeValue(forKey: deviceID)
+    guard let state = deviceStates.removeValue(forKey: deviceID) else { return }
+    await stop(state)
+  }
+
+  func stopAll() async {
+    pendingEvents.removeAll()
+    touchRoutes.removeAll()
+    let states = Array(deviceStates.values)
+    deviceStates.removeAll()
+    for state in states {
+      await stop(state)
+    }
+    await fallbackBackend.stop()
+  }
+
+  private func finishPreparation(
+    _ backend: any LivePreviewPointerBackend,
+    deviceID: String,
+    generation: UUID
+  ) async {
+    guard case .preparing(let currentGeneration, _) = deviceStates[deviceID],
+          currentGeneration == generation else {
+      await backend.stop()
+      return
+    }
+    deviceStates[deviceID] = .ready(generation: generation, backend: backend)
+  }
+
+  private func failPreparation(
+    _ error: Error,
+    deviceID: String,
+    generation: UUID
+  ) {
+    guard case .preparing(let currentGeneration, _) = deviceStates[deviceID],
+          currentGeneration == generation else { return }
+    deviceStates[deviceID] = .fallback(generation: generation)
+    SnapOLog.ui.info(
+      "uinput unavailable for \(deviceID, privacy: .private); using shell input: \(error.localizedDescription, privacy: .public)"
+    )
+  }
+
+  private func stop(_ state: DeviceState) async {
+    switch state {
+    case .preparing(_, let task):
+      task.cancel()
+    case .ready(_, let backend):
+      await backend.stop()
+    case .fallback:
+      break
+    }
   }
 
   private func flushQueue() async {
@@ -65,6 +155,8 @@ actor LivePreviewPointerInjector {
       let event = pendingEvents.removeFirst()
       do {
         try await send(event)
+      } catch is CancellationError {
+        // Teardown can cancel an in-flight backend operation.
       } catch {
         SnapOLog.ui.error(
           "Failed to send pointer event: \(error.localizedDescription, privacy: .public)"
@@ -81,25 +173,104 @@ actor LivePreviewPointerInjector {
   }
 
   private func send(_ event: LivePreviewPointerEvent) async throws {
-    let exec = await adb.exec()
-    var lastError: Error?
+    if event.source == .mouse {
+      try await fallbackBackend.send(event)
+      return
+    }
 
-    for attempt in 0 ..< Self.maximumSendAttempts {
+    switch event.action {
+    case .down:
+      try await sendTouchDown(event)
+    case .move:
+      try await sendTouchMove(event)
+    case .up, .cancel:
+      try await sendTouchEnd(event)
+    }
+  }
+
+  private func sendTouchDown(_ event: LivePreviewPointerEvent) async throws {
+    guard touchRoutes[event.deviceID] == nil else { return }
+    if deviceStates[event.deviceID] == nil {
+      prepare(deviceID: event.deviceID)
+    }
+    guard let state = deviceStates[event.deviceID] else { return }
+
+    switch state {
+    case .ready(let generation, let backend):
       do {
-        _ = try await exec.runShellString(
-          deviceID: event.deviceID,
-          command: event.shellCommand()
-        )
-        return
+        try await backend.send(event)
       } catch {
-        if Task.isCancelled { throw CancellationError() }
-        lastError = error
-        if attempt + 1 < Self.maximumSendAttempts {
-          await Task.yield()
+        let isCurrent = deviceStates[event.deviceID]?.generation == generation
+        if isCurrent {
+          deviceStates[event.deviceID] = .fallback(generation: generation)
+          touchRoutes[event.deviceID] = .discarded(generation: generation)
         }
+        await backend.stop()
+        if isCurrent { throw error }
+        return
+      }
+
+      guard deviceStates[event.deviceID]?.generation == generation,
+            touchRoutes[event.deviceID] == nil else { return }
+      touchRoutes[event.deviceID] = .preferred(
+        generation: generation,
+        backend: backend
+      )
+
+    case .preparing(let generation, _), .fallback(let generation):
+      try await fallbackBackend.send(event)
+      guard deviceStates[event.deviceID]?.generation == generation,
+            touchRoutes[event.deviceID] == nil else { return }
+      touchRoutes[event.deviceID] = .fallback(generation: generation)
+    }
+  }
+
+  private func sendTouchMove(_ event: LivePreviewPointerEvent) async throws {
+    switch touchRoutes[event.deviceID] {
+    case .preferred(let generation, let backend):
+      do {
+        try await backend.send(event)
+      } catch {
+        let isCurrent = deviceStates[event.deviceID]?.generation == generation &&
+          touchRoutes[event.deviceID]?.generation == generation
+        if isCurrent {
+          deviceStates[event.deviceID] = .fallback(generation: generation)
+          touchRoutes[event.deviceID] = .discarded(generation: generation)
+        }
+        await backend.stop()
+        if isCurrent { throw error }
+      }
+    case .fallback:
+      try await fallbackBackend.send(event)
+    case .discarded, nil:
+      break
+    }
+  }
+
+  private func sendTouchEnd(_ event: LivePreviewPointerEvent) async throws {
+    guard let route = touchRoutes[event.deviceID] else { return }
+    defer {
+      if touchRoutes[event.deviceID]?.generation == route.generation {
+        touchRoutes.removeValue(forKey: event.deviceID)
       }
     }
 
-    throw lastError ?? ADBError.serverUnavailable("Failed to send pointer event")
+    switch route {
+    case .preferred(let generation, let backend):
+      do {
+        try await backend.send(event)
+      } catch {
+        let isCurrent = deviceStates[event.deviceID]?.generation == generation
+        if isCurrent {
+          deviceStates[event.deviceID] = .fallback(generation: generation)
+        }
+        await backend.stop()
+        if isCurrent { throw error }
+      }
+    case .fallback:
+      try await fallbackBackend.send(event)
+    case .discarded:
+      break
+    }
   }
 }

--- a/snapo-app-mac/Snap-O/LivePreview/LivePreviewPointerInjector.swift
+++ b/snapo-app-mac/Snap-O/LivePreview/LivePreviewPointerInjector.swift
@@ -1,6 +1,6 @@
 import Foundation
 
-/// Serializes pointer events, selects a backend, and keeps each gesture on one backend.
+/// Serializes pointer events per source, selects a backend, and keeps each gesture on one backend.
 actor LivePreviewPointerInjector {
   private typealias PreferredBackendFactory = @Sendable (String) async throws -> any LivePreviewPointerBackend
 
@@ -38,8 +38,10 @@ actor LivePreviewPointerInjector {
   private let fallbackBackend: any LivePreviewPointerBackend
   private var deviceStates: [String: DeviceState] = [:]
   private var touchRoutes: [String: TouchRoute] = [:]
-  private var pendingEvents: [LivePreviewPointerEvent] = []
-  private var isFlushing = false
+  private var pendingTouchEvents: [LivePreviewPointerEvent] = []
+  private var pendingMouseEvents: [LivePreviewPointerEvent] = []
+  private var isFlushingTouchEvents = false
+  private var isFlushingMouseEvents = false
 
   init(adb: ADBService) {
     makePreferredBackend = { deviceID in
@@ -80,30 +82,55 @@ actor LivePreviewPointerInjector {
   }
 
   func enqueue(_ event: LivePreviewPointerEvent) async {
-    if event.action == .move,
-       let index = pendingEvents.lastIndex(where: {
-         $0.deviceID == event.deviceID && $0.source == event.source
-       }),
-       pendingEvents[index].action == .move {
-      pendingEvents[index] = event
+    if event.source == .mouse {
+      enqueueMouseEvent(event)
     } else {
-      pendingEvents.append(event)
+      enqueueTouchEvent(event)
+    }
+  }
+
+  private func enqueueTouchEvent(_ event: LivePreviewPointerEvent) {
+    if event.action == .down {
+      pendingMouseEvents.removeAll { $0.deviceID == event.deviceID }
+    }
+    if event.action == .move,
+       let index = pendingTouchEvents.lastIndex(where: { $0.deviceID == event.deviceID }),
+       pendingTouchEvents[index].action == .move {
+      pendingTouchEvents[index] = event
+    } else {
+      pendingTouchEvents.append(event)
     }
 
-    guard !isFlushing else { return }
-    isFlushing = true
-    Task { await flushQueue() }
+    guard !isFlushingTouchEvents else { return }
+    isFlushingTouchEvents = true
+    Task { await flushTouchQueue() }
+  }
+
+  private func enqueueMouseEvent(_ event: LivePreviewPointerEvent) {
+    if event.action == .move,
+       let index = pendingMouseEvents.lastIndex(where: { $0.deviceID == event.deviceID }),
+       pendingMouseEvents[index].action == .move {
+      pendingMouseEvents[index] = event
+    } else {
+      pendingMouseEvents.append(event)
+    }
+
+    guard !isFlushingMouseEvents else { return }
+    isFlushingMouseEvents = true
+    Task { await flushMouseQueue() }
   }
 
   func stopDevice(_ deviceID: String) async {
-    pendingEvents.removeAll { $0.deviceID == deviceID }
+    pendingTouchEvents.removeAll { $0.deviceID == deviceID }
+    pendingMouseEvents.removeAll { $0.deviceID == deviceID }
     touchRoutes.removeValue(forKey: deviceID)
     guard let state = deviceStates.removeValue(forKey: deviceID) else { return }
     await stop(state)
   }
 
   func stopAll() async {
-    pendingEvents.removeAll()
+    pendingTouchEvents.removeAll()
+    pendingMouseEvents.removeAll()
     touchRoutes.removeAll()
     let states = Array(deviceStates.values)
     deviceStates.removeAll()
@@ -150,9 +177,9 @@ actor LivePreviewPointerInjector {
     }
   }
 
-  private func flushQueue() async {
-    while !pendingEvents.isEmpty {
-      let event = pendingEvents.removeFirst()
+  private func flushTouchQueue() async {
+    while !pendingTouchEvents.isEmpty {
+      let event = pendingTouchEvents.removeFirst()
       do {
         try await send(event)
       } catch is CancellationError {
@@ -164,11 +191,33 @@ actor LivePreviewPointerInjector {
       }
     }
 
-    isFlushing = false
+    isFlushingTouchEvents = false
 
-    if !pendingEvents.isEmpty {
-      isFlushing = true
-      await flushQueue()
+    if !pendingTouchEvents.isEmpty {
+      isFlushingTouchEvents = true
+      await flushTouchQueue()
+    }
+  }
+
+  private func flushMouseQueue() async {
+    while !pendingMouseEvents.isEmpty {
+      let event = pendingMouseEvents.removeFirst()
+      do {
+        try await fallbackBackend.send(event)
+      } catch is CancellationError {
+        // Teardown can cancel an in-flight backend operation.
+      } catch {
+        SnapOLog.ui.error(
+          "Failed to send pointer event: \(error.localizedDescription, privacy: .public)"
+        )
+      }
+    }
+
+    isFlushingMouseEvents = false
+
+    if !pendingMouseEvents.isEmpty {
+      isFlushingMouseEvents = true
+      await flushMouseQueue()
     }
   }
 

--- a/snapo-app-mac/Snap-O/LivePreview/LivePreviewView.swift
+++ b/snapo-app-mac/Snap-O/LivePreview/LivePreviewView.swift
@@ -5,7 +5,7 @@ import SwiftUI
 /// Connects a live-preview session to its interactive AppKit surface.
 struct LivePreviewRenderer {
   let operation: LivePreviewOperationHandle
-  let sendPointer: (LivePreviewPointerAction, LivePreviewPointerSource, CGPoint) -> Void
+  let sendPointer: (LivePreviewPointerAction, LivePreviewPointerSource, CGPoint, CGSize) -> Void
 
   var session: LivePreviewSession {
     operation.session
@@ -288,7 +288,8 @@ final class LivePreviewDisplayView: NSView {
     _ source: LivePreviewPointerSource,
     _ location: CGPoint
   ) {
-    renderer?.sendPointer(action, source, location)
+    guard let renderer, let size = renderer.session.media?.size else { return }
+    renderer.sendPointer(action, source, location, size)
   }
 
   private func convertToDevicePoint(event: NSEvent) -> CGPoint? {

--- a/snapo-app-mac/Snap-O/LivePreview/ShellLivePreviewPointerBackend.swift
+++ b/snapo-app-mac/Snap-O/LivePreview/ShellLivePreviewPointerBackend.swift
@@ -1,0 +1,55 @@
+import Foundation
+import SnapODeviceClient
+
+struct ShellLivePreviewPointerBackend: LivePreviewPointerBackend {
+  private static let maximumSendAttempts = 2
+
+  private let adb: ADBService
+
+  init(adb: ADBService) {
+    self.adb = adb
+  }
+
+  func send(_ event: LivePreviewPointerEvent) async throws {
+    let exec = await adb.exec()
+    var lastError: Error?
+
+    for attempt in 0 ..< Self.maximumSendAttempts {
+      do {
+        _ = try await exec.runShellString(
+          deviceID: event.deviceID,
+          command: event.shellCommand()
+        )
+        return
+      } catch {
+        if Task.isCancelled { throw CancellationError() }
+        lastError = error
+        if attempt + 1 < Self.maximumSendAttempts {
+          await Task.yield()
+        }
+      }
+    }
+
+    throw lastError ?? ADBError.serverUnavailable("Failed to send pointer event")
+  }
+}
+
+private extension LivePreviewPointerEvent {
+  func shellCommand() -> String {
+    let maximumX = max(0, Int(displaySize.width.rounded()) - 1)
+    let maximumY = max(0, Int(displaySize.height.rounded()) - 1)
+    let roundedX = min(max(0, Int(location.x.rounded())), maximumX)
+    let roundedY = min(max(0, Int(location.y.rounded())), maximumY)
+
+    let components: [String] = [
+      "input",
+      source.rawValue,
+      "motionevent",
+      action.rawValue,
+      "\(roundedX)",
+      "\(roundedY)"
+    ]
+
+    return components.joined(separator: " ")
+  }
+}

--- a/snapo-app-mac/Snap-O/LivePreview/UInputLivePreviewPointerBackend.swift
+++ b/snapo-app-mac/Snap-O/LivePreview/UInputLivePreviewPointerBackend.swift
@@ -1,0 +1,83 @@
+import CoreGraphics
+import Foundation
+import SnapODeviceClient
+
+/// Owns one persistent virtual touchscreen for one Android device.
+actor UInputLivePreviewPointerBackend: LivePreviewPointerBackend {
+  private let adb: ADBService
+  private let deviceID: String
+  private let touchscreen: ADBVirtualTouchscreen
+  private var displayRotation: ADBDisplayRotation
+  private var lastDisplaySize: CGSize?
+  private var isStopped = false
+
+  static func start(
+    adb: ADBService,
+    deviceID: String
+  ) async throws -> UInputLivePreviewPointerBackend {
+    let exec = await adb.exec()
+    let touchscreen = try await exec.startVirtualTouchscreen(deviceID: deviceID)
+    return UInputLivePreviewPointerBackend(
+      adb: adb,
+      deviceID: deviceID,
+      touchscreen: touchscreen
+    )
+  }
+
+  private init(
+    adb: ADBService,
+    deviceID: String,
+    touchscreen: ADBVirtualTouchscreen
+  ) {
+    self.adb = adb
+    self.deviceID = deviceID
+    self.touchscreen = touchscreen
+    displayRotation = touchscreen.initialDisplayRotation
+  }
+
+  func send(_ event: LivePreviewPointerEvent) async throws {
+    guard !isStopped else { throw CancellationError() }
+    guard event.deviceID == deviceID, event.source == .touchscreen else {
+      throw ADBError.protocolFailure("virtual touchscreen received an event for the wrong device or source")
+    }
+
+    if event.action == .down {
+      if let lastDisplaySize, lastDisplaySize != event.displaySize {
+        let exec = await adb.exec()
+        if let refreshedRotation = try? await exec.displayRotation(deviceID: deviceID) {
+          displayRotation = refreshedRotation
+          self.lastDisplaySize = event.displaySize
+        }
+        guard !isStopped else { throw CancellationError() }
+      } else if lastDisplaySize == nil {
+        lastDisplaySize = event.displaySize
+      }
+    }
+
+    try touchscreen.send(
+      action: event.virtualTouchAction,
+      x: event.location.x,
+      y: event.location.y,
+      displayWidth: event.displaySize.width,
+      displayHeight: event.displaySize.height,
+      rotation: displayRotation
+    )
+  }
+
+  func stop() {
+    guard !isStopped else { return }
+    isStopped = true
+    touchscreen.close()
+  }
+}
+
+private extension LivePreviewPointerEvent {
+  var virtualTouchAction: ADBVirtualTouchAction {
+    switch action {
+    case .down: .down
+    case .move: .move
+    case .up: .up
+    case .cancel: .cancel
+    }
+  }
+}

--- a/snapo-app-mac/Snap-O/LivePreview/UInputLivePreviewPointerBackend.swift
+++ b/snapo-app-mac/Snap-O/LivePreview/UInputLivePreviewPointerBackend.swift
@@ -8,7 +8,6 @@ actor UInputLivePreviewPointerBackend: LivePreviewPointerBackend {
   private let deviceID: String
   private let touchscreen: ADBVirtualTouchscreen
   private var displayRotation: ADBDisplayRotation
-  private var lastDisplaySize: CGSize?
   private var isStopped = false
 
   static func start(
@@ -42,16 +41,10 @@ actor UInputLivePreviewPointerBackend: LivePreviewPointerBackend {
     }
 
     if event.action == .down {
-      if let lastDisplaySize, lastDisplaySize != event.displaySize {
-        let exec = await adb.exec()
-        if let refreshedRotation = try? await exec.displayRotation(deviceID: deviceID) {
-          displayRotation = refreshedRotation
-          self.lastDisplaySize = event.displaySize
-        }
-        guard !isStopped else { throw CancellationError() }
-      } else if lastDisplaySize == nil {
-        lastDisplaySize = event.displaySize
-      }
+      let exec = await adb.exec()
+      let refreshedRotation = try await exec.displayRotation(deviceID: deviceID)
+      guard !isStopped else { throw CancellationError() }
+      displayRotation = refreshedRotation
     }
 
     try touchscreen.send(

--- a/snapo-app-mac/SnapODeviceClient/Sources/SnapODeviceClient/ADB/ADBVirtualTouchscreen.swift
+++ b/snapo-app-mac/SnapODeviceClient/Sources/SnapODeviceClient/ADB/ADBVirtualTouchscreen.swift
@@ -1,0 +1,324 @@
+import Foundation
+
+public enum ADBDisplayRotation: Int, Sendable {
+  case rotation0 = 0
+  case rotation90 = 1
+  case rotation180 = 2
+  case rotation270 = 3
+}
+
+public enum ADBVirtualTouchAction: Sendable {
+  case down
+  case move
+  case up
+  case cancel
+}
+
+/// A virtual direct-touch device backed by a persistent Android `uinput` process.
+public final class ADBVirtualTouchscreen: @unchecked Sendable {
+  public let initialDisplayRotation: ADBDisplayRotation
+
+  private let connection: ADBSocketConnection
+  private var activeGeometry: UInputTouchscreenProtocol.Geometry?
+  private var nextTrackingID = 1
+  private var isClosed = false
+
+  fileprivate init(
+    connection: ADBSocketConnection,
+    initialDisplayRotation: ADBDisplayRotation
+  ) {
+    self.connection = connection
+    self.initialDisplayRotation = initialDisplayRotation
+  }
+
+  public func send(
+    action: ADBVirtualTouchAction,
+    x: Double,
+    y: Double,
+    displayWidth: Double,
+    displayHeight: Double,
+    rotation: ADBDisplayRotation
+  ) throws {
+    guard !isClosed else {
+      throw ADBError.protocolFailure("virtual touchscreen is closed")
+    }
+
+    switch action {
+    case .down:
+      guard activeGeometry == nil else {
+        throw ADBError.protocolFailure("virtual touchscreen already has an active pointer")
+      }
+
+      let geometry = try UInputTouchscreenProtocol.Geometry(
+        displayWidth: displayWidth,
+        displayHeight: displayHeight,
+        rotation: rotation
+      )
+      let point = geometry.rawPoint(x: x, y: y)
+      let trackingID = nextTrackingID
+      nextTrackingID = trackingID == UInputTouchscreenProtocol.maximumTrackingID ? 1 : trackingID + 1
+      try connection.writeLine(
+        UInputTouchscreenProtocol.injectCommand(
+          action: .down,
+          point: point,
+          trackingID: trackingID
+        )
+      )
+      activeGeometry = geometry
+
+    case .move:
+      guard let activeGeometry else { return }
+      let point = activeGeometry.rawPoint(x: x, y: y)
+      try connection.writeLine(
+        UInputTouchscreenProtocol.injectCommand(
+          action: .move,
+          point: point,
+          trackingID: nil
+        )
+      )
+
+    case .up, .cancel:
+      guard activeGeometry != nil else { return }
+      try connection.writeLine(
+        UInputTouchscreenProtocol.injectCommand(
+          action: action,
+          point: nil,
+          trackingID: nil
+        )
+      )
+      activeGeometry = nil
+    }
+  }
+
+  public func close() {
+    guard !isClosed else { return }
+    if activeGeometry != nil {
+      try? connection.writeLine(
+        UInputTouchscreenProtocol.injectCommand(
+          action: .cancel,
+          point: nil,
+          trackingID: nil
+        )
+      )
+    }
+    activeGeometry = nil
+    isClosed = true
+    connection.close()
+  }
+}
+
+public extension ADBClient {
+  /// Starts a virtual touchscreen when the device's Android build exposes a usable `uinput` tool.
+  func startVirtualTouchscreen(deviceID: String) async throws -> ADBVirtualTouchscreen {
+    let identifier = UUID().uuidString
+    let name = "Snap-O Live Preview \(identifier)"
+    let port = "snapo:live-preview:\(identifier)"
+    let registerCommand = try UInputTouchscreenProtocol.registerCommand(name: name, port: port)
+    let connection = try await makeConnection()
+
+    do {
+      try connection.sendTransport(to: deviceID)
+      try connection.sendShell("exec /system/bin/uinput -")
+      try connection.writeLine(registerCommand)
+      let rotation = try await waitForVirtualTouchscreen(deviceID: deviceID, name: name)
+      return ADBVirtualTouchscreen(
+        connection: connection,
+        initialDisplayRotation: rotation
+      )
+    } catch {
+      connection.close()
+      throw error
+    }
+  }
+
+  func displayRotation(deviceID: String) async throws -> ADBDisplayRotation {
+    let output = try await runShellString(
+      deviceID: deviceID,
+      command: "dumpsys input | grep -m 1 'Viewport INTERNAL: displayId=0'"
+    )
+    guard let rotation = UInputTouchscreenProtocol.displayRotation(from: output) else {
+      throw ADBError.parseFailure("Unable to determine display rotation")
+    }
+    return rotation
+  }
+
+  private func waitForVirtualTouchscreen(
+    deviceID: String,
+    name: String
+  ) async throws -> ADBDisplayRotation {
+    let clock = ContinuousClock()
+    let deadline = clock.now.advanced(by: .seconds(2))
+
+    while true {
+      try Task.checkCancellation()
+      let output = try await runShellString(deviceID: deviceID, command: "dumpsys input")
+      if UInputTouchscreenProtocol.isRegisteredTouchscreen(named: name, in: output),
+         let rotation = UInputTouchscreenProtocol.displayRotation(from: output) {
+        return rotation
+      }
+      guard clock.now < deadline else { break }
+      try await Task.sleep(for: .milliseconds(50))
+    }
+
+    throw ADBError.requestTimedOut("Android did not register the virtual touchscreen")
+  }
+}
+
+enum UInputTouchscreenProtocol {
+  static let maximumAxisValue = 32_767
+  static let maximumTrackingID = 65_535
+
+  struct Point: Equatable {
+    let x: Int
+    let y: Int
+  }
+
+  struct Geometry: Equatable {
+    let displayWidth: Double
+    let displayHeight: Double
+    let rotation: ADBDisplayRotation
+
+    init(
+      displayWidth: Double,
+      displayHeight: Double,
+      rotation: ADBDisplayRotation
+    ) throws {
+      guard displayWidth > 0, displayHeight > 0 else {
+        throw ADBError.protocolFailure("virtual touchscreen requires a positive display size")
+      }
+      self.displayWidth = displayWidth
+      self.displayHeight = displayHeight
+      self.rotation = rotation
+    }
+
+    func rawPoint(x: Double, y: Double) -> Point {
+      let normalizedX = Self.normalize(x, maximum: displayWidth - 1)
+      let normalizedY = Self.normalize(y, maximum: displayHeight - 1)
+      let raw: (x: Double, y: Double) = switch rotation {
+      case .rotation0:
+        (normalizedX, normalizedY)
+      case .rotation90:
+        (1 - normalizedY, normalizedX)
+      case .rotation180:
+        (1 - normalizedX, 1 - normalizedY)
+      case .rotation270:
+        (normalizedY, 1 - normalizedX)
+      }
+      return Point(
+        x: Int((raw.x * Double(maximumAxisValue)).rounded()),
+        y: Int((raw.y * Double(maximumAxisValue)).rounded())
+      )
+    }
+
+    private static func normalize(_ value: Double, maximum: Double) -> Double {
+      guard maximum > 0 else { return 0 }
+      return min(max(value, 0), maximum) / maximum
+    }
+  }
+
+  static func registerCommand(name: String, port: String) throws -> String {
+    let encodedName = try encodeString(name)
+    let encodedPort = try encodeString(port)
+    // A non-zero slot range makes InputReader retain unchanged axes as Type-B multitouch state.
+    return
+      #"{"id":1,"command":"register","name":"# + encodedName +
+      #", "vid":6353,"pid":20199,"bus":"usb","port":"# + encodedPort +
+      #", "configuration":[{"type":100,"data":[1,3]},{"type":101,"data":[330,325]},"# +
+      #"{"type":103,"data":[47,53,54,57]},{"type":110,"data":[1]}],"# +
+      #""abs_info":[{"code":47,"info":{"value":0,"minimum":0,"maximum":9,"fuzz":0,"flat":0,"resolution":0}},"# +
+      #"{"code":53,"info":{"value":0,"minimum":0,"maximum":32767,"fuzz":0,"flat":0,"resolution":0}},"# +
+      #"{"code":54,"info":{"value":0,"minimum":0,"maximum":32767,"fuzz":0,"flat":0,"resolution":0}},"# +
+      #"{"code":57,"info":{"value":0,"minimum":0,"maximum":65535,"fuzz":0,"flat":0,"resolution":0}}]}"#
+  }
+
+  static func injectCommand(
+    action: ADBVirtualTouchAction,
+    point: Point?,
+    trackingID: Int?
+  ) -> String {
+    let events: [Int] = switch action {
+    case .down:
+      if let point, let trackingID {
+        [
+          3, 47, 0,
+          3, 57, trackingID,
+          3, 53, point.x,
+          3, 54, point.y,
+          1, 330, 1,
+          1, 325, 1,
+          0, 0, 0
+        ]
+      } else {
+        []
+      }
+    case .move:
+      if let point {
+        [
+          3, 47, 0,
+          3, 53, point.x,
+          3, 54, point.y,
+          0, 0, 0
+        ]
+      } else {
+        []
+      }
+    case .up, .cancel:
+      [
+        3, 47, 0,
+        3, 57, -1,
+        1, 330, 0,
+        1, 325, 0,
+        0, 0, 0
+      ]
+    }
+    let values = events.map(String.init).joined(separator: ",")
+    return #"{"id":1,"command":"inject","events":["# + values + "]}"
+  }
+
+  static func displayRotation(from output: String) -> ADBDisplayRotation? {
+    guard let viewport = output.split(separator: "\n").first(where: {
+      $0.contains("Viewport INTERNAL: displayId=0")
+    }),
+          let marker = viewport.range(of: "orientation=") else { return nil }
+    let suffix = viewport[marker.upperBound...]
+    guard let value = suffix.first?.wholeNumberValue else { return nil }
+    return ADBDisplayRotation(rawValue: value)
+  }
+
+  static func isRegisteredTouchscreen(named name: String, in output: String) -> Bool {
+    let lines = output.split(separator: "\n", omittingEmptySubsequences: false).map(String.init)
+    guard let readerIndex = lines.firstIndex(where: { $0.hasPrefix("Input Reader State") }) else {
+      return false
+    }
+
+    var foundDevice = false
+    for line in lines[(readerIndex + 1)...] {
+      let trimmed = line.trimmingCharacters(in: .whitespaces)
+      if trimmed.hasPrefix("Device "), let colon = trimmed.firstIndex(of: ":") {
+        if foundDevice { return false }
+        let deviceName = trimmed[trimmed.index(after: colon)...].trimmingCharacters(in: .whitespaces)
+        foundDevice = deviceName == name
+        continue
+      }
+      if foundDevice, trimmed.hasPrefix("Sources:") {
+        if trimmed.contains("TOUCHSCREEN") { return true }
+        guard let hexadecimal = trimmed.split(separator: " ").last,
+              hexadecimal.hasPrefix("0x"),
+              let sources = UInt32(hexadecimal.dropFirst(2), radix: 16) else { return false }
+        let sourceTypeMask: UInt32 = 0x0000_FF00
+        let touchscreenType: UInt32 = 0x0000_1000
+        let pointerClass: UInt32 = 0x0000_0002
+        return sources & sourceTypeMask == touchscreenType && sources & pointerClass == pointerClass
+      }
+    }
+    return false
+  }
+
+  private static func encodeString(_ value: String) throws -> String {
+    let data = try JSONEncoder().encode(value)
+    guard let encoded = String(data: data, encoding: .utf8) else {
+      throw ADBError.parseFailure("Unable to encode uinput descriptor")
+    }
+    return encoded
+  }
+}

--- a/snapo-app-mac/SnapODeviceClient/Sources/SnapODeviceClient/ADB/ADBVirtualTouchscreen.swift
+++ b/snapo-app-mac/SnapODeviceClient/Sources/SnapODeviceClient/ADB/ADBVirtualTouchscreen.swift
@@ -165,8 +165,8 @@ public extension ADBClient {
 }
 
 enum UInputTouchscreenProtocol {
-  static let maximumAxisValue = 32_767
-  static let maximumTrackingID = 65_535
+  static let maximumAxisValue = 32767
+  static let maximumTrackingID = 65535
 
   struct Point: Equatable {
     let x: Int
@@ -279,7 +279,7 @@ enum UInputTouchscreenProtocol {
     guard let viewport = output.split(separator: "\n").first(where: {
       $0.contains("Viewport INTERNAL: displayId=0")
     }),
-          let marker = viewport.range(of: "orientation=") else { return nil }
+      let marker = viewport.range(of: "orientation=") else { return nil }
     let suffix = viewport[marker.upperBound...]
     guard let value = suffix.first?.wholeNumberValue else { return nil }
     return ADBDisplayRotation(rawValue: value)

--- a/snapo-app-mac/SnapODeviceClient/Tests/SnapODeviceClientTests/ADBVirtualTouchscreenTests.swift
+++ b/snapo-app-mac/SnapODeviceClient/Tests/SnapODeviceClientTests/ADBVirtualTouchscreenTests.swift
@@ -1,0 +1,177 @@
+import Foundation
+@testable import SnapODeviceClient
+import Testing
+
+@Suite("ADB virtual touchscreen")
+struct ADBVirtualTouchscreenTests {
+  @Test("registers a normalized direct touchscreen")
+  func registrationDescriptor() throws {
+    let command = try UInputTouchscreenProtocol.registerCommand(
+      name: #"Snap-O "Test""#,
+      port: "snapo:test"
+    )
+    let data = try #require(command.data(using: .utf8))
+    let object = try #require(
+      JSONSerialization.jsonObject(with: data) as? [String: Any]
+    )
+
+    #expect(object["name"] as? String == #"Snap-O "Test""#)
+    #expect(object["port"] as? String == "snapo:test")
+    let configurations = try #require(object["configuration"] as? [[String: Any]])
+    #expect(configurations.count == 4)
+    #expect(configurations[0]["type"] as? Int == 100)
+    #expect(integers(configurations[0]["data"]) == [1, 3])
+    #expect(integers(configurations[1]["data"]) == [330, 325])
+    #expect(integers(configurations[2]["data"]) == [47, 53, 54, 57])
+    #expect(integers(configurations[3]["data"]) == [1])
+
+    let axes = try #require(object["abs_info"] as? [[String: Any]])
+    #expect(axisRange(code: 47, in: axes) == 0 ... 9)
+    #expect(axisRange(code: 53, in: axes) == 0 ... 32_767)
+    #expect(axisRange(code: 54, in: axes) == 0 ... 32_767)
+    #expect(axisRange(code: 57, in: axes) == 0 ... 65_535)
+
+    #expect(command.contains(#""type":100,"data":[1,3]"#))
+    #expect(command.contains(#""type":101,"data":[330,325]"#))
+  }
+
+  @Test("maps logical coordinates through display rotation")
+  func rotationMapping() throws {
+    let maximum = UInputTouchscreenProtocol.maximumAxisValue
+    let originByRotation: [(ADBDisplayRotation, UInputTouchscreenProtocol.Point)] = [
+      (.rotation0, .init(x: 0, y: 0)),
+      (.rotation90, .init(x: maximum, y: 0)),
+      (.rotation180, .init(x: maximum, y: maximum)),
+      (.rotation270, .init(x: 0, y: maximum))
+    ]
+
+    for (rotation, expected) in originByRotation {
+      let geometry = try UInputTouchscreenProtocol.Geometry(
+        displayWidth: 2_400,
+        displayHeight: 1_080,
+        rotation: rotation
+      )
+      #expect(geometry.rawPoint(x: 0, y: 0) == expected)
+    }
+
+    let geometry = try UInputTouchscreenProtocol.Geometry(
+      displayWidth: 100,
+      displayHeight: 200,
+      rotation: .rotation0
+    )
+    #expect(geometry.rawPoint(x: -10, y: 500) == .init(x: 0, y: maximum))
+  }
+
+  @Test("encodes type-B down move and lift events")
+  func injectionEvents() throws {
+    let point = UInputTouchscreenProtocol.Point(x: 123, y: 456)
+    let down = try decodeInject(
+      UInputTouchscreenProtocol.injectCommand(
+        action: .down,
+        point: point,
+        trackingID: 7
+      )
+    )
+    #expect(down.events == [
+      3, 47, 0,
+      3, 57, 7,
+      3, 53, 123,
+      3, 54, 456,
+      1, 330, 1,
+      1, 325, 1,
+      0, 0, 0
+    ])
+
+    let move = try decodeInject(
+      UInputTouchscreenProtocol.injectCommand(
+        action: .move,
+        point: point,
+        trackingID: nil
+      )
+    )
+    #expect(move.events == [
+      3, 47, 0,
+      3, 53, 123,
+      3, 54, 456,
+      0, 0, 0
+    ])
+
+    let up = try decodeInject(
+      UInputTouchscreenProtocol.injectCommand(
+        action: .up,
+        point: nil,
+        trackingID: nil
+      )
+    )
+    let cancel = try decodeInject(
+      UInputTouchscreenProtocol.injectCommand(
+        action: .cancel,
+        point: nil,
+        trackingID: nil
+      )
+    )
+    #expect(up.events == [
+      3, 47, 0,
+      3, 57, -1,
+      1, 330, 0,
+      1, 325, 0,
+      0, 0, 0
+    ])
+    #expect(cancel.events == up.events)
+  }
+
+  @Test("waits for InputReader touchscreen registration")
+  func registrationDetection() {
+    let eventHubOnly = """
+    Event Hub State:
+      Devices:
+        27: Snap-O Test
+          Classes: TOUCH | TOUCH_MT | EXTERNAL
+    Input Reader State (Nums of device: 1):
+      Device 12: Other Device
+        Sources: TOUCHSCREEN
+    """
+    #expect(!UInputTouchscreenProtocol.isRegisteredTouchscreen(named: "Snap-O Test", in: eventHubOnly))
+
+    let registered = eventHubOnly + """
+
+      Device 27: Snap-O Test
+        Generation: 2
+        Sources: TOUCHSCREEN
+    """
+    #expect(UInputTouchscreenProtocol.isRegisteredTouchscreen(named: "Snap-O Test", in: registered))
+
+    let android12 = registered.replacingOccurrences(of: "Sources: TOUCHSCREEN", with: "Sources: 0x00001002")
+    #expect(UInputTouchscreenProtocol.isRegisteredTouchscreen(named: "Snap-O Test", in: android12))
+  }
+
+  @Test("parses the active display rotation")
+  func displayRotation() {
+    let viewport = "Viewport INTERNAL: displayId=0, port=0, orientation=3, logicalFrame=[0, 0, 2400, 1080]"
+    #expect(UInputTouchscreenProtocol.displayRotation(from: viewport) == .rotation270)
+    #expect(UInputTouchscreenProtocol.displayRotation(from: "orientation=unknown") == nil)
+  }
+
+  private func decodeInject(_ value: String) throws -> InjectCommand {
+    try JSONDecoder().decode(InjectCommand.self, from: Data(value.utf8))
+  }
+
+  private func integers(_ value: Any?) -> [Int]? {
+    (value as? [NSNumber])?.map(\.intValue)
+  }
+
+  private func axisRange(
+    code: Int,
+    in axes: [[String: Any]]
+  ) -> ClosedRange<Int>? {
+    guard let axis = axes.first(where: { $0["code"] as? Int == code }),
+          let info = axis["info"] as? [String: Any],
+          let minimum = info["minimum"] as? Int,
+          let maximum = info["maximum"] as? Int else { return nil }
+    return minimum ... maximum
+  }
+
+  private struct InjectCommand: Decodable {
+    let events: [Int]
+  }
+}

--- a/snapo-app-mac/SnapODeviceClient/Tests/SnapODeviceClientTests/ADBVirtualTouchscreenTests.swift
+++ b/snapo-app-mac/SnapODeviceClient/Tests/SnapODeviceClientTests/ADBVirtualTouchscreenTests.swift
@@ -27,9 +27,9 @@ struct ADBVirtualTouchscreenTests {
 
     let axes = try #require(object["abs_info"] as? [[String: Any]])
     #expect(axisRange(code: 47, in: axes) == 0 ... 9)
-    #expect(axisRange(code: 53, in: axes) == 0 ... 32_767)
-    #expect(axisRange(code: 54, in: axes) == 0 ... 32_767)
-    #expect(axisRange(code: 57, in: axes) == 0 ... 65_535)
+    #expect(axisRange(code: 53, in: axes) == 0 ... 32767)
+    #expect(axisRange(code: 54, in: axes) == 0 ... 32767)
+    #expect(axisRange(code: 57, in: axes) == 0 ... 65535)
 
     #expect(command.contains(#""type":100,"data":[1,3]"#))
     #expect(command.contains(#""type":101,"data":[330,325]"#))
@@ -47,8 +47,8 @@ struct ADBVirtualTouchscreenTests {
 
     for (rotation, expected) in originByRotation {
       let geometry = try UInputTouchscreenProtocol.Geometry(
-        displayWidth: 2_400,
-        displayHeight: 1_080,
+        displayWidth: 2400,
+        displayHeight: 1080,
         rotation: rotation
       )
       #expect(geometry.rawPoint(x: 0, y: 0) == expected)


### PR DESCRIPTION
## Summary

- inject Live Preview touch gestures through a persistent Android `uinput` virtual touchscreen when runtime registration succeeds
- retain the existing shell implementation as a transparent fallback and for mouse-hover events
- separate shell and uinput injection behind a common backend interface while keeping each gesture on one backend
- queue hover and touch independently so a one-shot shell hover cannot delay uinput gesture startup
- refresh the InputReader viewport rotation before every new touch gesture
- normalize and rotate coordinates across display orientations, and clean up virtual devices with renderer/device lifecycle

## Why

Shell `input touchscreen motionevent` enters below Android's InputReader, so system features such as **Show taps** cannot observe Live Preview touches. A direct virtual touchscreen follows the native input path and produces the expected system touch indicators.

## Root causes fixed

- a slot range of `0...0` made Android treat the stream as slotless multitouch, allowing an unchanged X or Y value to reset to zero during one-axis drags; the descriptor now advertises a real Type-B slot range
- mouse hover uses one-shot shell injection; the old shared queue made DOWN wait behind an in-flight hover, while moves were fast after startup because hover is suppressed during a drag. Hover and touch now flush independently, and DOWN drops queued hover events for that device
- inferring rotation changes from decoded frame dimensions missed 0↔180, 90↔270, and the first post-registration rotation; the backend now reads the actual InputReader viewport rotation on every DOWN
- asynchronous backend setup and teardown are generation-guarded so stale sessions cannot leak or switch transport mid-gesture

## Compatibility

The implementation probes actual uinput registration rather than assuming support from the Android API level. Unsupported or restricted devices continue using shell injection.

## Validation

- `swift test` — 19 tests passed
- `xcodebuild -project Snap-O.xcodeproj -scheme Snap-O CODE_SIGNING_ALLOWED=NO CODE_SIGNING_REQUIRED=NO build`
- SwiftFormat — 0 files require formatting
- SwiftLint — 0 violations
- emulator verification of native Show taps, portrait/landscape mapping, and one-axis drag retention