### PR TITLE
Add Snap-O 3.2.0 to appcast

### DIFF
--- a/appcast.xml
+++ b/appcast.xml
@@ -8,6 +8,15 @@
     <description>Software updates for Snap‑O</description>
 
     <item>
+        <title>Snap‑O 3.2.0</title>
+        <pubDate>Tue, 14 Jul 2026 10:07:12 +0000</pubDate>
+        <sparkle:minimumSystemVersion>15.0</sparkle:minimumSystemVersion>
+        <sparkle:version>20260714.00</sparkle:version>
+        <sparkle:shortVersionString>3.2.0</sparkle:shortVersionString>
+        <enclosure url="https://github.com/openai/snap-o/releases/download/3.2.0/Snap-O.dmg" length="2773930" type="application/octet-stream" sparkle:edSignature="HwwpuRtTa9iEd5suOHXAVMDcmF+6YaLCgdXZcK3RR4lnP6ix/oJmoBs9GKxZF4TDZoq6WZcYTZRdrMUo8Q7iBw==" />
+    </item>
+
+    <item>
         <title>Snap‑O 3.1.0</title>
         <pubDate>Wed, 24 Jun 2026 12:28:41 +0000</pubDate>
         <sparkle:minimumSystemVersion>15.0</sparkle:minimumSystemVersion>


### PR DESCRIPTION
## Summary

Publish the signed Sparkle appcast item for Snap-O 3.2.0.

- Version: `3.2.0`
- Build: `20260714.00`
- DMG size: `2773930` bytes
- GitHub release: https://github.com/openai/snap-o/releases/tag/3.2.0
- macOS workflow: https://github.com/openai/snap-o-release/actions/runs/29323771087

## Validation

- Verified the published DMG checksum.
- Preserved the workflow-generated Sparkle signature.
- `xmllint --noout appcast.xml`
- `git diff --check`
