### PR TITLE
Show loading state for captured response bodies

### DIFF
--- a/snapo-app-mac/Snap-O/NetworkInspector/NetworkInspectorService.swift
+++ b/snapo-app-mac/Snap-O/NetworkInspector/NetworkInspectorService.swift
@@ -3,6 +3,7 @@ import SnapODeviceClient
 
 actor NetworkInspectorService {
   private static let maximumBufferedOutputs = 4096
+  private static let bodyCommandTimeout: Duration = .seconds(10)
 
   private struct ServerState {
     let reference: NetworkServerReference
@@ -220,7 +221,7 @@ actor NetworkInspectorService {
     return try? await session.command(
       method: method,
       params: ["requestId": .string(requestID)],
-      timeout: .milliseconds(1500)
+      timeout: Self.bodyCommandTimeout
     )
   }
 

--- a/snapo-app-mac/SnapOCLI/RequestDetailsFetcher.swift
+++ b/snapo-app-mac/SnapOCLI/RequestDetailsFetcher.swift
@@ -71,6 +71,7 @@ private struct RequestDetailsSnapshot {
 struct RequestDetailsFetcher {
   private static let attemptLimit = 3
   private static let bodyCommandTimeout: Duration = .seconds(10)
+  private static let requestLookupTimeout: Duration = .seconds(5)
   private static let fetchTimeout: Duration = .seconds(70)
 
   let adb: ADBClient
@@ -95,7 +96,8 @@ struct RequestDetailsFetcher {
 
   private func fetch(using session: CLISession) async throws -> RequestDetailsResult {
     let clock = ContinuousClock()
-    let deadline = clock.now.advanced(by: Self.fetchTimeout)
+    var deadline = clock.now.advanced(by: Self.requestLookupTimeout)
+    var requestLocated = false
     var details = RequestDetailsSnapshot()
     var requestBodyAttempts = 0
     var responseBodyAttempts = 0
@@ -111,6 +113,11 @@ struct RequestDetailsFetcher {
       if case .network(let message) = record {
         details.update(message, requestID: requestID)
         requestBodyEncoding = requestBodyEncoding ?? details.requestBodyEncoding
+
+        if !requestLocated, details.requestSeen {
+          requestLocated = true
+          deadline = clock.now.advanced(by: Self.fetchTimeout)
+        }
 
         if !requestBodyResolved, details.requestSeen, !details.requestHasPostData {
           requestBodyResolved = true

--- a/snapo-app-mac/SnapOCLI/RequestDetailsFetcher.swift
+++ b/snapo-app-mac/SnapOCLI/RequestDetailsFetcher.swift
@@ -70,6 +70,8 @@ private struct RequestDetailsSnapshot {
 
 struct RequestDetailsFetcher {
   private static let attemptLimit = 3
+  private static let bodyCommandTimeout: Duration = .seconds(10)
+  private static let fetchTimeout: Duration = .seconds(70)
 
   let adb: ADBClient
   let server: CLIServerReference
@@ -93,7 +95,7 @@ struct RequestDetailsFetcher {
 
   private func fetch(using session: CLISession) async throws -> RequestDetailsResult {
     let clock = ContinuousClock()
-    let deadline = clock.now.advanced(by: .seconds(5))
+    let deadline = clock.now.advanced(by: Self.fetchTimeout)
     var details = RequestDetailsSnapshot()
     var requestBodyAttempts = 0
     var responseBodyAttempts = 0
@@ -134,7 +136,7 @@ struct RequestDetailsFetcher {
           let message = try await session.command(
             method: SnapONetworkProtocol.Method.getRequestPostData,
             params: ["requestId": .string(requestID)],
-            timeout: .milliseconds(500)
+            timeout: Self.bodyCommandTimeout
           )
           if let error = message.error {
             if error.message.lowercased().contains("no request body captured") {
@@ -165,7 +167,7 @@ struct RequestDetailsFetcher {
           let message = try await session.command(
             method: SnapONetworkProtocol.Method.getResponseBody,
             params: ["requestId": .string(requestID)],
-            timeout: .milliseconds(500)
+            timeout: Self.bodyCommandTimeout
           )
           if let error = message.error {
             if let failure = details.loadingFailedMessage, !failure.isEmpty {

--- a/snapo-link-android/network-httpurlconnection/src/main/java/com/openai/snapo/network/httpurlconnection/SnapOHttpUrlInterceptor.kt
+++ b/snapo-link-android/network-httpurlconnection/src/main/java/com/openai/snapo/network/httpurlconnection/SnapOHttpUrlInterceptor.kt
@@ -783,6 +783,7 @@ private class ResponseCapturingInputStream(
         publishLoadingFinishedIfNeeded(
             requestId = currentContext.requestId,
             totalBytes = totalBytes,
+            truncatedBytes = snapshot.truncatedBytes,
             error = error,
             after = bodyUpdate,
         )
@@ -841,6 +842,7 @@ private class ResponseCapturingInputStream(
     private fun publishLoadingFinishedIfNeeded(
         requestId: String,
         totalBytes: Long?,
+        truncatedBytes: Long?,
         error: Throwable?,
         after: Job?,
     ) {
@@ -853,6 +855,7 @@ private class ResponseCapturingInputStream(
                 tWallMs = nowWall,
                 tMonoNs = nowMono,
                 bodySize = totalBytes,
+                bodyTruncatedBytes = truncatedBytes,
             )
         }
     }

--- a/snapo-link-android/network-okhttp3/src/main/java/com/openai/snapo/network/okhttp3/SnapOOkHttpInterceptor.kt
+++ b/snapo-link-android/network-okhttp3/src/main/java/com/openai/snapo/network/okhttp3/SnapOOkHttpInterceptor.kt
@@ -359,6 +359,7 @@ class SnapOOkHttpInterceptor @JvmOverloads constructor(
                         tWallMs = completionWall,
                         tMonoNs = completionMono,
                         bodySize = completedBodySize,
+                        bodyTruncatedBytes = body?.truncatedBytes,
                     )
                 } else {
                     RequestFailed(

--- a/snapo-link-android/network/src/main/java/com/openai/snapo/network/CdpNetworkMapper.kt
+++ b/snapo-link-android/network/src/main/java/com/openai/snapo/network/CdpNetworkMapper.kt
@@ -89,6 +89,7 @@ private fun ResponseFinished.toCdpLoadingFinished(): CdpMessage {
                 requestId = id,
                 timestamp = tMonoNs.toMonotonicSeconds(),
                 encodedDataLength = bodySize?.toDouble(),
+                bodyTruncatedBytes = bodyTruncatedBytes,
             ),
         ),
     )

--- a/snapo-link-android/network/src/main/java/com/openai/snapo/network/CdpNetworkProtocol.kt
+++ b/snapo-link-android/network/src/main/java/com/openai/snapo/network/CdpNetworkProtocol.kt
@@ -79,6 +79,7 @@ internal data class CdpLoadingFinishedParams(
     val requestId: String,
     val timestamp: Double? = null,
     val encodedDataLength: Double? = null,
+    val bodyTruncatedBytes: Long? = null,
 )
 
 @Serializable

--- a/snapo-link-android/network/src/main/java/com/openai/snapo/network/Events.kt
+++ b/snapo-link-android/network/src/main/java/com/openai/snapo/network/Events.kt
@@ -58,6 +58,7 @@ data class ResponseFinished(
     override val tWallMs: Long,
     override val tMonoNs: Long,
     val bodySize: Long? = null,
+    val bodyTruncatedBytes: Long? = null,
 ) : PerRequestRecord
 
 /** Failure with partial timings if available. */

--- a/snapo-link-android/network/src/test/java/com/openai/snapo/network/NetworkProtocolCompatibilityTest.kt
+++ b/snapo-link-android/network/src/test/java/com/openai/snapo/network/NetworkProtocolCompatibilityTest.kt
@@ -39,4 +39,20 @@ class NetworkProtocolCompatibilityTest {
 
         assertEquals(17L, encoded.getValue("watermark").jsonPrimitive.content.toLong())
     }
+
+    @Test
+    fun `loading finished carries response size and truncation metadata`() {
+        val params = checkNotNull(
+            ResponseFinished(
+                id = "request-1",
+                tWallMs = 1_000L,
+                tMonoNs = 2_000_000_000L,
+                bodySize = 9_437_184L,
+                bodyTruncatedBytes = 4_194_304L,
+            ).toCdpMessage(requestUrl = null).params,
+        ).jsonObject
+
+        assertEquals(9_437_184.0, params.getValue("encodedDataLength").jsonPrimitive.content.toDouble(), 0.0)
+        assertEquals(4_194_304L, params.getValue("bodyTruncatedBytes").jsonPrimitive.content.toLong())
+    }
 }

--- a/snapo-link-android/samples/demo-okhttp/src/main/java/com/openai/snapo/demo/MainActivity.kt
+++ b/snapo-link-android/samples/demo-okhttp/src/main/java/com/openai/snapo/demo/MainActivity.kt
@@ -73,6 +73,8 @@ class MainActivity : ComponentActivity() {
                         onUnknownLengthGzipPostRequestClick = { runUnknownLengthGzipPostRequest(scope) },
                         onNoContentTypeTextResponseClick = { runNoContentTypeTextResponseRequest(scope) },
                         onImageResponseClick = { runImageResponseRequest(scope) },
+                        onCompleteLargeResponseClick = { runLargeResponseRequest(scope, complete = true) },
+                        onTruncatedLargeResponseClick = { runLargeResponseRequest(scope, complete = false) },
                         onSlowResponseClick = { runSlowResponseRequest(scope) },
                         onWebSocketDemoClick = { startWebSocketDemo(scope) },
                         modifier = Modifier.padding(innerPadding)
@@ -172,6 +174,18 @@ class MainActivity : ComponentActivity() {
         }
     }
 
+    private fun runLargeResponseRequest(scope: CoroutineScope, complete: Boolean) {
+        scope.launch {
+            val path = if (complete) "/large-response-complete" else "/large-response-truncated"
+            val url = resolveMockHttpUrl(path) ?: return@launch
+            val request = Request.Builder()
+                .url(url)
+                .header("X-SnapO-Demo", "okhttp-large-response")
+                .build()
+            executeRequest(scope, request, printResponseBody = false)
+        }
+    }
+
     private fun executeRequest(
         scope: CoroutineScope,
         request: Request,
@@ -257,6 +271,8 @@ fun Greeting(
     onUnknownLengthGzipPostRequestClick: () -> Unit,
     onNoContentTypeTextResponseClick: () -> Unit,
     onImageResponseClick: () -> Unit,
+    onCompleteLargeResponseClick: () -> Unit,
+    onTruncatedLargeResponseClick: () -> Unit,
     onSlowResponseClick: () -> Unit,
     onWebSocketDemoClick: () -> Unit,
     modifier: Modifier = Modifier,
@@ -282,6 +298,12 @@ fun Greeting(
         Button(onClick = onImageResponseClick) {
             Text("GET image (PNG)")
         }
+        Button(onClick = onCompleteLargeResponseClick) {
+            Text("GET 7 MiB JSON (complete)")
+        }
+        Button(onClick = onTruncatedLargeResponseClick) {
+            Text("GET 9 MiB JSON (truncated)")
+        }
         Button(onClick = onSlowResponseClick) {
             Text("Slow response")
         }
@@ -301,6 +323,8 @@ private fun GreetingPreview() {
             onUnknownLengthGzipPostRequestClick = {},
             onNoContentTypeTextResponseClick = {},
             onImageResponseClick = {},
+            onCompleteLargeResponseClick = {},
+            onTruncatedLargeResponseClick = {},
             onSlowResponseClick = {},
             onWebSocketDemoClick = {},
         )

--- a/snapo-link-android/samples/demo-shared/src/main/java/com/openai/snapo/demo/shared/DemoMockServer.kt
+++ b/snapo-link-android/samples/demo-shared/src/main/java/com/openai/snapo/demo/shared/DemoMockServer.kt
@@ -84,6 +84,8 @@ private fun createServer(): MockWebServer {
                         .body(noTypeBody)
                         .build()
                     "/image.png" -> imageResponse(imageBody)
+                    "/large-response-complete" -> largeJsonResponse(CompleteLargeBodyBytes)
+                    "/large-response-truncated" -> largeJsonResponse(TruncatedLargeBodyBytes)
                     "/slow-response" -> slowResponse(slowBody)
                     "/ws-echo" -> MockResponse.Builder()
                         .webSocketUpgrade(
@@ -114,6 +116,19 @@ private fun imageResponse(body: ByteString): MockResponse = MockResponse.Builder
     .body(Buffer().write(body))
     .build()
 
+private fun largeJsonResponse(bodyBytes: Int): MockResponse {
+    val prefix = "{\"message\":\""
+    val suffix = "\",\"source\":\"okhttp-demo\"}"
+    val body = prefix + "x".repeat(bodyBytes - prefix.length - suffix.length) + suffix
+    return MockResponse.Builder()
+        .code(200)
+        .setHeader("Content-Type", "application/json; charset=utf-8")
+        .setHeader("Content-Length", bodyBytes.toString())
+        .setHeader("Connection", "close")
+        .body(body)
+        .build()
+}
+
 private fun slowResponse(body: String): MockResponse = MockResponse.Builder()
     .code(200)
     .setHeader("Content-Type", "application/json; charset=utf-8")
@@ -138,6 +153,8 @@ fun String.toWebSocketUrl(): String {
 
 private const val DemoLogTag: String = "SnapODemo"
 private const val MockHost: String = "127.0.0.1"
+private const val CompleteLargeBodyBytes: Int = 7 * 1024 * 1024
+private const val TruncatedLargeBodyBytes: Int = 9 * 1024 * 1024
 private const val SlowBodyPayloadCharacters: Int = 1024 * 1024
 private const val SlowBodyInitialDelayMs: Long = 2_000L
 private const val SlowBodyChunkBytes: Long = 128L * 1024L

--- a/snapo-network-inspector-web/src/features/network-inspector/components/RequestDetail.test.tsx
+++ b/snapo-network-inspector-web/src/features/network-inspector/components/RequestDetail.test.tsx
@@ -1,0 +1,80 @@
+import { renderToStaticMarkup } from "react-dom/server";
+import { describe, expect, it } from "vitest";
+import type { NetworkClient } from "../../../network/client";
+import type { RequestRecord } from "../../../network/cdp";
+import type { InspectorUiState } from "../hooks/useInspectorUiState";
+import { RequestDetail } from "./RequestDetail";
+
+describe("Response Body loading state", () => {
+  it("shows the captured size and an accessible loading indicator before hydration completes", () => {
+    const markup = renderToStaticMarkup(
+      <RequestDetail
+        client={{} as NetworkClient}
+        record={request({ encodedDataLength: 7_340_032 })}
+        uiState={expandedUiState}
+      />
+    );
+
+    expect(markup).toContain("Response Body");
+    expect(markup).toContain("Captured 7.3 MB");
+    expect(markup).toContain('<div class="payload-card"><div class="body-loading" role="status">');
+    expect(markup).toContain("body-loading-spinner");
+    expect(markup).toContain('aria-hidden="true"');
+    expect(markup).toContain("Loading...");
+  });
+
+  it("shows the captured prefix and total size while a truncated body is loading", () => {
+    const markup = renderToStaticMarkup(
+      <RequestDetail
+        client={{} as NetworkClient}
+        record={request({ encodedDataLength: 9_437_184, responseBodyTruncatedBytes: 4_194_304 })}
+        uiState={expandedUiState}
+      />
+    );
+
+    expect(markup).toContain("Response Body");
+    expect(markup).toContain("Captured 5.2 MB of 9.4 MB");
+    expect(markup).toContain("Loading...");
+  });
+
+  it("does not leave a loading indicator behind when a body is unavailable", () => {
+    const markup = renderToStaticMarkup(
+      <RequestDetail
+        client={{} as NetworkClient}
+        record={request({ encodedDataLength: 7_340_032, responseBodyLoadCompleted: true })}
+        uiState={expandedUiState}
+      />
+    );
+
+    expect(markup).not.toContain("Response Body");
+    expect(markup).not.toContain("Loading...");
+  });
+});
+
+const expandedUiState: InspectorUiState = {
+  sectionExpanded: () => true,
+  setSectionExpanded: () => {},
+  prettyEnabled: (_key, fallback) => fallback,
+  setPrettyEnabled: () => {},
+  jsonExpanded: (_key, fallback) => fallback,
+  setJsonExpanded: () => {}
+};
+
+function request(overrides: Partial<RequestRecord>): RequestRecord {
+  return {
+    kind: "request",
+    server: { deviceId: "device", socketName: "socket", instanceId: "instance" },
+    requestId: "request",
+    method: "GET",
+    url: "https://example.com/large-response",
+    requestHeaders: [],
+    responseHeaders: [{ name: "Content-Type", value: "application/json" }],
+    status: { kind: "success", code: 200 },
+    startedAt: 1,
+    endedAt: 2,
+    streamEvents: [],
+    streamEventCount: 0,
+    updatedAt: 2,
+    ...overrides
+  };
+}

--- a/snapo-network-inspector-web/src/features/network-inspector/components/RequestDetail.tsx
+++ b/snapo-network-inspector-web/src/features/network-inspector/components/RequestDetail.tsx
@@ -1,3 +1,4 @@
+import { LoaderCircle } from "lucide-react";
 import { memo, useEffect, useState } from "react";
 import type { NetworkClient } from "../../../network/client";
 import { recordId, type Header, type RequestRecord } from "../../../network/cdp";
@@ -5,6 +6,7 @@ import { decodeRequestBodyForDisplay, makeBodyPayload } from "../../../network/p
 import { isLikelyStreamingRequest } from "../../../network/request-classification";
 import type { InspectorUiState } from "../hooks/useInspectorUiState";
 import { useAdaptiveTimingText } from "../hooks/useAdaptiveTimingText";
+import { responseBodyCaptureMetadata, shouldRequestResponseBody } from "../lib/records";
 import { BodySection, payloadMetadata } from "./PayloadView";
 import { HeadersTable, Section } from "./Section";
 import { FailureMessage, StatusBadge } from "./Status";
@@ -35,6 +37,7 @@ export const RequestDetail = memo(function RequestDetail({
         base64Encoded: record.responseBodyBase64Encoded,
         totalBytes: record.encodedDataLength
       });
+  const isResponseBodyLoading = !isSseResponse && shouldRequestResponseBody(record);
   const prefix = `request:${recordId(record)}`;
   const timingText = useAdaptiveTimingText(record.startedAt, record.endedAt, record.status);
 
@@ -99,19 +102,28 @@ export const RequestDetail = memo(function RequestDetail({
           />
         </Section>
       ) : null}
-      {responseBody == null ? null : (
+      {responseBody == null && !isResponseBodyLoading ? null : (
         <Section
           title="Response Body"
-          meta={payloadMetadata(responseBody)}
+          meta={responseBody == null ? responseBodyCaptureMetadata(record) : payloadMetadata(responseBody)}
           storageKey={`${prefix}:responseBody`}
           uiState={uiState}
         >
-          <BodySection
-            client={client}
-            payload={responseBody}
-            storageKey={`${prefix}:responseBody:payload`}
-            uiState={uiState}
-          />
+          {responseBody == null ? (
+            <div className="payload-card">
+              <div className="body-loading" role="status">
+                <LoaderCircle className="body-loading-spinner" size={14} aria-hidden="true" />
+                <span>Loading...</span>
+              </div>
+            </div>
+          ) : (
+            <BodySection
+              client={client}
+              payload={responseBody}
+              storageKey={`${prefix}:responseBody:payload`}
+              uiState={uiState}
+            />
+          )}
         </Section>
       )}
     </div>

--- a/snapo-network-inspector-web/src/features/network-inspector/lib/records.test.ts
+++ b/snapo-network-inspector-web/src/features/network-inspector/lib/records.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest";
 import type { RequestRecord } from "../../../network/cdp";
-import { shouldRequestRequestBody } from "./records";
+import { responseBodyCaptureMetadata, shouldRequestRequestBody, shouldRequestResponseBody } from "./records";
 
 describe("request body loading", () => {
   it("waits until request transmission has completed", () => {
@@ -13,6 +13,39 @@ describe("request body loading", () => {
     expect(shouldRequestRequestBody(request({ requestHasPostData: false, hasReceivedResponse: true }))).toBe(false);
     expect(shouldRequestRequestBody(request({ requestBodySize: 0, hasReceivedResponse: true }))).toBe(false);
     expect(shouldRequestRequestBody(request({ requestBody: "cached", hasReceivedResponse: true }))).toBe(false);
+  });
+});
+
+describe("response body loading", () => {
+  it("shows a captured-size label while a completed response body is loading", () => {
+    const complete = request({
+      status: { kind: "success", code: 200 },
+      endedAt: 2,
+      encodedDataLength: 7_340_032
+    });
+
+    expect(shouldRequestResponseBody(complete)).toBe(true);
+    expect(responseBodyCaptureMetadata(complete)).toBe("Captured 7.3 MB");
+  });
+
+  it("shows the captured prefix and total size for a truncated response", () => {
+    const truncated = request({
+      status: { kind: "success", code: 200 },
+      endedAt: 2,
+      encodedDataLength: 9_437_184,
+      responseBodyTruncatedBytes: 4_194_304
+    });
+
+    expect(shouldRequestResponseBody(truncated)).toBe(true);
+    expect(responseBodyCaptureMetadata(truncated)).toBe("Captured 5.2 MB of 9.4 MB");
+  });
+
+  it("stops requesting a response body after an unavailable body finishes loading", () => {
+    expect(
+      shouldRequestResponseBody(
+        request({ status: { kind: "success", code: 200 }, endedAt: 2, responseBodyLoadCompleted: true })
+      )
+    ).toBe(false);
   });
 });
 

--- a/snapo-network-inspector-web/src/features/network-inspector/lib/records.ts
+++ b/snapo-network-inspector-web/src/features/network-inspector/lib/records.ts
@@ -9,6 +9,7 @@ import {
 } from "../../../network/cdp";
 import type { SnapOServer } from "../../../network/bridge-types";
 import { isLikelyStreamingRequest } from "../../../network/request-classification";
+import { bodyMetadata } from "../../../network/payload";
 import { matchesNetworkSearch, parseNetworkSearchQuery } from "./search";
 
 export function filterRecords(
@@ -49,6 +50,7 @@ export function shouldRequestRequestBody(request: RequestRecord): boolean {
 
 export function shouldRequestResponseBody(request: RequestRecord): boolean {
   if (request.responseBody != null) return false;
+  if (request.responseBodyLoadCompleted) return false;
   if (request.status.kind !== "success") return false;
 
   if (isLikelyStreamingRequest(request)) {
@@ -59,6 +61,16 @@ export function shouldRequestResponseBody(request: RequestRecord): boolean {
 
   if (responseHasNoBody(request)) return false;
   return request.encodedDataLength == null || request.encodedDataLength !== 0;
+}
+
+export function responseBodyCaptureMetadata(request: RequestRecord): string | null {
+  const totalBytes = request.encodedDataLength;
+  if (totalBytes == null) return null;
+  const truncatedBytes = Math.max(0, request.responseBodyTruncatedBytes ?? 0);
+  return bodyMetadata({
+    capturedBytes: Math.max(0, totalBytes - truncatedBytes),
+    totalBytes
+  });
 }
 
 function isCompletedRequest(request: RequestRecord): boolean {

--- a/snapo-network-inspector-web/src/network/body-loader.test.ts
+++ b/snapo-network-inspector-web/src/network/body-loader.test.ts
@@ -86,6 +86,31 @@ describe("RequestBodyLoader", () => {
     expect(loaded).toEqual(["fresh"]);
     loader.dispose();
   });
+
+  it.each([
+    ["an empty result", false],
+    ["a failed load", true]
+  ])("marks a missing response body as completed after %s", async (_description, shouldFail) => {
+    const loaded: RequestBodies[] = [];
+    const request = job("request", bodyLoadPriority.selected);
+    request.input.includeRequestBody = false;
+    request.input.includeResponseBody = true;
+    const loader = new RequestBodyLoader(
+      async (input) => {
+        if (shouldFail) throw new Error("body unavailable");
+        return { requestId: input.requestId };
+      },
+      (_recordKey, bodies) => loaded.push(bodies),
+      1
+    );
+    loader.retainRecords(new Set([request.recordKey]));
+
+    loader.schedule([request]);
+    await nextTask();
+
+    expect(loaded).toEqual([{ requestId: "request", responseBodyLoadCompleted: true }]);
+    loader.dispose();
+  });
 });
 
 function job(requestId: string, priority: BodyLoadJob["priority"]): BodyLoadJob {

--- a/snapo-network-inspector-web/src/network/body-loader.ts
+++ b/snapo-network-inspector-web/src/network/body-loader.ts
@@ -101,11 +101,24 @@ export class RequestBodyLoader {
       void this.loadBodies(entry.input)
         .then((bodies) => {
           if (!this.disposed && !entry.cancelled && this.retainedRecordKeys.has(entry.recordKey)) {
-            this.didLoadBodies(entry.recordKey, bodies);
+            this.didLoadBodies(entry.recordKey, {
+              ...bodies,
+              ...(entry.input.includeResponseBody ? { responseBodyLoadCompleted: true } : {})
+            });
           }
         })
         .catch(() => {
-          // A completed request may no longer expose its body. One failed attempt is enough.
+          if (
+            entry.input.includeResponseBody &&
+            !this.disposed &&
+            !entry.cancelled &&
+            this.retainedRecordKeys.has(entry.recordKey)
+          ) {
+            this.didLoadBodies(entry.recordKey, {
+              requestId: entry.input.requestId,
+              responseBodyLoadCompleted: true
+            });
+          }
         })
         .finally(() => {
           this.runningCount -= 1;

--- a/snapo-network-inspector-web/src/network/body-retention.test.ts
+++ b/snapo-network-inspector-web/src/network/body-retention.test.ts
@@ -36,14 +36,16 @@ describe("RequestBodyCache", () => {
     cache.put("request", {
       requestId: "request",
       responseBody: "output",
-      responseBodyBase64Encoded: false
+      responseBodyBase64Encoded: false,
+      responseBodyLoadCompleted: true
     });
 
     expect(cache.peek("request")).toEqual({
       requestId: "request",
       requestBody: "input",
       responseBody: "output",
-      responseBodyBase64Encoded: false
+      responseBodyBase64Encoded: false,
+      responseBodyLoadCompleted: true
     });
   });
 

--- a/snapo-network-inspector-web/src/network/body-retention.ts
+++ b/snapo-network-inspector-web/src/network/body-retention.ts
@@ -88,7 +88,8 @@ function mergeBodies(existing: RequestBodies | undefined, incoming: RequestBodie
     requestId: incoming.requestId,
     requestBody: incoming.requestBody ?? existing?.requestBody,
     responseBody: incoming.responseBody ?? existing?.responseBody,
-    responseBodyBase64Encoded: incoming.responseBodyBase64Encoded ?? existing?.responseBodyBase64Encoded
+    responseBodyBase64Encoded: incoming.responseBodyBase64Encoded ?? existing?.responseBodyBase64Encoded,
+    responseBodyLoadCompleted: incoming.responseBodyLoadCompleted ?? existing?.responseBodyLoadCompleted
   };
 }
 

--- a/snapo-network-inspector-web/src/network/bridge-types.ts
+++ b/snapo-network-inspector-web/src/network/bridge-types.ts
@@ -44,6 +44,7 @@ export interface RequestBodies {
   requestBody?: string | null;
   responseBody?: string | null;
   responseBodyBase64Encoded?: boolean | null;
+  responseBodyLoadCompleted?: boolean;
 }
 
 export interface LoadBodiesInput {

--- a/snapo-network-inspector-web/src/network/cdp.test.ts
+++ b/snapo-network-inspector-web/src/network/cdp.test.ts
@@ -30,6 +30,34 @@ describe("reduceCdpMessage", () => {
     expect(request?.updatedAt).toBe(1_710_000_000_250);
   });
 
+  it("retains response truncation metadata from loading-finished events", () => {
+    let state = reduce(createEmptyInspectorState(), requestStarted("large-response", 1));
+    state = reduce(state, {
+      snapoSequence: 2,
+      method: "Network.responseReceived",
+      params: {
+        requestId: "large-response",
+        timestamp: 1.1,
+        type: "XHR",
+        response: { url: "https://example.com/large-response", status: 200, headers: {}, encodedDataLength: 9_437_184 }
+      }
+    });
+    state = reduce(state, {
+      snapoSequence: 3,
+      method: "Network.loadingFinished",
+      params: {
+        requestId: "large-response",
+        timestamp: 1.2,
+        encodedDataLength: 9_437_184,
+        bodyTruncatedBytes: 4_194_304
+      }
+    });
+
+    const request = state.requests.get(requestRecordKey(server, "large-response"));
+    expect(request?.encodedDataLength).toBe(9_437_184);
+    expect(request?.responseBodyTruncatedBytes).toBe(4_194_304);
+  });
+
   it("ignores duplicate and stale sequences independently for each server", () => {
     let state = createEmptyInspectorState();
     state = reduce(state, webSocketCreated(1));

--- a/snapo-network-inspector-web/src/network/cdp.ts
+++ b/snapo-network-inspector-web/src/network/cdp.ts
@@ -46,6 +46,8 @@ export interface RequestRecord {
   requestBodyEncoding?: string | null;
   responseBody?: string | null;
   responseBodyBase64Encoded?: boolean | null;
+  responseBodyTruncatedBytes?: number | null;
+  responseBodyLoadCompleted?: boolean;
   responseType?: string | null;
   hasReceivedResponse?: boolean;
   streamEvents: StreamEventRecord[];
@@ -304,12 +306,14 @@ function reduceLoadingFinished(
     const base = requestDefaults(existing, server, requestId(params), receivedAt);
     const eventAt = eventTimeMs(params, base, receivedAt);
     const encodedDataLength = params.encodedDataLength ?? existing?.encodedDataLength;
+    const responseBodyTruncatedBytes = numberAt(params, "bodyTruncatedBytes") ?? existing?.responseBodyTruncatedBytes;
     const status = base.status.kind === "success" ? base.status : { kind: "success" as const, code: 200 };
     return {
       ...base,
       status,
       endedAt: eventAt,
       encodedDataLength,
+      responseBodyTruncatedBytes,
       streamClosed: isLikelyStreamingRequest(base)
         ? {
             timestamp: eventAt,
@@ -484,7 +488,8 @@ export function applyRequestBodies(record: RequestRecord, bodies: RequestBodies)
     ...record,
     requestBody: bodies.requestBody ?? record.requestBody,
     responseBody: bodies.responseBody ?? record.responseBody,
-    responseBodyBase64Encoded: bodies.responseBodyBase64Encoded ?? record.responseBodyBase64Encoded
+    responseBodyBase64Encoded: bodies.responseBodyBase64Encoded ?? record.responseBodyBase64Encoded,
+    responseBodyLoadCompleted: bodies.responseBodyLoadCompleted ?? record.responseBodyLoadCompleted
   };
 }
 

--- a/snapo-network-inspector-web/src/network/payload.ts
+++ b/snapo-network-inspector-web/src/network/payload.ts
@@ -86,7 +86,7 @@ export function dataUrlForImage(payload: BodyPayload): string | null {
   return `data:${payload.contentType};base64,${payload.rawText.replace(/\s+/gu, "")}`;
 }
 
-export function bodyMetadata(payload: BodyPayload): string | null {
+export function bodyMetadata(payload: Pick<BodyPayload, "capturedBytes" | "totalBytes">): string | null {
   const parts: string[] = [];
   if (payload.capturedBytes > 0) {
     parts.push(`Captured ${formatBytes(payload.capturedBytes)}`);

--- a/snapo-network-inspector-web/src/styles.css
+++ b/snapo-network-inspector-web/src/styles.css
@@ -759,6 +759,20 @@ body.split-pane-resizing {
   padding: 8px 0 6px 8px;
 }
 
+.body-loading {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  color: var(--on-surface-variant);
+  font-size: 12px;
+  line-height: 16px;
+}
+
+.body-loading-spinner {
+  flex: 0 0 auto;
+  animation: spin 1s linear infinite;
+}
+
 .messages-empty {
   padding: 8px 0 0 10px;
 }


### PR DESCRIPTION

<img width="448" height="192" alt="CleanShot 2026-07-13 at 16 16 52@2x" src="https://github.com/user-attachments/assets/1af08f8a-8486-4908-b5f4-e726cc9099e6" />


## Summary

Large captured response bodies could appear to be missing because the app and CLI timed out while fetching them, and the inspector gave no indication that hydration was in progress.

- show the Response Body section immediately with the captured-size label and a concise, accessible spinner inside the standard payload box
- carry response truncation metadata through both Android interceptors and the CDP loading-finished event so complete and truncated sizes are accurate
- increase body-fetch timeouts, stop the spinner when hydration returns no body or fails, and add 7 MiB complete / 9 MiB truncated JSON cases to the OkHttp sample

## Validation

- Web: Prettier, TypeScript, Vitest (37 tests), ESLint, Stylelint, Vite build
- Android (JDK 17): network/OkHttp/HttpURLConnection unit tests, Detekt, demo-okhttp debug APK
- Swift: SnapODeviceClient tests (19 tests)
- macOS: Snap-O Xcode build
- Pixel 9 Pro XL: verified the 7 MiB body hydrates completely and the 9 MiB body reports a 5 MiB captured prefix with truncation metadata
