### PR TITLE
Use MB in network demo labels

### DIFF
--- a/snapo-link-android/samples/demo-okhttp/src/main/java/com/openai/snapo/demo/MainActivity.kt
+++ b/snapo-link-android/samples/demo-okhttp/src/main/java/com/openai/snapo/demo/MainActivity.kt
@@ -299,10 +299,10 @@ fun Greeting(
             Text("GET image (PNG)")
         }
         Button(onClick = onCompleteLargeResponseClick) {
-            Text("GET 7 MiB JSON (complete)")
+            Text("GET 7.3 MB JSON (complete)")
         }
         Button(onClick = onTruncatedLargeResponseClick) {
-            Text("GET 9 MiB JSON (truncated)")
+            Text("GET 9.4 MB JSON (truncated)")
         }
         Button(onClick = onSlowResponseClick) {
             Text("Slow response")

--- a/snapo-link-android/samples/demo-okhttp/src/main/java/com/openai/snapo/demo/MainActivity.kt
+++ b/snapo-link-android/samples/demo-okhttp/src/main/java/com/openai/snapo/demo/MainActivity.kt
@@ -299,10 +299,10 @@ fun Greeting(
             Text("GET image (PNG)")
         }
         Button(onClick = onCompleteLargeResponseClick) {
-            Text("GET 7.3 MB JSON (complete)")
+            Text("GET 7 MB JSON (complete)")
         }
         Button(onClick = onTruncatedLargeResponseClick) {
-            Text("GET 9.4 MB JSON (truncated)")
+            Text("GET 9 MB JSON (truncated)")
         }
         Button(onClick = onSlowResponseClick) {
             Text("Slow response")


### PR DESCRIPTION
## Summary

Use concise `MB` labels for the large-response Android demo buttons while preserving the existing `7 * 1024 * 1024`- and `9 * 1024 * 1024`-byte payload sizes. This removes binary-unit terminology without changing behavior.

## Validation

- `./gradlew :samples:demo-okhttp:assembleDebug --console=plain`
- Confirmed no binary-unit labels remain in source files.
