### PR TITLE
Fix OkHttp response body capture limits

### DIFF
--- a/snapo-link-android/network-okhttp3/src/main/java/com/openai/snapo/network/okhttp3/SnapOOkHttpInterceptor.kt
+++ b/snapo-link-android/network-okhttp3/src/main/java/com/openai/snapo/network/okhttp3/SnapOOkHttpInterceptor.kt
@@ -25,7 +25,6 @@ import okhttp3.TrailersSource
 import okio.Buffer
 import okio.BufferedSink
 import okio.BufferedSource
-import okio.ByteString.Companion.toByteString
 import okio.ForwardingSink
 import okio.ForwardingSource
 import okio.buffer
@@ -37,6 +36,7 @@ import java.nio.charset.CodingErrorAction
 import java.util.UUID
 import java.util.concurrent.TimeUnit
 import java.util.concurrent.atomic.AtomicBoolean
+import kotlin.io.encoding.Base64
 
 /** OkHttp interceptor that mirrors traffic to the active SnapO link if present. */
 class SnapOOkHttpInterceptor @JvmOverloads constructor(
@@ -733,7 +733,10 @@ internal fun resolveResponseBodyCapture(
     declaredBodySize: Long?,
 ): ResolvedResponseBodyCapture {
     val likelyText = capture.isLikelyText(contentType)
-    val bodyLimit = if (likelyText) textBodyMaxBytes else binaryBodyMaxBytes
+    val bodyLimit = resolveEffectiveMaxBytes(
+        maxBytes = if (likelyText) textBodyMaxBytes else binaryBodyMaxBytes,
+        contentLength = declaredBodySize,
+    )
     val retainedBodyBytes = capture.body.prefix(bodyLimit)
     val previewSource = capture.body.prefix(previewBytes)
     val charset = contentType.resolveCharset()
@@ -763,7 +766,7 @@ private fun ResponseBodyCapture.isLikelyText(contentType: MediaType?): Boolean =
 private fun ByteArray.encodeForInspector(likelyText: Boolean, charset: Charset): String? = when {
     isEmpty() -> null
     likelyText -> String(this, charset)
-    else -> toByteString().base64()
+    else -> Base64.encode(this)
 }
 
 private fun ResponseBodyCapture.resolvedBodySize(declaredBodySize: Long?): Long = when {

--- a/snapo-link-android/network-okhttp3/src/test/java/com/openai/snapo/network/okhttp3/BodyCaptureTest.kt
+++ b/snapo-link-android/network-okhttp3/src/test/java/com/openai/snapo/network/okhttp3/BodyCaptureTest.kt
@@ -25,6 +25,7 @@ import org.junit.Assert.assertTrue
 import org.junit.Assert.fail
 import org.junit.Test
 import java.io.IOException
+import java.util.Base64
 
 class BodyCaptureTest {
 
@@ -173,15 +174,15 @@ class BodyCaptureTest {
             textBodyMaxBytes = 4,
             binaryBodyMaxBytes = 6,
             previewBytes = 2,
-            declaredBodySize = 10L,
+            declaredBodySize = null,
         )
         val binary = resolveResponseBodyCapture(
             capture = capture,
             contentType = "application/octet-stream".toMediaType(),
             textBodyMaxBytes = 4,
-            binaryBodyMaxBytes = 4,
+            binaryBodyMaxBytes = 6,
             previewBytes = 2,
-            declaredBodySize = 10L,
+            declaredBodySize = null,
         )
         val omitted = resolveResponseBodyCapture(
             capture = capture,
@@ -189,34 +190,139 @@ class BodyCaptureTest {
             textBodyMaxBytes = 0,
             binaryBodyMaxBytes = 0,
             previewBytes = 2,
-            declaredBodySize = 10L,
+            declaredBodySize = null,
         )
 
         assertEquals("0123", text.body)
         assertEquals("01", text.preview)
         assertEquals(null, text.encoding)
         assertEquals(6L, text.truncatedBytes)
-        assertEquals("MDEyMw==", binary.body)
+        assertEquals("MDEyMzQ1", binary.body)
         assertEquals("MDE=", binary.preview)
         assertEquals("base64", binary.encoding)
-        assertEquals(6L, binary.truncatedBytes)
+        assertEquals(4L, binary.truncatedBytes)
         assertNull(omitted.body)
         assertEquals("01", omitted.preview)
         assertEquals(10L, omitted.truncatedBytes)
     }
 
     @Test
+    fun `known text response smaller than the complete-body threshold is retained in full`() {
+        val bodySize = 7_000_000
+        val bytes = ByteArray(bodySize) { 'a'.code.toByte() }
+        val capture = ResponseBodyCapture(body = bytes, totalBytes = bodySize.toLong(), reachedEof = true)
+
+        val resolved = resolveResponseBodyCapture(
+            capture = capture,
+            contentType = "text/plain; charset=utf-8".toMediaType(),
+            textBodyMaxBytes = DefaultTextBodyMaxBytes,
+            binaryBodyMaxBytes = DefaultBinaryBodyMaxBytes,
+            previewBytes = DefaultBodyPreviewBytes,
+            declaredBodySize = bodySize.toLong(),
+        )
+
+        val body = checkNotNull(resolved.body)
+        assertEquals(bodySize, body.length)
+        assertTrue(body.all { it == 'a' })
+        assertEquals("a".repeat(DefaultBodyPreviewBytes), resolved.preview)
+        assertNull(resolved.encoding)
+        assertNull(resolved.truncatedBytes)
+        assertEquals(bodySize.toLong(), resolved.bodySize)
+    }
+
+    @Test
+    fun `known binary response smaller than the complete-body threshold is retained in full`() {
+        val bodySize = 7_000_000
+        val bytes = ByteArray(bodySize) { index -> index.toByte() }
+        val capture = ResponseBodyCapture(body = bytes, totalBytes = bodySize.toLong(), reachedEof = true)
+
+        val resolved = resolveResponseBodyCapture(
+            capture = capture,
+            contentType = "application/octet-stream".toMediaType(),
+            textBodyMaxBytes = DefaultTextBodyMaxBytes,
+            binaryBodyMaxBytes = DefaultBinaryBodyMaxBytes,
+            previewBytes = DefaultBodyPreviewBytes,
+            declaredBodySize = bodySize.toLong(),
+        )
+
+        assertArrayEquals(bytes, Base64.getDecoder().decode(checkNotNull(resolved.body)))
+        assertEquals(
+            Base64.getEncoder().encodeToString(bytes.copyOf(DefaultBodyPreviewBytes)),
+            resolved.preview,
+        )
+        assertEquals("base64", resolved.encoding)
+        assertNull(resolved.truncatedBytes)
+        assertEquals(bodySize.toLong(), resolved.bodySize)
+    }
+
+    @Test
+    fun `known response larger than the complete-body threshold remains limited`() {
+        val bodySize = 8L * 1024L * 1024L + 1L
+        val captureLimit = DefaultTextBodyMaxBytes
+        val capture = ResponseBodyCapture(
+            body = ByteArray(captureLimit) { 'a'.code.toByte() },
+            totalBytes = bodySize,
+            reachedEof = true,
+        )
+
+        val resolved = resolveResponseBodyCapture(
+            capture = capture,
+            contentType = "text/plain; charset=utf-8".toMediaType(),
+            textBodyMaxBytes = captureLimit,
+            binaryBodyMaxBytes = DefaultBinaryBodyMaxBytes,
+            previewBytes = DefaultBodyPreviewBytes,
+            declaredBodySize = bodySize,
+        )
+
+        assertEquals(captureLimit, checkNotNull(resolved.body).length)
+        assertEquals(DefaultBodyPreviewBytes, checkNotNull(resolved.preview).length)
+        assertNull(resolved.encoding)
+        assertEquals(bodySize - captureLimit, resolved.truncatedBytes)
+        assertEquals(bodySize, resolved.bodySize)
+    }
+
+    @Test
+    fun `unknown-length response remains limited`() {
+        val captureLimit = 1_024
+        val bodySize = captureLimit + 257L
+        val capture = ResponseBodyCapture(
+            body = ByteArray(captureLimit) { 'a'.code.toByte() },
+            totalBytes = bodySize,
+            reachedEof = true,
+        )
+
+        val resolved = resolveResponseBodyCapture(
+            capture = capture,
+            contentType = "text/plain; charset=utf-8".toMediaType(),
+            textBodyMaxBytes = captureLimit,
+            binaryBodyMaxBytes = DefaultBinaryBodyMaxBytes,
+            previewBytes = 16,
+            declaredBodySize = null,
+        )
+
+        assertEquals(captureLimit, checkNotNull(resolved.body).length)
+        assertEquals(16, checkNotNull(resolved.preview).length)
+        assertNull(resolved.encoding)
+        assertEquals(bodySize - captureLimit, resolved.truncatedBytes)
+        assertEquals(bodySize, resolved.bodySize)
+    }
+
+    @Test
     fun `closing a partially consumed response completes once without claiming eof`() {
         val captures = mutableListOf<ResponseBodyCapture>()
-        val body = CapturingResponseBody(TrackingResponseBody("response body"), maxBytes = 4) { capture, _ ->
+        val delegate = TrackingResponseBody("response body")
+        val body = CapturingResponseBody(delegate, maxBytes = 4) { capture, _ ->
             captures += capture
         }
         val sink = Buffer()
 
         body.source().read(sink, 2L)
+        val readCount = delegate.readCount
         body.close()
         body.close()
 
+        assertTrue(readCount > 0)
+        assertEquals(readCount, delegate.readCount)
         assertEquals(1, captures.size)
         assertFalse(captures.single().reachedEof)
     }


### PR DESCRIPTION
## Summary

PR #188 moved OkHttp response capture onto the caller's actual read path. The capture tee correctly expands the buffer for a known response smaller than the existing 8 MiB complete-body threshold, but `resolveResponseBodyCapture` subsequently reapplied the raw 5 MiB body limit and truncated the already-captured response.

This restores the previous complete-body behavior while retaining lazy capture:

- apply the existing effective-limit calculation when resolving the type-specific text or binary body limit, so known responses below 8 MiB remain complete while larger and unknown-length responses stay bounded;
- preserve separate text/binary limits, previews, body-size and truncation metadata, and partial-read/early-close behavior;
- encode retained binary bytes directly with Kotlin Base64, avoiding an unnecessary full-body `ByteString` copy while remaining compatible with min SDK 24 and JVM tests.

## Regression coverage

- known 7,000,000-byte text response is retained completely with the default 5 MiB limit and reports no truncation;
- equivalent binary response round-trips through Base64 correctly and preserves its preview;
- known response above 8 MiB remains bounded and reports the exact truncated-byte count;
- unknown-length response remains bounded with accurate metadata;
- partial consumption followed by early close completes once without an additional upstream read;
- separate text/binary and preview limits remain covered.

## Validation

```text
JAVA_HOME=/Library/Java/JavaVirtualMachines/temurin-17.jdk/Contents/Home ANDROID_HOME=/Users/rz/Library/Android/sdk ./gradlew --no-daemon :network-okhttp3:testDebugUnitTest --console=plain
JAVA_HOME=/Library/Java/JavaVirtualMachines/temurin-17.jdk/Contents/Home ANDROID_HOME=/Users/rz/Library/Android/sdk ./gradlew --no-daemon :network-httpurlconnection:testDebugUnitTest :network:testDebugUnitTest build detekt validateMavenCentralRelease --console=plain
```

Both commands pass.
