### PR TITLE
Deduplicate Android network capture and add an SSE sample

### DIFF
--- a/snapo-link-android/network-httpurlconnection/src/main/java/com/openai/snapo/network/httpurlconnection/SnapOHttpUrlInterceptor.kt
+++ b/snapo-link-android/network-httpurlconnection/src/main/java/com/openai/snapo/network/httpurlconnection/SnapOHttpUrlInterceptor.kt
@@ -1,8 +1,6 @@
 package com.openai.snapo.network.httpurlconnection
 
 import android.os.SystemClock
-import android.util.Base64.NO_WRAP
-import android.util.Base64.encodeToString
 import com.openai.snapo.network.Header
 import com.openai.snapo.network.NetworkEventRecord
 import com.openai.snapo.network.NetworkInspector
@@ -10,9 +8,19 @@ import com.openai.snapo.network.RequestFailed
 import com.openai.snapo.network.RequestWillBeSent
 import com.openai.snapo.network.ResponseFinished
 import com.openai.snapo.network.ResponseReceived
-import com.openai.snapo.network.ResponseStreamClosed
-import com.openai.snapo.network.ResponseStreamEvent
 import com.openai.snapo.network.Timings
+import com.openai.snapo.network.capture.BodyContentType
+import com.openai.snapo.network.capture.DefaultBinaryBodyMaxBytes
+import com.openai.snapo.network.capture.DefaultBodyPreviewBytes
+import com.openai.snapo.network.capture.DefaultTextBodyMaxBytes
+import com.openai.snapo.network.capture.RawResponseBodyCapture
+import com.openai.snapo.network.capture.ResolvedRequestBody
+import com.openai.snapo.network.capture.SseStreamCapture
+import com.openai.snapo.network.capture.resolveEffectiveMaxBytes
+import com.openai.snapo.network.capture.resolveRequestBody
+import com.openai.snapo.network.capture.resolveRequestCaptureLimit
+import com.openai.snapo.network.capture.resolveResponseBody
+import com.openai.snapo.network.capture.resolveResponseCaptureLimit
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
@@ -30,8 +38,6 @@ import java.io.OutputStream
 import java.net.HttpURLConnection
 import java.net.ProtocolException
 import java.net.URL
-import java.nio.ByteBuffer
-import java.nio.charset.CodingErrorAction
 import java.security.Permission
 import java.util.UUID
 import java.util.concurrent.TimeUnit
@@ -74,26 +80,65 @@ class SnapOHttpUrlInterceptor @JvmOverloads constructor(
         }
     }
 
