### PR TITLE
Document direct Snap-O CLI downloads

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,18 +165,15 @@ Start a new Codex session after installing or updating the plugin.
 
 ## Linux Support
 
-You can inspect network requests from Snap-O on a Linux machine by using the `snapo` Python CLI tool:
-
-https://github.com/openai/snap-o/releases/latest/download/snapo
-
-This CLI tool is also shipped as part of the macOS app at `Snap-O.app/Contents/MacOS/snapo`.
-
-The dependency-free script is also available at `skills/snap-o-network-inspector/scripts/snapo`. Install Python 3 and Android Platform Tools, then put it on `PATH`:
+You can inspect network requests from Snap-O on a Linux machine by using the dependency-free `snapo` Python CLI tool. Install Python 3 and Android Platform Tools, then download the script from the `main` branch and put it on `PATH`:
 
 ```bash
 mkdir -p ~/.local/bin
-install -m 0755 skills/snap-o-network-inspector/scripts/snapo ~/.local/bin/snapo
+curl -fsSL https://raw.githubusercontent.com/openai/snap-o/main/skills/snap-o-network-inspector/scripts/snapo -o ~/.local/bin/snapo
+chmod +x ~/.local/bin/snapo
 ```
+
+The CLI is also shipped as part of the macOS app at `Snap-O.app/Contents/MacOS/snapo`.
 
 The script supports `snapo network list`, `requests`, and `show`. It resolves `adb` from `PATH`, `ANDROID_SDK_ROOT`, or `ANDROID_HOME`; use `--adb <path>` or `SNAPO_ADB` to select a specific ADB executable or wrapper. By default, server selection is left to the configured ADB command, which normally connects to `127.0.0.1:5037`. Pass `--adb-host <host> --adb-port <port>` to use an explicit remote ADB server.
 

--- a/README.md
+++ b/README.md
@@ -173,7 +173,7 @@ curl -fsSL https://raw.githubusercontent.com/openai/snap-o/main/skills/snap-o-ne
 chmod +x ~/.local/bin/snapo
 ```
 
-The CLI is also shipped as part of the macOS app at `Snap-O.app/Contents/MacOS/snapo`.
+This is the same CLI shipped as part of the macOS app at `Snap-O.app/Contents/MacOS/snapo`.
 
 The script supports `snapo network list`, `requests`, and `show`. It resolves `adb` from `PATH`, `ANDROID_SDK_ROOT`, or `ANDROID_HOME`; use `--adb <path>` or `SNAPO_ADB` to select a specific ADB executable or wrapper. By default, server selection is left to the configured ADB command, which normally connects to `127.0.0.1:5037`. Pass `--adb-host <host> --adb-port <port>` to use an explicit remote ADB server.
 


### PR DESCRIPTION
## Summary

- Download the standalone Snap-O network CLI directly from the repository's `main` branch.
- Remove the dependency on a separately published GitHub release asset.
- Keep the CLI bundled in both the Codex skill and `Snap-O.app/Contents/MacOS/snapo`.

## Validation

- `python3 -m unittest discover -s tests/snapo_cli -p 'test_*.py' -v` (37 tests passed)
- `xcodebuild -project Snap-O.xcodeproj -scheme Snap-O -derivedDataPath /private/tmp/snap-o-codex-readme-build CODE_SIGNING_ALLOWED=NO CODE_SIGNING_REQUIRED=NO build -quiet`
- Verified the built app's embedded `snapo` executable matches the skill's script.