-    internal fun updateLatestResponseBody(
+    internal fun completeResponseCapture(
         requestId: String,
-        bodyValues: () -> CapturedBodyValues,
-        bodyTruncatedBytes: Long?,
-        bodySize: Long?,
+        requestStartMono: Long,
+        capture: RawResponseBodyCapture,
+        contentType: BodyContentType?,
+        declaredBodySize: Long?,
+        error: Throwable?,
         after: Job? = null,
     ): Job? {
+        val completionWall = System.currentTimeMillis()
+        val completionMono = SystemClock.elapsedRealtimeNanos()
         val server = NetworkInspector.getOrNull() ?: return null
         return scope.launch {
             try {
                 after?.join()
-                val body = bodyValues()
-                server.updateLatestResponseBody(
-                    requestId = requestId,
-                    bodyPreview = body.bodyPreview,
-                    body = body.body,
-                    bodyEncoding = body.bodyEncoding,
-                    bodyTruncatedBytes = bodyTruncatedBytes,
-                    bodySize = bodySize,
-                )
+                val body = runCatching {
+                    resolveResponseBody(
+                        capture = capture,
+                        contentType = contentType,
+                        textBodyMaxBytes = textBodyMaxBytes,
+                        binaryBodyMaxBytes = binaryBodyMaxBytes,
+                        previewBytes = responseBodyPreviewBytes,
+                        declaredBodySize = declaredBodySize,
+                    )
+                }.getOrNull()
+                if (body != null) {
+                    runCatching {
+                        server.updateLatestResponseBody(
+                            requestId = requestId,
+                            bodyPreview = body.preview,
+                            body = body.body,
+                            bodyEncoding = body.encoding,
+                            bodyTruncatedBytes = body.truncatedBytes,
+                            bodySize = body.bodySize,
+                        )
+                    }
+                }
+                val completedBodySize = body?.bodySize
+                    ?: declaredBodySize
+                    ?: capture.totalBytes
+                val completionRecord = if (error == null) {
+                    ResponseFinished(
+                        id = requestId,
+                        tWallMs = completionWall,
+                        tMonoNs = completionMono,
+                        bodySize = completedBodySize,
+                        bodyTruncatedBytes = body?.truncatedBytes,
+                    )
+                } else {
+                    RequestFailed(
+                        id = requestId,
+                        tWallMs = completionWall,
+                        tMonoNs = completionMono,
+                        errorKind = error.javaClass.simpleName.ifEmpty { error.javaClass.name },
+                        message = error.message,
+                        timings = Timings(totalMs = nanosToMillis(completionMono - requestStartMono)),
+                    )
+                }
+                server.publish(completionRecord)
             } catch (_: Throwable) {
             }
         }
@@ -101,7 +146,7 @@ class SnapOHttpUrlInterceptor @JvmOverloads constructor(
 
     internal fun updateLatestRequestBody(
         requestId: String,
-        bodyValues: () -> RequestBodyValues,
+        bodyValues: () -> ResolvedRequestBody,
         bodyTruncatedBytes: Long?,
         bodySize: Long?,
         after: Job? = null,
@@ -362,7 +407,7 @@ private class InterceptingHttpURLConnection(
         val capture = requestBodyCapture?.snapshot()
         val contentType = requestContentType()
         val contentEncoding = requestContentEncoding()
-        val mediaType = parseMediaType(contentType)
+        val mediaType = BodyContentType.parse(contentType)
         val requestBodyBytes = capture?.bytes
         val bodySize = capture?.totalBytes ?: requestContentLength()
         val truncatedBytes = capture?.truncatedBytes
@@ -370,9 +415,9 @@ private class InterceptingHttpURLConnection(
         publishedRequestBodyBytes = capture?.totalBytes ?: 0L
 
         requestPublication = interceptor.publish {
-            val bodyValues = resolveRequestBodyValues(
+            val bodyValues = resolveRequestBody(
                 bytes = requestBodyBytes,
-                mediaType = mediaType,
+                contentType = mediaType,
                 contentEncoding = contentEncoding,
                 hasBody = hasBody,
             )
@@ -398,14 +443,14 @@ private class InterceptingHttpURLConnection(
         val capture = requestBodyCapture?.snapshot() ?: return
         if (capture.totalBytes == publishedRequestBodyBytes) return
         publishedRequestBodyBytes = capture.totalBytes
-        val mediaType = parseMediaType(requestContentType())
+        val mediaType = BodyContentType.parse(requestContentType())
         val contentEncoding = requestContentEncoding()
         requestPublication = interceptor.updateLatestRequestBody(
             requestId = currentContext.requestId,
             bodyValues = {
-                resolveRequestBodyValues(
+                resolveRequestBody(
                     bytes = capture.bytes,
-                    mediaType = mediaType,
+                    contentType = mediaType,
                     contentEncoding = contentEncoding,
                 )
             },
@@ -468,8 +513,8 @@ private class InterceptingHttpURLConnection(
         ) {
             return stream
         }
-        val mediaType = parseMediaType(meta?.contentType)
-        if (mediaType?.isEventStream() == true) {
+        val mediaType = BodyContentType.parse(meta?.contentType)
+        if (mediaType?.isEventStream == true) {
             return SseCapturingInputStream(
                 delegate = stream,
                 interceptor = interceptor,
@@ -478,37 +523,39 @@ private class InterceptingHttpURLConnection(
                 initialPublication = responsePublication,
             )
         }
-        val effectiveMax = resolveEffectiveMaxBytes(
-            maxBytes = if (mediaType?.isTextLike() == true) {
-                interceptor.textBodyMaxBytes
-            } else {
-                interceptor.binaryBodyMaxBytes
-            },
+        val effectiveMax = resolveResponseCaptureLimit(
+            contentType = mediaType,
             contentLength = meta?.contentLength,
+            textBodyMaxBytes = interceptor.textBodyMaxBytes,
+            binaryBodyMaxBytes = interceptor.binaryBodyMaxBytes,
+            previewBytes = interceptor.responseBodyPreviewBytes,
         )
-        val capture = BodyCaptureSink(effectiveMax)
         return ResponseCapturingInputStream(
             delegate = stream,
-            capture = capture,
-            interceptor = interceptor,
-            mediaType = mediaType,
-            captureContext = ResponseCaptureContext(
-                request = context,
-                response = meta,
-                publication = responsePublication,
-            ),
+            maxBytes = effectiveMax,
+            onComplete = completion@{ capture, error ->
+                val currentContext = context ?: return@completion
+                interceptor.completeResponseCapture(
+                    requestId = currentContext.requestId,
+                    requestStartMono = currentContext.startMono,
+                    capture = capture,
+                    contentType = mediaType,
+                    declaredBodySize = meta?.contentLength,
+                    error = error,
+                    after = responsePublication,
+                )
+            },
         )
     }
 
     private fun ensureRequestBodyCapture(): BodyCaptureSink? {
-        val mediaType = parseMediaType(requestContentType())
-        val captureLimit = if (
-            hasNonIdentityContentEncoding(requestContentEncoding()) || mediaType?.isTextLike() != true
-        ) {
-            interceptor.binaryBodyMaxBytes
-        } else {
-            interceptor.textBodyMaxBytes
-        }
+        val mediaType = BodyContentType.parse(requestContentType())
+        val captureLimit = resolveRequestCaptureLimit(
+            contentType = mediaType,
+            contentEncoding = requestContentEncoding(),
+            textBodyMaxBytes = interceptor.textBodyMaxBytes,
+            binaryBodyMaxBytes = interceptor.binaryBodyMaxBytes,
+        )
         if (captureLimit <= 0) return null
         return requestBodyCapture ?: BodyCaptureSink(captureLimit).also {
             requestBodyCapture = it
@@ -650,31 +697,6 @@ private data class BodyCaptureSnapshot(
     val truncatedBytes: Long?,
 )
 
-internal data class RequestBodyValues(
-    val body: String?,
-    val encoding: String?,
-)
-
-private fun resolveRequestBodyValues(
-    bytes: ByteArray?,
-    mediaType: ParsedMediaType?,
-    contentEncoding: String?,
-    hasBody: Boolean = true,
-): RequestBodyValues {
-    val usesBase64 = hasNonIdentityContentEncoding(contentEncoding) || mediaType?.isTextLike() != true
-    if (bytes == null || bytes.isEmpty()) {
-        return RequestBodyValues(
-            body = null,
-            encoding = "base64".takeIf { hasBody && usesBase64 },
-        )
-    }
-    return when {
-        usesBase64 ->
-            RequestBodyValues(body = encodeToString(bytes, NO_WRAP), encoding = "base64")
-        else -> RequestBodyValues(body = String(bytes, mediaType.charsetOrUtf8()), encoding = null)
-    }
-}
-
 private class CapturingOutputStream(
     delegate: OutputStream,
     private val capture: BodyCaptureSink,
@@ -707,21 +729,14 @@ private class CapturingOutputStream(
     }
 }
 
-private data class ResponseCaptureContext(
-    val request: InterceptContext?,
-    val response: ResponseMeta?,
-    val publication: Job?,
-)
-
-private class ResponseCapturingInputStream(
+internal class ResponseCapturingInputStream(
     delegate: InputStream,
-    private val capture: BodyCaptureSink,
-    private val interceptor: SnapOHttpUrlInterceptor,
-    private val mediaType: ParsedMediaType?,
-    private val captureContext: ResponseCaptureContext,
+    maxBytes: Int,
+    private val onComplete: (RawResponseBodyCapture, Throwable?) -> Unit,
 ) : FilterInputStream(delegate) {
 
     private val completed = AtomicBoolean(false)
+    private val capture = BodyCaptureSink(maxBytes)
 
     override fun read(): Int {
         return try {
@@ -729,11 +744,11 @@ private class ResponseCapturingInputStream(
             if (value >= 0) {
                 capture.append(byteArrayOf(value.toByte()), 0, 1)
             } else {
-                complete(null)
+                complete(error = null, reachedEof = true)
             }
             value
         } catch (error: IOException) {
-            complete(error)
+            complete(error = error, reachedEof = false)
             throw error
         }
     }
@@ -744,189 +759,68 @@ private class ResponseCapturingInputStream(
             if (count > 0) {
                 capture.append(b, off, count)
             } else if (count == -1) {
-                complete(null)
+                complete(error = null, reachedEof = true)
             }
             count
         } catch (error: IOException) {
-            complete(error)
+            complete(error = error, reachedEof = false)
             throw error
         }
     }
 
     override fun close() {
-        try {
-            super.close()
-        } finally {
-            complete(null)
-        }
+        val result = runCatching { super.close() }
+        complete(error = result.exceptionOrNull(), reachedEof = false)
+        result.getOrThrow()
     }
 
-    private fun complete(error: Throwable?) {
+    private fun complete(error: Throwable?, reachedEof: Boolean) {
         if (!completed.compareAndSet(false, true)) return
-        val currentContext = captureContext.request ?: return
         val snapshot = capture.snapshot()
-        val meta = captureContext.response
-        val totalBytes = snapshot.totalBytes.takeIf { it > 0L } ?: meta?.contentLength
-        val bodyUpdate = interceptor.updateLatestResponseBody(
-            requestId = currentContext.requestId,
-            bodyValues = {
-                resolveCapturedBodyValues(
+        try {
+            onComplete(
+                RawResponseBodyCapture(
                     bytes = snapshot.bytes,
-                    mediaType = mediaType,
-                    previewBytes = interceptor.responseBodyPreviewBytes,
-                )
-            },
-            bodyTruncatedBytes = snapshot.truncatedBytes,
-            bodySize = totalBytes,
-            after = captureContext.publication,
-        )
-        publishLoadingFinishedIfNeeded(
-            requestId = currentContext.requestId,
-            totalBytes = totalBytes,
-            truncatedBytes = snapshot.truncatedBytes,
-            error = error,
-            after = bodyUpdate,
-        )
-        publishFailureIfNeeded(currentContext, error, after = bodyUpdate)
-    }
-
-    private fun resolveCapturedBodyValues(
-        bytes: ByteArray,
-        mediaType: ParsedMediaType?,
-        previewBytes: Int,
-    ): CapturedBodyValues {
-        if (bytes.isEmpty()) {
-            return CapturedBodyValues(
-                bodyPreview = null,
-                body = null,
-                bodyEncoding = null,
+                    totalBytes = snapshot.totalBytes,
+                    reachedEof = reachedEof,
+                ),
+                error,
             )
-        }
-        val charset = mediaType?.charsetOrUtf8() ?: Charsets.UTF_8
-        val isKnownText = mediaType?.isTextLike() == true
-        val bodyText = if (isKnownText) {
-            String(bytes, charset)
-        } else if (mediaType == null) {
-            decodeUtf8TextIfLikely(bytes)
-        } else {
-            null
-        }
-
-        return if (bodyText != null) {
-            val preview = if (previewBytes > 0) {
-                val limit = previewBytes.coerceAtMost(bytes.size)
-                String(bytes, 0, limit, charset)
-            } else {
-                null
-            }
-            CapturedBodyValues(
-                bodyPreview = preview,
-                body = bodyText,
-                bodyEncoding = null,
-            )
-        } else {
-            val preview = if (previewBytes > 0) {
-                val limit = previewBytes.coerceAtMost(bytes.size)
-                encodeToString(bytes, 0, limit, NO_WRAP)
-            } else {
-                null
-            }
-            CapturedBodyValues(
-                bodyPreview = preview,
-                body = encodeToString(bytes, NO_WRAP),
-                bodyEncoding = "base64",
-            )
+        } catch (_: Throwable) {
         }
     }
-
-    private fun publishLoadingFinishedIfNeeded(
-        requestId: String,
-        totalBytes: Long?,
-        truncatedBytes: Long?,
-        error: Throwable?,
-        after: Job?,
-    ) {
-        if (error != null) return
-        val nowWall = System.currentTimeMillis()
-        val nowMono = SystemClock.elapsedRealtimeNanos()
-        interceptor.publish(after = after) {
-            ResponseFinished(
-                id = requestId,
-                tWallMs = nowWall,
-                tMonoNs = nowMono,
-                bodySize = totalBytes,
-                bodyTruncatedBytes = truncatedBytes,
-            )
-        }
-    }
-
-    private fun publishFailureIfNeeded(currentContext: InterceptContext, error: Throwable?, after: Job?) {
-        if (error == null) return
-        val failWall = System.currentTimeMillis()
-        val failMono = SystemClock.elapsedRealtimeNanos()
-        interceptor.publish(after = after) {
-            RequestFailed(
-                id = currentContext.requestId,
-                tWallMs = failWall,
-                tMonoNs = failMono,
-                errorKind = error.javaClass.simpleName.ifEmpty { error.javaClass.name },
-                message = error.message,
-                timings = Timings(totalMs = nanosToMillis(failMono - currentContext.startMono)),
-            )
-        }
-    }
-}
-
-internal data class CapturedBodyValues(
-    val bodyPreview: String?,
-    val body: String?,
-    val bodyEncoding: String?,
-)
-
-private fun decodeUtf8TextIfLikely(bytes: ByteArray): String? {
-    if (bytes.isEmpty()) return ""
-    val decoded = runCatching {
-        Charsets.UTF_8
-            .newDecoder()
-            .onMalformedInput(CodingErrorAction.REPORT)
-            .onUnmappableCharacter(CodingErrorAction.REPORT)
-            .decode(ByteBuffer.wrap(bytes))
-            .toString()
-    }.getOrNull() ?: return null
-    if (decoded.isEmpty()) return decoded
-    val printable = decoded.count { ch ->
-        ch == '\n' || ch == '\r' || ch == '\t' || (ch >= ' ' && ch != '\u007f')
-    }
-    val printableRatio = printable.toDouble() / decoded.length.toDouble()
-    return decoded.takeIf { printableRatio >= MinLikelyTextRatio }
 }
 
 private class SseCapturingInputStream(
     delegate: InputStream,
     private val interceptor: SnapOHttpUrlInterceptor,
-    private val context: InterceptContext?,
-    private val charset: java.nio.charset.Charset,
+    context: InterceptContext?,
+    charset: java.nio.charset.Charset,
     initialPublication: Job?,
 ) : FilterInputStream(delegate) {
 
-    private val parser = SseBuffer(charset)
-    private val closed = AtomicBoolean(false)
     private val publicationLock = Any()
     private var previousPublication = initialPublication
-    private var totalBytes: Long = 0L
-    private var nextSequence: Long = 0L
+    private val capture = context?.let { currentContext ->
+        SseStreamCapture(
+            requestId = currentContext.requestId,
+            charset = charset,
+        ) { record ->
+            publish { record }
+        }
+    }
 
     override fun read(): Int {
         return try {
             val value = super.read()
             if (value >= 0) {
-                handleBytes(byteArrayOf(value.toByte()))
+                capture?.append(byteArrayOf(value.toByte()))
             } else {
-                onClosed(null)
+                capture?.complete()
             }
             value
         } catch (error: IOException) {
-            onClosed(error)
+            capture?.complete(error)
             throw error
         }
     }
@@ -935,78 +829,21 @@ private class SseCapturingInputStream(
         return try {
             val count = super.read(b, off, len)
             if (count > 0) {
-                handleBytes(b.copyOfRange(off, off + count))
+                capture?.append(b, offset = off, length = count)
             } else if (count == -1) {
-                onClosed(null)
+                capture?.complete()
             }
             count
         } catch (error: IOException) {
-            onClosed(error)
+            capture?.complete(error)
             throw error
         }
     }
 
     override fun close() {
-        try {
-            super.close()
-        } finally {
-            onClosed(null)
-        }
-    }
-
-    private fun handleBytes(bytes: ByteArray) {
-        val currentContext = context ?: return
-        if (bytes.isEmpty()) return
-        totalBytes += bytes.size.toLong()
-        val events = parser.append(bytes)
-        for (raw in events) {
-            val sequence = ++nextSequence
-            val nowWall = System.currentTimeMillis()
-            val nowMono = SystemClock.elapsedRealtimeNanos()
-            publish {
-                ResponseStreamEvent(
-                    id = currentContext.requestId,
-                    tWallMs = nowWall,
-                    tMonoNs = nowMono,
-                    sequence = sequence,
-                    raw = raw,
-                )
-            }
-        }
-    }
-
-    private fun onClosed(error: Throwable?) {
-        if (!closed.compareAndSet(false, true)) return
-        val currentContext = context ?: return
-        val tailEvents = parser.drainRemaining()
-        for (raw in tailEvents) {
-            val sequence = ++nextSequence
-            val nowWall = System.currentTimeMillis()
-            val nowMono = SystemClock.elapsedRealtimeNanos()
-            publish {
-                ResponseStreamEvent(
-                    id = currentContext.requestId,
-                    tWallMs = nowWall,
-                    tMonoNs = nowMono,
-                    sequence = sequence,
-                    raw = raw,
-                )
-            }
-        }
-
-        val nowWall = System.currentTimeMillis()
-        val nowMono = SystemClock.elapsedRealtimeNanos()
-        publish {
-            ResponseStreamClosed(
-                id = currentContext.requestId,
-                tWallMs = nowWall,
-                tMonoNs = nowMono,
-                reason = if (error == null) "completed" else "error",
-                message = error?.message ?: error?.javaClass?.simpleName,
-                totalEvents = nextSequence,
-                totalBytes = totalBytes,
-            )
-        }
+        val result = runCatching { super.close() }
+        capture?.complete(result.exceptionOrNull())
+        result.getOrThrow()
     }
 
     private fun publish(builder: () -> NetworkEventRecord) {
@@ -1019,123 +856,9 @@ private class SseCapturingInputStream(
     }
 }
 
-private data class ParsedMediaType(
-    val type: String,
-    val subtype: String,
-    val charset: java.nio.charset.Charset?,
-)
-
-private fun parseMediaType(value: String?): ParsedMediaType? {
-    val raw = value ?: return null
-    val parts = raw.split(';')
-    val typePart = parts.firstOrNull()?.trim().orEmpty()
-    val typePieces = typePart.split('/')
-    if (typePieces.size != 2) return null
-    val type = typePieces[0].trim().lowercase()
-    val subtype = typePieces[1].trim().lowercase()
-    if (type.isEmpty() || subtype.isEmpty()) return null
-
-    var charset: java.nio.charset.Charset? = null
-    for (index in 1 until parts.size) {
-        val rawCharset = extractCharset(parts[index].trim())
-        if (rawCharset != null) {
-            charset = runCatching { java.nio.charset.Charset.forName(rawCharset) }.getOrNull()
-        }
-    }
-
-    return ParsedMediaType(type = type, subtype = subtype, charset = charset)
-}
-
-private fun ParsedMediaType.isTextLike(): Boolean {
-    if (type == "text") return true
-    return listOf(
-        "json",
-        "xml",
-        "html",
-        "javascript",
-        "form",
-        "graphql",
-        "plain",
-        "csv",
-        "yaml",
-    ).any(subtype::contains)
-}
-
-private fun ParsedMediaType.isEventStream(): Boolean =
-    type == "text" && subtype == "event-stream"
-
-private fun ParsedMediaType.charsetOrUtf8(): java.nio.charset.Charset =
-    charset ?: Charsets.UTF_8
-
-private fun extractCharset(param: String): String? {
-    if (!param.startsWith("charset=", ignoreCase = true)) return null
-    val valueStart = param.indexOf('=') + 1
-    if (valueStart <= 0 || valueStart >= param.length) return null
-    return param.substring(valueStart).trim().trim('"')
-}
-
-internal fun resolveEffectiveMaxBytes(maxBytes: Int, contentLength: Long?): Int {
-    if (maxBytes <= 0) return 0
-    val knownLength = contentLength?.takeIf { it >= 0L } ?: return maxBytes
-    return if (knownLength < CompleteBodyCaptureThresholdBytes) {
-        maxOf(maxBytes.toLong(), knownLength).toInt()
-    } else {
-        maxBytes
-    }
-}
-
 private fun nanosToMillis(deltaNs: Long): Long? {
     if (deltaNs <= 0L) return null
     return TimeUnit.NANOSECONDS.toMillis(deltaNs)
 }
 
-private class SseBuffer(private val charset: java.nio.charset.Charset) {
-    private val buffer = StringBuilder()
-
-    fun append(bytes: ByteArray): List<String> {
-        if (bytes.isEmpty()) return emptyList()
-        buffer.append(bytes.toNormalizedString(charset))
-        return drainInternal(flushTail = false)
-    }
-
-    fun drainRemaining(): List<String> = drainInternal(flushTail = true)
-
-    private fun drainInternal(flushTail: Boolean): List<String> {
-        if (buffer.isEmpty()) return emptyList()
-        val events = ArrayList<String>()
-        while (true) {
-            val boundary = buffer.indexOf("\n\n")
-            if (boundary < 0) {
-                if (flushTail && buffer.isNotEmpty()) {
-                    events += buffer.toString()
-                    buffer.setLength(0)
-                }
-                return events
-            }
-            events += buffer.substring(0, boundary)
-            buffer.delete(0, boundary + 2)
-        }
-    }
-}
-
-private fun ByteArray.toNormalizedString(charset: java.nio.charset.Charset): String {
-    val raw = String(this, charset)
-    if (raw.indexOf('\r') == -1) return raw
-    return raw.replace("\r\n", "\n").replace('\r', '\n')
-}
-
-private fun hasNonIdentityContentEncoding(contentEncoding: String?): Boolean {
-    val encodings = contentEncoding
-        ?.split(',')
-        ?.map { token -> token.substringBefore(';').trim().lowercase() }
-        ?.filter { token -> token.isNotEmpty() }
-        .orEmpty()
-    return encodings.any { token -> token != "identity" }
-}
-
 private val DefaultDispatcher: CoroutineDispatcher = Dispatchers.Default
-private const val DefaultBodyPreviewBytes: Int = 4096
-private const val DefaultTextBodyMaxBytes: Int = 5 * 1024 * 1024
-private const val DefaultBinaryBodyMaxBytes: Int = DefaultTextBodyMaxBytes
-private const val MinLikelyTextRatio: Double = 0.85
-private const val CompleteBodyCaptureThresholdBytes: Long = 8L * 1024L * 1024L

--- a/snapo-link-android/network-httpurlconnection/src/main/java/com/openai/snapo/network/httpurlconnection/SnapOHttpUrlInterceptor.kt
+++ b/snapo-link-android/network-httpurlconnection/src/main/java/com/openai/snapo/network/httpurlconnection/SnapOHttpUrlInterceptor.kt
@@ -4,30 +4,23 @@ import android.os.SystemClock
 import com.openai.snapo.network.Header
 import com.openai.snapo.network.NetworkEventRecord
 import com.openai.snapo.network.NetworkInspector
-import com.openai.snapo.network.RequestFailed
 import com.openai.snapo.network.RequestWillBeSent
-import com.openai.snapo.network.ResponseFinished
 import com.openai.snapo.network.ResponseReceived
 import com.openai.snapo.network.Timings
 import com.openai.snapo.network.capture.BodyContentType
+import com.openai.snapo.network.capture.CaptureEventPublisher
 import com.openai.snapo.network.capture.DefaultBinaryBodyMaxBytes
 import com.openai.snapo.network.capture.DefaultBodyPreviewBytes
 import com.openai.snapo.network.capture.DefaultTextBodyMaxBytes
 import com.openai.snapo.network.capture.RawResponseBodyCapture
-import com.openai.snapo.network.capture.ResolvedRequestBody
 import com.openai.snapo.network.capture.SseStreamCapture
 import com.openai.snapo.network.capture.resolveEffectiveMaxBytes
 import com.openai.snapo.network.capture.resolveRequestBody
 import com.openai.snapo.network.capture.resolveRequestCaptureLimit
-import com.openai.snapo.network.capture.resolveResponseBody
 import com.openai.snapo.network.capture.resolveResponseCaptureLimit
 import kotlinx.coroutines.CoroutineDispatcher
-import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
-import kotlinx.coroutines.SupervisorJob
-import kotlinx.coroutines.cancel
-import kotlinx.coroutines.launch
 import java.io.ByteArrayOutputStream
 import java.io.Closeable
 import java.io.FilterInputStream
@@ -54,7 +47,12 @@ class SnapOHttpUrlInterceptor @JvmOverloads constructor(
     internal val responseBodyPreviewBytes = responseBodyPreviewBytes.coerceAtLeast(0)
     internal val textBodyMaxBytes = resolveEffectiveMaxBytes(textBodyMaxBytes, contentLength = null)
     internal val binaryBodyMaxBytes = resolveEffectiveMaxBytes(binaryBodyMaxBytes, contentLength = null)
-    private val scope = CoroutineScope(SupervisorJob() + dispatcher)
+    internal val publisher = CaptureEventPublisher(
+        responseBodyPreviewBytes = this.responseBodyPreviewBytes,
+        textBodyMaxBytes = this.textBodyMaxBytes,
+        binaryBodyMaxBytes = this.binaryBodyMaxBytes,
+        dispatcher = dispatcher,
+    )
 
     fun open(url: URL): HttpURLConnection = intercept(url.openConnection() as HttpURLConnection)
 
@@ -66,106 +64,7 @@ class SnapOHttpUrlInterceptor @JvmOverloads constructor(
         }
 
     override fun close() {
-        scope.cancel()
-    }
-
-    internal fun publish(after: Job? = null, builder: () -> NetworkEventRecord): Job? {
-        val server = NetworkInspector.getOrNull() ?: return null
-        return scope.launch {
-            try {
-                after?.join()
-                server.publish(builder())
-            } catch (_: Throwable) {
-            }
-        }
-    }
-
-    internal fun completeResponseCapture(
-        requestId: String,
-        requestStartMono: Long,
-        capture: RawResponseBodyCapture,
-        contentType: BodyContentType?,
-        declaredBodySize: Long?,
-        error: Throwable?,
-        after: Job? = null,
-    ): Job? {
-        val completionWall = System.currentTimeMillis()
-        val completionMono = SystemClock.elapsedRealtimeNanos()
-        val server = NetworkInspector.getOrNull() ?: return null
-        return scope.launch {
-            try {
-                after?.join()
-                val body = runCatching {
-                    resolveResponseBody(
-                        capture = capture,
-                        contentType = contentType,
-                        textBodyMaxBytes = textBodyMaxBytes,
-                        binaryBodyMaxBytes = binaryBodyMaxBytes,
-                        previewBytes = responseBodyPreviewBytes,
-                        declaredBodySize = declaredBodySize,
-                    )
-                }.getOrNull()
-                if (body != null) {
-                    runCatching {
-                        server.updateLatestResponseBody(
-                            requestId = requestId,
-                            bodyPreview = body.preview,
-                            body = body.body,
-                            bodyEncoding = body.encoding,
-                            bodyTruncatedBytes = body.truncatedBytes,
-                            bodySize = body.bodySize,
-                        )
-                    }
-                }
-                val completedBodySize = body?.bodySize
-                    ?: declaredBodySize
-                    ?: capture.totalBytes
-                val completionRecord = if (error == null) {
-                    ResponseFinished(
-                        id = requestId,
-                        tWallMs = completionWall,
-                        tMonoNs = completionMono,
-                        bodySize = completedBodySize,
-                        bodyTruncatedBytes = body?.truncatedBytes,
-                    )
-                } else {
-                    RequestFailed(
-                        id = requestId,
-                        tWallMs = completionWall,
-                        tMonoNs = completionMono,
-                        errorKind = error.javaClass.simpleName.ifEmpty { error.javaClass.name },
-                        message = error.message,
-                        timings = Timings(totalMs = nanosToMillis(completionMono - requestStartMono)),
-                    )
-                }
-                server.publish(completionRecord)
-            } catch (_: Throwable) {
-            }
-        }
-    }
-
-    internal fun updateLatestRequestBody(
-        requestId: String,
-        bodyValues: () -> ResolvedRequestBody,
-        bodyTruncatedBytes: Long?,
-        bodySize: Long?,
-        after: Job? = null,
-    ): Job? {
-        val server = NetworkInspector.getOrNull() ?: return null
-        return scope.launch {
-            try {
-                after?.join()
-                val body = bodyValues()
-                server.updateLatestRequestBody(
-                    requestId = requestId,
-                    body = body.body,
-                    bodyEncoding = body.encoding,
-                    bodyTruncatedBytes = bodyTruncatedBytes,
-                    bodySize = bodySize,
-                )
-            } catch (_: Throwable) {
-            }
-        }
+        publisher.close()
     }
 }
 
@@ -414,7 +313,7 @@ private class InterceptingHttpURLConnection(
         val hasBody = delegate.doOutput || requestBodyCapture != null || (bodySize?.let { it > 0L } == true)
         publishedRequestBodyBytes = capture?.totalBytes ?: 0L
 
-        requestPublication = interceptor.publish {
+        requestPublication = interceptor.publisher.publish {
             val bodyValues = resolveRequestBody(
                 bytes = requestBodyBytes,
                 contentType = mediaType,
@@ -445,7 +344,7 @@ private class InterceptingHttpURLConnection(
         publishedRequestBodyBytes = capture.totalBytes
         val mediaType = BodyContentType.parse(requestContentType())
         val contentEncoding = requestContentEncoding()
-        requestPublication = interceptor.updateLatestRequestBody(
+        requestPublication = interceptor.publisher.updateRequestBody(
             requestId = currentContext.requestId,
             bodyValues = {
                 resolveRequestBody(
@@ -481,7 +380,7 @@ private class InterceptingHttpURLConnection(
 
         if (!responsePublished) {
             responsePublished = true
-            responsePublication = interceptor.publish(after = requestPublication) {
+            responsePublication = interceptor.publisher.publish(after = requestPublication) {
                 ResponseReceived(
                     id = currentContext.requestId,
                     tWallMs = responseWall,
@@ -535,7 +434,7 @@ private class InterceptingHttpURLConnection(
             maxBytes = effectiveMax,
             onComplete = completion@{ capture, error ->
                 val currentContext = context ?: return@completion
-                interceptor.completeResponseCapture(
+                interceptor.publisher.completeResponse(
                     requestId = currentContext.requestId,
                     requestStartMono = currentContext.startMono,
                     capture = capture,
@@ -564,34 +463,23 @@ private class InterceptingHttpURLConnection(
 
     private fun handleFailure(error: Throwable) {
         val currentContext = context ?: return
-        val failWall = System.currentTimeMillis()
-        val failMono = SystemClock.elapsedRealtimeNanos()
-        interceptor.publish(after = requestPublication) {
-            RequestFailed(
-                id = currentContext.requestId,
-                tWallMs = failWall,
-                tMonoNs = failMono,
-                errorKind = error.javaClass.simpleName.ifEmpty { error.javaClass.name },
-                message = error.message,
-                timings = Timings(totalMs = nanosToMillis(failMono - currentContext.startMono)),
-            )
-        }
+        interceptor.publisher.publishFailure(
+            requestId = currentContext.requestId,
+            requestStartMono = currentContext.startMono,
+            error = error,
+            after = requestPublication,
+        )
     }
 
     private fun publishLoadingFinishedOnce(totalBytes: Long?) {
         if (responseFinishedPublished) return
         val currentContext = context ?: return
         responseFinishedPublished = true
-        val nowWall = System.currentTimeMillis()
-        val nowMono = SystemClock.elapsedRealtimeNanos()
-        interceptor.publish(after = responsePublication) {
-            ResponseFinished(
-                id = currentContext.requestId,
-                tWallMs = nowWall,
-                tMonoNs = nowMono,
-                bodySize = totalBytes,
-            )
-        }
+        interceptor.publisher.publishFinished(
+            requestId = currentContext.requestId,
+            bodySize = totalBytes,
+            after = responsePublication,
+        )
     }
 
     private fun responseHasNoBody(method: String?, code: Int, contentLength: Long?): Boolean {
@@ -848,7 +736,7 @@ private class SseCapturingInputStream(
 
     private fun publish(builder: () -> NetworkEventRecord) {
         synchronized(publicationLock) {
-            previousPublication = interceptor.publish(
+            previousPublication = interceptor.publisher.publish(
                 after = previousPublication,
                 builder = builder,
             ) ?: previousPublication

--- a/snapo-link-android/network-httpurlconnection/src/test/java/com/openai/snapo/network/httpurlconnection/SnapOHttpUrlInterceptorTest.kt
+++ b/snapo-link-android/network-httpurlconnection/src/test/java/com/openai/snapo/network/httpurlconnection/SnapOHttpUrlInterceptorTest.kt
@@ -1,21 +1,21 @@
 package com.openai.snapo.network.httpurlconnection
 
+import com.openai.snapo.network.capture.RawResponseBodyCapture
+import org.junit.Assert.assertArrayEquals
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNull
 import org.junit.Assert.assertSame
+import org.junit.Assert.assertTrue
+import org.junit.Assert.fail
 import org.junit.Test
+import java.io.ByteArrayInputStream
+import java.io.IOException
+import java.io.InputStream
 import java.net.HttpURLConnection
 import java.net.URL
 
 class SnapOHttpUrlInterceptorTest {
-
-    @Test
-    fun `small known bodies can expand the configured capture limit`() {
-        assertEquals(7_000_000, resolveEffectiveMaxBytes(maxBytes = 1_024, contentLength = 7_000_000L))
-        assertEquals(1_024, resolveEffectiveMaxBytes(maxBytes = 1_024, contentLength = 512L))
-        assertEquals(12 * 1024 * 1024, resolveEffectiveMaxBytes(12 * 1024 * 1024, contentLength = null))
-        assertEquals(1_024, resolveEffectiveMaxBytes(maxBytes = 1_024, contentLength = 9L * 1024L * 1024L))
-        assertEquals(0, resolveEffectiveMaxBytes(-1, contentLength = null))
-    }
 
     @Test
     fun `capture defaults preserve full body limits`() {
@@ -37,6 +37,94 @@ class SnapOHttpUrlInterceptorTest {
         } finally {
             interceptor.close()
         }
+    }
+
+    @Test
+    fun `response stream preserves bytes and reports eof once`() {
+        val bytes = "response body".encodeToByteArray()
+        val captures = mutableListOf<RawResponseBodyCapture>()
+        val errors = mutableListOf<Throwable?>()
+        val stream = ResponseCapturingInputStream(ByteArrayInputStream(bytes), maxBytes = 4) { capture, error ->
+            captures += capture
+            errors += error
+        }
+
+        assertArrayEquals(bytes, stream.readBytes())
+        stream.close()
+
+        assertEquals(1, captures.size)
+        assertArrayEquals("resp".encodeToByteArray(), captures.single().bytes)
+        assertEquals(bytes.size.toLong(), captures.single().totalBytes)
+        assertTrue(captures.single().reachedEof)
+        assertNull(errors.single())
+    }
+
+    @Test
+    fun `closing a partial response does not claim eof`() {
+        val captures = mutableListOf<RawResponseBodyCapture>()
+        val stream = ResponseCapturingInputStream(
+            ByteArrayInputStream("response body".encodeToByteArray()),
+            maxBytes = 4,
+        ) { capture, _ ->
+            captures += capture
+        }
+
+        assertEquals('r'.code, stream.read())
+        stream.close()
+        stream.close()
+
+        assertEquals(1, captures.size)
+        assertFalse(captures.single().reachedEof)
+        assertEquals(1L, captures.single().totalBytes)
+    }
+
+    @Test
+    fun `response stream preserves upstream failure`() {
+        val expected = IOException("upstream failed")
+        var capturedError: Throwable? = null
+        val stream = ResponseCapturingInputStream(
+            object : InputStream() {
+                override fun read(): Int = throw expected
+            },
+            maxBytes = 4,
+        ) { capture, error ->
+            assertFalse(capture.reachedEof)
+            capturedError = error
+        }
+
+        try {
+            stream.read()
+            fail("Expected the upstream failure")
+        } catch (error: IOException) {
+            assertSame(expected, error)
+        }
+
+        assertSame(expected, capturedError)
+    }
+
+    @Test
+    fun `response stream reports and preserves upstream close failure`() {
+        val expected = IOException("close failed")
+        var capturedError: Throwable? = null
+        val stream = ResponseCapturingInputStream(
+            object : InputStream() {
+                override fun read(): Int = -1
+                override fun close(): Unit = throw expected
+            },
+            maxBytes = 4,
+        ) { capture, error ->
+            assertFalse(capture.reachedEof)
+            capturedError = error
+        }
+
+        try {
+            stream.close()
+            fail("Expected the close failure")
+        } catch (error: IOException) {
+            assertSame(expected, error)
+        }
+
+        assertSame(expected, capturedError)
     }
 
     private class FakeHttpURLConnection : HttpURLConnection(URL("https://example.com")) {

--- a/snapo-link-android/network-okhttp3/src/main/java/com/openai/snapo/network/okhttp3/Constants.kt
+++ b/snapo-link-android/network-okhttp3/src/main/java/com/openai/snapo/network/okhttp3/Constants.kt
@@ -2,11 +2,14 @@ package com.openai.snapo.network.okhttp3
 
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.Dispatchers
+import com.openai.snapo.network.capture.DefaultBinaryBodyMaxBytes as SharedDefaultBinaryBodyMaxBytes
+import com.openai.snapo.network.capture.DefaultBodyPreviewBytes as SharedDefaultBodyPreviewBytes
+import com.openai.snapo.network.capture.DefaultTextBodyMaxBytes as SharedDefaultTextBodyMaxBytes
 
 @Suppress("InjectDispatcher")
 internal val DefaultDispatcher: CoroutineDispatcher = Dispatchers.Default
-internal const val DefaultBodyPreviewBytes: Int = 4096
-internal const val DefaultTextBodyMaxBytes: Int = 5 * 1024 * 1024
-internal const val DefaultBinaryBodyMaxBytes: Int = DefaultTextBodyMaxBytes
+internal const val DefaultBodyPreviewBytes: Int = SharedDefaultBodyPreviewBytes
+internal const val DefaultTextBodyMaxBytes: Int = SharedDefaultTextBodyMaxBytes
+internal const val DefaultBinaryBodyMaxBytes: Int = SharedDefaultBinaryBodyMaxBytes
 internal const val DefaultTextPreviewChars: Int = DefaultTextBodyMaxBytes
 internal const val DefaultBinaryPreviewBytes: Int = 512

--- a/snapo-link-android/network-okhttp3/src/main/java/com/openai/snapo/network/okhttp3/SnapOOkHttpInterceptor.kt
+++ b/snapo-link-android/network-okhttp3/src/main/java/com/openai/snapo/network/okhttp3/SnapOOkHttpInterceptor.kt
@@ -3,25 +3,17 @@ package com.openai.snapo.network.okhttp3
 import android.os.SystemClock
 import android.util.Base64.NO_WRAP
 import android.util.Base64.encodeToString
-import com.openai.snapo.network.NetworkEventRecord
 import com.openai.snapo.network.NetworkInspector
-import com.openai.snapo.network.RequestFailed
-import com.openai.snapo.network.ResponseFinished
-import com.openai.snapo.network.Timings
 import com.openai.snapo.network.capture.BodyContentType
+import com.openai.snapo.network.capture.CaptureEventPublisher
 import com.openai.snapo.network.capture.RawResponseBodyCapture
 import com.openai.snapo.network.capture.ResolvedRequestBody
 import com.openai.snapo.network.capture.resolveEffectiveMaxBytes
 import com.openai.snapo.network.capture.resolveRequestBody
-import com.openai.snapo.network.capture.resolveResponseBody
 import com.openai.snapo.network.capture.resolveResponseCaptureLimit
 import com.openai.snapo.network.capture.shouldEncodeBodyAsBase64
 import kotlinx.coroutines.CoroutineDispatcher
-import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Job
-import kotlinx.coroutines.SupervisorJob
-import kotlinx.coroutines.cancel
-import kotlinx.coroutines.launch
 import okhttp3.Headers
 import okhttp3.Interceptor
 import okhttp3.MediaType
@@ -55,7 +47,12 @@ class SnapOOkHttpInterceptor @JvmOverloads constructor(
     private val responseBodyPreviewBytes = responseBodyPreviewBytes.coerceAtLeast(0)
     private val textBodyMaxBytes = resolveEffectiveMaxBytes(textBodyMaxBytes, contentLength = null)
     private val binaryBodyMaxBytes = resolveEffectiveMaxBytes(binaryBodyMaxBytes, contentLength = null)
-    private val scope = CoroutineScope(SupervisorJob() + dispatcher)
+    private val publisher = CaptureEventPublisher(
+        responseBodyPreviewBytes = this.responseBodyPreviewBytes,
+        textBodyMaxBytes = this.textBodyMaxBytes,
+        binaryBodyMaxBytes = this.binaryBodyMaxBytes,
+        dispatcher = dispatcher,
+    )
 
     @Suppress("TooGenericExceptionCaught")
     override fun intercept(chain: Interceptor.Chain): Response {
@@ -72,18 +69,32 @@ class SnapOOkHttpInterceptor @JvmOverloads constructor(
         val request = chain.request()
         val requestBody = request.body
         val declaredRequestBodySize = requestBody.safeContentLength()
-        val requestPublication = publishRequest(context, request, declaredRequestBodySize)
+        val requestPublication = publisher.publish {
+            OkhttpEventFactory.createRequestWillBeSent(
+                context,
+                request,
+                hasBody = requestBody != null,
+                body = null,
+                bodyEncoding = requestBodyEncoding(request),
+                truncatedBytes = null,
+                bodySize = declaredRequestBodySize,
+            )
+        }
         val requestCapture = RequestCaptureTracker(requestPublication) { capture, after ->
-            updateRequestBody(
-                context = context,
+            publisher.updateRequestBody(
+                requestId = context.requestId,
+                bodyValues = { encodeRequestBody(capture, request) },
+                bodyTruncatedBytes = capture.truncatedBytes,
+                bodySize = maxOf(declaredRequestBodySize ?: 0L, capture.totalBytes),
                 after = after,
-                request = request,
-                declaredBodySize = declaredRequestBodySize,
-                capture = capture,
             )
         }
         val interceptedRequest = request.withCapturingBody(
-            maxBytes = requestCaptureLimit(request),
+            maxBytes = resolveRequestCaptureLimit(
+                request = request,
+                textBodyMaxBytes = textBodyMaxBytes,
+                binaryBodyMaxBytes = binaryBodyMaxBytes,
+            ),
             onComplete = requestCapture::captured,
         )
 
@@ -102,53 +113,17 @@ class SnapOOkHttpInterceptor @JvmOverloads constructor(
         requestCompletion: Job?,
         error: Throwable,
     ): Nothing {
-        handleFailure(context, error, after = requestCompletion)
+        publisher.publishFailure(
+            requestId = context.requestId,
+            requestStartMono = context.startMono,
+            error = error,
+            after = requestCompletion,
+        )
         throw error
     }
 
     override fun close() {
-        scope.cancel()
-    }
-
-    private fun publishRequest(
-        context: InterceptContext,
-        request: Request,
-        declaredBodySize: Long?,
-    ): Job? = publish {
-        OkhttpEventFactory.createRequestWillBeSent(
-            context,
-            request,
-            hasBody = request.body != null,
-            body = null,
-            bodyEncoding = requestBodyEncoding(request),
-            truncatedBytes = null,
-            bodySize = declaredBodySize,
-        )
-    }
-
-    private fun updateRequestBody(
-        context: InterceptContext,
-        after: Job?,
-        request: Request,
-        declaredBodySize: Long?,
-        capture: RequestBodyCapture?,
-    ): Job? {
-        if (capture == null) return after
-        val server = NetworkInspector.getOrNull() ?: return null
-        return scope.launch {
-            try {
-                after?.join()
-                val encoded = encodeRequestBody(capture, request)
-                server.updateLatestRequestBody(
-                    requestId = context.requestId,
-                    body = encoded.body,
-                    bodyEncoding = encoded.encoding,
-                    bodyTruncatedBytes = capture.truncatedBytes,
-                    bodySize = maxOf(declaredBodySize ?: 0L, capture.totalBytes),
-                )
-            } catch (_: Throwable) {
-            }
-        }
+        publisher.close()
     }
 
     private fun handleResponse(context: InterceptContext, response: Response, after: Job?): Response {
@@ -165,7 +140,7 @@ class SnapOOkHttpInterceptor @JvmOverloads constructor(
                 endMono = endMono,
                 after = after,
             )
-            publishLoadingFinished(context, bodySize = 0L, after = responsePublication)
+            publisher.publishFinished(context.requestId, bodySize = 0L, after = responsePublication)
             return response
         }
         val contentType = responseBody.contentType().toBodyContentType()
@@ -213,7 +188,7 @@ class SnapOOkHttpInterceptor @JvmOverloads constructor(
             after = after,
         )
         if (bodySize == 0L) {
-            publishLoadingFinished(context, bodySize = 0L, after = responsePublication)
+            publisher.publishFinished(context.requestId, bodySize = 0L, after = responsePublication)
             return response
         }
         val capturingBody = CapturingResponseBody(
@@ -226,13 +201,14 @@ class SnapOOkHttpInterceptor @JvmOverloads constructor(
                 previewBytes = responseBodyPreviewBytes,
             ),
             onComplete = { capture, error ->
-                completeResponseCapture(
-                    context = context,
+                publisher.completeResponse(
+                    requestId = context.requestId,
+                    requestStartMono = context.startMono,
+                    capture = capture,
                     contentType = contentType,
                     declaredBodySize = bodySize,
-                    responsePublication = responsePublication,
-                    capture = capture,
                     error = error,
+                    after = responsePublication,
                 )
             },
         )
@@ -252,19 +228,7 @@ class SnapOOkHttpInterceptor @JvmOverloads constructor(
         endMono: Long,
         after: Job?,
     ): Response {
-        val responsePublication = publish(after = after) {
-            OkhttpEventFactory.createResponseReceived(
-                context = context,
-                response = response,
-                endWall = endWall,
-                endMono = endMono,
-                bodyPreview = null,
-                bodyText = null,
-                bodyEncoding = null,
-                truncatedBytes = null,
-                bodySize = bodySize,
-            )
-        }
+        val responsePublication = publishResponseMetadata(context, response, bodySize, endWall, endMono, after)
         val publicationLock = Any()
         var previousPublication = responsePublication
         val streamingBody = StreamingResponseRelayBody(
@@ -273,7 +237,7 @@ class SnapOOkHttpInterceptor @JvmOverloads constructor(
             charset = contentType?.charsetOrUtf8() ?: Charsets.UTF_8,
             onRecord = { recordBuilder ->
                 synchronized(publicationLock) {
-                    previousPublication = publish(
+                    previousPublication = publisher.publish(
                         after = previousPublication,
                         builder = recordBuilder,
                     ) ?: previousPublication
@@ -291,7 +255,7 @@ class SnapOOkHttpInterceptor @JvmOverloads constructor(
         endMono: Long,
         after: Job?,
     ): Job? {
-        return publish(after = after) {
+        return publisher.publish(after = after) {
             OkhttpEventFactory.createResponseReceived(
                 context = context,
                 response = response,
@@ -303,119 +267,6 @@ class SnapOOkHttpInterceptor @JvmOverloads constructor(
                 truncatedBytes = null,
                 bodySize = bodySize,
             )
-        }
-    }
-
-    private fun requestCaptureLimit(request: Request): Int {
-        return resolveRequestCaptureLimit(
-            request = request,
-            textBodyMaxBytes = textBodyMaxBytes,
-            binaryBodyMaxBytes = binaryBodyMaxBytes,
-        )
-    }
-
-    private fun completeResponseCapture(
-        context: InterceptContext,
-        contentType: BodyContentType?,
-        declaredBodySize: Long?,
-        responsePublication: Job?,
-        capture: RawResponseBodyCapture,
-        error: Throwable?,
-    ) {
-        val completionWall = System.currentTimeMillis()
-        val completionMono = SystemClock.elapsedRealtimeNanos()
-        val server = NetworkInspector.getOrNull() ?: return
-        scope.launch {
-            try {
-                responsePublication?.join()
-                val body = runCatching {
-                    resolveResponseBody(
-                        capture = capture,
-                        contentType = contentType,
-                        textBodyMaxBytes = textBodyMaxBytes,
-                        binaryBodyMaxBytes = binaryBodyMaxBytes,
-                        previewBytes = responseBodyPreviewBytes,
-                        declaredBodySize = declaredBodySize,
-                    )
-                }.getOrNull()
-                if (body != null) {
-                    runCatching {
-                        server.updateLatestResponseBody(
-                            requestId = context.requestId,
-                            bodyPreview = body.preview,
-                            body = body.body,
-                            bodyEncoding = body.encoding,
-                            bodyTruncatedBytes = body.truncatedBytes,
-                            bodySize = body.bodySize,
-                        )
-                    }
-                }
-                val completedBodySize = body?.bodySize
-                    ?: declaredBodySize
-                    ?: capture.totalBytes
-                val completionRecord = if (error == null) {
-                    ResponseFinished(
-                        id = context.requestId,
-                        tWallMs = completionWall,
-                        tMonoNs = completionMono,
-                        bodySize = completedBodySize,
-                        bodyTruncatedBytes = body?.truncatedBytes,
-                    )
-                } else {
-                    RequestFailed(
-                        id = context.requestId,
-                        tWallMs = completionWall,
-                        tMonoNs = completionMono,
-                        errorKind = error.javaClass.simpleName.ifEmpty { error.javaClass.name },
-                        message = error.message,
-                        timings = Timings(totalMs = nanosToMillis(completionMono - context.startMono)),
-                    )
-                }
-                server.publish(completionRecord)
-            } catch (_: Throwable) {
-            }
-        }
-    }
-
-    private fun handleFailure(context: InterceptContext, error: Throwable, after: Job? = null) {
-        val failWall = System.currentTimeMillis()
-        val failMono = SystemClock.elapsedRealtimeNanos()
-        publish(after = after) {
-            RequestFailed(
-                id = context.requestId,
-                tWallMs = failWall,
-                tMonoNs = failMono,
-                errorKind = error.javaClass.simpleName.ifEmpty { error.javaClass.name },
-                message = error.message,
-                timings = Timings(totalMs = nanosToMillis(failMono - context.startMono)),
-            )
-        }
-    }
-
-    private fun publishLoadingFinished(context: InterceptContext, bodySize: Long?, after: Job? = null) {
-        val finishWall = System.currentTimeMillis()
-        val finishMono = SystemClock.elapsedRealtimeNanos()
-        publish(after = after) {
-            ResponseFinished(
-                id = context.requestId,
-                tWallMs = finishWall,
-                tMonoNs = finishMono,
-                bodySize = bodySize,
-            )
-        }
-    }
-
-    private inline fun publish(
-        after: Job? = null,
-        crossinline builder: () -> NetworkEventRecord,
-    ): Job? {
-        val server = NetworkInspector.getOrNull() ?: return null
-        return scope.launch {
-            try {
-                after?.join()
-                server.publish(builder())
-            } catch (_: Throwable) {
-            }
         }
     }
 }

--- a/snapo-link-android/network-okhttp3/src/main/java/com/openai/snapo/network/okhttp3/SnapOOkHttpInterceptor.kt
+++ b/snapo-link-android/network-okhttp3/src/main/java/com/openai/snapo/network/okhttp3/SnapOOkHttpInterceptor.kt
@@ -8,6 +8,14 @@ import com.openai.snapo.network.NetworkInspector
 import com.openai.snapo.network.RequestFailed
 import com.openai.snapo.network.ResponseFinished
 import com.openai.snapo.network.Timings
+import com.openai.snapo.network.capture.BodyContentType
+import com.openai.snapo.network.capture.RawResponseBodyCapture
+import com.openai.snapo.network.capture.ResolvedRequestBody
+import com.openai.snapo.network.capture.resolveEffectiveMaxBytes
+import com.openai.snapo.network.capture.resolveRequestBody
+import com.openai.snapo.network.capture.resolveResponseBody
+import com.openai.snapo.network.capture.resolveResponseCaptureLimit
+import com.openai.snapo.network.capture.shouldEncodeBodyAsBase64
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Job
@@ -30,13 +38,11 @@ import okio.ForwardingSource
 import okio.buffer
 import java.io.Closeable
 import java.io.IOException
-import java.nio.ByteBuffer
 import java.nio.charset.Charset
-import java.nio.charset.CodingErrorAction
 import java.util.UUID
 import java.util.concurrent.TimeUnit
 import java.util.concurrent.atomic.AtomicBoolean
-import kotlin.io.encoding.Base64
+import com.openai.snapo.network.capture.resolveRequestCaptureLimit as resolveSharedRequestCaptureLimit
 
 /** OkHttp interceptor that mirrors traffic to the active SnapO link if present. */
 class SnapOOkHttpInterceptor @JvmOverloads constructor(
@@ -162,8 +168,8 @@ class SnapOOkHttpInterceptor @JvmOverloads constructor(
             publishLoadingFinished(context, bodySize = 0L, after = responsePublication)
             return response
         }
-        val contentType = responseBody.contentType()
-        return if (contentType.isEventStream()) {
+        val contentType = responseBody.contentType().toBodyContentType()
+        return if (contentType?.isEventStream == true) {
             handleStreamingResponse(
                 context,
                 response,
@@ -192,7 +198,7 @@ class SnapOOkHttpInterceptor @JvmOverloads constructor(
         context: InterceptContext,
         response: Response,
         body: ResponseBody,
-        contentType: MediaType?,
+        contentType: BodyContentType?,
         bodySize: Long?,
         endWall: Long,
         endMono: Long,
@@ -212,7 +218,13 @@ class SnapOOkHttpInterceptor @JvmOverloads constructor(
         }
         val capturingBody = CapturingResponseBody(
             delegate = body,
-            maxBytes = responseCaptureLimit(contentType, bodySize),
+            maxBytes = resolveResponseCaptureLimit(
+                contentType = contentType,
+                contentLength = bodySize,
+                textBodyMaxBytes = textBodyMaxBytes,
+                binaryBodyMaxBytes = binaryBodyMaxBytes,
+                previewBytes = responseBodyPreviewBytes,
+            ),
             onComplete = { capture, error ->
                 completeResponseCapture(
                     context = context,
@@ -234,7 +246,7 @@ class SnapOOkHttpInterceptor @JvmOverloads constructor(
         context: InterceptContext,
         response: Response,
         body: ResponseBody,
-        contentType: MediaType?,
+        contentType: BodyContentType?,
         bodySize: Long?,
         endWall: Long,
         endMono: Long,
@@ -258,7 +270,7 @@ class SnapOOkHttpInterceptor @JvmOverloads constructor(
         val streamingBody = StreamingResponseRelayBody(
             delegate = body,
             requestId = context.requestId,
-            charset = contentType.resolveCharset(),
+            charset = contentType?.charsetOrUtf8() ?: Charsets.UTF_8,
             onRecord = { recordBuilder ->
                 synchronized(publicationLock) {
                     previousPublication = publish(
@@ -302,24 +314,12 @@ class SnapOOkHttpInterceptor @JvmOverloads constructor(
         )
     }
 
-    private fun responseCaptureLimit(contentType: MediaType?, contentLength: Long?): Int {
-        val bodyLimit = when {
-            contentType == null -> maxOf(textBodyMaxBytes, binaryBodyMaxBytes)
-            contentType.isTextLike() -> textBodyMaxBytes
-            else -> binaryBodyMaxBytes
-        }
-        return resolveEffectiveMaxBytes(
-            maxBytes = maxOf(bodyLimit, responseBodyPreviewBytes),
-            contentLength = contentLength,
-        )
-    }
-
     private fun completeResponseCapture(
         context: InterceptContext,
-        contentType: MediaType?,
+        contentType: BodyContentType?,
         declaredBodySize: Long?,
         responsePublication: Job?,
-        capture: ResponseBodyCapture,
+        capture: RawResponseBodyCapture,
         error: Throwable?,
     ) {
         val completionWall = System.currentTimeMillis()
@@ -329,7 +329,7 @@ class SnapOOkHttpInterceptor @JvmOverloads constructor(
             try {
                 responsePublication?.join()
                 val body = runCatching {
-                    resolveResponseBodyCapture(
+                    resolveResponseBody(
                         capture = capture,
                         contentType = contentType,
                         textBodyMaxBytes = textBodyMaxBytes,
@@ -431,12 +431,6 @@ internal data class RequestBodyCapture(
     val body: ByteArray,
     val totalBytes: Long,
     val truncatedBytes: Long,
-)
-
-internal data class ResponseBodyCapture(
-    val body: ByteArray,
-    val totalBytes: Long,
-    val reachedEof: Boolean,
 )
 
 private class RequestCaptureTracker(
@@ -542,7 +536,7 @@ internal class CapturingRequestBody(
 internal class CapturingResponseBody(
     private val delegate: ResponseBody,
     maxBytes: Int,
-    private val onComplete: (ResponseBodyCapture, Throwable?) -> Unit,
+    private val onComplete: (RawResponseBodyCapture, Throwable?) -> Unit,
 ) : ResponseBody() {
     private val closed = AtomicBoolean(false)
     private val completionNotified = AtomicBoolean(false)
@@ -589,8 +583,8 @@ internal class CapturingResponseBody(
         val snapshot = capture.snapshot()
         try {
             onComplete(
-                ResponseBodyCapture(
-                    body = snapshot.body,
+                RawResponseBodyCapture(
+                    bytes = snapshot.body,
                     totalBytes = snapshot.totalBytes,
                     reachedEof = reachedEof,
                 ),
@@ -640,39 +634,6 @@ private fun Response.hasNoBodyByProtocol(): Boolean {
         code == 304
 }
 
-private fun MediaType?.isTextLike(): Boolean = when {
-    this == null -> false
-    type.lowercase() == "text" -> true
-    else -> listOf(
-        "json",
-        "xml",
-        "html",
-        "javascript",
-        "form",
-        "graphql",
-        "plain",
-        "csv",
-        "yaml",
-    ).any(subtype.lowercase()::contains)
-}
-
-private fun MediaType?.isMultipartFormData(): Boolean {
-    val mediaType = this ?: return false
-    return mediaType.type.equals("multipart", ignoreCase = true) &&
-        mediaType.subtype.equals("form-data", ignoreCase = true)
-}
-
-private fun MediaType?.isEventStream(): Boolean {
-    val mediaType = this ?: return false
-    return mediaType.type.equals("text", ignoreCase = true) &&
-        mediaType.subtype.equals("event-stream", ignoreCase = true)
-}
-
-private data class EncodedBody(
-    val body: String?,
-    val encoding: String?,
-)
-
 internal fun resolveRequestCaptureLimit(
     request: Request,
     textBodyMaxBytes: Int,
@@ -682,12 +643,13 @@ internal fun resolveRequestCaptureLimit(
     val contentType = resolveRequestContentType(
         captureContentType = runCatching { requestBody.contentType() }.getOrNull(),
         request = request,
+    ).toBodyContentType()
+    return resolveSharedRequestCaptureLimit(
+        contentType = contentType,
+        contentEncoding = request.header("Content-Encoding"),
+        textBodyMaxBytes = textBodyMaxBytes,
+        binaryBodyMaxBytes = binaryBodyMaxBytes,
     )
-    return if (requestBodyUsesBase64(request, contentType)) {
-        binaryBodyMaxBytes
-    } else {
-        textBodyMaxBytes
-    }
 }
 
 private fun requestBodyEncoding(request: Request): String? {
@@ -695,116 +657,32 @@ private fun requestBodyEncoding(request: Request): String? {
     val contentType = resolveRequestContentType(
         captureContentType = runCatching { requestBody.contentType() }.getOrNull(),
         request = request,
-    )
-    return "base64".takeIf { requestBodyUsesBase64(request, contentType) }
-}
-
-private fun encodeRequestBody(capture: RequestBodyCapture, request: Request): EncodedBody {
-    val contentType = resolveRequestContentType(capture.contentType, request)
-    return when {
-        requestBodyUsesBase64(request, contentType) ->
-            EncodedBody(encodeToString(capture.body, NO_WRAP), "base64")
-
-        contentType.isMultipartFormData() ->
-            EncodedBody(formatMultipartBody(capture.body, contentType), null)
-
-        else -> EncodedBody(String(capture.body, contentType.resolveCharset()), null)
+    ).toBodyContentType()
+    return "base64".takeIf {
+        shouldEncodeBodyAsBase64(
+            contentType = contentType,
+            contentEncoding = request.header("Content-Encoding"),
+        )
     }
 }
 
-private fun requestBodyUsesBase64(request: Request, contentType: MediaType?): Boolean {
-    return hasNonIdentityContentEncoding(request.header("Content-Encoding")) ||
-        (!contentType.isTextLike() && !contentType.isMultipartFormData())
-}
-
-internal data class ResolvedResponseBodyCapture(
-    val preview: String?,
-    val body: String?,
-    val encoding: String?,
-    val truncatedBytes: Long?,
-    val bodySize: Long,
-)
-
-internal fun resolveResponseBodyCapture(
-    capture: ResponseBodyCapture,
-    contentType: MediaType?,
-    textBodyMaxBytes: Int,
-    binaryBodyMaxBytes: Int,
-    previewBytes: Int,
-    declaredBodySize: Long?,
-): ResolvedResponseBodyCapture {
-    val likelyText = capture.isLikelyText(contentType)
-    val bodyLimit = resolveEffectiveMaxBytes(
-        maxBytes = if (likelyText) textBodyMaxBytes else binaryBodyMaxBytes,
-        contentLength = declaredBodySize,
-    )
-    val retainedBodyBytes = capture.body.prefix(bodyLimit)
-    val previewSource = capture.body.prefix(previewBytes)
-    val charset = contentType.resolveCharset()
-    val body = retainedBodyBytes.encodeForInspector(likelyText, charset)
-    val preview = previewSource.encodeForInspector(likelyText, charset)
-    val bodySize = capture.resolvedBodySize(declaredBodySize)
-    val truncatedBytes = capture.resolvedTruncatedBytes(
-        bodySize = bodySize,
-        retainedBytes = retainedBodyBytes.size,
-        hasDeclaredBodySize = declaredBodySize != null,
-    )
-    return ResolvedResponseBodyCapture(
-        preview = preview,
-        body = body,
-        encoding = "base64".takeIf { body != null && !likelyText },
-        truncatedBytes = truncatedBytes,
-        bodySize = bodySize,
-    )
-}
-
-private fun ResponseBodyCapture.isLikelyText(contentType: MediaType?): Boolean = when {
-    contentType?.isTextLike() == true -> true
-    contentType != null -> false
-    else -> body.decodeUtf8TextIfLikely() != null
-}
-
-private fun ByteArray.encodeForInspector(likelyText: Boolean, charset: Charset): String? = when {
-    isEmpty() -> null
-    likelyText -> String(this, charset)
-    else -> Base64.encode(this)
-}
-
-private fun ResponseBodyCapture.resolvedBodySize(declaredBodySize: Long?): Long = when {
-    reachedEof -> totalBytes
-    declaredBodySize != null -> maxOf(declaredBodySize, totalBytes)
-    else -> totalBytes
-}
-
-private fun ResponseBodyCapture.resolvedTruncatedBytes(
-    bodySize: Long,
-    retainedBytes: Int,
-    hasDeclaredBodySize: Boolean,
-): Long? {
-    val truncatedBytes = (bodySize - retainedBytes.toLong()).coerceAtLeast(0L)
-    val truncationIsKnown = reachedEof || hasDeclaredBodySize || totalBytes > retainedBytes
-    return truncatedBytes.takeIf { it > 0L && truncationIsKnown }
-}
-
-private fun ByteArray.prefix(maxBytes: Int): ByteArray {
-    if (maxBytes <= 0 || isEmpty()) return ByteArray(0)
-    return if (size <= maxBytes) this else copyOf(maxBytes)
-}
-
-private fun hasNonIdentityContentEncoding(contentEncoding: String?): Boolean {
-    val encodings = contentEncoding
-        ?.split(',')
-        ?.map { token -> token.substringBefore(';').trim().lowercase() }
-        ?.filter { token -> token.isNotEmpty() }
-        .orEmpty()
-    return encodings.any { token -> token != "identity" }
-}
-
-private fun MediaType?.resolveCharset(): Charset {
-    return try {
-        this?.charset(Charsets.UTF_8) ?: Charsets.UTF_8
-    } catch (_: IllegalArgumentException) {
-        Charsets.UTF_8
+private fun encodeRequestBody(capture: RequestBodyCapture, request: Request): ResolvedRequestBody {
+    val mediaType = resolveRequestContentType(capture.contentType, request)
+    val contentType = mediaType.toBodyContentType()
+    return if (
+        contentType?.isMultipartFormData == true &&
+        !shouldEncodeBodyAsBase64(
+            contentType = contentType,
+            contentEncoding = request.header("Content-Encoding"),
+        )
+    ) {
+        ResolvedRequestBody(body = formatMultipartBody(capture.body, mediaType), encoding = null)
+    } else {
+        resolveRequestBody(
+            bytes = capture.body,
+            contentType = contentType,
+            contentEncoding = request.header("Content-Encoding"),
+        )
     }
 }
 
@@ -817,22 +695,14 @@ private fun resolveRequestContentType(
     return headerValue.toMediaTypeOrNull()
 }
 
-private fun ByteArray.decodeUtf8TextIfLikely(): String? {
-    if (isEmpty()) return ""
-    val decoded = runCatching {
-        Charsets.UTF_8
-            .newDecoder()
-            .onMalformedInput(CodingErrorAction.REPORT)
-            .onUnmappableCharacter(CodingErrorAction.REPORT)
-            .decode(ByteBuffer.wrap(this))
-            .toString()
-    }.getOrNull() ?: return null
-    if (decoded.isEmpty()) return decoded
-    val printable = decoded.count { ch ->
-        ch == '\n' || ch == '\r' || ch == '\t' || (ch >= ' ' && ch != '\u007f')
-    }
-    val printableRatio = printable.toDouble() / decoded.length.toDouble()
-    return decoded.takeIf { printableRatio >= MinLikelyTextRatio }
+private fun MediaType?.toBodyContentType(): BodyContentType? {
+    val mediaType = this ?: return null
+    val charset = runCatching { mediaType.charset() }.getOrNull()
+    return BodyContentType(
+        type = mediaType.type,
+        subtype = mediaType.subtype,
+        charset = charset,
+    )
 }
 
 private fun formatMultipartBody(bodyBytes: ByteArray, contentType: MediaType?): String {
@@ -1084,16 +954,4 @@ internal fun nanosToMillis(deltaNs: Long): Long? {
     return TimeUnit.NANOSECONDS.toMillis(deltaNs)
 }
 
-internal fun resolveEffectiveMaxBytes(maxBytes: Int, contentLength: Long?): Int {
-    if (maxBytes <= 0) return 0
-    val knownLength = contentLength?.takeIf { it >= 0L } ?: return maxBytes
-    return if (knownLength < CompleteBodyCaptureThresholdBytes) {
-        maxOf(maxBytes.toLong(), knownLength).toInt()
-    } else {
-        maxBytes
-    }
-}
-
-private const val MinLikelyTextRatio: Double = 0.85
 private const val SegmentByteCount: Long = 8L * 1024L
-private const val CompleteBodyCaptureThresholdBytes: Long = 8L * 1024L * 1024L

--- a/snapo-link-android/network-okhttp3/src/main/java/com/openai/snapo/network/okhttp3/Sse.kt
+++ b/snapo-link-android/network-okhttp3/src/main/java/com/openai/snapo/network/okhttp3/Sse.kt
@@ -1,9 +1,7 @@
 package com.openai.snapo.network.okhttp3
 
-import android.os.SystemClock
 import com.openai.snapo.network.NetworkEventRecord
-import com.openai.snapo.network.ResponseStreamClosed
-import com.openai.snapo.network.ResponseStreamEvent
+import com.openai.snapo.network.capture.SseStreamCapture
 import okhttp3.MediaType
 import okhttp3.ResponseBody
 import okio.Buffer
@@ -12,8 +10,6 @@ import okio.ForwardingSource
 import okio.Source
 import okio.buffer
 import java.nio.charset.Charset
-import java.util.ArrayList
-import java.util.concurrent.atomic.AtomicBoolean
 
 internal class StreamingResponseRelayBody(
     private val delegate: ResponseBody,
@@ -35,11 +31,9 @@ internal class StreamingResponseRelayBody(
     override fun source(): BufferedSource = bufferedSource
 
     override fun close() {
-        try {
-            bufferedSource.close()
-        } finally {
-            relay.onClosed(null)
-        }
+        val result = runCatching { bufferedSource.close() }
+        relay.onClosed(result.exceptionOrNull())
+        result.getOrThrow()
     }
 }
 
@@ -49,13 +43,15 @@ internal fun interface ResponseStreamListener {
 
 private class ResponseStreamRelay(
     private val listener: ResponseStreamListener,
-    private val requestId: String,
+    requestId: String,
     charset: Charset,
 ) {
-    private val closed = AtomicBoolean(false)
-    private val parser = SseBuffer(charset)
-    private var nextSequence: Long = 0L
-    private var totalBytes: Long = 0L
+    private val capture = SseStreamCapture(
+        requestId = requestId,
+        charset = charset,
+    ) { record ->
+        listener.onResponseStreamRecord { record }
+    }
 
     fun wrapSource(upstream: Source): Source {
         return object : ForwardingSource(upstream) {
@@ -65,7 +61,7 @@ private class ResponseStreamRelay(
                     if (read > 0) {
                         val copy = Buffer()
                         sink.copyTo(copy, sink.size - read, read)
-                        handleBytes(copy.readByteArray())
+                        capture.append(copy.readByteArray())
                     } else if (read == -1L) {
                         onClosed(null)
                     }
@@ -76,109 +72,14 @@ private class ResponseStreamRelay(
             }
 
             override fun close() {
-                try {
-                    super.close()
-                } finally {
-                    onClosed(null)
-                }
+                val result = runCatching { super.close() }
+                onClosed(result.exceptionOrNull())
+                result.getOrThrow()
             }
         }
-    }
-
-    private fun handleBytes(bytes: ByteArray) {
-        val events = synchronized(this) {
-            totalBytes += bytes.size
-            parser.append(bytes).map { raw ->
-                val sequence = ++nextSequence
-                raw.toParsedSseEvent(sequence)
-            }
-        }
-        publishEvents(events)
     }
 
     fun onClosed(error: Throwable?) {
-        if (!closed.compareAndSet(false, true)) return
-        val tailEvents = synchronized(this) {
-            parser.drainRemaining().map { raw ->
-                val sequence = ++nextSequence
-                raw.toParsedSseEvent(sequence)
-            }
-        }
-        publishEvents(tailEvents)
-
-        val nowWall = System.currentTimeMillis()
-        val nowMono = SystemClock.elapsedRealtimeNanos()
-        listener.onResponseStreamRecord {
-            ResponseStreamClosed(
-                id = requestId,
-                tWallMs = nowWall,
-                tMonoNs = nowMono,
-                reason = if (error == null) "completed" else "error",
-                message = error?.message ?: error?.javaClass?.simpleName,
-                totalEvents = nextSequence,
-                totalBytes = totalBytes,
-            )
-        }
+        capture.complete(error)
     }
-
-    private fun publishEvents(events: List<ParsedSseEvent>) {
-        for (event in events) {
-            val nowWall = System.currentTimeMillis()
-            val nowMono = SystemClock.elapsedRealtimeNanos()
-            listener.onResponseStreamRecord {
-                ResponseStreamEvent(
-                    id = requestId,
-                    tWallMs = nowWall,
-                    tMonoNs = nowMono,
-                    sequence = event.sequence,
-                    raw = event.raw,
-                )
-            }
-        }
-    }
-}
-
-private class SseBuffer(private val charset: Charset) {
-    private val buffer = StringBuilder()
-
-    fun append(bytes: ByteArray): List<String> {
-        if (bytes.isEmpty()) return emptyList()
-        buffer.append(bytes.toNormalizedString(charset))
-        return drainInternal(flushTail = false)
-    }
-
-    fun drainRemaining(): List<String> = drainInternal(flushTail = true)
-
-    private fun drainInternal(flushTail: Boolean): List<String> {
-        if (buffer.isEmpty()) return emptyList()
-        val events = ArrayList<String>()
-        while (true) {
-            val boundary = buffer.indexOf("\n\n")
-            if (boundary < 0) {
-                if (flushTail && buffer.isNotEmpty()) {
-                    events += buffer.toString()
-                    buffer.setLength(0)
-                }
-                return events
-            }
-            events += buffer.substring(0, boundary)
-            buffer.delete(0, boundary + 2)
-        }
-    }
-}
-
-private data class ParsedSseEvent(
-    val sequence: Long,
-    val raw: String,
-)
-
-private fun String.toParsedSseEvent(sequence: Long): ParsedSseEvent = ParsedSseEvent(
-    sequence = sequence,
-    raw = this,
-)
-
-private fun ByteArray.toNormalizedString(charset: Charset): String {
-    val raw = String(this, charset)
-    if (raw.indexOf('\r') == -1) return raw
-    return raw.replace("\r\n", "\n").replace('\r', '\n')
 }

--- a/snapo-link-android/network-okhttp3/src/test/java/com/openai/snapo/network/okhttp3/BodyCaptureTest.kt
+++ b/snapo-link-android/network-okhttp3/src/test/java/com/openai/snapo/network/okhttp3/BodyCaptureTest.kt
@@ -1,5 +1,6 @@
 package com.openai.snapo.network.okhttp3
 
+import com.openai.snapo.network.capture.RawResponseBodyCapture
 import okhttp3.Headers
 import okhttp3.MediaType
 import okhttp3.MediaType.Companion.toMediaType
@@ -25,7 +26,6 @@ import org.junit.Assert.assertTrue
 import org.junit.Assert.fail
 import org.junit.Test
 import java.io.IOException
-import java.util.Base64
 
 class BodyCaptureTest {
 
@@ -76,7 +76,7 @@ class BodyCaptureTest {
     @Test
     fun `response body is not read until the caller consumes it`() {
         val delegate = TrackingResponseBody("response body")
-        val captures = mutableListOf<ResponseBodyCapture>()
+        val captures = mutableListOf<RawResponseBodyCapture>()
         val body = CapturingResponseBody(delegate = delegate, maxBytes = 4) { capture, error ->
             assertNull(error)
             captures += capture
@@ -89,14 +89,14 @@ class BodyCaptureTest {
         assertEquals("response body", body.string())
         assertTrue(delegate.readCount > 0)
         assertEquals(1, captures.size)
-        assertArrayEquals("resp".encodeToByteArray(), captures.single().body)
+        assertArrayEquals("resp".encodeToByteArray(), captures.single().bytes)
         assertEquals(13L, captures.single().totalBytes)
         assertTrue(captures.single().reachedEof)
     }
 
     @Test
     fun `reading trailers first still passes the response through the capture tee`() {
-        val captures = mutableListOf<ResponseBodyCapture>()
+        val captures = mutableListOf<RawResponseBodyCapture>()
         val body = CapturingResponseBody(TrackingResponseBody("response body"), maxBytes = 4) { capture, _ ->
             captures += capture
         }
@@ -125,14 +125,14 @@ class BodyCaptureTest {
 
     @Test
     fun `zero response capture limit still preserves the caller body`() {
-        var capture: ResponseBodyCapture? = null
+        var capture: RawResponseBodyCapture? = null
         val body = CapturingResponseBody(TrackingResponseBody("complete"), maxBytes = 0) { value, _ ->
             capture = value
         }
 
         assertEquals("complete", body.string())
         val captured = checkNotNull(capture)
-        assertArrayEquals(ByteArray(0), captured.body)
+        assertArrayEquals(ByteArray(0), captured.bytes)
         assertEquals(8L, captured.totalBytes)
     }
 
@@ -161,155 +161,8 @@ class BodyCaptureTest {
     }
 
     @Test
-    fun `response formatter applies body and preview limits after capture`() {
-        val capture = ResponseBodyCapture(
-            body = "0123456789".encodeToByteArray(),
-            totalBytes = 10L,
-            reachedEof = true,
-        )
-
-        val text = resolveResponseBodyCapture(
-            capture = capture,
-            contentType = "text/plain; charset=utf-8".toMediaType(),
-            textBodyMaxBytes = 4,
-            binaryBodyMaxBytes = 6,
-            previewBytes = 2,
-            declaredBodySize = null,
-        )
-        val binary = resolveResponseBodyCapture(
-            capture = capture,
-            contentType = "application/octet-stream".toMediaType(),
-            textBodyMaxBytes = 4,
-            binaryBodyMaxBytes = 6,
-            previewBytes = 2,
-            declaredBodySize = null,
-        )
-        val omitted = resolveResponseBodyCapture(
-            capture = capture,
-            contentType = "text/plain".toMediaType(),
-            textBodyMaxBytes = 0,
-            binaryBodyMaxBytes = 0,
-            previewBytes = 2,
-            declaredBodySize = null,
-        )
-
-        assertEquals("0123", text.body)
-        assertEquals("01", text.preview)
-        assertEquals(null, text.encoding)
-        assertEquals(6L, text.truncatedBytes)
-        assertEquals("MDEyMzQ1", binary.body)
-        assertEquals("MDE=", binary.preview)
-        assertEquals("base64", binary.encoding)
-        assertEquals(4L, binary.truncatedBytes)
-        assertNull(omitted.body)
-        assertEquals("01", omitted.preview)
-        assertEquals(10L, omitted.truncatedBytes)
-    }
-
-    @Test
-    fun `known text response smaller than the complete-body threshold is retained in full`() {
-        val bodySize = 7_000_000
-        val bytes = ByteArray(bodySize) { 'a'.code.toByte() }
-        val capture = ResponseBodyCapture(body = bytes, totalBytes = bodySize.toLong(), reachedEof = true)
-
-        val resolved = resolveResponseBodyCapture(
-            capture = capture,
-            contentType = "text/plain; charset=utf-8".toMediaType(),
-            textBodyMaxBytes = DefaultTextBodyMaxBytes,
-            binaryBodyMaxBytes = DefaultBinaryBodyMaxBytes,
-            previewBytes = DefaultBodyPreviewBytes,
-            declaredBodySize = bodySize.toLong(),
-        )
-
-        val body = checkNotNull(resolved.body)
-        assertEquals(bodySize, body.length)
-        assertTrue(body.all { it == 'a' })
-        assertEquals("a".repeat(DefaultBodyPreviewBytes), resolved.preview)
-        assertNull(resolved.encoding)
-        assertNull(resolved.truncatedBytes)
-        assertEquals(bodySize.toLong(), resolved.bodySize)
-    }
-
-    @Test
-    fun `known binary response smaller than the complete-body threshold is retained in full`() {
-        val bodySize = 7_000_000
-        val bytes = ByteArray(bodySize) { index -> index.toByte() }
-        val capture = ResponseBodyCapture(body = bytes, totalBytes = bodySize.toLong(), reachedEof = true)
-
-        val resolved = resolveResponseBodyCapture(
-            capture = capture,
-            contentType = "application/octet-stream".toMediaType(),
-            textBodyMaxBytes = DefaultTextBodyMaxBytes,
-            binaryBodyMaxBytes = DefaultBinaryBodyMaxBytes,
-            previewBytes = DefaultBodyPreviewBytes,
-            declaredBodySize = bodySize.toLong(),
-        )
-
-        assertArrayEquals(bytes, Base64.getDecoder().decode(checkNotNull(resolved.body)))
-        assertEquals(
-            Base64.getEncoder().encodeToString(bytes.copyOf(DefaultBodyPreviewBytes)),
-            resolved.preview,
-        )
-        assertEquals("base64", resolved.encoding)
-        assertNull(resolved.truncatedBytes)
-        assertEquals(bodySize.toLong(), resolved.bodySize)
-    }
-
-    @Test
-    fun `known response larger than the complete-body threshold remains limited`() {
-        val bodySize = 8L * 1024L * 1024L + 1L
-        val captureLimit = DefaultTextBodyMaxBytes
-        val capture = ResponseBodyCapture(
-            body = ByteArray(captureLimit) { 'a'.code.toByte() },
-            totalBytes = bodySize,
-            reachedEof = true,
-        )
-
-        val resolved = resolveResponseBodyCapture(
-            capture = capture,
-            contentType = "text/plain; charset=utf-8".toMediaType(),
-            textBodyMaxBytes = captureLimit,
-            binaryBodyMaxBytes = DefaultBinaryBodyMaxBytes,
-            previewBytes = DefaultBodyPreviewBytes,
-            declaredBodySize = bodySize,
-        )
-
-        assertEquals(captureLimit, checkNotNull(resolved.body).length)
-        assertEquals(DefaultBodyPreviewBytes, checkNotNull(resolved.preview).length)
-        assertNull(resolved.encoding)
-        assertEquals(bodySize - captureLimit, resolved.truncatedBytes)
-        assertEquals(bodySize, resolved.bodySize)
-    }
-
-    @Test
-    fun `unknown-length response remains limited`() {
-        val captureLimit = 1_024
-        val bodySize = captureLimit + 257L
-        val capture = ResponseBodyCapture(
-            body = ByteArray(captureLimit) { 'a'.code.toByte() },
-            totalBytes = bodySize,
-            reachedEof = true,
-        )
-
-        val resolved = resolveResponseBodyCapture(
-            capture = capture,
-            contentType = "text/plain; charset=utf-8".toMediaType(),
-            textBodyMaxBytes = captureLimit,
-            binaryBodyMaxBytes = DefaultBinaryBodyMaxBytes,
-            previewBytes = 16,
-            declaredBodySize = null,
-        )
-
-        assertEquals(captureLimit, checkNotNull(resolved.body).length)
-        assertEquals(16, checkNotNull(resolved.preview).length)
-        assertNull(resolved.encoding)
-        assertEquals(bodySize - captureLimit, resolved.truncatedBytes)
-        assertEquals(bodySize, resolved.bodySize)
-    }
-
-    @Test
     fun `closing a partially consumed response completes once without claiming eof`() {
-        val captures = mutableListOf<ResponseBodyCapture>()
+        val captures = mutableListOf<RawResponseBodyCapture>()
         val delegate = TrackingResponseBody("response body")
         val body = CapturingResponseBody(delegate, maxBytes = 4) { capture, _ ->
             captures += capture

--- a/snapo-link-android/network-okhttp3/src/test/java/com/openai/snapo/network/okhttp3/SnapOOkHttpInterceptorTest.kt
+++ b/snapo-link-android/network-okhttp3/src/test/java/com/openai/snapo/network/okhttp3/SnapOOkHttpInterceptorTest.kt
@@ -19,15 +19,6 @@ import org.junit.Test
 class SnapOOkHttpInterceptorTest {
 
     @Test
-    fun `small known bodies can expand the configured capture limit`() {
-        assertEquals(7_000_000, resolveEffectiveMaxBytes(maxBytes = 1_024, contentLength = 7_000_000L))
-        assertEquals(1_024, resolveEffectiveMaxBytes(maxBytes = 1_024, contentLength = 512L))
-        assertEquals(12 * 1024 * 1024, resolveEffectiveMaxBytes(12 * 1024 * 1024, contentLength = null))
-        assertEquals(1_024, resolveEffectiveMaxBytes(maxBytes = 1_024, contentLength = 9L * 1024L * 1024L))
-        assertEquals(0, resolveEffectiveMaxBytes(-1, contentLength = null))
-    }
-
-    @Test
     fun `capture defaults preserve full body and websocket preview limits`() {
         assertEquals(5 * 1024 * 1024, DefaultTextBodyMaxBytes)
         assertEquals(DefaultTextBodyMaxBytes, DefaultBinaryBodyMaxBytes)

--- a/snapo-link-android/network/src/main/java/com/openai/snapo/network/capture/BodyCapturePolicy.kt
+++ b/snapo-link-android/network/src/main/java/com/openai/snapo/network/capture/BodyCapturePolicy.kt
@@ -1,7 +1,6 @@
-@file:androidx.annotation.RestrictTo(androidx.annotation.RestrictTo.Scope.LIBRARY_GROUP)
-
 package com.openai.snapo.network.capture
 
+import androidx.annotation.RestrictTo
 import java.nio.ByteBuffer
 import java.nio.charset.Charset
 import java.nio.charset.CodingErrorAction
@@ -12,6 +11,7 @@ import kotlin.io.encoding.Base64
  *
  * This is library-group API. Applications should configure capture through their client integration.
  */
+@RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
 data class BodyContentType(
     val type: String,
     val subtype: String,
@@ -35,6 +35,7 @@ data class BodyContentType(
     fun charsetOrUtf8(): Charset = charset ?: Charsets.UTF_8
 
     companion object {
+        @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
         fun parse(value: String?): BodyContentType? {
             val parts = value?.split(';') ?: return null
             val typePieces = parts.firstOrNull()
@@ -57,17 +58,20 @@ data class BodyContentType(
 }
 
 /** Raw response bytes captured by a client-specific stream wrapper. */
+@RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
 data class RawResponseBodyCapture(
     val bytes: ByteArray,
     val totalBytes: Long,
     val reachedEof: Boolean,
 )
 
+@RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
 data class ResolvedRequestBody(
     val body: String?,
     val encoding: String?,
 )
 
+@RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
 data class ResolvedResponseBody(
     val preview: String?,
     val body: String?,
@@ -76,10 +80,16 @@ data class ResolvedResponseBody(
     val bodySize: Long,
 )
 
+@field:RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
 const val DefaultBodyPreviewBytes: Int = 4096
+
+@field:RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
 const val DefaultTextBodyMaxBytes: Int = 5 * 1024 * 1024
+
+@field:RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
 const val DefaultBinaryBodyMaxBytes: Int = DefaultTextBodyMaxBytes
 
+@RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
 fun resolveEffectiveMaxBytes(maxBytes: Int, contentLength: Long?): Int {
     if (maxBytes <= 0) return 0
     val knownLength = contentLength?.takeIf { it >= 0L } ?: return maxBytes
@@ -90,6 +100,7 @@ fun resolveEffectiveMaxBytes(maxBytes: Int, contentLength: Long?): Int {
     }
 }
 
+@RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
 fun resolveRequestCaptureLimit(
     contentType: BodyContentType?,
     contentEncoding: String?,
@@ -106,6 +117,7 @@ fun resolveRequestCaptureLimit(
     textBodyMaxBytes
 }
 
+@RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
 fun resolveResponseCaptureLimit(
     contentType: BodyContentType?,
     contentLength: Long?,
@@ -124,6 +136,7 @@ fun resolveResponseCaptureLimit(
     )
 }
 
+@RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
 fun shouldEncodeBodyAsBase64(
     contentType: BodyContentType?,
     contentEncoding: String?,
@@ -131,6 +144,7 @@ fun shouldEncodeBodyAsBase64(
     return hasNonIdentityContentEncoding(contentEncoding) || contentType?.isTextLike != true
 }
 
+@RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
 fun resolveRequestBody(
     bytes: ByteArray?,
     contentType: BodyContentType?,
@@ -154,6 +168,7 @@ fun resolveRequestBody(
     }
 }
 
+@RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
 fun resolveResponseBody(
     capture: RawResponseBodyCapture,
     contentType: BodyContentType?,

--- a/snapo-link-android/network/src/main/java/com/openai/snapo/network/capture/BodyCapturePolicy.kt
+++ b/snapo-link-android/network/src/main/java/com/openai/snapo/network/capture/BodyCapturePolicy.kt
@@ -1,0 +1,269 @@
+@file:androidx.annotation.RestrictTo(androidx.annotation.RestrictTo.Scope.LIBRARY_GROUP)
+
+package com.openai.snapo.network.capture
+
+import java.nio.ByteBuffer
+import java.nio.charset.Charset
+import java.nio.charset.CodingErrorAction
+import kotlin.io.encoding.Base64
+
+/**
+ * Parsed content metadata shared by Snap-O's client-specific network integrations.
+ *
+ * This is library-group API. Applications should configure capture through their client integration.
+ */
+data class BodyContentType(
+    val type: String,
+    val subtype: String,
+    val charset: Charset? = null,
+) {
+    val isTextLike: Boolean
+        get() {
+            if (type.equals("text", ignoreCase = true)) return true
+            val normalizedSubtype = subtype.lowercase()
+            return TextLikeSubtypes.any(normalizedSubtype::contains)
+        }
+
+    val isEventStream: Boolean
+        get() = type.equals("text", ignoreCase = true) &&
+            subtype.equals("event-stream", ignoreCase = true)
+
+    val isMultipartFormData: Boolean
+        get() = type.equals("multipart", ignoreCase = true) &&
+            subtype.equals("form-data", ignoreCase = true)
+
+    fun charsetOrUtf8(): Charset = charset ?: Charsets.UTF_8
+
+    companion object {
+        fun parse(value: String?): BodyContentType? {
+            val parts = value?.split(';') ?: return null
+            val typePieces = parts.firstOrNull()
+                ?.trim()
+                ?.split('/')
+                .orEmpty()
+            if (typePieces.size != 2) return null
+            val type = typePieces[0].trim().lowercase()
+            val subtype = typePieces[1].trim().lowercase()
+            if (type.isEmpty() || subtype.isEmpty()) return null
+
+            val charset = parts.asSequence()
+                .drop(1)
+                .mapNotNull(::extractCharset)
+                .mapNotNull { rawCharset -> runCatching { Charset.forName(rawCharset) }.getOrNull() }
+                .lastOrNull()
+            return BodyContentType(type = type, subtype = subtype, charset = charset)
+        }
+    }
+}
+
+/** Raw response bytes captured by a client-specific stream wrapper. */
+data class RawResponseBodyCapture(
+    val bytes: ByteArray,
+    val totalBytes: Long,
+    val reachedEof: Boolean,
+)
+
+data class ResolvedRequestBody(
+    val body: String?,
+    val encoding: String?,
+)
+
+data class ResolvedResponseBody(
+    val preview: String?,
+    val body: String?,
+    val encoding: String?,
+    val truncatedBytes: Long?,
+    val bodySize: Long,
+)
+
+const val DefaultBodyPreviewBytes: Int = 4096
+const val DefaultTextBodyMaxBytes: Int = 5 * 1024 * 1024
+const val DefaultBinaryBodyMaxBytes: Int = DefaultTextBodyMaxBytes
+
+fun resolveEffectiveMaxBytes(maxBytes: Int, contentLength: Long?): Int {
+    if (maxBytes <= 0) return 0
+    val knownLength = contentLength?.takeIf { it >= 0L } ?: return maxBytes
+    return if (knownLength < CompleteBodyCaptureThresholdBytes) {
+        maxOf(maxBytes.toLong(), knownLength).toInt()
+    } else {
+        maxBytes
+    }
+}
+
+fun resolveRequestCaptureLimit(
+    contentType: BodyContentType?,
+    contentEncoding: String?,
+    textBodyMaxBytes: Int,
+    binaryBodyMaxBytes: Int,
+): Int = if (
+    shouldEncodeBodyAsBase64(
+        contentType = contentType,
+        contentEncoding = contentEncoding,
+    )
+) {
+    binaryBodyMaxBytes
+} else {
+    textBodyMaxBytes
+}
+
+fun resolveResponseCaptureLimit(
+    contentType: BodyContentType?,
+    contentLength: Long?,
+    textBodyMaxBytes: Int,
+    binaryBodyMaxBytes: Int,
+    previewBytes: Int,
+): Int {
+    val bodyLimit = when {
+        contentType == null -> maxOf(textBodyMaxBytes, binaryBodyMaxBytes)
+        contentType.isTextLike -> textBodyMaxBytes
+        else -> binaryBodyMaxBytes
+    }
+    return resolveEffectiveMaxBytes(
+        maxBytes = maxOf(bodyLimit, previewBytes),
+        contentLength = contentLength,
+    )
+}
+
+fun shouldEncodeBodyAsBase64(
+    contentType: BodyContentType?,
+    contentEncoding: String?,
+): Boolean {
+    return hasNonIdentityContentEncoding(contentEncoding) || contentType?.isTextLike != true
+}
+
+fun resolveRequestBody(
+    bytes: ByteArray?,
+    contentType: BodyContentType?,
+    contentEncoding: String?,
+    hasBody: Boolean = true,
+): ResolvedRequestBody {
+    val usesBase64 = shouldEncodeBodyAsBase64(contentType, contentEncoding)
+    if (bytes == null || bytes.isEmpty()) {
+        return ResolvedRequestBody(
+            body = null,
+            encoding = "base64".takeIf { hasBody && usesBase64 },
+        )
+    }
+    return if (usesBase64) {
+        ResolvedRequestBody(body = Base64.encode(bytes), encoding = "base64")
+    } else {
+        ResolvedRequestBody(
+            body = String(bytes, contentType?.charsetOrUtf8() ?: Charsets.UTF_8),
+            encoding = null,
+        )
+    }
+}
+
+fun resolveResponseBody(
+    capture: RawResponseBodyCapture,
+    contentType: BodyContentType?,
+    textBodyMaxBytes: Int,
+    binaryBodyMaxBytes: Int,
+    previewBytes: Int,
+    declaredBodySize: Long?,
+): ResolvedResponseBody {
+    val likelyText = capture.isLikelyText(contentType)
+    val bodyLimit = resolveEffectiveMaxBytes(
+        maxBytes = if (likelyText) textBodyMaxBytes else binaryBodyMaxBytes,
+        contentLength = declaredBodySize,
+    )
+    val retainedBodyBytes = capture.bytes.prefix(bodyLimit)
+    val previewSource = capture.bytes.prefix(previewBytes)
+    val charset = contentType?.charsetOrUtf8() ?: Charsets.UTF_8
+    val body = retainedBodyBytes.encodeForInspector(likelyText, charset)
+    val preview = previewSource.encodeForInspector(likelyText, charset)
+    val bodySize = capture.resolvedBodySize(declaredBodySize)
+    val truncatedBytes = capture.resolvedTruncatedBytes(
+        bodySize = bodySize,
+        retainedBytes = retainedBodyBytes.size,
+        hasDeclaredBodySize = declaredBodySize != null,
+    )
+    return ResolvedResponseBody(
+        preview = preview,
+        body = body,
+        encoding = "base64".takeIf { body != null && !likelyText },
+        truncatedBytes = truncatedBytes,
+        bodySize = bodySize,
+    )
+}
+
+private fun RawResponseBodyCapture.isLikelyText(contentType: BodyContentType?): Boolean = when {
+    contentType?.isTextLike == true -> true
+    contentType != null -> false
+    else -> bytes.decodeUtf8TextIfLikely() != null
+}
+
+private fun ByteArray.encodeForInspector(likelyText: Boolean, charset: Charset): String? = when {
+    isEmpty() -> null
+    likelyText -> String(this, charset)
+    else -> Base64.encode(this)
+}
+
+private fun RawResponseBodyCapture.resolvedBodySize(declaredBodySize: Long?): Long = when {
+    reachedEof -> totalBytes
+    declaredBodySize != null -> maxOf(declaredBodySize, totalBytes)
+    else -> totalBytes
+}
+
+private fun RawResponseBodyCapture.resolvedTruncatedBytes(
+    bodySize: Long,
+    retainedBytes: Int,
+    hasDeclaredBodySize: Boolean,
+): Long? {
+    val truncatedBytes = (bodySize - retainedBytes.toLong()).coerceAtLeast(0L)
+    val truncationIsKnown = reachedEof || hasDeclaredBodySize || totalBytes > retainedBytes
+    return truncatedBytes.takeIf { it > 0L && truncationIsKnown }
+}
+
+private fun ByteArray.prefix(maxBytes: Int): ByteArray {
+    if (maxBytes <= 0 || isEmpty()) return ByteArray(0)
+    return if (size <= maxBytes) this else copyOf(maxBytes)
+}
+
+private fun ByteArray.decodeUtf8TextIfLikely(): String? {
+    if (isEmpty()) return ""
+    val decoded = runCatching {
+        Charsets.UTF_8
+            .newDecoder()
+            .onMalformedInput(CodingErrorAction.REPORT)
+            .onUnmappableCharacter(CodingErrorAction.REPORT)
+            .decode(ByteBuffer.wrap(this))
+            .toString()
+    }.getOrNull() ?: return null
+    if (decoded.isEmpty()) return decoded
+    val printable = decoded.count { ch ->
+        ch == '\n' || ch == '\r' || ch == '\t' || (ch >= ' ' && ch != '\u007f')
+    }
+    val printableRatio = printable.toDouble() / decoded.length.toDouble()
+    return decoded.takeIf { printableRatio >= MinLikelyTextRatio }
+}
+
+private fun hasNonIdentityContentEncoding(contentEncoding: String?): Boolean {
+    val encodings = contentEncoding
+        ?.split(',')
+        ?.map { token -> token.substringBefore(';').trim().lowercase() }
+        ?.filter { token -> token.isNotEmpty() }
+        .orEmpty()
+    return encodings.any { token -> token != "identity" }
+}
+
+private fun extractCharset(parameter: String): String? {
+    val trimmed = parameter.trim()
+    if (!trimmed.startsWith("charset=", ignoreCase = true)) return null
+    return trimmed.substringAfter('=').trim().trim('"').takeIf(String::isNotEmpty)
+}
+
+private val TextLikeSubtypes = listOf(
+    "json",
+    "xml",
+    "html",
+    "javascript",
+    "form",
+    "graphql",
+    "plain",
+    "csv",
+    "yaml",
+)
+
+private const val MinLikelyTextRatio: Double = 0.85
+private const val CompleteBodyCaptureThresholdBytes: Long = 8L * 1024L * 1024L

--- a/snapo-link-android/network/src/main/java/com/openai/snapo/network/capture/CaptureEventPublisher.kt
+++ b/snapo-link-android/network/src/main/java/com/openai/snapo/network/capture/CaptureEventPublisher.kt
@@ -1,0 +1,198 @@
+package com.openai.snapo.network.capture
+
+import android.os.SystemClock
+import androidx.annotation.RestrictTo
+import com.openai.snapo.network.NetworkEventRecord
+import com.openai.snapo.network.NetworkInspector
+import com.openai.snapo.network.RequestFailed
+import com.openai.snapo.network.ResponseFinished
+import com.openai.snapo.network.Timings
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.launch
+import java.io.Closeable
+import java.util.concurrent.TimeUnit
+
+/** Publishes client-neutral capture updates with optional predecessor ordering. */
+@RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
+@Suppress("LongParameterList")
+class CaptureEventPublisher internal constructor(
+    private val responseBodyPreviewBytes: Int,
+    private val textBodyMaxBytes: Int,
+    private val binaryBodyMaxBytes: Int,
+    dispatcher: CoroutineDispatcher,
+    private val sinkProvider: () -> CaptureEventSink?,
+    private val wallTimeMillis: () -> Long,
+    private val monotonicNanos: () -> Long,
+) : Closeable {
+
+    constructor(
+        responseBodyPreviewBytes: Int,
+        textBodyMaxBytes: Int,
+        binaryBodyMaxBytes: Int,
+        dispatcher: CoroutineDispatcher,
+    ) : this(
+        responseBodyPreviewBytes = responseBodyPreviewBytes,
+        textBodyMaxBytes = textBodyMaxBytes,
+        binaryBodyMaxBytes = binaryBodyMaxBytes,
+        dispatcher = dispatcher,
+        sinkProvider = {
+            NetworkInspector.getOrNull()?.let { server ->
+                CaptureEventSink(
+                    publish = server::publish,
+                    updateRequestBody = server::updateLatestRequestBody,
+                    updateResponseBody = server::updateLatestResponseBody,
+                )
+            }
+        },
+        wallTimeMillis = System::currentTimeMillis,
+        monotonicNanos = SystemClock::elapsedRealtimeNanos,
+    )
+
+    private val scope = CoroutineScope(SupervisorJob() + dispatcher)
+
+    @Volatile
+    private var activeSink: CaptureEventSink? = null
+
+    override fun close() {
+        scope.cancel()
+    }
+
+    fun publish(after: Job? = null, builder: () -> NetworkEventRecord): Job? = launch(after) { sink ->
+        sink.publish(builder())
+    }
+
+    fun updateRequestBody(
+        requestId: String,
+        bodyValues: () -> ResolvedRequestBody,
+        bodyTruncatedBytes: Long?,
+        bodySize: Long?,
+        after: Job? = null,
+    ): Job? = launch(after) { sink ->
+        val body = bodyValues()
+        sink.updateRequestBody(
+            requestId,
+            body.body,
+            body.encoding,
+            bodyTruncatedBytes,
+            bodySize,
+        )
+    }
+
+    fun completeResponse(
+        requestId: String,
+        requestStartMono: Long,
+        capture: RawResponseBodyCapture,
+        contentType: BodyContentType?,
+        declaredBodySize: Long?,
+        error: Throwable?,
+        after: Job? = null,
+    ): Job? {
+        val completionWall = wallTimeMillis()
+        val completionMono = monotonicNanos()
+        return launch(after) { sink ->
+            val body = runCatching {
+                resolveResponseBody(
+                    capture = capture,
+                    contentType = contentType,
+                    textBodyMaxBytes = textBodyMaxBytes,
+                    binaryBodyMaxBytes = binaryBodyMaxBytes,
+                    previewBytes = responseBodyPreviewBytes,
+                    declaredBodySize = declaredBodySize,
+                )
+            }.getOrNull()
+            if (body != null) {
+                runCatching {
+                    sink.updateResponseBody(
+                        requestId,
+                        body.preview,
+                        body.body,
+                        body.encoding,
+                        body.truncatedBytes,
+                        body.bodySize,
+                    )
+                }
+            }
+            sink.publish(
+                if (error == null) {
+                    ResponseFinished(
+                        id = requestId,
+                        tWallMs = completionWall,
+                        tMonoNs = completionMono,
+                        bodySize = body?.bodySize ?: declaredBodySize ?: capture.totalBytes,
+                        bodyTruncatedBytes = body?.truncatedBytes,
+                    )
+                } else {
+                    failureRecord(requestId, requestStartMono, completionWall, completionMono, error)
+                },
+            )
+        }
+    }
+
+    fun publishFailure(
+        requestId: String,
+        requestStartMono: Long,
+        error: Throwable,
+        after: Job? = null,
+    ): Job? {
+        val failureWall = wallTimeMillis()
+        val failureMono = monotonicNanos()
+        return publish(after) {
+            failureRecord(requestId, requestStartMono, failureWall, failureMono, error)
+        }
+    }
+
+    fun publishFinished(requestId: String, bodySize: Long?, after: Job? = null): Job? {
+        val finishWall = wallTimeMillis()
+        val finishMono = monotonicNanos()
+        return publish(after) {
+            ResponseFinished(
+                id = requestId,
+                tWallMs = finishWall,
+                tMonoNs = finishMono,
+                bodySize = bodySize,
+            )
+        }
+    }
+
+    private fun launch(after: Job?, block: suspend (CaptureEventSink) -> Unit): Job? {
+        val sink = activeSink ?: synchronized(this) {
+            activeSink ?: sinkProvider()?.also { activeSink = it }
+        } ?: return null
+        return scope.launch {
+            try {
+                after?.join()
+                block(sink)
+            } catch (_: Throwable) {
+            }
+        }
+    }
+
+    private fun failureRecord(
+        requestId: String,
+        requestStartMono: Long,
+        wallTime: Long,
+        monotonicTime: Long,
+        error: Throwable,
+    ): RequestFailed = RequestFailed(
+        id = requestId,
+        tWallMs = wallTime,
+        tMonoNs = monotonicTime,
+        errorKind = error.javaClass.simpleName.ifEmpty { error.javaClass.name },
+        message = error.message,
+        timings = Timings(
+            totalMs = TimeUnit.NANOSECONDS.toMillis(monotonicTime - requestStartMono)
+                .takeIf { monotonicTime > requestStartMono },
+        ),
+    )
+}
+
+@RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
+internal data class CaptureEventSink(
+    val publish: suspend (NetworkEventRecord) -> Unit,
+    val updateRequestBody: suspend (String, String?, String?, Long?, Long?) -> Unit,
+    val updateResponseBody: suspend (String, String?, String?, String?, Long?, Long?) -> Unit,
+)

--- a/snapo-link-android/network/src/main/java/com/openai/snapo/network/capture/SseStreamCapture.kt
+++ b/snapo-link-android/network/src/main/java/com/openai/snapo/network/capture/SseStreamCapture.kt
@@ -1,8 +1,7 @@
-@file:androidx.annotation.RestrictTo(androidx.annotation.RestrictTo.Scope.LIBRARY_GROUP)
-
 package com.openai.snapo.network.capture
 
 import android.os.SystemClock
+import androidx.annotation.RestrictTo
 import com.openai.snapo.network.NetworkEventRecord
 import com.openai.snapo.network.ResponseStreamClosed
 import com.openai.snapo.network.ResponseStreamEvent
@@ -16,6 +15,7 @@ import java.nio.charset.CodingErrorAction
  *
  * Stream reads and publication ordering remain owned by the client-specific adapters.
  */
+@RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
 class SseStreamCapture internal constructor(
     private val requestId: String,
     charset: Charset,
@@ -39,8 +39,9 @@ class SseStreamCapture internal constructor(
     private val decoder = charset.newDecoder()
         .onMalformedInput(CodingErrorAction.REPLACE)
         .onUnmappableCharacter(CodingErrorAction.REPLACE)
+    private val decoderOutput = CharBuffer.allocate(DecoderBufferChars)
     private val text = StringBuilder()
-    private var undecodedBytes = ByteArray(0)
+    private var undecodedBytes = emptyBytes
     private var pendingCarriageReturn = false
     private var totalBytes = 0L
     private var nextSequence = 0L
@@ -54,8 +55,7 @@ class SseStreamCapture internal constructor(
         synchronized(lock) {
             if (completed) return
             totalBytes += length.toLong()
-            appendDecoded(decode(bytes, offset, length, endOfInput = false))
-            drainEvents(flushTail = false).forEach(::emit)
+            decodeAndAppend(bytes, offset, length, endOfInput = false)
         }
     }
 
@@ -63,9 +63,13 @@ class SseStreamCapture internal constructor(
         synchronized(lock) {
             if (completed) return
             completed = true
-            appendDecoded(decode(ByteArray(0), 0, 0, endOfInput = true))
+            decodeAndAppend(emptyBytes, 0, 0, endOfInput = true)
             flushPendingCarriageReturn()
-            drainEvents(flushTail = true).forEach(::emit)
+            if (text.isNotEmpty()) {
+                val tail = text.toString()
+                text.setLength(0)
+                emit(eventRecord(tail))
+            }
             emit(
                 ResponseStreamClosed(
                     id = requestId,
@@ -80,12 +84,12 @@ class SseStreamCapture internal constructor(
         }
     }
 
-    private fun decode(
+    private fun decodeAndAppend(
         bytes: ByteArray,
         offset: Int,
         length: Int,
         endOfInput: Boolean,
-    ): String {
+    ) {
         val input = if (undecodedBytes.isEmpty()) {
             ByteBuffer.wrap(bytes, offset, length)
         } else {
@@ -99,70 +103,59 @@ class SseStreamCapture internal constructor(
             )
             ByteBuffer.wrap(combined)
         }
-        val decoded = StringBuilder()
-        val output = CharBuffer.allocate(DecoderBufferChars)
         while (true) {
-            val result = decoder.decode(input, output, endOfInput)
-            output.flip()
-            decoded.append(output)
-            output.clear()
+            val result = decoder.decode(input, decoderOutput, endOfInput)
+            decoderOutput.flip()
+            appendDecoded(decoderOutput)
+            decoderOutput.clear()
             if (!result.isOverflow) break
         }
 
         undecodedBytes = if (!endOfInput && input.hasRemaining()) {
             ByteArray(input.remaining()).also(input::get)
         } else {
-            ByteArray(0)
+            emptyBytes
         }
 
         if (endOfInput) {
             while (true) {
-                val result = decoder.flush(output)
-                output.flip()
-                decoded.append(output)
-                output.clear()
+                val result = decoder.flush(decoderOutput)
+                decoderOutput.flip()
+                appendDecoded(decoderOutput)
+                decoderOutput.clear()
                 if (!result.isOverflow) break
             }
         }
-        return decoded.toString()
     }
 
-    private fun appendDecoded(decoded: String) {
+    private fun appendDecoded(decoded: CharSequence) {
         for (character in decoded) {
             if (pendingCarriageReturn) {
-                text.append('\n')
+                appendNormalized('\n')
                 pendingCarriageReturn = false
                 if (character == '\n') continue
             }
             if (character == '\r') {
                 pendingCarriageReturn = true
             } else {
-                text.append(character)
+                appendNormalized(character)
             }
         }
     }
 
     private fun flushPendingCarriageReturn() {
         if (!pendingCarriageReturn) return
-        text.append('\n')
+        appendNormalized('\n')
         pendingCarriageReturn = false
     }
 
-    private fun drainEvents(flushTail: Boolean): List<NetworkEventRecord> {
-        if (text.isEmpty()) return emptyList()
-        val records = ArrayList<NetworkEventRecord>()
-        while (true) {
-            val boundary = text.indexOf("\n\n")
-            if (boundary < 0) {
-                if (flushTail && text.isNotEmpty()) {
-                    records += eventRecord(text.toString())
-                    text.setLength(0)
-                }
-                return records
-            }
-            records += eventRecord(text.substring(0, boundary))
-            text.delete(0, boundary + 2)
-        }
+    private fun appendNormalized(character: Char) {
+        text.append(character)
+        if (character != '\n' || text.length < 2 || text[text.length - 2] != '\n') return
+        text.setLength(text.length - 2)
+        val event = text.toString()
+        text.setLength(0)
+        emit(eventRecord(event))
     }
 
     private fun eventRecord(raw: String): ResponseStreamEvent {
@@ -185,5 +178,6 @@ class SseStreamCapture internal constructor(
 
     private companion object {
         const val DecoderBufferChars: Int = 1024
+        val emptyBytes = ByteArray(0)
     }
 }

--- a/snapo-link-android/network/src/main/java/com/openai/snapo/network/capture/SseStreamCapture.kt
+++ b/snapo-link-android/network/src/main/java/com/openai/snapo/network/capture/SseStreamCapture.kt
@@ -1,0 +1,189 @@
+@file:androidx.annotation.RestrictTo(androidx.annotation.RestrictTo.Scope.LIBRARY_GROUP)
+
+package com.openai.snapo.network.capture
+
+import android.os.SystemClock
+import com.openai.snapo.network.NetworkEventRecord
+import com.openai.snapo.network.ResponseStreamClosed
+import com.openai.snapo.network.ResponseStreamEvent
+import java.nio.ByteBuffer
+import java.nio.CharBuffer
+import java.nio.charset.Charset
+import java.nio.charset.CodingErrorAction
+
+/**
+ * Client-neutral SSE decoding and stream state shared by Snap-O's network integrations.
+ *
+ * Stream reads and publication ordering remain owned by the client-specific adapters.
+ */
+class SseStreamCapture internal constructor(
+    private val requestId: String,
+    charset: Charset,
+    private val onRecord: (NetworkEventRecord) -> Unit,
+    private val wallTimeMillis: () -> Long,
+    private val monotonicNanos: () -> Long,
+) {
+    constructor(
+        requestId: String,
+        charset: Charset,
+        onRecord: (NetworkEventRecord) -> Unit,
+    ) : this(
+        requestId = requestId,
+        charset = charset,
+        onRecord = onRecord,
+        wallTimeMillis = System::currentTimeMillis,
+        monotonicNanos = SystemClock::elapsedRealtimeNanos,
+    )
+
+    private val lock = Any()
+    private val decoder = charset.newDecoder()
+        .onMalformedInput(CodingErrorAction.REPLACE)
+        .onUnmappableCharacter(CodingErrorAction.REPLACE)
+    private val text = StringBuilder()
+    private var undecodedBytes = ByteArray(0)
+    private var pendingCarriageReturn = false
+    private var totalBytes = 0L
+    private var nextSequence = 0L
+    private var completed = false
+
+    fun append(bytes: ByteArray, offset: Int = 0, length: Int = bytes.size - offset) {
+        require(offset >= 0 && length >= 0 && offset <= bytes.size - length) {
+            "offset and length must describe a valid byte range"
+        }
+        if (length == 0) return
+        synchronized(lock) {
+            if (completed) return
+            totalBytes += length.toLong()
+            appendDecoded(decode(bytes, offset, length, endOfInput = false))
+            drainEvents(flushTail = false).forEach(::emit)
+        }
+    }
+
+    fun complete(error: Throwable? = null) {
+        synchronized(lock) {
+            if (completed) return
+            completed = true
+            appendDecoded(decode(ByteArray(0), 0, 0, endOfInput = true))
+            flushPendingCarriageReturn()
+            drainEvents(flushTail = true).forEach(::emit)
+            emit(
+                ResponseStreamClosed(
+                    id = requestId,
+                    tWallMs = wallTimeMillis(),
+                    tMonoNs = monotonicNanos(),
+                    reason = if (error == null) "completed" else "error",
+                    message = error?.message ?: error?.javaClass?.simpleName,
+                    totalEvents = nextSequence,
+                    totalBytes = totalBytes,
+                ),
+            )
+        }
+    }
+
+    private fun decode(
+        bytes: ByteArray,
+        offset: Int,
+        length: Int,
+        endOfInput: Boolean,
+    ): String {
+        val input = if (undecodedBytes.isEmpty()) {
+            ByteBuffer.wrap(bytes, offset, length)
+        } else {
+            val combined = ByteArray(undecodedBytes.size + length)
+            undecodedBytes.copyInto(combined)
+            bytes.copyInto(
+                combined,
+                destinationOffset = undecodedBytes.size,
+                startIndex = offset,
+                endIndex = offset + length,
+            )
+            ByteBuffer.wrap(combined)
+        }
+        val decoded = StringBuilder()
+        val output = CharBuffer.allocate(DecoderBufferChars)
+        while (true) {
+            val result = decoder.decode(input, output, endOfInput)
+            output.flip()
+            decoded.append(output)
+            output.clear()
+            if (!result.isOverflow) break
+        }
+
+        undecodedBytes = if (!endOfInput && input.hasRemaining()) {
+            ByteArray(input.remaining()).also(input::get)
+        } else {
+            ByteArray(0)
+        }
+
+        if (endOfInput) {
+            while (true) {
+                val result = decoder.flush(output)
+                output.flip()
+                decoded.append(output)
+                output.clear()
+                if (!result.isOverflow) break
+            }
+        }
+        return decoded.toString()
+    }
+
+    private fun appendDecoded(decoded: String) {
+        for (character in decoded) {
+            if (pendingCarriageReturn) {
+                text.append('\n')
+                pendingCarriageReturn = false
+                if (character == '\n') continue
+            }
+            if (character == '\r') {
+                pendingCarriageReturn = true
+            } else {
+                text.append(character)
+            }
+        }
+    }
+
+    private fun flushPendingCarriageReturn() {
+        if (!pendingCarriageReturn) return
+        text.append('\n')
+        pendingCarriageReturn = false
+    }
+
+    private fun drainEvents(flushTail: Boolean): List<NetworkEventRecord> {
+        if (text.isEmpty()) return emptyList()
+        val records = ArrayList<NetworkEventRecord>()
+        while (true) {
+            val boundary = text.indexOf("\n\n")
+            if (boundary < 0) {
+                if (flushTail && text.isNotEmpty()) {
+                    records += eventRecord(text.toString())
+                    text.setLength(0)
+                }
+                return records
+            }
+            records += eventRecord(text.substring(0, boundary))
+            text.delete(0, boundary + 2)
+        }
+    }
+
+    private fun eventRecord(raw: String): ResponseStreamEvent {
+        val sequence = ++nextSequence
+        return ResponseStreamEvent(
+            id = requestId,
+            tWallMs = wallTimeMillis(),
+            tMonoNs = monotonicNanos(),
+            sequence = sequence,
+            raw = raw,
+        )
+    }
+
+    private fun emit(record: NetworkEventRecord) {
+        try {
+            onRecord(record)
+        } catch (_: Throwable) {
+        }
+    }
+
+    private companion object {
+        const val DecoderBufferChars: Int = 1024
+    }
+}

--- a/snapo-link-android/network/src/test/java/com/openai/snapo/network/capture/BodyCapturePolicyTest.kt
+++ b/snapo-link-android/network/src/test/java/com/openai/snapo/network/capture/BodyCapturePolicyTest.kt
@@ -1,5 +1,6 @@
 package com.openai.snapo.network.capture
 
+import org.junit.Assert.assertArrayEquals
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNull
 import org.junit.Assert.assertTrue
@@ -164,6 +165,50 @@ class BodyCapturePolicyTest {
         assertEquals(10L, partial.bodySize)
         assertEquals(6L, partial.truncatedBytes)
         assertEquals("base64", partial.encoding)
+    }
+
+    @Test
+    fun `known text response smaller than the complete-body threshold is retained in full`() {
+        val bodySize = 7_000_000
+        val bytes = ByteArray(bodySize) { 'a'.code.toByte() }
+
+        val resolved = resolveResponseBody(
+            capture = RawResponseBodyCapture(bytes = bytes, totalBytes = bodySize.toLong(), reachedEof = true),
+            contentType = BodyContentType.parse("text/plain; charset=utf-8"),
+            textBodyMaxBytes = DefaultTextBodyMaxBytes,
+            binaryBodyMaxBytes = DefaultBinaryBodyMaxBytes,
+            previewBytes = DefaultBodyPreviewBytes,
+            declaredBodySize = bodySize.toLong(),
+        )
+
+        val body = checkNotNull(resolved.body)
+        assertEquals(bodySize, body.length)
+        assertTrue(body.all { it == 'a' })
+        assertEquals("a".repeat(DefaultBodyPreviewBytes), resolved.preview)
+        assertNull(resolved.encoding)
+        assertNull(resolved.truncatedBytes)
+        assertEquals(bodySize.toLong(), resolved.bodySize)
+    }
+
+    @Test
+    fun `known binary response smaller than the complete-body threshold is retained in full`() {
+        val bodySize = 7_000_000
+        val bytes = ByteArray(bodySize) { index -> index.toByte() }
+
+        val resolved = resolveResponseBody(
+            capture = RawResponseBodyCapture(bytes = bytes, totalBytes = bodySize.toLong(), reachedEof = true),
+            contentType = BodyContentType.parse("application/octet-stream"),
+            textBodyMaxBytes = DefaultTextBodyMaxBytes,
+            binaryBodyMaxBytes = DefaultBinaryBodyMaxBytes,
+            previewBytes = DefaultBodyPreviewBytes,
+            declaredBodySize = bodySize.toLong(),
+        )
+
+        assertArrayEquals(bytes, Base64.getDecoder().decode(checkNotNull(resolved.body)))
+        assertEquals(Base64.getEncoder().encodeToString(bytes.copyOf(DefaultBodyPreviewBytes)), resolved.preview)
+        assertEquals("base64", resolved.encoding)
+        assertNull(resolved.truncatedBytes)
+        assertEquals(bodySize.toLong(), resolved.bodySize)
     }
 
     @Test

--- a/snapo-link-android/network/src/test/java/com/openai/snapo/network/capture/BodyCapturePolicyTest.kt
+++ b/snapo-link-android/network/src/test/java/com/openai/snapo/network/capture/BodyCapturePolicyTest.kt
@@ -1,0 +1,209 @@
+package com.openai.snapo.network.capture
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import java.util.Base64
+
+class BodyCapturePolicyTest {
+
+    @Test
+    fun `content types share text stream multipart and charset classification`() {
+        val json = BodyContentType.parse("Application/Problem+Json; charset=\"UTF-16\"")
+        val stream = BodyContentType.parse("text/event-stream; charset=not-a-charset")
+        val multipart = BodyContentType.parse("multipart/form-data; boundary=abc")
+
+        assertTrue(checkNotNull(json).isTextLike)
+        assertEquals(Charsets.UTF_16, json.charsetOrUtf8())
+        assertTrue(checkNotNull(stream).isTextLike)
+        assertTrue(stream.isEventStream)
+        assertEquals(Charsets.UTF_8, stream.charsetOrUtf8())
+        assertTrue(checkNotNull(multipart).isTextLike)
+        assertTrue(multipart.isMultipartFormData)
+        assertNull(BodyContentType.parse("invalid"))
+    }
+
+    @Test
+    fun `capture limits use shared text binary preview and known length policy`() {
+        val text = BodyContentType.parse("text/plain")
+        val binary = BodyContentType.parse("application/octet-stream")
+
+        assertEquals(100, resolveRequestCaptureLimit(text, null, 100, 20))
+        assertEquals(20, resolveRequestCaptureLimit(binary, null, 100, 20))
+        assertEquals(20, resolveRequestCaptureLimit(text, "gzip", 100, 20))
+        assertEquals(
+            120,
+            resolveResponseCaptureLimit(text, null, textBodyMaxBytes = 40, binaryBodyMaxBytes = 80, previewBytes = 120),
+        )
+        assertEquals(
+            80,
+            resolveResponseCaptureLimit(null, null, textBodyMaxBytes = 40, binaryBodyMaxBytes = 80, previewBytes = 10),
+        )
+        assertEquals(
+            7_000_000,
+            resolveResponseCaptureLimit(
+                contentType = text,
+                contentLength = 7_000_000L,
+                textBodyMaxBytes = 1_024,
+                binaryBodyMaxBytes = 1_024,
+                previewBytes = 16,
+            ),
+        )
+        assertEquals(7_000_000, resolveEffectiveMaxBytes(maxBytes = 1_024, contentLength = 7_000_000L))
+        assertEquals(1_024, resolveEffectiveMaxBytes(maxBytes = 1_024, contentLength = 9L * 1024L * 1024L))
+        assertEquals(0, resolveEffectiveMaxBytes(maxBytes = -1, contentLength = null))
+    }
+
+    @Test
+    fun `request bodies share text binary compression and empty body encoding`() {
+        val text = BodyContentType.parse("text/plain; charset=utf-8")
+        val binary = BodyContentType.parse("application/octet-stream")
+
+        assertEquals(
+            ResolvedRequestBody(body = "hello", encoding = null),
+            resolveRequestBody("hello".encodeToByteArray(), text, contentEncoding = null),
+        )
+        assertEquals(
+            ResolvedRequestBody(
+                body = Base64.getEncoder().encodeToString("hello".encodeToByteArray()),
+                encoding = "base64",
+            ),
+            resolveRequestBody("hello".encodeToByteArray(), binary, contentEncoding = null),
+        )
+        assertEquals(
+            "base64",
+            resolveRequestBody(ByteArray(0), text, contentEncoding = "br").encoding,
+        )
+        assertNull(resolveRequestBody(ByteArray(0), text, contentEncoding = null).body)
+        assertNull(
+            resolveRequestBody(
+                bytes = null,
+                contentType = null,
+                contentEncoding = null,
+                hasBody = false,
+            ).encoding,
+        )
+    }
+
+    @Test
+    fun `response bodies share text binary preview and truncation policy`() {
+        val capture = RawResponseBodyCapture(
+            bytes = "0123456789".encodeToByteArray(),
+            totalBytes = 10L,
+            reachedEof = true,
+        )
+
+        val text = resolveResponseBody(
+            capture = capture,
+            contentType = BodyContentType.parse("text/plain; charset=utf-8"),
+            textBodyMaxBytes = 4,
+            binaryBodyMaxBytes = 6,
+            previewBytes = 2,
+            declaredBodySize = null,
+        )
+        val binary = resolveResponseBody(
+            capture = capture,
+            contentType = BodyContentType.parse("application/octet-stream"),
+            textBodyMaxBytes = 4,
+            binaryBodyMaxBytes = 6,
+            previewBytes = 2,
+            declaredBodySize = null,
+        )
+        val omitted = resolveResponseBody(
+            capture = capture,
+            contentType = BodyContentType.parse("text/plain"),
+            textBodyMaxBytes = 0,
+            binaryBodyMaxBytes = 0,
+            previewBytes = 2,
+            declaredBodySize = null,
+        )
+
+        assertEquals("0123", text.body)
+        assertEquals("01", text.preview)
+        assertNull(text.encoding)
+        assertEquals(6L, text.truncatedBytes)
+        assertEquals("MDEyMzQ1", binary.body)
+        assertEquals("MDE=", binary.preview)
+        assertEquals("base64", binary.encoding)
+        assertEquals(4L, binary.truncatedBytes)
+        assertNull(omitted.body)
+        assertEquals("01", omitted.preview)
+        assertEquals(10L, omitted.truncatedBytes)
+    }
+
+    @Test
+    fun `unknown content uses utf8 sniffing and partial close uses declared size`() {
+        val text = resolveResponseBody(
+            capture = RawResponseBodyCapture(
+                bytes = "printable".encodeToByteArray(),
+                totalBytes = 9L,
+                reachedEof = true,
+            ),
+            contentType = null,
+            textBodyMaxBytes = 20,
+            binaryBodyMaxBytes = 4,
+            previewBytes = 4,
+            declaredBodySize = null,
+        )
+        val partial = resolveResponseBody(
+            capture = RawResponseBodyCapture(
+                bytes = byteArrayOf(0, 1, 2, 3),
+                totalBytes = 4L,
+                reachedEof = false,
+            ),
+            contentType = null,
+            textBodyMaxBytes = 20,
+            binaryBodyMaxBytes = 2,
+            previewBytes = 2,
+            declaredBodySize = 10L,
+        )
+
+        assertEquals("printable", text.body)
+        assertNull(text.encoding)
+        assertEquals(10L, partial.bodySize)
+        assertEquals(6L, partial.truncatedBytes)
+        assertEquals("base64", partial.encoding)
+    }
+
+    @Test
+    fun `large and unknown length responses remain limited`() {
+        val captureLimit = 1_024
+        val knownBodySize = 8L * 1024L * 1024L + 1L
+        val contentType = BodyContentType.parse("text/plain; charset=utf-8")
+        val capturedBytes = ByteArray(captureLimit) { 'a'.code.toByte() }
+
+        val known = resolveResponseBody(
+            capture = RawResponseBodyCapture(
+                bytes = capturedBytes,
+                totalBytes = knownBodySize,
+                reachedEof = true,
+            ),
+            contentType = contentType,
+            textBodyMaxBytes = captureLimit,
+            binaryBodyMaxBytes = captureLimit,
+            previewBytes = 16,
+            declaredBodySize = knownBodySize,
+        )
+        val unknownBodySize = captureLimit + 257L
+        val unknown = resolveResponseBody(
+            capture = RawResponseBodyCapture(
+                bytes = capturedBytes,
+                totalBytes = unknownBodySize,
+                reachedEof = true,
+            ),
+            contentType = contentType,
+            textBodyMaxBytes = captureLimit,
+            binaryBodyMaxBytes = captureLimit,
+            previewBytes = 16,
+            declaredBodySize = null,
+        )
+
+        assertEquals(captureLimit, checkNotNull(known.body).length)
+        assertEquals(knownBodySize - captureLimit, known.truncatedBytes)
+        assertEquals(knownBodySize, known.bodySize)
+        assertEquals(captureLimit, checkNotNull(unknown.body).length)
+        assertEquals(unknownBodySize - captureLimit, unknown.truncatedBytes)
+        assertEquals(unknownBodySize, unknown.bodySize)
+    }
+}

--- a/snapo-link-android/network/src/test/java/com/openai/snapo/network/capture/CaptureEventPublisherTest.kt
+++ b/snapo-link-android/network/src/test/java/com/openai/snapo/network/capture/CaptureEventPublisherTest.kt
@@ -1,0 +1,247 @@
+package com.openai.snapo.network.capture
+
+import com.openai.snapo.network.NetworkEventRecord
+import com.openai.snapo.network.RequestFailed
+import com.openai.snapo.network.RequestWillBeSent
+import com.openai.snapo.network.ResponseFinished
+import com.openai.snapo.network.Timings
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.runBlocking
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Test
+import java.io.IOException
+
+class CaptureEventPublisherTest {
+
+    @Test
+    fun `predecessor gates request publication and lazy body update`() {
+        val sink = RecordingSink()
+        val predecessor = Job()
+        var builderCalls = 0
+        var bodyCalls = 0
+
+        publisher(sink).use { publisher ->
+            val publication = publisher.publish(after = predecessor) {
+                builderCalls += 1
+                request("request")
+            }
+            val bodyUpdate = publisher.updateRequestBody(
+                requestId = "request",
+                bodyValues = {
+                    bodyCalls += 1
+                    ResolvedRequestBody(body = "request body", encoding = null)
+                },
+                bodyTruncatedBytes = 2L,
+                bodySize = 14L,
+                after = publication,
+            )
+
+            assertEquals(0, builderCalls)
+            assertEquals(0, bodyCalls)
+            assertEquals(emptyList<String>(), sink.operations)
+
+            predecessor.complete()
+            await(bodyUpdate)
+
+            assertEquals(1, builderCalls)
+            assertEquals(1, bodyCalls)
+            assertEquals(
+                listOf("publish:RequestWillBeSent", "request:request:request body:null:2:14"),
+                sink.operations,
+            )
+        }
+    }
+
+    @Test
+    fun `successful response updates the body before publishing finished`() {
+        val sink = RecordingSink()
+
+        publisher(sink, wallTime = 123L, monotonicTime = 9_000_000L).use { publisher ->
+            await(
+                publisher.completeResponse(
+                    requestId = "request",
+                    requestStartMono = 1_000_000L,
+                    capture = capture(byteArrayOf(0, 1, 2, 3), totalBytes = 10L),
+                    contentType = BodyContentType.parse("application/octet-stream"),
+                    declaredBodySize = null,
+                    error = null,
+                ),
+            )
+        }
+
+        assertEquals(
+            listOf("response:request:AAE=:AAECAw==:base64:6:10", "publish:ResponseFinished"),
+            sink.operations,
+        )
+        assertEquals(
+            ResponseFinished(
+                id = "request",
+                tWallMs = 123L,
+                tMonoNs = 9_000_000L,
+                bodySize = 10L,
+                bodyTruncatedBytes = 6L,
+            ),
+            sink.records.single(),
+        )
+    }
+
+    @Test
+    fun `partial response failure updates the body before publishing failure and timing`() {
+        val sink = RecordingSink()
+
+        publisher(sink, wallTime = 456L, monotonicTime = 15_000_000L).use { publisher ->
+            await(
+                publisher.completeResponse(
+                    requestId = "request",
+                    requestStartMono = 3_000_000L,
+                    capture = capture("part".encodeToByteArray(), totalBytes = 4L, reachedEof = false),
+                    contentType = BodyContentType.parse("text/plain"),
+                    declaredBodySize = 10L,
+                    error = IOException("read failed"),
+                ),
+            )
+        }
+
+        assertEquals(listOf("response:request:pa:part:null:6:10", "publish:RequestFailed"), sink.operations)
+        assertEquals(
+            RequestFailed(
+                id = "request",
+                tWallMs = 456L,
+                tMonoNs = 15_000_000L,
+                errorKind = "IOException",
+                message = "read failed",
+                timings = Timings(totalMs = 12L),
+            ),
+            sink.records.single(),
+        )
+    }
+
+    @Test
+    fun `sink and resolver failures are isolated and later chained publication still runs`() {
+        val sink = RecordingSink(failResponseUpdate = true)
+
+        publisher(sink).use { publisher ->
+            val failedRequestUpdate = publisher.updateRequestBody(
+                requestId = "request",
+                bodyValues = { error("request resolver failed") },
+                bodyTruncatedBytes = null,
+                bodySize = 4L,
+            )
+            val responseCompletion = publisher.completeResponse(
+                requestId = "request",
+                requestStartMono = 0L,
+                capture = capture("body".encodeToByteArray(), totalBytes = 4L),
+                contentType = BodyContentType.parse("text/plain"),
+                declaredBodySize = null,
+                error = null,
+                after = failedRequestUpdate,
+            )
+            await(publisher.publish(after = responseCompletion) { request("later") })
+        }
+
+        assertEquals(listOf("publish:ResponseFinished", "publish:RequestWillBeSent"), sink.operations)
+    }
+
+    @Test
+    fun `unavailable sink does not evaluate lazy builders`() {
+        var builderCalls = 0
+        var bodyCalls = 0
+
+        publisher(sinkProvider = { null }).use { publisher ->
+            assertNull(
+                publisher.publish {
+                    builderCalls += 1
+                    request("request")
+                },
+            )
+            assertNull(
+                publisher.updateRequestBody(
+                    requestId = "request",
+                    bodyValues = {
+                        bodyCalls += 1
+                        ResolvedRequestBody(body = "body", encoding = null)
+                    },
+                    bodyTruncatedBytes = null,
+                    bodySize = 4L,
+                ),
+            )
+        }
+
+        assertEquals(0, builderCalls)
+        assertEquals(0, bodyCalls)
+    }
+
+    @Test
+    fun `sink lookup retries null and caches the first available sink`() {
+        val sink = RecordingSink()
+        var lookups = 0
+
+        publisher(
+            sinkProvider = {
+                lookups += 1
+                sink.value.takeIf { lookups > 1 }
+            },
+        ).use { publisher ->
+            assertNull(publisher.publish { request("unavailable") })
+            await(publisher.publish { request("first") })
+            await(publisher.publish { request("second") })
+        }
+
+        assertEquals(2, lookups)
+        assertEquals(listOf("first", "second"), sink.records.map { (it as RequestWillBeSent).id })
+    }
+
+    private fun publisher(
+        sink: RecordingSink? = null,
+        wallTime: Long = 100L,
+        monotonicTime: Long = 1_000_000L,
+        sinkProvider: () -> CaptureEventSink? = { checkNotNull(sink).value },
+    ): CaptureEventPublisher = CaptureEventPublisher(
+        responseBodyPreviewBytes = 2,
+        textBodyMaxBytes = 4,
+        binaryBodyMaxBytes = 4,
+        dispatcher = Dispatchers.Unconfined,
+        sinkProvider = sinkProvider,
+        wallTimeMillis = { wallTime },
+        monotonicNanos = { monotonicTime },
+    )
+
+    private fun capture(bytes: ByteArray, totalBytes: Long, reachedEof: Boolean = true): RawResponseBodyCapture =
+        RawResponseBodyCapture(bytes = bytes, totalBytes = totalBytes, reachedEof = reachedEof)
+
+    private fun request(id: String): RequestWillBeSent = RequestWillBeSent(
+        id = id,
+        tWallMs = 1L,
+        tMonoNs = 1L,
+        method = "GET",
+        url = "https://example.com/$id",
+        body = null,
+        bodyEncoding = null,
+        bodyTruncatedBytes = null,
+        bodySize = null,
+    )
+
+    private fun await(job: Job?) {
+        runBlocking { checkNotNull(job).join() }
+    }
+
+    private class RecordingSink(failResponseUpdate: Boolean = false) {
+        val operations = mutableListOf<String>()
+        val records = mutableListOf<NetworkEventRecord>()
+        val value = CaptureEventSink(
+            publish = {
+                records += it
+                operations += "publish:${it.javaClass.simpleName}"
+            },
+            updateRequestBody = { id, body, encoding, truncated, size ->
+                operations += "request:$id:$body:$encoding:$truncated:$size"
+            },
+            updateResponseBody = { id, preview, body, encoding, truncated, size ->
+                check(!failResponseUpdate) { "response update failed" }
+                operations += "response:$id:$preview:$body:$encoding:$truncated:$size"
+            },
+        )
+    }
+}

--- a/snapo-link-android/network/src/test/java/com/openai/snapo/network/capture/SseStreamCaptureTest.kt
+++ b/snapo-link-android/network/src/test/java/com/openai/snapo/network/capture/SseStreamCaptureTest.kt
@@ -145,6 +145,24 @@ class SseStreamCaptureTest {
         assertEquals("\uFFFD", events[1].raw)
     }
 
+    @Test(timeout = 10_000)
+    fun `large event remains incremental when read one byte at a time`() {
+        val records = mutableListOf<NetworkEventRecord>()
+        val capture = capture(records)
+        val event = "data: " + "x".repeat(512 * 1_024)
+        val bytes = "$event\n\n".encodeToByteArray()
+
+        for (index in bytes.indices) {
+            capture.append(bytes, offset = index, length = 1)
+        }
+        capture.complete()
+
+        assertEquals(event, records.filterIsInstance<ResponseStreamEvent>().single().raw)
+        val closed = records.filterIsInstance<ResponseStreamClosed>().single()
+        assertEquals(1L, closed.totalEvents)
+        assertEquals(bytes.size.toLong(), closed.totalBytes)
+    }
+
     private fun capture(records: MutableList<NetworkEventRecord>): SseStreamCapture {
         return capture(records::add)
     }

--- a/snapo-link-android/network/src/test/java/com/openai/snapo/network/capture/SseStreamCaptureTest.kt
+++ b/snapo-link-android/network/src/test/java/com/openai/snapo/network/capture/SseStreamCaptureTest.kt
@@ -1,0 +1,163 @@
+package com.openai.snapo.network.capture
+
+import com.openai.snapo.network.NetworkEventRecord
+import com.openai.snapo.network.ResponseStreamClosed
+import com.openai.snapo.network.ResponseStreamEvent
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import java.io.IOException
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.TimeUnit
+import java.util.concurrent.atomic.AtomicBoolean
+
+class SseStreamCaptureTest {
+
+    @Test
+    fun `events remain framed when utf8 and crlf boundaries split across reads`() {
+        val records = mutableListOf<NetworkEventRecord>()
+        val capture = capture(records)
+        val bytes = "data: 😀\r\n\r\ndata: second\n\n".encodeToByteArray()
+
+        bytes.forEach { byte -> capture.append(byteArrayOf(byte)) }
+        capture.complete()
+
+        assertEquals(
+            listOf("data: 😀", "data: second"),
+            records.filterIsInstance<ResponseStreamEvent>().map(ResponseStreamEvent::raw),
+        )
+        assertEquals(
+            listOf(1L, 2L),
+            records.filterIsInstance<ResponseStreamEvent>().map(ResponseStreamEvent::sequence),
+        )
+        val closed = records.filterIsInstance<ResponseStreamClosed>().single()
+        assertEquals(2L, closed.totalEvents)
+        assertEquals(bytes.size.toLong(), closed.totalBytes)
+    }
+
+    @Test
+    fun `complete flushes tail before one close record`() {
+        val records = mutableListOf<NetworkEventRecord>()
+        val capture = capture(records)
+
+        capture.append("data: tail".encodeToByteArray())
+        capture.complete()
+        capture.complete(IOException("ignored"))
+        capture.append("\n\n".encodeToByteArray())
+
+        assertTrue(records[0] is ResponseStreamEvent)
+        assertEquals("data: tail", (records[0] as ResponseStreamEvent).raw)
+        val closed = records[1] as ResponseStreamClosed
+        assertEquals("completed", closed.reason)
+        assertEquals(1L, closed.totalEvents)
+        assertEquals("data: tail".encodeToByteArray().size.toLong(), closed.totalBytes)
+        assertEquals(2, records.size)
+    }
+
+    @Test
+    fun `append honors byte ranges and error details`() {
+        val records = mutableListOf<NetworkEventRecord>()
+        val capture = capture(records)
+        val source = "ignoreddata: kept\n\nignored".encodeToByteArray()
+        val selected = "data: kept\n\n".encodeToByteArray()
+
+        capture.append(source, offset = "ignored".length, length = selected.size)
+        capture.complete(IOException("stream failed"))
+
+        assertEquals("data: kept", records.filterIsInstance<ResponseStreamEvent>().single().raw)
+        val closed = records.filterIsInstance<ResponseStreamClosed>().single()
+        assertEquals("error", closed.reason)
+        assertEquals("stream failed", closed.message)
+        assertEquals(selected.size.toLong(), closed.totalBytes)
+    }
+
+    @Test
+    fun `empty stream emits only a close record`() {
+        val records = mutableListOf<NetworkEventRecord>()
+
+        capture(records).complete()
+
+        val closed = records.single() as ResponseStreamClosed
+        assertEquals(0L, closed.totalEvents)
+        assertEquals(0L, closed.totalBytes)
+    }
+
+    @Test
+    fun `observer failures are isolated and later records are still delivered`() {
+        val records = mutableListOf<NetworkEventRecord>()
+        var callbackCount = 0
+        val capture = capture { record ->
+            callbackCount += 1
+            if (callbackCount == 1) error("observer failed")
+            records += record
+        }
+
+        capture.append("data: first\n\ndata: second\n\n".encodeToByteArray())
+        capture.complete()
+
+        assertEquals("data: second", records.filterIsInstance<ResponseStreamEvent>().single().raw)
+        assertEquals(2L, records.filterIsInstance<ResponseStreamClosed>().single().totalEvents)
+    }
+
+    @Test
+    fun `concurrent close is delivered after an in-flight event`() {
+        val records = mutableListOf<NetworkEventRecord>()
+        val eventEntered = CountDownLatch(1)
+        val releaseEvent = CountDownLatch(1)
+        val eventReleased = AtomicBoolean(false)
+        val capture = capture { record ->
+            if (record is ResponseStreamEvent) {
+                eventEntered.countDown()
+                eventReleased.set(releaseEvent.await(5, TimeUnit.SECONDS))
+            }
+            records += record
+        }
+        val appendThread = Thread {
+            capture.append("data: event\n\n".encodeToByteArray())
+        }
+        val closeThread = Thread(capture::complete)
+
+        appendThread.start()
+        assertTrue(eventEntered.await(5, TimeUnit.SECONDS))
+        closeThread.start()
+        releaseEvent.countDown()
+        appendThread.join()
+        closeThread.join()
+
+        assertTrue(eventReleased.get())
+        assertTrue(records[0] is ResponseStreamEvent)
+        assertTrue(records[1] is ResponseStreamClosed)
+    }
+
+    @Test
+    fun `decoder handles output buffers and incomplete final characters`() {
+        val records = mutableListOf<NetworkEventRecord>()
+        val capture = capture(records)
+        val longEvent = "data: " + "x".repeat(2_048)
+        val incompleteUtf8 = byteArrayOf(0xF0.toByte(), 0x9F.toByte())
+
+        capture.append("$longEvent\n\n".encodeToByteArray())
+        capture.append(incompleteUtf8)
+        capture.complete()
+
+        val events = records.filterIsInstance<ResponseStreamEvent>()
+        assertEquals(longEvent, events[0].raw)
+        assertEquals("\uFFFD", events[1].raw)
+    }
+
+    private fun capture(records: MutableList<NetworkEventRecord>): SseStreamCapture {
+        return capture(records::add)
+    }
+
+    private fun capture(onRecord: (NetworkEventRecord) -> Unit): SseStreamCapture {
+        var wallTime = 100L
+        var monotonicTime = 200L
+        return SseStreamCapture(
+            requestId = "request",
+            charset = Charsets.UTF_8,
+            onRecord = onRecord,
+            wallTimeMillis = { wallTime++ },
+            monotonicNanos = { monotonicTime++ },
+        )
+    }
+}

--- a/snapo-link-android/samples/demo-okhttp/src/main/java/com/openai/snapo/demo/MainActivity.kt
+++ b/snapo-link-android/samples/demo-okhttp/src/main/java/com/openai/snapo/demo/MainActivity.kt
@@ -75,6 +75,7 @@ class MainActivity : ComponentActivity() {
                         onImageResponseClick = { runImageResponseRequest(scope) },
                         onCompleteLargeResponseClick = { runLargeResponseRequest(scope, complete = true) },
                         onTruncatedLargeResponseClick = { runLargeResponseRequest(scope, complete = false) },
+                        onSseResponseClick = { runSseResponseRequest(scope) },
                         onSlowResponseClick = { runSlowResponseRequest(scope) },
                         onWebSocketDemoClick = { startWebSocketDemo(scope) },
                         modifier = Modifier.padding(innerPadding)
@@ -174,6 +175,18 @@ class MainActivity : ComponentActivity() {
         }
     }
 
+    private fun runSseResponseRequest(scope: CoroutineScope) {
+        scope.launch {
+            val url = resolveMockHttpUrl("/sse") ?: return@launch
+            val request = Request.Builder()
+                .url(url)
+                .header("Accept", "text/event-stream")
+                .header("X-SnapO-Demo", "okhttp-sse")
+                .build()
+            executeRequest(scope, request)
+        }
+    }
+
     private fun runLargeResponseRequest(scope: CoroutineScope, complete: Boolean) {
         scope.launch {
             val path = if (complete) "/large-response-complete" else "/large-response-truncated"
@@ -264,6 +277,7 @@ private fun gzip(bytes: ByteArray): ByteArray {
     return output.toByteArray()
 }
 
+@Suppress("LongParameterList")
 @Composable
 fun Greeting(
     onNetworkRequestClick: () -> Unit,
@@ -273,6 +287,7 @@ fun Greeting(
     onImageResponseClick: () -> Unit,
     onCompleteLargeResponseClick: () -> Unit,
     onTruncatedLargeResponseClick: () -> Unit,
+    onSseResponseClick: () -> Unit,
     onSlowResponseClick: () -> Unit,
     onWebSocketDemoClick: () -> Unit,
     modifier: Modifier = Modifier,
@@ -304,6 +319,9 @@ fun Greeting(
         Button(onClick = onTruncatedLargeResponseClick) {
             Text("GET 9 MB JSON (truncated)")
         }
+        Button(onClick = onSseResponseClick) {
+            Text("GET SSE stream")
+        }
         Button(onClick = onSlowResponseClick) {
             Text("Slow response")
         }
@@ -325,6 +343,7 @@ private fun GreetingPreview() {
             onImageResponseClick = {},
             onCompleteLargeResponseClick = {},
             onTruncatedLargeResponseClick = {},
+            onSseResponseClick = {},
             onSlowResponseClick = {},
             onWebSocketDemoClick = {},
         )

--- a/snapo-link-android/samples/demo-shared/src/main/java/com/openai/snapo/demo/shared/DemoMockServer.kt
+++ b/snapo-link-android/samples/demo-shared/src/main/java/com/openai/snapo/demo/shared/DemoMockServer.kt
@@ -44,6 +44,13 @@ private fun createServer(): MockWebServer {
     val imageBody = checkNotNull(DemoAppIconPng.decodeBase64())
     val formBody = """{"ok":true,"endpoint":"form-post","source":"mockwebserver"}"""
     val slowBody = """{"message":"${"x".repeat(SlowBodyPayloadCharacters)}","source":"okhttp-demo"}"""
+    val sseBody = """
+        data: {"step":1,"message":"Starting"}
+
+        data: {"step":2,"message":"Streaming"}
+
+        data: {"step":3,"message":"Complete"}
+    """.trimIndent() + "\n\n"
     return MockWebServer().apply {
         dispatcher = object : Dispatcher() {
             override fun dispatch(request: RecordedRequest): MockResponse {
@@ -87,6 +94,7 @@ private fun createServer(): MockWebServer {
                     "/large-response-complete" -> largeJsonResponse(CompleteLargeBodyBytes)
                     "/large-response-truncated" -> largeJsonResponse(TruncatedLargeBodyBytes)
                     "/slow-response" -> slowResponse(slowBody)
+                    "/sse" -> sseResponse(sseBody)
                     "/ws-echo" -> MockResponse.Builder()
                         .webSocketUpgrade(
                             object : WebSocketListener() {
@@ -143,6 +151,18 @@ private fun slowResponse(body: String): MockResponse = MockResponse.Builder()
     )
     .build()
 
+private fun sseResponse(body: String): MockResponse = MockResponse.Builder()
+    .code(200)
+    .setHeader("Content-Type", "text/event-stream; charset=utf-8")
+    .setHeader("Connection", "close")
+    .body(body)
+    .throttleBody(
+        bytesPerPeriod = SseChunkBytes,
+        period = SseChunkDelayMs,
+        unit = TimeUnit.MILLISECONDS,
+    )
+    .build()
+
 fun String.toWebSocketUrl(): String {
     return when {
         startsWith("http://") -> "ws://${removePrefix("http://")}"
@@ -159,6 +179,8 @@ private const val SlowBodyPayloadCharacters: Int = 1024 * 1024
 private const val SlowBodyInitialDelayMs: Long = 2_000L
 private const val SlowBodyChunkBytes: Long = 128L * 1024L
 private const val SlowBodyChunkDelayMs: Long = 250L
+private const val SseChunkBytes: Long = 32L
+private const val SseChunkDelayMs: Long = 350L
 
 private val DemoAppIconPng: String = """
     iVBORw0KGgoAAAANSUhEUgAAAIAAAACACAMAAAD04JH5AAAAAXNSR0IArs4c6QAAAARnQU1BAACxjwv8YQUAAAHsUExURUdwTJDci5/jm1vOVDnJMTfHLjvI


### PR DESCRIPTION
## Summary

- share body classification, capture limits, response formatting, SSE decoding, and ordered event publication between the OkHttp and HttpURLConnection integrations while keeping client-specific stream and lifecycle handling local
- consolidate behavior-focused tests around the shared capture core and preserve adapter coverage for stream behavior and failures
- add a finite, throttled SSE example to the OkHttp sample so incremental EventSource capture can be exercised on an emulator

## Why

The two Android integrations had duplicated capture policy and publication logic that could drift independently. This keeps the common behavior in one place without forcing unlike client lifecycles into a shared abstraction, and adds a practical way to validate the streaming path.

## Validation

- 67 Android capture tests passed with zero failures/errors
- detekt passed for the shared network modules and updated samples
- Android lint passed for the OkHttp sample
- release builds passed for all network libraries and all three samples
- API 36 emulator validation passed for OkHttp, HttpURLConnection, and Ktor/OkHttp, including request/response bodies, multipart, WebSocket, large-body truncation, and a live SSE stream
- live SSE emitted three ordered `Network.eventSourceMessageReceived` events about 350 ms apart followed by `Network.loadingFinished`; `Network.getResponseBody` reconstructed the exact stream