### PR TITLE
Add Snap-O Tweaks for live Compose values

### DIFF
--- a/contracts/tweaks/README.md
+++ b/contracts/tweaks/README.md
@@ -1,0 +1,382 @@
+# Snap-O Tweaks protocol
+
+Status: phase one. The network inspector protocol is unchanged.
+
+Snap-O Tweaks exposes adjustable values from the currently composed Android UI
+through a debug-only app-local socket. Agents and desktop tools can use HTTP to
+inspect those values and change them while the app runs.
+
+## Transport
+
+Android listens on:
+
+```text
+snapo_tweaks_<pid>
+```
+
+Discover and forward the socket:
+
+```bash
+adb -s emulator-5554 shell cat /proc/net/unix
+adb -s emulator-5554 forward tcp:0 localabstract:snapo_tweaks_12345
+```
+
+ADB prints the assigned localhost port:
+
+```bash
+curl -fsS http://127.0.0.1:43817/tweaks
+```
+
+Implement HTTP with Android `LocalServerSocket`, standard streams, and Android
+`JsonReader`/`JsonWriter`. Use one request per connection, JSON for app and
+tweak responses, PNG for `/app/icon`, `Content-Length`, bounded request
+sizes, a read timeout, and `Connection: close`. No server dependency, Android
+TCP port, or `INTERNET` permission is needed.
+
+## REST API
+
+### GET /app
+
+Return exactly the app's user-facing Android label and package name:
+
+```json
+{
+  "name": "Snap-O Tweaks Demo",
+  "packageName": "com.openai.snapo.demo.tweaks"
+}
+```
+
+Resolve `name` from the actual Android app label.
+
+### GET /app/icon
+
+Lazily return the app icon as a 96 × 96 PNG with `Content-Type: image/png`.
+Return `404` when the icon is unavailable.
+
+### GET /tweaks
+
+Return a flat list of currently registered tweaks:
+
+```json
+{
+  "tweaks": [
+    {
+      "name": "Font size",
+      "type": "int",
+      "default": 36,
+      "value": 36,
+      "min": 16,
+      "max": 72,
+      "step": 1
+    },
+    {
+      "name": "Font weight",
+      "type": "int",
+      "default": 600,
+      "value": 600,
+      "min": 100,
+      "max": 900,
+      "step": 100
+    },
+    {
+      "name": "Text color",
+      "type": "color",
+      "default": "#18212F",
+      "value": "#18212F"
+    },
+    {
+      "name": "Background color",
+      "type": "color",
+      "default": "#F7F8FA",
+      "value": "#F7F8FA"
+    },
+    {
+      "name": "Accent color",
+      "type": "color",
+      "default": "#5468FF",
+      "value": "#5468FF"
+    },
+    {
+      "name": "Animation duration",
+      "type": "int",
+      "default": 400,
+      "value": 400,
+      "min": 100,
+      "max": 1500,
+      "step": 50
+    },
+    {
+      "name": "Spring stiffness",
+      "type": "float",
+      "default": 280.0,
+      "value": 280.0,
+      "min": 80.0,
+      "max": 800.0,
+      "step": 20.0
+    },
+    {
+      "name": "Spring damping",
+      "type": "float",
+      "default": 0.7,
+      "value": 0.7,
+      "min": 0.1,
+      "max": 1.0,
+      "step": 0.05
+    },
+    {
+      "name": "Use spring",
+      "type": "boolean",
+      "default": true,
+      "value": true
+    },
+    {
+      "name": "Preview text",
+      "type": "string",
+      "default": "Make it feel right.",
+      "value": "Make it feel right."
+    }
+  ]
+}
+```
+
+A tweak name represents one shared value, not one composable. Multiple active
+composables may register the same name; the tweak appears only once, and an
+update changes the value observed by every usage. A tweak remains registered
+until its last usage leaves composition.
+
+Usages with the same name must agree on the tweak type, default, and
+constraints. Conflicting declarations are a configuration error.
+
+Supported types are `int`, `float`, `boolean`, `color`, and `string`. Integer
+tweaks accept only whole numbers; float tweaks accept whole or fractional
+numbers. Numeric tweaks may include `min`, `max`, and `step`. Only include
+constraints actually supplied by the app. A `step` is relative to `min`, or to
+`default` if no `min` is supplied. Colors use `#RRGGBB`, or `#RRGGBBAA` when
+translucent.
+
+Numeric JSON values may contain at most 128 characters and 64 significant
+digits, with a decimal scale between -64 and 64. Reject values outside those
+limits with `422` before changing any tweaks.
+
+### PATCH /tweaks
+
+```bash
+curl -fsS -X PATCH http://127.0.0.1:43817/tweaks \
+  -H 'Content-Type: application/json' \
+  -d '{
+    "values": {
+      "Font size": 48,
+      "Font weight": 700,
+      "Accent color": "#3B82F6",
+      "Animation duration": 550,
+      "Spring damping": 0.8,
+      "Use spring": false,
+      "Preview text": "A calmer direction."
+    }
+  }'
+```
+
+```json
+{
+  "tweaks": [
+    { "name": "Font size", "value": 48 },
+    { "name": "Font weight", "value": 700 },
+    { "name": "Accent color", "value": "#3B82F6" },
+    { "name": "Animation duration", "value": 550 },
+    { "name": "Spring damping", "value": 0.8 },
+    { "name": "Use spring", "value": false },
+    { "name": "Preview text", "value": "A calmer direction." }
+  ]
+}
+```
+
+Validate all values before changing any of them. Return `400` for malformed
+requests, `404` when an endpoint or requested tweak does not exist, `405`
+for an unsupported method, `413` for an oversized body, and `422` when a value
+has the wrong type or violates a constraint. Errors use a small JSON body:
+
+```json
+{
+  "error": "Unknown tweak: Font size"
+}
+```
+
+Apply changes on the Android main thread. If any value is invalid, do not update
+any tweaks in that request. Reset a value by patching it with its default.
+
+## Compose API
+
+```kotlin
+import com.openai.snapo.tweaks.tweakBoolean
+import com.openai.snapo.tweaks.tweakColor
+import com.openai.snapo.tweaks.tweakFloat
+import com.openai.snapo.tweaks.tweakInt
+import com.openai.snapo.tweaks.tweakString
+
+@Composable
+fun TweakSpecimen() {
+    val textColor = tweakColor(
+        name = "Text color",
+        default = Color(0xFF18212F),
+    )
+
+    val backgroundColor = tweakColor(
+        name = "Background color",
+        default = Color(0xFFF7F8FA),
+    )
+
+    val accentColor = tweakColor(
+        name = "Accent color",
+        default = Color(0xFF5468FF),
+    )
+
+    MaterialTheme(
+        colorScheme = lightColorScheme(
+            primary = accentColor,
+            background = backgroundColor,
+            onBackground = textColor,
+            surface = backgroundColor,
+            onSurface = textColor,
+        ),
+    ) {
+        TypographySpecimen()
+        MotionSpecimen()
+    }
+}
+
+@Composable
+fun TypographySpecimen() {
+    val fontSize = tweakInt(
+        name = "Font size",
+        default = 36,
+        min = 16,
+        max = 72,
+        step = 1,
+    )
+
+    val fontWeight = tweakInt(
+        name = "Font weight",
+        default = 600,
+        min = 100,
+        max = 900,
+        step = 100,
+    )
+
+    Text(
+        text = tweakString("Preview text", "Make it feel right."),
+        fontSize = fontSize.sp,
+        fontWeight = FontWeight(fontWeight),
+        color = MaterialTheme.colorScheme.onSurface,
+    )
+
+    SpecimenAccessory()
+}
+
+@Composable
+fun SpecimenAccessory() {
+    val fontSize = tweakInt("Font size", 36, min = 16, max = 72, step = 1)
+
+    Text(text = "$fontSize sp")
+}
+
+@Composable
+fun MotionSpecimen() {
+    val durationMillis = tweakInt(
+        name = "Animation duration",
+        default = 400,
+        min = 100,
+        max = 1_500,
+        step = 50,
+    )
+
+    val springStiffness = tweakFloat(
+        name = "Spring stiffness",
+        default = 280f,
+        min = 80f,
+        max = 800f,
+        step = 20f,
+    )
+
+    val springDamping = tweakFloat(
+        name = "Spring damping",
+        default = 0.7f,
+        min = 0.1f,
+        max = 1f,
+        step = 0.05f,
+    )
+
+    val useSpring = tweakBoolean(
+        name = "Use spring",
+        default = true,
+    )
+
+    val animationSpec = if (useSpring) {
+        spring<Float>(dampingRatio = springDamping, stiffness = springStiffness)
+    } else {
+        tween<Float>(durationMillis = durationMillis)
+    }
+
+    MotionContent(animationSpec)
+}
+```
+
+Read each tweak in the composable that uses it. Theme colors are intentionally
+read at the theme boundary; font, text, and animation changes recompose their
+respective leaf composables rather than the entire screen. Both typography
+composables read the same Font size state, so one host update changes both.
+When a value only affects layout or drawing, read its state in the corresponding
+layout or draw callback instead of composition.
+`DisposableEffect` registers each usage and removes the tweak only after its
+final usage leaves composition. Screen navigation therefore determines what
+appears in the response.
+
+Provide `tweakInt`, `tweakFloat`, `tweakColor`, `tweakBoolean`, and
+`tweakString`. Numeric tweaks accept optional `min`, `max`, and `step` values
+of the same type. Convert integer values into Compose units at the call site,
+such as `tweakInt("Font size", 36).sp`. The real and no-op artifacts expose the
+same package and public Compose API.
+
+## Setup
+
+```kotlin
+dependencies {
+    debugImplementation(project(":tweaks"))
+    releaseImplementation(project(":tweaks-noop"))
+}
+```
+
+```text
+:tweaks              Compose API, debug registry, HTTP, and abstract socket.
+:tweaks-noop         Matching Compose API that returns default values.
+:samples:demo-tweaks Standalone Compose sample with no network integration.
+```
+
+Install the standalone debug sample on a connected Android device:
+
+```bash
+./gradlew :samples:demo-tweaks:installDebug
+```
+
+From the repository root, start the sample's optional host-side tweak panel:
+
+```bash
+node snapo-link-android/samples/demo-tweaks/panel/server.mjs
+```
+
+Open `http://127.0.0.1:4175`. The dependency-free panel discovers connected
+devices and live tweak sockets, creates its own ADB forward, displays the app
+icon and tweaks, and reconnects when the app process changes. It is a model-built
+demo, not a required setup step or the expected way to use Snap-O Tweaks. Any
+agent or host can use the same endpoints to create its own UI. See the sample
+panel's README for device and package selection.
+
+A non-exported `ContentProvider` in the debug artifact starts the runtime only
+when `ApplicationInfo.FLAG_DEBUGGABLE` is set. The release artifact returns
+default values, contains no provider, and starts no server. Sample release
+builds enable R8, so unused no-op calls and their tweak-name strings can be
+removed. Verify the release APK contains neither tweak-name strings nor the
+debug provider, registry, server, or socket.
+
+Phase one requires no Ktor, OkHttp, extra JSON library, Snap-O Mac UI, network
+protocol change, actions, streaming, groups, scopes, units, separate tweak
+IDs, or revisions.

--- a/snapo-link-android/build-logic/src/main/kotlin/com/openai/snapo/buildlogic/android/AndroidApplicationConventionPlugin.kt
+++ b/snapo-link-android/build-logic/src/main/kotlin/com/openai/snapo/buildlogic/android/AndroidApplicationConventionPlugin.kt
@@ -22,9 +22,9 @@ class AndroidApplicationConventionPlugin : Plugin<Project> {
 
             buildTypes {
                 maybeCreate("release").apply {
-                    // Keep release builds lightweight for samples without extra optimization steps.
-                    isMinifyEnabled = false
+                    isMinifyEnabled = true
                     isShrinkResources = false
+                    proguardFiles(getDefaultProguardFile("proguard-android-optimize.txt"))
                 }
             }
 

--- a/snapo-link-android/samples/demo-tweaks/build.gradle.kts
+++ b/snapo-link-android/samples/demo-tweaks/build.gradle.kts
@@ -1,0 +1,32 @@
+plugins {
+    id("snapo.android.application")
+    id("snapo.detekt")
+    alias(libs.plugins.kotlin.compose)
+}
+
+android {
+    namespace = "com.openai.snapo.demo.tweaks"
+
+    defaultConfig {
+        applicationId = "com.openai.snapo.demo.tweaks"
+        versionCode = 1
+        versionName = "1.0"
+    }
+
+    buildFeatures {
+        compose = true
+    }
+}
+
+dependencies {
+    implementation(libs.androidx.activity.compose)
+
+    implementation(platform(libs.androidx.compose.bom))
+    implementation(libs.androidx.compose.foundation)
+    implementation(libs.androidx.compose.ui)
+    implementation(libs.androidx.compose.ui.graphics)
+    implementation(libs.androidx.compose.material3)
+
+    debugImplementation(project(":tweaks"))
+    releaseImplementation(project(":tweaks-noop"))
+}

--- a/snapo-link-android/samples/demo-tweaks/panel/README.md
+++ b/snapo-link-android/samples/demo-tweaks/panel/README.md
@@ -1,0 +1,114 @@
+# Snap-O Tweaks panel demo
+
+A model built this panel as one way to see and change live app values.
+The app must use Snap-O Tweaks.
+
+This is only a demo, not part of the feature. It is not the expected way to use
+Snap-O Tweaks. You do not need this panel. Any tool can use `/app` and
+`/tweaks` to build its own UI.
+
+## What you need
+
+- `Node.js 22.12+`.
+- `Android Platform Tools` (`adb`).
+- An Android device or emulator with `USB debugging` on.
+- A debug app with Snap-O Tweaks.
+
+## Run the Android app
+
+From `snapo-link-android`, run:
+
+```bash
+./gradlew :samples:demo-tweaks:installDebug
+```
+
+Open **Snap-O Tweaks Demo** on your device.
+
+## Run the tweaks panel
+
+From the root of this project, run:
+
+```bash
+node snapo-link-android/samples/demo-tweaks/panel/server.mjs
+```
+
+Or run:
+
+```bash
+cd snapo-link-android/samples/demo-tweaks/panel
+npm start
+```
+
+Open `http://127.0.0.1:4175`.
+
+There is no install or build step. The panel will set up its own `adb` port
+forward.
+
+## How it can find an app
+
+To find an app, the panel will:
+
+1. List each device that `adb` can use.
+2. Put a real device before an emulator.
+3. Start with the last real device.
+4. Find a live app by its `snapo_tweaks_<pid>` name.
+5. Use or make an `adb` port forward.
+6. Use `/app` to find the app name.
+
+The panel can connect to any Snap-O Tweaks app. It does not depend on one app
+or process. If the app starts again, the next request will find it.
+
+The panel can only show values from the current screen. After a screen change,
+use **Refresh** to load the new values.
+
+## Use a different device or app
+
+To choose a device:
+
+```bash
+npm start -- --serial YOUR_DEVICE_SERIAL
+```
+
+To choose an app:
+
+```bash
+npm start -- --package com.openai.snapo.demo.tweaks
+```
+
+You can use both at once:
+
+```bash
+npm start -- --serial YOUR_DEVICE_SERIAL \
+  --package com.openai.snapo.demo.tweaks
+```
+
+To use a local endpoint:
+
+```bash
+npm start -- --target http://127.0.0.1:43817
+```
+
+A target set this way will not follow an app that starts again. To use a
+different port:
+
+```bash
+npm start -- --port 4176
+```
+
+## Change a live value
+
+Move a slider or choose a color. The app will change at once. The panel will
+wait for each request before it can send the next value. You can set one value
+or all values back.
+
+## Test the panel
+
+```bash
+npm test
+```
+
+Or run:
+
+```bash
+node --test
+```

--- a/snapo-link-android/samples/demo-tweaks/panel/app.js
+++ b/snapo-link-android/samples/demo-tweaks/panel/app.js
@@ -1,0 +1,429 @@
+const state = {
+  tweaks: [],
+  rows: new Map(),
+  pending: new Map(),
+  timer: undefined,
+  saving: false,
+};
+
+const elements = {
+  appName: document.querySelector("#app-name"),
+  packageName: document.querySelector("#package-name"),
+  status: document.querySelector("#connection-status"),
+  statusText: document.querySelector("#status-text"),
+  error: document.querySelector("#error-message"),
+  reset: document.querySelector("#reset-button"),
+  refresh: document.querySelector("#refresh-button"),
+};
+
+function node(tag, className, text) {
+  const element = document.createElement(tag);
+  if (className) element.className = className;
+  if (text !== undefined) element.textContent = text;
+  return element;
+}
+
+function setStatus(value, label = value) {
+  elements.status.dataset.state = value;
+  elements.status.setAttribute("aria-label", label);
+  elements.status.setAttribute("title", label);
+  elements.statusText.textContent = label;
+}
+
+function setError(message) {
+  elements.error.hidden = !message;
+  elements.error.textContent = message ?? "";
+}
+
+async function request(path, options) {
+  const response = await fetch(path, {
+    cache: "no-store",
+    ...options,
+  });
+  const payload = await response.json();
+
+  if (!response.ok) {
+    throw new Error(payload.error ?? `Request failed (${response.status}).`);
+  }
+
+  return payload;
+}
+
+function updateResetButton() {
+  elements.reset.disabled =
+    state.saving ||
+    state.tweaks.length === 0 ||
+    state.tweaks.every((tweak) => tweak.value === tweak.default);
+}
+
+function updateTweakRow(tweak) {
+  const fields = state.rows.get(tweak.name);
+  if (!fields) return;
+
+  const changed = tweak.value !== tweak.default;
+  fields.row.dataset.changed = String(changed);
+  fields.reset.hidden = !changed;
+
+  if (fields.number) fields.number.value = numberText(tweak.value);
+  if (fields.slider) fields.slider.value = numberText(tweak.value);
+  if (fields.color) fields.color.value = tweak.value.slice(0, 7);
+  if (fields.hex) fields.hex.value = tweak.value;
+  if (fields.text) fields.text.value = tweak.value;
+  if (fields.checkbox) fields.checkbox.checked = tweak.value;
+}
+
+function applyAccent() {
+  const accent = state.tweaks.find(
+    (tweak) => tweak.name === "Accent color" && tweak.type === "color",
+  );
+
+  if (accent) {
+    document.documentElement.style.setProperty("--accent", accent.value);
+  }
+}
+
+function updateValue(tweak, value, delay = 75) {
+  tweak.value = value;
+  state.pending.set(tweak.name, value);
+  updateTweakRow(tweak);
+  updateResetButton();
+  applyAccent();
+  clearTimeout(state.timer);
+  state.timer = undefined;
+
+  if (state.saving) return;
+
+  if (delay === 0) {
+    void flushPending();
+    return;
+  }
+
+  state.timer = setTimeout(flushPending, delay);
+}
+
+async function flushPending() {
+  if (state.saving || state.pending.size === 0) return;
+
+  const values = Object.fromEntries(state.pending);
+  state.pending.clear();
+  state.saving = true;
+  setStatus("connected", "Saving…");
+  updateResetButton();
+
+  try {
+    const result = await request("/tweaks", {
+      method: "PATCH",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ values }),
+    });
+
+    for (const update of result.tweaks) {
+      const tweak = state.tweaks.find((item) => item.name === update.name);
+      if (tweak && !state.pending.has(update.name)) {
+        tweak.value = update.value;
+        updateTweakRow(tweak);
+      }
+    }
+
+    setError();
+    setStatus("connected", "Connected");
+  } catch (error) {
+    setError(error.message);
+    setStatus("error", "Update failed");
+    await reloadTweaks();
+  } finally {
+    state.saving = false;
+    updateResetButton();
+
+    if (state.pending.size > 0) {
+      clearTimeout(state.timer);
+      state.timer = undefined;
+      void flushPending();
+    }
+  }
+}
+
+function makeTweakLine(tweak) {
+  const line = node("div", "tweak-line");
+  const actions = node("div", "tweak-actions");
+  const reset = node("button", "tweak-reset", "Reset");
+  reset.type = "button";
+  reset.hidden = tweak.value === tweak.default;
+  reset.setAttribute("aria-label", `Reset ${tweak.name}`);
+  reset.addEventListener("click", () => {
+    updateValue(tweak, tweak.default, 0);
+  });
+
+  actions.append(reset);
+  line.append(node("span", "tweak-label", tweak.name), actions);
+  return { line, actions, reset };
+}
+
+function registerTweakRow(tweak, row, fields) {
+  state.rows.set(tweak.name, { row, ...fields });
+  updateTweakRow(tweak);
+  return row;
+}
+
+function numberText(value) {
+  return Number.parseFloat(Number(value).toFixed(6)).toString();
+}
+
+function makeNumberTweak(tweak) {
+  const row = node("div", "tweak-row");
+  const { line, actions, reset } = makeTweakLine(tweak);
+  const input = node("input", "number-input");
+  input.type = "number";
+  input.value = numberText(tweak.value);
+  input.setAttribute("aria-label", `${tweak.name} value`);
+
+  if (tweak.min !== undefined) input.min = numberText(tweak.min);
+  if (tweak.max !== undefined) input.max = numberText(tweak.max);
+  input.step = numberText(tweak.step ?? (tweak.type === "int" ? 1 : 0.01));
+
+  actions.append(input);
+  row.append(line);
+
+  let slider;
+  if (tweak.min !== undefined && tweak.max !== undefined) {
+    slider = node("input", "range-input");
+    slider.type = "range";
+    slider.min = numberText(tweak.min);
+    slider.max = numberText(tweak.max);
+    slider.step = input.step;
+    slider.value = numberText(tweak.value);
+    slider.setAttribute("aria-label", tweak.name);
+
+    slider.addEventListener("input", () => {
+      const value = Number(slider.value);
+      input.value = numberText(value);
+      input.setAttribute("aria-invalid", "false");
+      updateValue(tweak, value, 0);
+    });
+
+    const labels = node("div", "range-labels");
+    labels.append(
+      node("span", undefined, numberText(tweak.min)),
+      node("span", undefined, numberText(tweak.max)),
+    );
+    row.append(slider, labels);
+  }
+
+  input.addEventListener("input", () => {
+    const value = Number(input.value);
+    const valid =
+      input.value !== "" &&
+      input.validity.valid &&
+      Number.isFinite(value) &&
+      (tweak.type !== "int" || Number.isInteger(value));
+
+    input.setAttribute("aria-invalid", String(!valid));
+    if (!valid) return;
+
+    if (slider) slider.value = numberText(value);
+    updateValue(tweak, value);
+  });
+
+  return registerTweakRow(tweak, row, {
+    reset,
+    number: input,
+    slider,
+  });
+}
+
+function makeColorTweak(tweak) {
+  const row = node("div", "tweak-row");
+  const { line, actions, reset } = makeTweakLine(tweak);
+  const inputs = node("div", "color-inputs");
+
+  const picker = node("input", "color-input");
+  picker.type = "color";
+  picker.value = tweak.value.slice(0, 7);
+  picker.setAttribute("aria-label", `${tweak.name} color`);
+
+  const hex = node("input", "hex-input");
+  hex.type = "text";
+  hex.value = tweak.value;
+  hex.spellcheck = false;
+  hex.maxLength = 9;
+  hex.setAttribute("aria-label", `${tweak.name} hex`);
+
+  picker.addEventListener("input", () => {
+    const alpha = tweak.value.length === 9 ? tweak.value.slice(7) : "";
+    const value = `${picker.value.toUpperCase()}${alpha.toUpperCase()}`;
+    hex.value = value;
+    hex.setAttribute("aria-invalid", "false");
+    updateValue(tweak, value, 0);
+  });
+
+  hex.addEventListener("input", () => {
+    const valid = /^#[\da-f]{6}(?:[\da-f]{2})?$/i.test(hex.value);
+    hex.setAttribute("aria-invalid", String(!valid));
+    if (!valid) return;
+
+    const value = hex.value.toUpperCase();
+    picker.value = value.slice(0, 7);
+    updateValue(tweak, value);
+  });
+
+  inputs.append(picker, hex);
+  actions.append(inputs);
+  row.append(line);
+  return registerTweakRow(tweak, row, {
+    reset,
+    color: picker,
+    hex,
+  });
+}
+
+function makeBooleanTweak(tweak) {
+  const row = node("div", "tweak-row");
+  const { line, actions, reset } = makeTweakLine(tweak);
+  const input = node("input", "boolean-input");
+  input.type = "checkbox";
+  input.checked = tweak.value;
+  input.setAttribute("aria-label", tweak.name);
+  input.addEventListener("change", () => {
+    updateValue(tweak, input.checked, 0);
+  });
+
+  actions.append(input);
+  row.append(line);
+  return registerTweakRow(tweak, row, {
+    reset,
+    checkbox: input,
+  });
+}
+
+function makeStringTweak(tweak) {
+  const row = node("div", "tweak-row");
+  const { line, reset } = makeTweakLine(tweak);
+  const input = node("input", "string-input");
+  input.type = "text";
+  input.value = tweak.value;
+  input.setAttribute("aria-label", tweak.name);
+  input.addEventListener("input", () => {
+    updateValue(tweak, input.value, 130);
+  });
+
+  row.append(line, input);
+  return registerTweakRow(tweak, row, {
+    reset,
+    text: input,
+  });
+}
+
+function makeTweak(tweak) {
+  switch (tweak.type) {
+    case "int":
+    case "float":
+      return makeNumberTweak(tweak);
+    case "color":
+      return makeColorTweak(tweak);
+    case "boolean":
+      return makeBooleanTweak(tweak);
+    case "string":
+      return makeStringTweak(tweak);
+    default:
+      return null;
+  }
+}
+
+function sectionFor(tweak) {
+  if (/animation|duration|spring|damping|stiffness|motion/i.test(tweak.name)) {
+    return "motion";
+  }
+
+  if (/font|text|color|background|accent|preview/i.test(tweak.name)) {
+    return "appearance";
+  }
+
+  return "other";
+}
+
+function renderTweaks() {
+  state.rows.clear();
+
+  for (const name of ["appearance", "motion", "other"]) {
+    const section = document.querySelector(`#${name}-section`);
+    const list = document.querySelector(`#${name}-tweaks`);
+    const count = document.querySelector(`#${name}-count`);
+    const tweaks = state.tweaks.filter((tweak) => sectionFor(tweak) === name);
+
+    if (count) count.textContent = String(tweaks.length);
+    list.replaceChildren(
+      ...tweaks.map(makeTweak).filter((tweak) => tweak !== null),
+    );
+    section.hidden = list.childElementCount === 0;
+  }
+
+  applyAccent();
+  updateResetButton();
+}
+
+async function reloadTweaks() {
+  const result = await request("/tweaks");
+  state.tweaks = result.tweaks;
+  renderTweaks();
+}
+
+async function load() {
+  setStatus("connecting", "Connecting");
+
+  try {
+    const [app, result] = await Promise.all([
+      request("/app"),
+      request("/tweaks"),
+    ]);
+
+    elements.appName.textContent = app.name;
+    elements.packageName.textContent = app.packageName;
+    document.title = `${app.name} · Snap-O Tweaks`;
+    state.tweaks = result.tweaks;
+    renderTweaks();
+    setError();
+    setStatus("connected", "Connected");
+  } catch (error) {
+    setError(error.message);
+    setStatus("error", "Disconnected");
+  }
+}
+
+async function resetTweaks() {
+  clearTimeout(state.timer);
+  state.pending.clear();
+  state.saving = true;
+  setStatus("connected", "Resetting…");
+  updateResetButton();
+
+  try {
+    const values = Object.fromEntries(
+      state.tweaks.map((tweak) => [tweak.name, tweak.default]),
+    );
+
+    await request("/tweaks", {
+      method: "PATCH",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ values }),
+    });
+
+    await reloadTweaks();
+    setError();
+    setStatus("connected", "Connected");
+  } catch (error) {
+    setError(error.message);
+    setStatus("error", "Reset failed");
+  } finally {
+    state.saving = false;
+    updateResetButton();
+  }
+}
+
+elements.refresh.addEventListener("click", load);
+elements.reset.addEventListener("click", resetTweaks);
+
+document.querySelector(".app-icon").addEventListener("error", (event) => {
+  event.currentTarget.hidden = true;
+});
+
+load();

--- a/snapo-link-android/samples/demo-tweaks/panel/app.test.mjs
+++ b/snapo-link-android/samples/demo-tweaks/panel/app.test.mjs
@@ -1,0 +1,511 @@
+import assert from "node:assert/strict";
+import { setTimeout as delay } from "node:timers/promises";
+import { test } from "node:test";
+
+const descriptors = [
+  {
+    name: "Font size",
+    type: "int",
+    default: 36,
+    value: 36,
+    min: 16,
+    max: 72,
+    step: 1,
+  },
+  {
+    name: "Font weight",
+    type: "int",
+    default: 600,
+    value: 600,
+    min: 100,
+    max: 900,
+    step: 100,
+  },
+  {
+    name: "Text color",
+    type: "color",
+    default: "#18212F",
+    value: "#18212F",
+  },
+  {
+    name: "Background color",
+    type: "color",
+    default: "#F7F8FA",
+    value: "#F7F8FA",
+  },
+  {
+    name: "Accent color",
+    type: "color",
+    default: "#5468FF",
+    value: "#5468FF",
+  },
+  {
+    name: "Animation duration",
+    type: "int",
+    default: 400,
+    value: 400,
+    min: 100,
+    max: 1500,
+    step: 50,
+  },
+  {
+    name: "Spring stiffness",
+    type: "float",
+    default: 280,
+    value: 280,
+    min: 80,
+    max: 800,
+    step: 20,
+  },
+  {
+    name: "Spring damping",
+    type: "float",
+    default: 0.7,
+    value: 0.7,
+    min: 0.1,
+    max: 1,
+    step: 0.05,
+  },
+  {
+    name: "Use spring",
+    type: "boolean",
+    default: true,
+    value: true,
+  },
+  {
+    name: "Preview text",
+    type: "string",
+    default: "Make it feel right.",
+    value: "Make it feel right.",
+  },
+];
+
+class FakeElement {
+  constructor(tag = "div") {
+    this.tagName = tag.toUpperCase();
+    this.children = [];
+    this.dataset = {};
+    this.attributes = new Map();
+    this.listeners = new Map();
+    this.hidden = false;
+    this.disabled = false;
+    this.value = "";
+    this.checked = false;
+    this.textContent = "";
+  }
+
+  get childElementCount() {
+    return this.children.length;
+  }
+
+  get validity() {
+    const value = Number(this.value);
+
+    if (this.value === "" || !Number.isFinite(value)) {
+      return { valid: false };
+    }
+
+    if (this.min !== undefined && value < Number(this.min)) {
+      return { valid: false };
+    }
+
+    if (this.max !== undefined && value > Number(this.max)) {
+      return { valid: false };
+    }
+
+    if (this.step !== undefined && this.step !== "any") {
+      const minimum = this.min === undefined ? 0 : Number(this.min);
+      const position = (value - minimum) / Number(this.step);
+
+      if (Math.abs(position - Math.round(position)) > 1e-8) {
+        return { valid: false };
+      }
+    }
+
+    return { valid: true };
+  }
+
+  setAttribute(name, value) {
+    this.attributes.set(name, String(value));
+  }
+
+  getAttribute(name) {
+    return this.attributes.get(name) ?? null;
+  }
+
+  append(...elements) {
+    this.children.push(...elements);
+  }
+
+  replaceChildren(...elements) {
+    this.children = [...elements];
+  }
+
+  addEventListener(name, listener) {
+    const listeners = this.listeners.get(name) ?? [];
+    listeners.push(listener);
+    this.listeners.set(name, listeners);
+  }
+
+  async emit(name) {
+    for (const listener of this.listeners.get(name) ?? []) {
+      await listener({ currentTarget: this });
+    }
+  }
+}
+
+function findInput(element, label) {
+  if (element.getAttribute("aria-label") === label) return element;
+
+  for (const child of element.children) {
+    const result = findInput(child, label);
+    if (result) return result;
+  }
+
+  return null;
+}
+
+function makeDocument() {
+  const selectors = [
+    "#app-name",
+    "#package-name",
+    "#connection-status",
+    "#status-text",
+    "#error-message",
+    "#reset-button",
+    "#refresh-button",
+    "#appearance-section",
+    "#appearance-tweaks",
+    "#appearance-count",
+    "#motion-section",
+    "#motion-tweaks",
+    "#motion-count",
+    "#other-section",
+    "#other-tweaks",
+    "#other-count",
+    ".app-icon",
+  ];
+  const elements = new Map(
+    selectors.map((selector) => [selector, new FakeElement()]),
+  );
+  const properties = new Map();
+
+  return {
+    elements,
+    documentElement: {
+      style: {
+        setProperty(name, value) {
+          properties.set(name, value);
+        },
+      },
+    },
+    properties,
+    createElement(tag) {
+      return new FakeElement(tag);
+    },
+    querySelector(selector) {
+      return elements.get(selector) ?? null;
+    },
+  };
+}
+
+function jsonResponse(payload, status = 200) {
+  return {
+    ok: status >= 200 && status < 300,
+    status,
+    async json() {
+      return structuredClone(payload);
+    },
+  };
+}
+
+test("browser panel renders, streams, validates, and resets live tweaks", async () => {
+  const document = makeDocument();
+  const tweaks = structuredClone(descriptors);
+  const patches = [];
+  const originalDocument = globalThis.document;
+  const originalFetch = globalThis.fetch;
+
+  globalThis.document = document;
+  globalThis.fetch = async (pathname, options) => {
+    if (pathname === "/app") {
+      return jsonResponse({
+        name: "Snap-O Tweaks Demo",
+        packageName: "com.openai.snapo.demo.tweaks",
+      });
+    }
+
+    if (pathname === "/tweaks" && options?.method === "PATCH") {
+      const { values } = JSON.parse(options.body);
+      patches.push(values);
+
+      for (const tweak of tweaks) {
+        if (Object.hasOwn(values, tweak.name)) {
+          tweak.value = values[tweak.name];
+        }
+      }
+
+      return jsonResponse({
+        tweaks: Object.entries(values).map(([name, value]) => ({
+          name,
+          value,
+        })),
+      });
+    }
+
+    if (pathname === "/tweaks") {
+      return jsonResponse({ tweaks });
+    }
+
+    return jsonResponse({ error: "Not found." }, 404);
+  };
+
+  try {
+    await import(`./app.js?browser-test=${Date.now()}`);
+    await delay(0);
+
+    assert.equal(
+      document.querySelector("#app-name").textContent,
+      "Snap-O Tweaks Demo",
+    );
+    assert.equal(document.title, "Snap-O Tweaks Demo · Snap-O Tweaks");
+    assert.equal(
+      document.querySelector("#package-name").textContent,
+      "com.openai.snapo.demo.tweaks",
+    );
+    assert.equal(document.querySelector("#status-text").textContent, "Connected");
+    assert.equal(
+      document.querySelector("#connection-status").getAttribute("aria-label"),
+      "Connected",
+    );
+    assert.equal(document.querySelector("#appearance-section").hidden, false);
+    assert.equal(document.querySelector("#motion-section").hidden, false);
+    assert.equal(document.querySelector("#other-section").hidden, true);
+    assert.equal(
+      document.querySelector("#appearance-tweaks").childElementCount,
+      6,
+    );
+    assert.equal(document.querySelector("#motion-tweaks").childElementCount, 4);
+    assert.equal(document.querySelector("#appearance-count").textContent, "6");
+    assert.equal(document.querySelector("#motion-count").textContent, "4");
+    assert.equal(document.properties.get("--accent"), "#5468FF");
+    assert.equal(document.querySelector("#reset-button").disabled, true);
+
+    const appearance = document.querySelector("#appearance-tweaks");
+    const motion = document.querySelector("#motion-tweaks");
+
+    const fontSize = findInput(appearance, "Font size");
+    fontSize.value = "48";
+    await fontSize.emit("input");
+    assert.equal(findInput(appearance, "Font size value").value, "48");
+
+    const fontWeight = findInput(appearance, "Font weight value");
+    fontWeight.value = "700";
+    await fontWeight.emit("input");
+
+    const textColor = findInput(appearance, "Text color color");
+    textColor.value = "#102030";
+    await textColor.emit("input");
+
+    const background = findInput(appearance, "Background color hex");
+    background.value = "#f3f4f6";
+    await background.emit("input");
+
+    const accent = findInput(appearance, "Accent color color");
+    accent.value = "#3b82f6";
+    await accent.emit("input");
+
+    const duration = findInput(motion, "Animation duration");
+    duration.value = "550";
+    await duration.emit("input");
+
+    const stiffness = findInput(motion, "Spring stiffness");
+    stiffness.value = "400";
+    await stiffness.emit("input");
+
+    const damping = findInput(motion, "Spring damping value");
+    damping.value = "0.8";
+    await damping.emit("input");
+
+    const spring = findInput(motion, "Use spring");
+    spring.checked = false;
+    await spring.emit("change");
+
+    const preview = findInput(appearance, "Preview text");
+    preview.value = "A calmer direction.";
+    await preview.emit("input");
+
+    await delay(180);
+
+    assert.ok(patches.length > 0);
+    assert.deepEqual(Object.assign({}, ...patches), {
+      "Font size": 48,
+      "Font weight": 700,
+      "Text color": "#102030",
+      "Background color": "#F3F4F6",
+      "Accent color": "#3B82F6",
+      "Animation duration": 550,
+      "Spring stiffness": 400,
+      "Spring damping": 0.8,
+      "Use spring": false,
+      "Preview text": "A calmer direction.",
+    });
+    assert.equal(document.properties.get("--accent"), "#3B82F6");
+    assert.equal(document.querySelector("#reset-button").disabled, false);
+
+    const resetAccent = findInput(appearance, "Reset Accent color");
+    assert.equal(resetAccent.hidden, false);
+    await resetAccent.emit("click");
+    await delay(0);
+    assert.deepEqual(patches.at(-1), { "Accent color": "#5468FF" });
+    assert.equal(resetAccent.hidden, true);
+    assert.equal(document.properties.get("--accent"), "#5468FF");
+
+    const patchesBeforeInvalid = patches.length;
+    fontWeight.value = "701";
+    await fontWeight.emit("input");
+    assert.equal(fontWeight.getAttribute("aria-invalid"), "true");
+    await delay(100);
+    assert.equal(patches.length, patchesBeforeInvalid);
+
+    const patchesBeforeReset = patches.length;
+    await document.querySelector("#reset-button").emit("click");
+
+    assert.equal(patches.length, patchesBeforeReset + 1);
+    assert.deepEqual(
+      patches.at(-1),
+      Object.fromEntries(descriptors.map((tweak) => [tweak.name, tweak.default])),
+    );
+    assert.equal(document.querySelector("#reset-button").disabled, true);
+    assert.equal(document.properties.get("--accent"), "#5468FF");
+    assert.equal(document.querySelector("#status-text").textContent, "Connected");
+    assert.equal(document.querySelector("#error-message").hidden, true);
+  } finally {
+    globalThis.document = originalDocument;
+    globalThis.fetch = originalFetch;
+  }
+});
+
+test("sliders stream immediately and wait for each request before sending the latest values", async () => {
+  const document = makeDocument();
+  const tweaks = structuredClone(descriptors);
+  const patches = [];
+  const originalDocument = globalThis.document;
+  const originalFetch = globalThis.fetch;
+  let requestsInFlight = 0;
+  let maximumRequestsInFlight = 0;
+  let finishFirstRequest;
+
+  globalThis.document = document;
+  globalThis.fetch = async (pathname, options) => {
+    if (pathname === "/app") {
+      return jsonResponse({
+        name: "Snap-O Tweaks Demo",
+        packageName: "com.openai.snapo.demo.tweaks",
+      });
+    }
+
+    if (pathname === "/tweaks" && options?.method === "PATCH") {
+      const { values } = JSON.parse(options.body);
+      patches.push(values);
+      requestsInFlight += 1;
+      maximumRequestsInFlight = Math.max(
+        maximumRequestsInFlight,
+        requestsInFlight,
+      );
+
+      const finish = () => {
+        for (const tweak of tweaks) {
+          if (Object.hasOwn(values, tweak.name)) {
+            tweak.value = values[tweak.name];
+          }
+        }
+
+        requestsInFlight -= 1;
+        return jsonResponse({
+          tweaks: Object.entries(values).map(([name, value]) => ({
+            name,
+            value,
+          })),
+        });
+      };
+
+      if (patches.length === 1) {
+        return new Promise((resolve) => {
+          finishFirstRequest = () => resolve(finish());
+        });
+      }
+
+      return finish();
+    }
+
+    if (pathname === "/tweaks") {
+      return jsonResponse({ tweaks });
+    }
+
+    return jsonResponse({ error: "Not found." }, 404);
+  };
+
+  try {
+    await import(`./app.js?slider-stream-test=${Date.now()}`);
+    await delay(0);
+
+    const appearance = document.querySelector("#appearance-tweaks");
+    const slider = findInput(appearance, "Font size");
+
+    slider.value = "37";
+    await slider.emit("input");
+
+    assert.deepEqual(patches, [{ "Font size": 37 }]);
+    assert.equal(requestsInFlight, 1);
+    assert.equal(document.querySelector("#status-text").textContent, "Saving…");
+    assert.equal(
+      document.querySelector("#connection-status").getAttribute("aria-label"),
+      "Saving…",
+    );
+
+    for (const value of ["38", "39", "40"]) {
+      slider.value = value;
+      await slider.emit("input");
+    }
+
+    const fontWeight = findInput(appearance, "Font weight");
+    fontWeight.value = "700";
+    await fontWeight.emit("input");
+
+    const color = findInput(appearance, "Accent color color");
+    color.value = "#3b82f6";
+    await color.emit("input");
+
+    await delay(10);
+
+    assert.deepEqual(patches, [{ "Font size": 37 }]);
+    assert.equal(requestsInFlight, 1);
+
+    const finish = finishFirstRequest;
+    finishFirstRequest = undefined;
+    finish();
+    await delay(10);
+
+    assert.deepEqual(patches, [
+      { "Font size": 37 },
+      {
+        "Font size": 40,
+        "Font weight": 700,
+        "Accent color": "#3B82F6",
+      },
+    ]);
+    assert.equal(maximumRequestsInFlight, 1);
+    assert.equal(requestsInFlight, 0);
+    assert.equal(document.querySelector("#status-text").textContent, "Connected");
+    assert.equal(document.properties.get("--accent"), "#3B82F6");
+  } finally {
+    if (finishFirstRequest) {
+      finishFirstRequest();
+      await delay(0);
+    }
+
+    globalThis.document = originalDocument;
+    globalThis.fetch = originalFetch;
+  }
+});

--- a/snapo-link-android/samples/demo-tweaks/panel/index.html
+++ b/snapo-link-android/samples/demo-tweaks/panel/index.html
@@ -1,0 +1,83 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <meta name="color-scheme" content="light dark" />
+    <meta
+      name="description"
+      content="Optional browser panel for the Snap-O Tweaks sample."
+    />
+    <meta name="theme-color" content="#fafaf9" />
+    <title>Snap-O Tweaks</title>
+    <link rel="stylesheet" href="/styles.css" />
+    <script type="module" src="/app.js"></script>
+  </head>
+  <body>
+    <main class="panel">
+      <header class="app-header">
+        <div class="app-bar">
+          <div class="app-identity">
+            <div class="app-icon-frame">
+              <img
+                class="app-icon"
+                src="/app/icon"
+                alt=""
+                width="38"
+                height="38"
+              />
+              <span
+                id="connection-status"
+                class="connection-status"
+                role="status"
+                aria-label="Connecting"
+              >
+                <span class="status-dot"></span>
+                <span id="status-text" class="visually-hidden">Connecting</span>
+              </span>
+            </div>
+            <div class="app-heading">
+              <p id="app-name" class="app-name">Connecting…</p>
+              <p id="package-name" class="package-name"></p>
+            </div>
+          </div>
+
+          <div class="toolbar">
+            <button id="refresh-button" class="toolbar-button" type="button">
+              Refresh
+            </button>
+            <button id="reset-button" class="toolbar-button" type="button" disabled>
+              Reset all
+            </button>
+          </div>
+        </div>
+      </header>
+
+      <p id="error-message" class="error-message" role="alert" hidden></p>
+
+      <section id="appearance-section" class="tweak-section" hidden>
+        <div class="section-heading">
+          <h2>Appearance</h2>
+          <span id="appearance-count" class="section-count"></span>
+        </div>
+        <div id="appearance-tweaks" class="tweak-list"></div>
+      </section>
+
+      <section id="motion-section" class="tweak-section" hidden>
+        <div class="section-heading">
+          <h2>Motion</h2>
+          <span id="motion-count" class="section-count"></span>
+        </div>
+        <div id="motion-tweaks" class="tweak-list"></div>
+      </section>
+
+      <section id="other-section" class="tweak-section" hidden>
+        <div class="section-heading">
+          <h2>Other</h2>
+          <span id="other-count" class="section-count"></span>
+        </div>
+        <div id="other-tweaks" class="tweak-list"></div>
+      </section>
+    </main>
+  </body>
+</html>

--- a/snapo-link-android/samples/demo-tweaks/panel/package.json
+++ b/snapo-link-android/samples/demo-tweaks/panel/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "snapo-tweaks-sample-panel",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "engines": {
+    "node": ">=22.12.0"
+  },
+  "scripts": {
+    "start": "node server.mjs",
+    "test": "node --test"
+  }
+}

--- a/snapo-link-android/samples/demo-tweaks/panel/server.mjs
+++ b/snapo-link-android/samples/demo-tweaks/panel/server.mjs
@@ -1,0 +1,512 @@
+import { execFile } from "node:child_process";
+import { createServer } from "node:http";
+import { homedir } from "node:os";
+import path from "node:path";
+import { readFile } from "node:fs/promises";
+import { fileURLToPath, pathToFileURL } from "node:url";
+import { promisify } from "node:util";
+
+const runFile = promisify(execFile);
+const directory = path.dirname(fileURLToPath(import.meta.url));
+const maximumBodyBytes = 64 * 1024;
+
+const staticFiles = new Map([
+  ["/", { name: "index.html", type: "text/html; charset=utf-8" }],
+  ["/app.js", { name: "app.js", type: "text/javascript; charset=utf-8" }],
+  ["/styles.css", { name: "styles.css", type: "text/css; charset=utf-8" }],
+]);
+
+const tweakRoutes = new Set(["/app", "/app/icon", "/tweaks"]);
+
+export function parseAdbDevices(output) {
+  return output
+    .split(/\r?\n/)
+    .map((line) => line.trim())
+    .filter((line) => /^\S+\s+device(?:\s|$)/.test(line))
+    .map((line) => {
+      const [serial] = line.split(/\s+/);
+      const model = line.match(/\bmodel:(\S+)/)?.[1];
+      const transport = line.match(/\btransport_id:(\d+)/)?.[1];
+
+      return {
+        serial,
+        model: model?.replaceAll("_", " ") ?? serial,
+        transportId: Number(transport ?? 0),
+      };
+    })
+    .sort((left, right) => {
+      const leftIsEmulator = left.serial.startsWith("emulator-");
+      const rightIsEmulator = right.serial.startsWith("emulator-");
+
+      if (leftIsEmulator !== rightIsEmulator) {
+        return Number(leftIsEmulator) - Number(rightIsEmulator);
+      }
+
+      return right.transportId - left.transportId;
+    });
+}
+
+export function parseTweakSockets(output) {
+  return [...new Set(
+    [...output.matchAll(/@snapo_tweaks_(\d+)\b/g)].map((match) => match[1]),
+  )]
+    .map((identifier) => ({
+      name: `snapo_tweaks_${identifier}`,
+      pid: Number(identifier),
+    }))
+    .sort((left, right) => right.pid - left.pid);
+}
+
+export function parseAdbForwards(output) {
+  return output
+    .split(/\r?\n/)
+    .map((line) => line.trim().split(/\s+/))
+    .filter(
+      ([serial, local, remote]) =>
+        Boolean(serial) &&
+        /^tcp:\d+$/.test(local ?? "") &&
+        /^localabstract:snapo_tweaks_\d+$/.test(remote ?? ""),
+    )
+    .map(([serial, local, remote]) => ({
+      serial,
+      port: Number(local.slice(4)),
+      socket: remote,
+    }))
+    .sort((left, right) => {
+      const leftIsEmulator = left.serial.startsWith("emulator-");
+      const rightIsEmulator = right.serial.startsWith("emulator-");
+      return Number(leftIsEmulator) - Number(rightIsEmulator);
+    });
+}
+
+function adbCandidates() {
+  const candidates = [];
+
+  for (const root of [process.env.ANDROID_HOME, process.env.ANDROID_SDK_ROOT]) {
+    if (root) candidates.push(path.join(root, "platform-tools", "adb"));
+  }
+
+  candidates.push(path.join(homedir(), "Library/Android/sdk/platform-tools/adb"));
+  candidates.push("adb");
+  return [...new Set(candidates)];
+}
+
+async function probeTweakTarget(target, packageName, fetcher) {
+  try {
+    const response = await fetcher(new URL("/app", target), {
+      signal: AbortSignal.timeout(1_500),
+    });
+
+    if (!response.ok) return false;
+
+    const app = await response.json();
+    if (typeof app.name !== "string" || typeof app.packageName !== "string") {
+      return false;
+    }
+
+    return !packageName || app.packageName === packageName;
+  } catch {
+    return false;
+  }
+}
+
+async function createDeviceForward(adb, serial, socket, run) {
+  const { stdout } = await run(
+    adb,
+    ["-s", serial, "forward", "tcp:0", `localabstract:${socket}`],
+    { timeout: 4_000 },
+  );
+  const port = Number(stdout.trim());
+
+  if (!Number.isInteger(port) || port < 1 || port > 65_535) {
+    throw new Error("ADB returned an invalid tweak forward.");
+  }
+
+  return { port, target: new URL(`http://127.0.0.1:${port}`) };
+}
+
+async function discoverOnDevice({
+  adb,
+  device,
+  forwards,
+  packageName,
+  run,
+  fetcher,
+}) {
+  let sockets = [];
+
+  try {
+    const { stdout } = await run(
+      adb,
+      ["-s", device.serial, "shell", "cat", "/proc/net/unix"],
+      { timeout: 4_000 },
+    );
+    sockets = parseTweakSockets(stdout);
+  } catch {
+    // Existing ADB forwards can still work when socket inspection is unavailable.
+  }
+
+  const deviceForwards = forwards.filter(
+    (forward) => forward.serial === device.serial,
+  );
+
+  for (const socket of sockets) {
+    const existing = deviceForwards.filter(
+      (forward) => forward.socket === `localabstract:${socket.name}`,
+    );
+
+    for (const forward of existing) {
+      const target = new URL(`http://127.0.0.1:${forward.port}`);
+      if (await probeTweakTarget(target, packageName, fetcher)) {
+        return target;
+      }
+    }
+
+    let created;
+
+    try {
+      created = await createDeviceForward(adb, device.serial, socket.name, run);
+
+      if (await probeTweakTarget(created.target, packageName, fetcher)) {
+        return created.target;
+      }
+    } catch {
+      continue;
+    }
+
+    try {
+      await run(
+        adb,
+        ["-s", device.serial, "forward", "--remove", `tcp:${created.port}`],
+        { timeout: 4_000 },
+      );
+    } catch {
+      // Discovery must not fail because a rejected temporary forward vanished.
+    }
+  }
+
+  for (const forward of deviceForwards) {
+    const target = new URL(`http://127.0.0.1:${forward.port}`);
+
+    if (await probeTweakTarget(target, packageName, fetcher)) {
+      return target;
+    }
+  }
+
+  return null;
+}
+
+export async function discoverTweakTarget({
+  serial,
+  packageName,
+  adb,
+  run = runFile,
+  fetcher = fetch,
+} = {}) {
+  for (const executable of adb ? [adb] : adbCandidates()) {
+    let devices;
+    let forwards;
+
+    try {
+      const [deviceResult, forwardResult] = await Promise.all([
+        run(executable, ["devices", "-l"], { timeout: 4_000 }),
+        run(executable, ["forward", "--list"], { timeout: 4_000 }),
+      ]);
+      devices = parseAdbDevices(deviceResult.stdout);
+      forwards = parseAdbForwards(forwardResult.stdout);
+    } catch {
+      continue;
+    }
+
+    if (serial) {
+      devices = devices.filter((device) => device.serial === serial);
+    }
+
+    for (const device of devices) {
+      const target = await discoverOnDevice({
+        adb: executable,
+        device,
+        forwards,
+        packageName,
+        run,
+        fetcher,
+      });
+
+      if (target) return target;
+    }
+  }
+
+  const selection = [
+    serial && `device ${serial}`,
+    packageName && `package ${packageName}`,
+  ].filter(Boolean);
+  const scope = selection.length > 0 ? ` for ${selection.join(" and ")}` : "";
+
+  throw new Error(
+    `No running Snap-O Tweaks app found${scope}. ` +
+      "Connect an authorized Android device and open a tweaks-enabled app, " +
+      "or pass --target http://127.0.0.1:<port>.",
+  );
+}
+
+function validateTarget(value) {
+  const target = value instanceof URL ? value : new URL(value);
+
+  if (
+    target.protocol !== "http:" ||
+    !["127.0.0.1", "localhost", "[::1]"].includes(target.hostname)
+  ) {
+    throw new Error("The tweak target must be an HTTP localhost URL.");
+  }
+
+  return target;
+}
+
+function jsonResponse(response, status, payload, additionalHeaders = {}) {
+  const data = Buffer.from(JSON.stringify(payload));
+  response.writeHead(status, {
+    "Cache-Control": "no-store",
+    "Content-Type": "application/json; charset=utf-8",
+    "Content-Length": data.length,
+    "X-Content-Type-Options": "nosniff",
+    ...additionalHeaders,
+  });
+  response.end(data);
+}
+
+async function readRequestBody(request) {
+  let size = 0;
+  const chunks = [];
+
+  for await (const chunk of request) {
+    size += chunk.length;
+
+    if (size > maximumBodyBytes) {
+      const error = new Error("Request body exceeds 64 KB.");
+      error.status = 413;
+      throw error;
+    }
+
+    chunks.push(chunk);
+  }
+
+  return Buffer.concat(chunks);
+}
+
+async function serveStatic(request, response, file) {
+  if (request.method !== "GET" && request.method !== "HEAD") {
+    jsonResponse(response, 405, { error: "Method not allowed." }, {
+      Allow: "GET, HEAD",
+    });
+    return;
+  }
+
+  const data = await readFile(path.join(directory, file.name));
+  response.writeHead(200, {
+    "Cache-Control": "no-store",
+    "Content-Type": file.type,
+    "Content-Length": data.length,
+    "X-Content-Type-Options": "nosniff",
+  });
+  response.end(request.method === "HEAD" ? undefined : data);
+}
+
+async function proxyTweak(request, response, connection, pathname) {
+  const headers = {};
+  let body;
+
+  if (request.method === "PATCH") {
+    headers["Content-Type"] = request.headers["content-type"] ?? "application/json";
+    body = await readRequestBody(request);
+  }
+
+  const performRequest = () => fetch(new URL(pathname, connection.target), {
+    method: request.method,
+    headers,
+    body,
+    signal: AbortSignal.timeout(8_000),
+  });
+
+  let upstream;
+
+  try {
+    upstream = await performRequest();
+  } catch (error) {
+    if (connection.fixed) throw error;
+
+    await connection.reconnect();
+    upstream = await performRequest();
+  }
+
+  const data = Buffer.from(await upstream.arrayBuffer());
+  const responseHeaders = {
+    "Cache-Control": "no-store",
+    "Content-Length": data.length,
+    "X-Content-Type-Options": "nosniff",
+  };
+
+  for (const name of ["content-type", "allow"]) {
+    const value = upstream.headers.get(name);
+    if (value) responseHeaders[name] = value;
+  }
+
+  response.writeHead(upstream.status, responseHeaders);
+  response.end(data);
+}
+
+function createHandler(connection) {
+  return async (request, response) => {
+    try {
+      const pathname = new URL(request.url, "http://127.0.0.1").pathname;
+      const file = staticFiles.get(pathname);
+
+      if (file) {
+        await serveStatic(request, response, file);
+        return;
+      }
+
+      if (tweakRoutes.has(pathname)) {
+        await proxyTweak(request, response, connection, pathname);
+        return;
+      }
+
+      jsonResponse(response, 404, { error: "Not found." });
+    } catch (error) {
+      if (!response.headersSent) {
+        const status = error.status === 413 ? 413 : 502;
+        const message =
+          status === 413
+            ? error.message
+            : "Cannot reach the Android tweaks endpoint.";
+        jsonResponse(response, status, { error: message });
+      } else {
+        response.destroy(error);
+      }
+    }
+  };
+}
+
+export async function createTweakPanelServer({
+  target,
+  serial,
+  packageName,
+  discoverTarget = discoverTweakTarget,
+  hostname = "127.0.0.1",
+  port = 0,
+} = {}) {
+  const configuredTarget = target ?? process.env.SNAPO_TWEAKS_URL;
+  const connection = {
+    target: validateTarget(
+      configuredTarget ?? (await discoverTarget({ serial, packageName })),
+    ),
+    fixed: Boolean(configuredTarget),
+    reconnecting: undefined,
+    async reconnect() {
+      if (!this.reconnecting) {
+        this.reconnecting = Promise.resolve()
+          .then(() => discoverTarget({ serial, packageName }))
+          .then((next) => {
+            this.target = validateTarget(next);
+          })
+          .finally(() => {
+            this.reconnecting = undefined;
+          });
+      }
+
+      return this.reconnecting;
+    },
+  };
+  const server = createServer(createHandler(connection));
+
+  await new Promise((resolve, reject) => {
+    server.once("error", reject);
+    server.listen(port, hostname, () => {
+      server.removeListener("error", reject);
+      resolve();
+    });
+  });
+
+  const address = server.address();
+
+  return {
+    server,
+    get target() {
+      return connection.target;
+    },
+    url: `http://${hostname}:${address.port}`,
+    close() {
+      return new Promise((resolve, reject) => {
+        server.close((error) => (error ? reject(error) : resolve()));
+      });
+    },
+  };
+}
+
+export function parseArguments(args) {
+  const options = { port: 4175 };
+
+  for (let index = 0; index < args.length; index += 1) {
+    const argument = args[index];
+
+    if (argument === "--target") {
+      options.target = args[++index];
+    } else if (argument.startsWith("--target=")) {
+      options.target = argument.slice("--target=".length);
+    } else if (argument === "--serial") {
+      options.serial = args[++index];
+    } else if (argument.startsWith("--serial=")) {
+      options.serial = argument.slice("--serial=".length);
+    } else if (argument === "--package") {
+      options.packageName = args[++index];
+    } else if (argument.startsWith("--package=")) {
+      options.packageName = argument.slice("--package=".length);
+    } else if (argument === "--port") {
+      options.port = Number(args[++index]);
+    } else if (argument.startsWith("--port=")) {
+      options.port = Number(argument.slice("--port=".length));
+    } else {
+      throw new Error(`Unknown argument: ${argument}`);
+    }
+  }
+
+  if (!Number.isInteger(options.port) || options.port < 0 || options.port > 65_535) {
+    throw new Error("The port must be a whole number from 0 to 65535.");
+  }
+
+  if (Object.hasOwn(options, "serial") && !options.serial) {
+    throw new Error("The --serial option requires an Android device serial.");
+  }
+
+  if (Object.hasOwn(options, "packageName") && !options.packageName) {
+    throw new Error("The --package option requires an Android package name.");
+  }
+
+  if (Object.hasOwn(options, "target") && !options.target) {
+    throw new Error("The --target option requires an HTTP localhost URL.");
+  }
+
+  return options;
+}
+
+async function main() {
+  const panel = await createTweakPanelServer(parseArguments(process.argv.slice(2)));
+  console.log(`Snap-O Tweaks panel: ${panel.url}`);
+  console.log(`Android tweaks endpoint: ${panel.target}`);
+
+  for (const signal of ["SIGINT", "SIGTERM"]) {
+    process.once(signal, async () => {
+      await panel.close();
+      process.exit(0);
+    });
+  }
+}
+
+if (
+  process.argv[1] &&
+  import.meta.url === pathToFileURL(path.resolve(process.argv[1])).href
+) {
+  main().catch((error) => {
+    console.error(error.message);
+    process.exitCode = 1;
+  });
+}

--- a/snapo-link-android/samples/demo-tweaks/panel/server.test.mjs
+++ b/snapo-link-android/samples/demo-tweaks/panel/server.test.mjs
@@ -1,0 +1,497 @@
+import assert from "node:assert/strict";
+import { createServer } from "node:http";
+import { after, before, test } from "node:test";
+
+import {
+  createTweakPanelServer,
+  discoverTweakTarget,
+  parseAdbDevices,
+  parseAdbForwards,
+  parseArguments,
+  parseTweakSockets,
+} from "./server.mjs";
+
+const app = {
+  name: "Snap-O Tweaks Demo",
+  packageName: "com.openai.snapo.demo.tweaks",
+};
+
+const initialTweaks = [
+  {
+    name: "Font size",
+    type: "int",
+    default: 36,
+    value: 36,
+    min: 16,
+    max: 72,
+    step: 1,
+  },
+  {
+    name: "Accent color",
+    type: "color",
+    default: "#5468FF",
+    value: "#5468FF",
+  },
+  {
+    name: "Use spring",
+    type: "boolean",
+    default: true,
+    value: true,
+  },
+];
+
+const icon = Buffer.from([
+  0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a, 0x11, 0x22,
+]);
+
+let upstream;
+let upstreamUrl;
+let panel;
+
+function reply(response, status, body, headers = {}) {
+  const bytes = Buffer.isBuffer(body)
+    ? body
+    : Buffer.from(JSON.stringify(body));
+
+  response.writeHead(status, {
+    "Content-Length": bytes.length,
+    "Content-Type": Buffer.isBuffer(body)
+      ? "image/png"
+      : "application/json; charset=utf-8",
+    ...headers,
+  });
+  response.end(bytes);
+}
+
+before(async () => {
+  upstream = createServer(async (request, response) => {
+    if (request.url === "/app" && request.method === "GET") {
+      reply(response, 200, app);
+      return;
+    }
+
+    if (request.url === "/app/icon" && request.method === "GET") {
+      reply(response, 200, icon);
+      return;
+    }
+
+    if (request.url === "/tweaks" && request.method === "GET") {
+      reply(response, 200, { tweaks: initialTweaks });
+      return;
+    }
+
+    if (request.url === "/tweaks" && request.method === "PATCH") {
+      const chunks = [];
+      for await (const chunk of request) chunks.push(chunk);
+      const payload = JSON.parse(Buffer.concat(chunks).toString("utf8"));
+
+      if (payload.values?.["Font size"] === 48.5) {
+        reply(response, 422, { error: "Font size must be a whole number." });
+        return;
+      }
+
+      reply(response, 200, {
+        tweaks: Object.entries(payload.values).map(([name, value]) => ({
+          name,
+          value,
+        })),
+      });
+      return;
+    }
+
+    reply(response, 405, { error: "Method not allowed." }, { Allow: "GET" });
+  });
+
+  await new Promise((resolve) => upstream.listen(0, "127.0.0.1", resolve));
+  upstreamUrl = `http://127.0.0.1:${upstream.address().port}`;
+  panel = await createTweakPanelServer({ target: upstreamUrl });
+});
+
+after(async () => {
+  if (panel) await panel.close();
+  if (upstream) await new Promise((resolve) => upstream.close(resolve));
+});
+
+test("serves the host-side tweaks panel", async () => {
+  const response = await fetch(panel.url);
+  const html = await response.text();
+
+  assert.equal(response.status, 200);
+  assert.match(response.headers.get("content-type"), /text\/html/);
+  assert.match(html, /Snap-O Tweaks/);
+  assert.match(html, /\/app\.js/);
+  assert.match(html, /\/styles\.css/);
+  assert.match(
+    html,
+    /class="app-icon-frame">[\s\S]*?class="app-icon"[\s\S]*?id="connection-status"/,
+  );
+  assert.doesNotMatch(html, /class="masthead"/);
+  assert.doesNotMatch(html, /<h1\b/);
+});
+
+test("serves the browser application and stylesheet", async () => {
+  for (const [pathname, type] of [
+    ["/app.js", /text\/javascript/],
+    ["/styles.css", /text\/css/],
+  ]) {
+    const response = await fetch(new URL(pathname, panel.url));
+    assert.equal(response.status, 200);
+    assert.match(response.headers.get("content-type"), type);
+    assert.ok((await response.text()).length > 0);
+  }
+});
+
+test("proxies app metadata without adding an icon URL", async () => {
+  const response = await fetch(new URL("/app", panel.url));
+  assert.equal(response.status, 200);
+  assert.deepEqual(await response.json(), app);
+});
+
+test("proxies the application icon as an unchanged PNG", async () => {
+  const response = await fetch(new URL("/app/icon", panel.url));
+
+  assert.equal(response.status, 200);
+  assert.equal(response.headers.get("content-type"), "image/png");
+  assert.equal(Number(response.headers.get("content-length")), icon.length);
+  assert.deepEqual(Buffer.from(await response.arrayBuffer()), icon);
+});
+
+test("proxies the original flat tweak descriptors", async () => {
+  const response = await fetch(new URL("/tweaks", panel.url));
+
+  assert.equal(response.status, 200);
+  assert.deepEqual(await response.json(), { tweaks: initialTweaks });
+});
+
+test("forwards live tweak patches", async () => {
+  const response = await fetch(new URL("/tweaks", panel.url), {
+    method: "PATCH",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ values: { "Font size": 48 } }),
+  });
+
+  assert.equal(response.status, 200);
+  assert.deepEqual(await response.json(), {
+    tweaks: [{ name: "Font size", value: 48 }],
+  });
+});
+
+test("preserves Android validation errors", async () => {
+  const response = await fetch(new URL("/tweaks", panel.url), {
+    method: "PATCH",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ values: { "Font size": 48.5 } }),
+  });
+
+  assert.equal(response.status, 422);
+  assert.deepEqual(await response.json(), {
+    error: "Font size must be a whole number.",
+  });
+});
+
+test("preserves allowed methods from the Android app", async () => {
+  const response = await fetch(new URL("/app", panel.url), { method: "POST" });
+
+  assert.equal(response.status, 405);
+  assert.equal(response.headers.get("allow"), "GET");
+});
+
+test("does not expose arbitrary proxy paths", async () => {
+  const response = await fetch(new URL("/somewhere-else", panel.url));
+
+  assert.equal(response.status, 404);
+  assert.deepEqual(await response.json(), { error: "Not found." });
+});
+
+test("rejects non-local Android tweaks targets", async () => {
+  await assert.rejects(
+    createTweakPanelServer({ target: "https://example.com" }),
+    /localhost URL/,
+  );
+});
+
+test("finds physical-device tweaks forwards before emulators", () => {
+  const output = [
+    "emulator-5554 tcp:56426 localabstract:snapo_tweaks_25725",
+    "51091FDAS002W3 tcp:59318 localabstract:snapo_tweaks_28795",
+    "emulator-5554 tcp:61074 localabstract:snapo_tweaks_26103",
+    "51091FDAS002W3 tcp:4000 localabstract:snapo_network_28795",
+  ].join("\n");
+
+  assert.deepEqual(parseAdbForwards(output), [
+    {
+      serial: "51091FDAS002W3",
+      port: 59318,
+      socket: "localabstract:snapo_tweaks_28795",
+    },
+    {
+      serial: "emulator-5554",
+      port: 56426,
+      socket: "localabstract:snapo_tweaks_25725",
+    },
+    {
+      serial: "emulator-5554",
+      port: 61074,
+      socket: "localabstract:snapo_tweaks_26103",
+    },
+  ]);
+});
+
+test("prefers the most recently connected physical Android device", () => {
+  const output = [
+    "List of devices attached",
+    "emulator-5554 device product:sdk model:Android_SDK transport_id:1",
+    "OLD123 device product:oriole model:Pixel_6 transport_id:4",
+    "NEW456 device product:komodo model:Pixel_9_Pro_XL transport_id:8",
+    "LOCKED789 unauthorized usb:1-2",
+    "OFFLINE321 offline transport_id:12",
+  ].join("\n");
+
+  assert.deepEqual(parseAdbDevices(output), [
+    { serial: "NEW456", model: "Pixel 9 Pro XL", transportId: 8 },
+    { serial: "OLD123", model: "Pixel 6", transportId: 4 },
+    { serial: "emulator-5554", model: "Android SDK", transportId: 1 },
+  ]);
+});
+
+test("discovers only live Snap-O Tweaks app sockets", () => {
+  const output = [
+    "0000: 0001 01 10 @snapo_network_8800",
+    "0000: 0001 01 11 @snapo_tweaks_4312",
+    "0000: 0001 01 12 @snapo_tweaks_6976",
+    "0000: 0001 01 13 @snapo_tweaks_4312",
+    "0000: 0001 01 14 @unrelated_debug_socket",
+  ].join("\n");
+
+  assert.deepEqual(parseTweakSockets(output), [
+    { name: "snapo_tweaks_6976", pid: 6976 },
+    { name: "snapo_tweaks_4312", pid: 4312 },
+  ]);
+});
+
+test("creates its own ADB forward for a running app", async () => {
+  const calls = [];
+  const run = async (executable, args) => {
+    calls.push([executable, ...args]);
+
+    if (args[0] === "devices") {
+      return {
+        stdout: [
+          "List of devices attached",
+          "PIXEL123 device model:Pixel_9_Pro_XL transport_id:9",
+        ].join("\n"),
+      };
+    }
+
+    if (args[0] === "forward") {
+      return { stdout: "" };
+    }
+
+    if (args.includes("/proc/net/unix")) {
+      return { stdout: "0000: 0001 01 10 @snapo_tweaks_6976\n" };
+    }
+
+    if (args.includes("tcp:0")) {
+      return { stdout: "49231\n" };
+    }
+
+    throw new Error(`Unexpected ADB arguments: ${args.join(" ")}`);
+  };
+
+  const fetcher = async (url) => {
+    assert.equal(url.href, "http://127.0.0.1:49231/app");
+    return new Response(JSON.stringify(app), {
+      headers: { "Content-Type": "application/json" },
+    });
+  };
+
+  const target = await discoverTweakTarget({
+    adb: "sample-adb",
+    run,
+    fetcher,
+  });
+
+  assert.equal(target.href, "http://127.0.0.1:49231/");
+  assert.deepEqual(
+    calls.find((call) => call.includes("tcp:0")),
+    [
+      "sample-adb",
+      "-s",
+      "PIXEL123",
+      "forward",
+      "tcp:0",
+      "localabstract:snapo_tweaks_6976",
+    ],
+  );
+});
+
+test("reuses an existing live forward", async () => {
+  const calls = [];
+  const run = async (executable, args) => {
+    calls.push([executable, ...args]);
+
+    if (args[0] === "devices") {
+      return {
+        stdout: "List of devices attached\nPIXEL123 device transport_id:9\n",
+      };
+    }
+
+    if (args[0] === "forward") {
+      return {
+        stdout:
+          "PIXEL123 tcp:49231 localabstract:snapo_tweaks_6976\n",
+      };
+    }
+
+    if (args.includes("/proc/net/unix")) {
+      return { stdout: "0000: 0001 01 10 @snapo_tweaks_6976\n" };
+    }
+
+    throw new Error(`Unexpected ADB arguments: ${args.join(" ")}`);
+  };
+
+  const target = await discoverTweakTarget({
+    adb: "sample-adb",
+    run,
+    fetcher: async () => new Response(JSON.stringify(app)),
+  });
+
+  assert.equal(target.href, "http://127.0.0.1:49231/");
+  assert.equal(calls.some((call) => call.includes("tcp:0")), false);
+});
+
+test("honors explicit device and Android package selection", async () => {
+  const calls = [];
+  const run = async (executable, args) => {
+    calls.push([executable, ...args]);
+
+    if (args[0] === "devices") {
+      return {
+        stdout: [
+          "List of devices attached",
+          "NEW456 device model:Pixel_9 transport_id:8",
+          "CHOSEN123 device model:Pixel_8 transport_id:5",
+        ].join("\n"),
+      };
+    }
+
+    if (args[0] === "forward") {
+      return {
+        stdout:
+          "CHOSEN123 tcp:49231 localabstract:snapo_tweaks_6976\n",
+      };
+    }
+
+    if (args.includes("/proc/net/unix")) {
+      return { stdout: "0000: 0001 01 10 @snapo_tweaks_6976\n" };
+    }
+
+    throw new Error(`Unexpected ADB arguments: ${args.join(" ")}`);
+  };
+
+  const target = await discoverTweakTarget({
+    serial: "CHOSEN123",
+    packageName: app.packageName,
+    adb: "sample-adb",
+    run,
+    fetcher: async () => new Response(JSON.stringify(app)),
+  });
+
+  assert.equal(target.href, "http://127.0.0.1:49231/");
+  assert.equal(
+    calls.some((call) => call.includes("NEW456") && call.includes("shell")),
+    false,
+  );
+});
+
+test("recovers automatically when the Android app process changes", async () => {
+  const replacementApp = {
+    name: "Reconnected Tweaks Demo",
+    packageName: app.packageName,
+  };
+
+  function makeUpstream(identity) {
+    return createServer((request, response) => {
+      if (request.url === "/app") {
+        reply(response, 200, identity);
+      } else if (request.url === "/tweaks") {
+        reply(response, 200, { tweaks: initialTweaks });
+      } else {
+        reply(response, 404, { error: "Not found." });
+      }
+    });
+  }
+
+  const original = makeUpstream(app);
+  const replacement = makeUpstream(replacementApp);
+  await Promise.all([
+    new Promise((resolve) => original.listen(0, "127.0.0.1", resolve)),
+    new Promise((resolve) => replacement.listen(0, "127.0.0.1", resolve)),
+  ]);
+
+  const originalTarget = new URL(
+    `http://127.0.0.1:${original.address().port}`,
+  );
+  const replacementTarget = new URL(
+    `http://127.0.0.1:${replacement.address().port}`,
+  );
+  let target = originalTarget;
+  let discoveries = 0;
+  const recoveringPanel = await createTweakPanelServer({
+    async discoverTarget() {
+      discoveries += 1;
+      return target;
+    },
+  });
+
+  try {
+    const first = await fetch(new URL("/app", recoveringPanel.url));
+    assert.deepEqual(await first.json(), app);
+    assert.equal(discoveries, 1);
+
+    target = replacementTarget;
+    original.closeAllConnections();
+    await new Promise((resolve) => original.close(resolve));
+
+    const recovered = await fetch(new URL("/app", recoveringPanel.url));
+    assert.equal(recovered.status, 200);
+    assert.deepEqual(await recovered.json(), replacementApp);
+    assert.equal(discoveries, 2);
+    assert.equal(recoveringPanel.target.href, replacementTarget.href);
+
+    const tweaks = await fetch(new URL("/tweaks", recoveringPanel.url));
+    assert.equal(tweaks.status, 200);
+    assert.deepEqual(await tweaks.json(), { tweaks: initialTweaks });
+  } finally {
+    await recoveringPanel.close();
+    replacement.closeAllConnections();
+    await new Promise((resolve) => replacement.close(resolve));
+
+    if (original.listening) {
+      original.closeAllConnections();
+      await new Promise((resolve) => original.close(resolve));
+    }
+  }
+});
+
+test("parses explicit device, package, and port options", () => {
+  assert.deepEqual(
+    parseArguments([
+      "--serial",
+      "PIXEL123",
+      "--package",
+      "com.openai.snapo.demo.tweaks",
+      "--port",
+      "4176",
+    ]),
+    {
+      port: 4176,
+      serial: "PIXEL123",
+      packageName: "com.openai.snapo.demo.tweaks",
+    },
+  );
+
+  assert.throws(() => parseArguments(["--serial"]), /requires an Android device/);
+  assert.throws(() => parseArguments(["--package"]), /requires an Android package/);
+  assert.throws(() => parseArguments(["--target"]), /requires an HTTP localhost/);
+});

--- a/snapo-link-android/samples/demo-tweaks/panel/styles.css
+++ b/snapo-link-android/samples/demo-tweaks/panel/styles.css
@@ -1,0 +1,369 @@
+:root {
+  color-scheme: light dark;
+  font-family:
+    ui-sans-serif,
+    -apple-system,
+    BlinkMacSystemFont,
+    "Segoe UI",
+    sans-serif;
+  font-synthesis: none;
+  text-rendering: optimizeLegibility;
+  -webkit-font-smoothing: antialiased;
+
+  --background: #f7f7f7;
+  --text: #151515;
+  --muted: #6b6b6b;
+  --subtle: #929292;
+  --line: #e3e3e3;
+  --input-background: #ebebea;
+  --input-hover: #e4e4e3;
+  --accent: #5468ff;
+  --success: #23a84a;
+  --error: #d04a3c;
+}
+
+@media (prefers-color-scheme: dark) {
+  :root {
+    --background: #111;
+    --text: #f1f1f1;
+    --muted: #b5b5b5;
+    --subtle: #858585;
+    --line: #292929;
+    --input-background: #212121;
+    --input-hover: #292929;
+    --accent: #8390ff;
+    --success: #5bcf8b;
+    --error: #ff7b6d;
+  }
+}
+
+* {
+  box-sizing: border-box;
+}
+
+html {
+  min-width: 320px;
+  min-height: 100%;
+  background: var(--background);
+}
+
+body {
+  margin: 0;
+  color: var(--text);
+}
+
+button,
+input {
+  font: inherit;
+}
+
+button {
+  color: inherit;
+}
+
+.panel {
+  width: min(100%, 560px);
+  margin-inline: auto;
+  padding: 24px clamp(20px, 5vw, 34px) 52px;
+}
+
+.app-header {
+  padding-bottom: 19px;
+}
+
+.app-bar {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 14px;
+  min-height: 40px;
+}
+
+.app-identity {
+  display: flex;
+  flex: 1;
+  align-items: center;
+  gap: 11px;
+  min-width: 0;
+}
+
+.app-icon-frame {
+  position: relative;
+  flex: 0 0 38px;
+  width: 38px;
+  height: 38px;
+}
+
+.app-icon {
+  display: block;
+  width: 38px;
+  height: 38px;
+  object-fit: contain;
+}
+
+.connection-status {
+  position: absolute;
+  right: -2px;
+  bottom: -2px;
+  display: grid;
+  width: 13px;
+  height: 13px;
+  place-items: center;
+  border: 2px solid var(--background);
+  border-radius: 50%;
+  background: var(--background);
+}
+
+.status-dot {
+  width: 9px;
+  height: 9px;
+  border-radius: 50%;
+  background: var(--subtle);
+}
+
+.connection-status[data-state="connected"] .status-dot {
+  background: var(--success);
+}
+
+.connection-status[data-state="error"] .status-dot {
+  background: var(--error);
+}
+
+.visually-hidden {
+  position: absolute;
+  overflow: hidden;
+  width: 1px;
+  height: 1px;
+  clip-path: inset(50%);
+  white-space: nowrap;
+}
+
+.app-heading {
+  min-width: 0;
+}
+
+.app-name {
+  overflow: hidden;
+  margin: 0;
+  font-size: 13px;
+  font-weight: 590;
+  line-height: 1.35;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.package-name {
+  overflow: hidden;
+  margin: 3px 0 0;
+  color: var(--muted);
+  font-size: 11px;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.toolbar {
+  display: flex;
+  flex: 0 0 auto;
+  align-items: center;
+  gap: 13px;
+}
+
+.toolbar-button,
+.tweak-reset {
+  border: 0;
+  background: transparent;
+  padding: 4px 0;
+  color: var(--muted);
+  font-size: 11px;
+  white-space: nowrap;
+}
+
+.toolbar-button:hover:not(:disabled),
+.tweak-reset:hover {
+  color: var(--text);
+}
+
+.toolbar-button:disabled {
+  color: var(--subtle);
+}
+
+.error-message {
+  margin: 0 0 16px;
+  color: var(--error);
+  font-size: 12px;
+  line-height: 1.5;
+}
+
+.tweak-section {
+  border-top: 1px solid var(--line);
+  padding-block: 19px 21px;
+}
+
+.section-heading {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: 12px;
+  margin-bottom: 18px;
+}
+
+.section-heading h2 {
+  margin: 0;
+  font-size: 12px;
+  font-weight: 640;
+  letter-spacing: -0.01em;
+}
+
+.section-count {
+  color: var(--subtle);
+  font-size: 11px;
+  font-variant-numeric: tabular-nums;
+}
+
+.tweak-list {
+  display: grid;
+  gap: 17px;
+}
+
+.tweak-row {
+  display: grid;
+  gap: 8px;
+}
+
+.tweak-line {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  min-height: 28px;
+}
+
+.tweak-label {
+  overflow: hidden;
+  color: var(--text);
+  font-size: 12px;
+  text-overflow: ellipsis;
+}
+
+.tweak-actions {
+  display: flex;
+  flex: 0 0 auto;
+  align-items: center;
+  gap: 9px;
+}
+
+.number-input,
+.hex-input {
+  min-width: 0;
+  border: 1px solid transparent;
+  border-radius: 4px;
+  background: var(--input-background);
+  padding: 5px 8px;
+  color: var(--text);
+  font-size: 11px;
+  font-variant-numeric: tabular-nums;
+  transition: background-color 120ms ease;
+}
+
+.number-input:hover,
+.hex-input:hover {
+  background: var(--input-hover);
+}
+
+.number-input {
+  width: 68px;
+  text-align: right;
+}
+
+.hex-input {
+  width: 88px;
+  text-transform: uppercase;
+}
+
+.number-input[aria-invalid="true"],
+.hex-input[aria-invalid="true"] {
+  border-color: var(--error);
+}
+
+.range-input {
+  width: 100%;
+  height: 17px;
+  margin: 0;
+  accent-color: var(--accent);
+}
+
+.range-labels {
+  display: flex;
+  justify-content: space-between;
+  margin-top: -3px;
+  color: var(--subtle);
+  font-size: 10px;
+  font-variant-numeric: tabular-nums;
+}
+
+.color-inputs {
+  display: flex;
+  align-items: center;
+  gap: 7px;
+}
+
+.color-input {
+  width: 26px;
+  height: 26px;
+  border: 1px solid var(--line);
+  border-radius: 4px;
+  background: transparent;
+  padding: 2px;
+}
+
+.boolean-input {
+  width: 16px;
+  height: 16px;
+  margin: 0;
+  accent-color: var(--accent);
+}
+
+.string-input {
+  width: 100%;
+  min-height: 34px;
+  border: 1px solid transparent;
+  border-radius: 4px;
+  background: var(--input-background);
+  padding: 8px 9px;
+  color: var(--text);
+  font-size: 12px;
+  transition: background-color 120ms ease;
+}
+
+.string-input:hover {
+  background: var(--input-hover);
+}
+
+.string-input::placeholder {
+  color: var(--subtle);
+}
+
+button:focus-visible,
+input:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: 2px;
+}
+
+@media (max-width: 390px) {
+  .panel {
+    padding: 20px 18px 42px;
+  }
+
+  .toolbar {
+    gap: 10px;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  *,
+  *::before,
+  *::after {
+    scroll-behavior: auto !important;
+    transition-duration: 0.01ms !important;
+  }
+}

--- a/snapo-link-android/samples/demo-tweaks/src/main/AndroidManifest.xml
+++ b/snapo-link-android/samples/demo-tweaks/src/main/AndroidManifest.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="utf-8"?>
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
+
+    <application
+        android:allowBackup="false"
+        android:icon="@drawable/ic_launcher"
+        android:label="@string/app_name"
+        android:supportsRtl="true"
+        android:theme="@style/Theme.SnapOTweaksDemo">
+        <activity
+            android:name=".MainActivity"
+            android:exported="true">
+            <intent-filter>
+                <action android:name="android.intent.action.MAIN" />
+
+                <category android:name="android.intent.category.LAUNCHER" />
+            </intent-filter>
+        </activity>
+    </application>
+
+</manifest>

--- a/snapo-link-android/samples/demo-tweaks/src/main/java/com/openai/snapo/demo/tweaks/MainActivity.kt
+++ b/snapo-link-android/samples/demo-tweaks/src/main/java/com/openai/snapo/demo/tweaks/MainActivity.kt
@@ -1,0 +1,287 @@
+package com.openai.snapo.demo.tweaks
+
+import android.os.Bundle
+import androidx.activity.ComponentActivity
+import androidx.activity.compose.setContent
+import androidx.activity.enableEdgeToEdge
+import androidx.compose.animation.core.FastOutSlowInEasing
+import androidx.compose.animation.core.FiniteAnimationSpec
+import androidx.compose.animation.core.animateFloatAsState
+import androidx.compose.animation.core.spring
+import androidx.compose.animation.core.tween
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.BoxWithConstraints
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.WindowInsets
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.offset
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.safeDrawing
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.windowInsetsPadding
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material3.Button
+import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.material3.lightColorScheme
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.State
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.saveable.rememberSaveable
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.semantics.Role
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.IntOffset
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import com.openai.snapo.tweaks.tweakBoolean
+import com.openai.snapo.tweaks.tweakColor
+import com.openai.snapo.tweaks.tweakFloat
+import com.openai.snapo.tweaks.tweakInt
+import com.openai.snapo.tweaks.tweakString
+
+class MainActivity : ComponentActivity() {
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        enableEdgeToEdge()
+
+        setContent {
+            TweakDemo()
+        }
+    }
+}
+
+@Composable
+private fun TweakDemo() {
+    val textColor = tweakColor("Text color", Color(0xFF18212F))
+    val backgroundColor = tweakColor("Background color", Color(0xFFF7F8FA))
+    val accentColor = tweakColor("Accent color", Color(0xFF5468FF))
+
+    MaterialTheme(
+        colorScheme = lightColorScheme(
+            primary = accentColor,
+            onPrimary = Color.White,
+            background = backgroundColor,
+            onBackground = textColor,
+            surface = backgroundColor,
+            onSurface = textColor,
+        ),
+    ) {
+        Surface(
+            modifier = Modifier.fillMaxSize(),
+            color = backgroundColor,
+            contentColor = textColor,
+        ) {
+            TweakDemoContent()
+        }
+    }
+}
+
+@Composable
+private fun TweakDemoContent() {
+    val dividerColor = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.12f)
+
+    Column(
+        modifier = Modifier
+            .fillMaxSize()
+            .windowInsetsPadding(WindowInsets.safeDrawing)
+            .verticalScroll(rememberScrollState())
+            .padding(horizontal = 28.dp, vertical = 28.dp),
+        verticalArrangement = Arrangement.spacedBy(30.dp),
+    ) {
+        DemoHeader()
+        HorizontalDivider(color = dividerColor)
+        TypographyPreview()
+        HorizontalDivider(color = dividerColor)
+        MotionPreview()
+    }
+}
+
+@Composable
+private fun DemoHeader() {
+    Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
+        Text(
+            text = "Snap-O Tweaks",
+            style = MaterialTheme.typography.labelLarge,
+            color = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.6f),
+        )
+        Text(
+            text = "Live tweaks",
+            style = MaterialTheme.typography.headlineMedium,
+            fontWeight = FontWeight.SemiBold,
+        )
+        Text(
+            text = "Type, color, and motion respond instantly.",
+            style = MaterialTheme.typography.bodyMedium,
+            color = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.7f),
+        )
+    }
+}
+
+@Composable
+private fun TypographyPreview() {
+    val fontSize = tweakInt("Font size", 36, min = 16, max = 72, step = 1)
+    val fontWeight = tweakInt("Font weight", 600, min = 100, max = 900, step = 100)
+    val previewText = tweakString("Preview text", "Make it feel right.")
+
+    Column(verticalArrangement = Arrangement.spacedBy(12.dp)) {
+        Text(
+            text = "Typography",
+            style = MaterialTheme.typography.titleSmall,
+            color = MaterialTheme.colorScheme.primary,
+        )
+        Text(
+            text = previewText,
+            color = MaterialTheme.colorScheme.onSurface,
+            fontSize = fontSize.sp,
+            fontWeight = FontWeight(fontWeight),
+            lineHeight = (fontSize * 1.2f).sp,
+        )
+        TypographyDetails()
+    }
+}
+
+@Composable
+private fun TypographyDetails() {
+    val fontSize = tweakInt("Font size", 36, min = 16, max = 72, step = 1)
+    val fontWeight = tweakInt("Font weight", 600, min = 100, max = 900, step = 100)
+
+    Text(
+        text = "$fontSize sp · $fontWeight",
+        style = MaterialTheme.typography.bodySmall,
+        color = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.6f),
+    )
+}
+
+@Composable
+private fun MotionPreview() {
+    var isStateB by rememberSaveable { mutableStateOf(false) }
+    val duration = tweakInt("Animation duration", 400, min = 100, max = 1500, step = 50)
+    val stiffness = tweakFloat("Spring stiffness", 280f, min = 80f, max = 800f, step = 20f)
+    val damping = tweakFloat("Spring damping", 0.7f, min = 0.1f, max = 1f, step = 0.05f)
+    val useSpring = tweakBoolean("Use spring", true)
+
+    val animationSpec: FiniteAnimationSpec<Float> = if (useSpring) {
+        spring(
+            dampingRatio = damping,
+            stiffness = stiffness,
+        )
+    } else {
+        tween(
+            durationMillis = duration,
+            easing = FastOutSlowInEasing,
+        )
+    }
+    val progress = animateFloatAsState(
+        targetValue = if (isStateB) 1f else 0f,
+        animationSpec = animationSpec,
+        label = "Snap-O Tweaks transition",
+    )
+
+    Column(verticalArrangement = Arrangement.spacedBy(14.dp)) {
+        Text(
+            text = "Motion",
+            style = MaterialTheme.typography.titleSmall,
+            color = MaterialTheme.colorScheme.primary,
+        )
+        MotionTrack(
+            progress = progress,
+            isStateB = isStateB,
+            onToggle = { isStateB = !isStateB },
+        )
+        Button(onClick = { isStateB = !isStateB }) {
+            Text("Tap to animate")
+        }
+        AnimationDetails(
+            isStateB = isStateB,
+        )
+    }
+}
+
+@Composable
+private fun MotionTrack(
+    progress: State<Float>,
+    isStateB: Boolean,
+    onToggle: () -> Unit,
+) {
+    val accentColor = MaterialTheme.colorScheme.primary
+    val mutedColor = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.55f)
+
+    Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
+        Row(
+            modifier = Modifier.fillMaxWidth(),
+            horizontalArrangement = Arrangement.SpaceBetween,
+        ) {
+            Text("State A", color = if (isStateB) mutedColor else accentColor)
+            Text("State B", color = if (isStateB) accentColor else mutedColor)
+        }
+        BoxWithConstraints(
+            modifier = Modifier
+                .fillMaxWidth()
+                .height(64.dp)
+                .clickable(role = Role.Button, onClick = onToggle),
+            contentAlignment = Alignment.CenterStart,
+        ) {
+            Box(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .height(2.dp)
+                    .background(accentColor.copy(alpha = 0.22f)),
+            )
+
+            val markerSize = 40.dp
+            val markerTravel = (maxWidth - markerSize).coerceAtLeast(0.dp)
+
+            Box(
+                modifier = Modifier
+                    .offset {
+                        IntOffset(
+                            x = (markerTravel * progress.value).roundToPx(),
+                            y = 0,
+                        )
+                    }
+                    .size(markerSize)
+                    .background(accentColor, CircleShape),
+            )
+        }
+    }
+}
+
+@Composable
+private fun AnimationDetails(
+    isStateB: Boolean,
+) {
+    val useSpring = tweakBoolean("Use spring", true)
+    val description = if (useSpring) {
+        val stiffness = tweakFloat("Spring stiffness", 280f, min = 80f, max = 800f, step = 20f)
+        val damping = tweakFloat("Spring damping", 0.7f, min = 0.1f, max = 1f, step = 0.05f)
+
+        "Spring · $stiffness stiffness · $damping damping"
+    } else {
+        val duration = tweakInt("Animation duration", 400, min = 100, max = 1500, step = 50)
+
+        "Tween · $duration ms"
+    }
+    val selectedState = if (isStateB) "State B" else "State A"
+
+    Text(
+        text = "$description · $selectedState",
+        style = MaterialTheme.typography.bodySmall,
+        color = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.65f),
+    )
+}

--- a/snapo-link-android/samples/demo-tweaks/src/main/res/drawable/ic_launcher.xml
+++ b/snapo-link-android/samples/demo-tweaks/src/main/res/drawable/ic_launcher.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="utf-8"?>
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="108dp"
+    android:height="108dp"
+    android:viewportWidth="108"
+    android:viewportHeight="108">
+
+    <path
+        android:fillColor="#18212F"
+        android:pathData="M0,0h108v108h-108z" />
+    <path
+        android:fillColor="#F7F8FA"
+        android:pathData="M25,37h58v5H25zM25,66h58v5H25z" />
+    <path
+        android:fillColor="#5468FF"
+        android:pathData="M43,39.5m-9,0a9,9 0,1 0,18,0a9,9 0,1 0,-18,0M67,68.5m-9,0a9,9 0,1 0,18,0a9,9 0,1 0,-18,0" />
+
+</vector>

--- a/snapo-link-android/samples/demo-tweaks/src/main/res/values/strings.xml
+++ b/snapo-link-android/samples/demo-tweaks/src/main/res/values/strings.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <string name="app_name">Snap-O Tweaks Demo</string>
+</resources>

--- a/snapo-link-android/samples/demo-tweaks/src/main/res/values/themes.xml
+++ b/snapo-link-android/samples/demo-tweaks/src/main/res/values/themes.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <style name="Theme.SnapOTweaksDemo" parent="android:Theme.Material.Light.NoActionBar">
+        <item name="android:windowBackground">#F7F8FA</item>
+        <item name="android:windowLightStatusBar">true</item>
+    </style>
+</resources>

--- a/snapo-link-android/settings.gradle.kts
+++ b/snapo-link-android/settings.gradle.kts
@@ -21,11 +21,14 @@ dependencyResolutionManagement {
 }
 
 rootProject.name = "snapo-link-android"
+include(":tweaks")
+include(":tweaks-noop")
 include(":network")
 include(":network-okhttp3")
 include(":network-okhttp3-noop")
 include(":network-httpurlconnection")
 include(":network-httpurlconnection-noop")
+include(":samples:demo-tweaks")
 include(":samples:demo-okhttp")
 include(":samples:demo-ktor-okhttp")
 include(":samples:demo-httpurlconnection")

--- a/snapo-link-android/tweaks-noop/build.gradle.kts
+++ b/snapo-link-android/tweaks-noop/build.gradle.kts
@@ -1,0 +1,22 @@
+plugins {
+    id("snapo.android.library")
+    id("snapo.maven.publish")
+    id("snapo.detekt")
+    alias(libs.plugins.kotlin.compose)
+}
+
+description = "No-op Compose tweaks for excluding Snap-O live adjustments from release builds."
+
+android {
+    namespace = "com.openai.snapo.tweaks"
+
+    buildFeatures {
+        compose = true
+    }
+}
+
+dependencies {
+    api(platform(libs.androidx.compose.bom))
+    api("androidx.compose.runtime:runtime")
+    api(libs.androidx.compose.ui.graphics)
+}

--- a/snapo-link-android/tweaks-noop/src/main/AndroidManifest.xml
+++ b/snapo-link-android/tweaks-noop/src/main/AndroidManifest.xml
@@ -1,0 +1,2 @@
+<?xml version="1.0" encoding="utf-8"?>
+<manifest xmlns:android="http://schemas.android.com/apk/res/android" />

--- a/snapo-link-android/tweaks-noop/src/main/java/com/openai/snapo/tweaks/Tweaks.kt
+++ b/snapo-link-android/tweaks-noop/src/main/java/com/openai/snapo/tweaks/Tweaks.kt
@@ -1,0 +1,47 @@
+@file:Suppress("UNUSED_PARAMETER")
+
+package com.openai.snapo.tweaks
+
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.graphics.Color
+
+/** Returns the release-build floating-point value unchanged. */
+@Composable
+fun tweakFloat(
+    name: String,
+    default: Float,
+    min: Float? = null,
+    max: Float? = null,
+    step: Float? = null,
+): Float = default
+
+/** Returns the release-build integer value unchanged. */
+@Composable
+fun tweakInt(
+    name: String,
+    default: Int,
+    min: Int? = null,
+    max: Int? = null,
+    step: Int? = null,
+): Int = default
+
+/** Returns the release-build color unchanged. */
+@Composable
+fun tweakColor(
+    name: String,
+    default: Color,
+): Color = default
+
+/** Returns the release-build boolean value unchanged. */
+@Composable
+fun tweakBoolean(
+    name: String,
+    default: Boolean,
+): Boolean = default
+
+/** Returns the release-build text unchanged. */
+@Composable
+fun tweakString(
+    name: String,
+    default: String,
+): String = default

--- a/snapo-link-android/tweaks/build.gradle.kts
+++ b/snapo-link-android/tweaks/build.gradle.kts
@@ -1,0 +1,24 @@
+plugins {
+    id("snapo.android.library")
+    id("snapo.maven.publish")
+    id("snapo.detekt")
+    alias(libs.plugins.kotlin.compose)
+}
+
+description = "Debug-only live Compose tweaks for inspecting and adjusting a running app with Snap-O."
+
+android {
+    namespace = "com.openai.snapo.tweaks"
+
+    buildFeatures {
+        compose = true
+    }
+}
+
+dependencies {
+    api(platform(libs.androidx.compose.bom))
+    api("androidx.compose.runtime:runtime")
+    api(libs.androidx.compose.ui.graphics)
+
+    testImplementation(libs.junit4)
+}

--- a/snapo-link-android/tweaks/src/main/AndroidManifest.xml
+++ b/snapo-link-android/tweaks/src/main/AndroidManifest.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8"?>
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
+
+    <application>
+        <provider
+            android:name="com.openai.snapo.tweaks.SnapOTweaksInitProvider"
+            android:authorities="${applicationId}.snapo-tweaks-init"
+            android:exported="false" />
+    </application>
+
+</manifest>

--- a/snapo-link-android/tweaks/src/main/java/com/openai/snapo/tweaks/SnapOTweaksInitProvider.kt
+++ b/snapo-link-android/tweaks/src/main/java/com/openai/snapo/tweaks/SnapOTweaksInitProvider.kt
@@ -1,0 +1,74 @@
+package com.openai.snapo.tweaks
+
+import android.content.ContentProvider
+import android.content.ContentValues
+import android.content.Context
+import android.content.pm.ApplicationInfo
+import android.database.Cursor
+import android.net.Uri
+import android.util.Log
+import com.openai.snapo.tweaks.internal.TweakAppInfoProvider
+import com.openai.snapo.tweaks.internal.TweakHttpServer
+import java.io.IOException
+
+/** Starts the local Snap-O Tweaks server only in a debuggable application. */
+class SnapOTweaksInitProvider : ContentProvider() {
+
+    override fun onCreate(): Boolean {
+        val applicationContext = context?.applicationContext ?: return false
+        if (applicationContext.applicationInfo.flags and ApplicationInfo.FLAG_DEBUGGABLE == 0) {
+            return false
+        }
+
+        return TweaksRuntime.start(applicationContext)
+    }
+
+    override fun query(
+        uri: Uri,
+        projection: Array<out String>?,
+        selection: String?,
+        selectionArgs: Array<out String>?,
+        sortOrder: String?,
+    ): Cursor? = null
+
+    override fun getType(uri: Uri): String? = null
+
+    override fun insert(uri: Uri, values: ContentValues?): Uri? = null
+
+    override fun delete(
+        uri: Uri,
+        selection: String?,
+        selectionArgs: Array<out String>?,
+    ): Int = 0
+
+    override fun update(
+        uri: Uri,
+        values: ContentValues?,
+        selection: String?,
+        selectionArgs: Array<out String>?,
+    ): Int = 0
+}
+
+private object TweaksRuntime {
+    @Volatile
+    private var server: TweakHttpServer? = null
+
+    @Synchronized
+    fun start(context: Context): Boolean {
+        if (server != null) {
+            return true
+        }
+
+        return try {
+            val startedServer = TweakHttpServer(
+                appInfoProvider = TweakAppInfoProvider(context),
+            )
+            startedServer.start()
+            server = startedServer
+            true
+        } catch (error: IOException) {
+            Log.e("SnapOTweaks", "Could not start the Snap-O Tweaks server.", error)
+            false
+        }
+    }
+}

--- a/snapo-link-android/tweaks/src/main/java/com/openai/snapo/tweaks/Tweaks.kt
+++ b/snapo-link-android/tweaks/src/main/java/com/openai/snapo/tweaks/Tweaks.kt
@@ -1,0 +1,146 @@
+package com.openai.snapo.tweaks
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.DisposableEffect
+import androidx.compose.runtime.State
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.toArgb
+import com.openai.snapo.tweaks.internal.TweakDescriptor
+import com.openai.snapo.tweaks.internal.TweakRegistry
+import com.openai.snapo.tweaks.internal.TweakType
+
+/** Exposes a floating-point value to Snap-O Tweaks. */
+@Composable
+fun tweakFloat(
+    name: String,
+    default: Float,
+    min: Float? = null,
+    max: Float? = null,
+    step: Float? = null,
+): Float = rememberTweakValue(
+    TweakDescriptor(
+        name = name,
+        type = TweakType.FLOAT,
+        default = default,
+        min = min,
+        max = max,
+        step = step,
+    ),
+) { value -> value as Float }
+
+/** Exposes an integer value to Snap-O Tweaks. */
+@Composable
+fun tweakInt(
+    name: String,
+    default: Int,
+    min: Int? = null,
+    max: Int? = null,
+    step: Int? = null,
+): Int = rememberTweakValue(
+    TweakDescriptor(
+        name = name,
+        type = TweakType.INT,
+        default = default,
+        min = min,
+        max = max,
+        step = step,
+    ),
+) { value -> value as Int }
+
+/** Exposes a color as an RGB or RGBA hexadecimal string. */
+@Composable
+fun tweakColor(
+    name: String,
+    default: Color,
+): Color = rememberTweakValue(
+    TweakDescriptor(
+        name = name,
+        type = TweakType.COLOR,
+        default = default.toTweakColor(),
+    ),
+) { value -> (value as String).toTweakColor() }
+
+/** Exposes a boolean value to Snap-O Tweaks. */
+@Composable
+fun tweakBoolean(
+    name: String,
+    default: Boolean,
+): Boolean = rememberTweakValue(
+    TweakDescriptor(
+        name = name,
+        type = TweakType.BOOLEAN,
+        default = default,
+    ),
+) { value -> value as Boolean }
+
+/** Exposes a text value to Snap-O Tweaks. */
+@Composable
+fun tweakString(
+    name: String,
+    default: String,
+): String = rememberTweakValue(
+    TweakDescriptor(
+        name = name,
+        type = TweakType.STRING,
+        default = default,
+    ),
+) { value -> value as String }
+
+@Composable
+private fun <T> rememberTweakValue(
+    descriptor: TweakDescriptor,
+    decode: (Any) -> T,
+): T {
+    val registeredState = remember(descriptor) {
+        mutableStateOf<State<Any>?>(null)
+    }
+
+    DisposableEffect(descriptor) {
+        registeredState.value = TweakRegistry.register(descriptor)
+
+        onDispose {
+            TweakRegistry.unregister(descriptor.name)
+        }
+    }
+
+    return decode(registeredState.value?.value ?: descriptor.default)
+}
+
+private fun Color.toTweakColor(): String {
+    val argb = toArgb()
+    val redGreenBlue = (argb and 0x00FF_FFFF)
+        .toString(radix = 16)
+        .padStart(length = 6, padChar = '0')
+        .uppercase()
+    val alpha = argb ushr 24
+
+    return if (alpha == 0xFF) {
+        "#$redGreenBlue"
+    } else {
+        val alphaHex = alpha
+            .toString(radix = 16)
+            .padStart(length = 2, padChar = '0')
+            .uppercase()
+        "#$redGreenBlue$alphaHex"
+    }
+}
+
+private fun String.toTweakColor(): Color {
+    require(startsWith('#')) { "Tweak colors must start with #." }
+
+    val digits = substring(startIndex = 1)
+    val argb = when (digits.length) {
+        6 -> 0xFF00_0000L or digits.toLong(radix = 16)
+        8 -> {
+            val rgba = digits.toLong(radix = 16)
+            val alpha = rgba and 0xFF
+            (alpha shl 24) or (rgba ushr 8)
+        }
+
+        else -> error("Tweak colors must use #RRGGBB or #RRGGBBAA.")
+    }
+
+    return Color(argb.toInt())
+}

--- a/snapo-link-android/tweaks/src/main/java/com/openai/snapo/tweaks/internal/TweakAppInfoProvider.kt
+++ b/snapo-link-android/tweaks/src/main/java/com/openai/snapo/tweaks/internal/TweakAppInfoProvider.kt
@@ -1,0 +1,77 @@
+package com.openai.snapo.tweaks.internal
+
+import android.content.Context
+import android.content.res.Resources
+import android.graphics.Bitmap
+import android.graphics.Canvas
+import java.io.ByteArrayOutputStream
+
+internal data class TweakAppInfo(
+    val name: String,
+    val packageName: String,
+)
+
+internal class TweakAppInfoProvider(context: Context) {
+    private val applicationContext = context.applicationContext
+
+    private val appInfo: TweakAppInfo by lazy {
+        TweakAppInfo(
+            name = loadName(),
+            packageName = applicationContext.packageName,
+        )
+    }
+
+    private val appIcon: ByteArray? by lazy { renderIcon() }
+
+    fun load(): TweakAppInfo = appInfo
+
+    fun loadIcon(): ByteArray? = appIcon
+
+    private fun loadName(): String = try {
+        applicationContext.packageManager
+            .getApplicationLabel(applicationContext.applicationInfo)
+            .toString()
+            .ifBlank { applicationContext.packageName }
+    } catch (_: Resources.NotFoundException) {
+        applicationContext.packageName
+    } catch (_: SecurityException) {
+        applicationContext.packageName
+    }
+
+    private fun renderIcon(): ByteArray? = try {
+        val drawable = applicationContext.packageManager
+            .getApplicationIcon(applicationContext.applicationInfo)
+        val bitmap = Bitmap.createBitmap(
+            TARGET_ICON_SIZE,
+            TARGET_ICON_SIZE,
+            Bitmap.Config.ARGB_8888,
+        )
+
+        try {
+            drawable.setBounds(0, 0, TARGET_ICON_SIZE, TARGET_ICON_SIZE)
+            drawable.draw(Canvas(bitmap))
+            encodeIcon(bitmap)
+        } finally {
+            bitmap.recycle()
+        }
+    } catch (_: Resources.NotFoundException) {
+        null
+    } catch (_: SecurityException) {
+        null
+    } catch (_: IllegalArgumentException) {
+        null
+    }
+
+    private fun encodeIcon(bitmap: Bitmap): ByteArray? = ByteArrayOutputStream().use { stream ->
+        if (!bitmap.compress(Bitmap.CompressFormat.PNG, ICON_PNG_QUALITY, stream)) {
+            null
+        } else {
+            stream.toByteArray()
+        }
+    }
+
+    private companion object {
+        const val TARGET_ICON_SIZE = 96
+        const val ICON_PNG_QUALITY = 100
+    }
+}

--- a/snapo-link-android/tweaks/src/main/java/com/openai/snapo/tweaks/internal/TweakHttpServer.kt
+++ b/snapo-link-android/tweaks/src/main/java/com/openai/snapo/tweaks/internal/TweakHttpServer.kt
@@ -1,0 +1,502 @@
+package com.openai.snapo.tweaks.internal
+
+import android.net.LocalServerSocket
+import android.net.LocalSocket
+import android.os.Handler
+import android.os.Looper
+import android.os.Process
+import android.util.JsonReader
+import android.util.JsonToken
+import android.util.JsonWriter
+import java.io.ByteArrayInputStream
+import java.io.ByteArrayOutputStream
+import java.io.Closeable
+import java.io.IOException
+import java.io.InputStream
+import java.io.InputStreamReader
+import java.io.OutputStream
+import java.io.StringWriter
+import java.net.SocketTimeoutException
+import java.nio.charset.StandardCharsets
+import java.util.Locale
+import java.util.concurrent.ExecutionException
+import java.util.concurrent.FutureTask
+import java.util.concurrent.TimeUnit
+import java.util.concurrent.TimeoutException
+import kotlin.concurrent.thread
+
+private const val MaxHeaderBytes = 16 * 1024
+private const val MaxBodyBytes = 64 * 1024
+private const val SocketTimeoutMillis = 5_000
+private const val MainThreadTimeoutMillis = 5_000L
+
+internal class TweakHttpServer(
+    private val appInfoProvider: TweakAppInfoProvider,
+    private val socketName: String = "snapo_tweaks_${Process.myPid()}",
+    private val mainHandler: Handler = Handler(Looper.getMainLooper()),
+) : Closeable {
+    private val lifecycleLock = Any()
+
+    @Volatile
+    private var running = false
+
+    private var server: LocalServerSocket? = null
+    private var acceptThread: Thread? = null
+
+    fun start() {
+        synchronized(lifecycleLock) {
+            if (running) return
+
+            val localServer = LocalServerSocket(socketName)
+            server = localServer
+            running = true
+            acceptThread = thread(
+                isDaemon = true,
+                name = "Snap-O Tweaks",
+            ) {
+                acceptConnections(localServer)
+            }
+        }
+    }
+
+    override fun close() {
+        synchronized(lifecycleLock) {
+            running = false
+            runCatching { server?.close() }
+            server = null
+            acceptThread?.interrupt()
+            acceptThread = null
+        }
+    }
+
+    private fun acceptConnections(localServer: LocalServerSocket) {
+        while (running) {
+            val socket = try {
+                localServer.accept()
+            } catch (_: IOException) {
+                if (!running) return
+                continue
+            }
+
+            runCatching {
+                socket.use(::handleConnection)
+            }
+        }
+    }
+
+    private fun handleConnection(socket: LocalSocket) {
+        socket.soTimeout = SocketTimeoutMillis
+
+        val response = try {
+            route(readRequest(socket.inputStream))
+        } catch (error: TweakUpdateException) {
+            errorResponse(error.statusCode, error.message ?: "Invalid tweak update.")
+        } catch (error: HttpFailure) {
+            errorResponse(error.statusCode, error.message, error.allowedMethods)
+        } catch (_: SocketTimeoutException) {
+            errorResponse(408, "The request timed out.")
+        } catch (_: IOException) {
+            errorResponse(400, "Malformed HTTP or JSON request.")
+        } catch (_: IllegalStateException) {
+            errorResponse(400, "Malformed JSON request.")
+        } catch (_: NumberFormatException) {
+            errorResponse(400, "Malformed JSON number.")
+        }
+
+        writeResponse(socket.outputStream, response)
+    }
+
+    private fun route(request: HttpRequest): HttpResponse = when (request.path) {
+        "/app" -> routeApp(request)
+        "/app/icon" -> routeAppIcon(request)
+        "/tweaks" -> routeTweaks(request)
+        else -> throw HttpFailure(404, "Unknown endpoint: ${request.path}")
+    }
+
+    private fun routeApp(request: HttpRequest): HttpResponse {
+        if (request.method != "GET") {
+            throw HttpFailure(
+                statusCode = 405,
+                message = "Unsupported method: ${request.method}",
+                allowedMethods = "GET",
+            )
+        }
+
+        return appInfoResponse(appInfoProvider.load())
+    }
+
+    private fun routeAppIcon(request: HttpRequest): HttpResponse {
+        if (request.method != "GET") {
+            throw HttpFailure(
+                statusCode = 405,
+                message = "Unsupported method: ${request.method}",
+                allowedMethods = "GET",
+            )
+        }
+
+        val icon = appInfoProvider.loadIcon()
+            ?: throw HttpFailure(404, "Application icon is unavailable.")
+
+        return HttpResponse(
+            statusCode = 200,
+            body = icon,
+            contentType = "image/png",
+        )
+    }
+
+    private fun routeTweaks(request: HttpRequest): HttpResponse = when (request.method) {
+        "GET" -> tweaksResponse(TweakRegistry.snapshot(), includeDescriptors = true)
+        "PATCH" -> {
+            requireJsonRequest(request)
+            val changes = readPatchValues(request.body)
+            tweaksResponse(updateOnMainThread(changes), includeDescriptors = false)
+        }
+
+        else -> throw HttpFailure(
+            statusCode = 405,
+            message = "Unsupported method: ${request.method}",
+            allowedMethods = "GET, PATCH",
+        )
+    }
+
+    private fun readRequest(input: InputStream): HttpRequest {
+        val firstLine = readLine(input)
+        val parts = firstLine.split(' ')
+        if (parts.size != 3 || parts[2] !in listOf("HTTP/1.0", "HTTP/1.1")) {
+            throw HttpFailure(400, "Malformed HTTP request line.")
+        }
+
+        val headers = readHeaders(input, firstLine.length)
+        val contentLength = readContentLength(headers)
+        val body = readBody(input, contentLength)
+
+        return HttpRequest(
+            method = parts[0],
+            path = parts[1],
+            headers = headers,
+            body = body,
+        )
+    }
+
+    private fun readHeaders(input: InputStream, requestLineBytes: Int): Map<String, String> {
+        val headers = LinkedHashMap<String, String>()
+        var totalBytes = requestLineBytes
+
+        while (true) {
+            val line = readLine(input)
+            totalBytes += line.length + 2
+            if (totalBytes > MaxHeaderBytes) {
+                invalidRequest("HTTP headers are too large.")
+            }
+            if (line.isEmpty()) return headers
+
+            val separator = line.indexOf(':')
+            if (separator <= 0) {
+                invalidRequest("Malformed HTTP header.")
+            }
+
+            val name = line.substring(0, separator).trim().lowercase(Locale.ROOT)
+            val value = line.substring(separator + 1).trim()
+            if (headers.put(name, value) != null && name == "content-length") {
+                invalidRequest("Duplicate Content-Length header.")
+            }
+        }
+    }
+
+    private fun readLine(input: InputStream): String {
+        val buffer = ByteArrayOutputStream()
+
+        while (true) {
+            val next = input.read()
+            if (next == -1) {
+                throw HttpFailure(400, "Incomplete HTTP request.")
+            }
+            if (next == '\n'.code) break
+            if (buffer.size() >= MaxHeaderBytes) {
+                throw HttpFailure(400, "HTTP request line is too large.")
+            }
+            buffer.write(next)
+        }
+
+        return buffer.toString(StandardCharsets.ISO_8859_1.name()).removeSuffix("\r")
+    }
+
+    private fun readContentLength(headers: Map<String, String>): Int {
+        if (headers.containsKey("transfer-encoding")) {
+            invalidRequest("Transfer-Encoding is unsupported.")
+        }
+
+        val rawLength = headers["content-length"] ?: return 0
+        val contentLength = rawLength.toIntOrNull()
+            ?: invalidRequest("Invalid Content-Length header.")
+        if (contentLength < 0) {
+            invalidRequest("Content-Length cannot be negative.")
+        }
+        if (contentLength > MaxBodyBytes) {
+            throw HttpFailure(413, "The request body is too large.")
+        }
+
+        return contentLength
+    }
+
+    private fun readBody(input: InputStream, contentLength: Int): ByteArray {
+        val body = ByteArray(contentLength)
+        var position = 0
+
+        while (position < contentLength) {
+            val count = input.read(body, position, contentLength - position)
+            if (count < 0) {
+                throw HttpFailure(400, "Incomplete HTTP request body.")
+            }
+            position += count
+        }
+
+        return body
+    }
+
+    private fun requireJsonRequest(request: HttpRequest) {
+        if (request.body.isEmpty()) {
+            throw HttpFailure(400, "PATCH requires a JSON request body.")
+        }
+
+        val contentType = request.headers["content-type"]
+        if (contentType != null &&
+            !contentType.substringBefore(';').trim().equals("application/json", ignoreCase = true)
+        ) {
+            throw HttpFailure(400, "PATCH requires application/json.")
+        }
+    }
+
+    private fun readPatchValues(body: ByteArray): Map<String, Any?> {
+        val values = LinkedHashMap<String, Any?>()
+
+        JsonReader(InputStreamReader(ByteArrayInputStream(body), StandardCharsets.UTF_8)).use { reader ->
+            reader.beginObject()
+            if (!reader.hasNext() || reader.nextName() != "values") {
+                invalidRequest("PATCH must contain a values object.")
+            }
+
+            readTweakValues(reader, values)
+            if (reader.hasNext()) {
+                invalidRequest("PATCH must contain exactly one values object.")
+            }
+            reader.endObject()
+            if (reader.peek() != JsonToken.END_DOCUMENT) {
+                invalidRequest("Unexpected content after the JSON request.")
+            }
+        }
+
+        return values
+    }
+
+    private fun readTweakValues(
+        reader: JsonReader,
+        values: MutableMap<String, Any?>,
+    ) {
+        reader.beginObject()
+
+        while (reader.hasNext()) {
+            val name = reader.nextName()
+            if (values.containsKey(name)) {
+                invalidRequest("Duplicate tweak: $name")
+            }
+            values[name] = readJsonValue(reader)
+        }
+
+        reader.endObject()
+    }
+
+    private fun readJsonValue(reader: JsonReader): Any? = when (reader.peek()) {
+        JsonToken.STRING -> reader.nextString()
+        JsonToken.NUMBER -> TweakNumbers.parse(reader.nextString())
+        JsonToken.BOOLEAN -> reader.nextBoolean()
+        JsonToken.NULL -> {
+            reader.nextNull()
+            null
+        }
+
+        else -> throw HttpFailure(422, "Tweak values must be primitive JSON values.")
+    }
+
+    private fun updateOnMainThread(values: Map<String, Any?>): List<TweakSnapshot> {
+        if (Looper.myLooper() == Looper.getMainLooper()) {
+            return TweakRegistry.update(values)
+        }
+
+        val update = FutureTask { TweakRegistry.update(values) }
+        if (!mainHandler.post(update)) {
+            throw HttpFailure(503, "The Android main thread is unavailable.")
+        }
+
+        return awaitUpdate(update)
+    }
+
+    private fun awaitUpdate(update: FutureTask<List<TweakSnapshot>>): List<TweakSnapshot> =
+        try {
+            update.get(MainThreadTimeoutMillis, TimeUnit.MILLISECONDS)
+        } catch (error: ExecutionException) {
+            throw updateFailure(error)
+        } catch (_: TimeoutException) {
+            update.cancel(false)
+            throw HttpFailure(504, "The tweak update timed out.")
+        } catch (_: InterruptedException) {
+            update.cancel(false)
+            Thread.currentThread().interrupt()
+            throw HttpFailure(503, "The tweak update was interrupted.")
+        }
+
+    private fun updateFailure(error: ExecutionException): Exception {
+        val cause = error.cause
+
+        return if (cause is TweakUpdateException) {
+            cause
+        } else {
+            HttpFailure(500, "The tweak update could not be applied.", error)
+        }
+    }
+
+    private fun appInfoResponse(appInfo: TweakAppInfo): HttpResponse {
+        val output = StringWriter()
+        JsonWriter(output).use { writer ->
+            writer.beginObject()
+            writer.name("name").value(appInfo.name)
+            writer.name("packageName").value(appInfo.packageName)
+            writer.endObject()
+        }
+
+        return HttpResponse(200, output.toString().toByteArray(StandardCharsets.UTF_8))
+    }
+
+    private fun tweaksResponse(
+        tweaks: List<TweakSnapshot>,
+        includeDescriptors: Boolean,
+    ): HttpResponse {
+        val output = StringWriter()
+        JsonWriter(output).use { writer ->
+            writer.beginObject()
+            writer.name("tweaks").beginArray()
+
+            tweaks.forEach { tweak ->
+                writeTweak(writer, tweak, includeDescriptors)
+            }
+
+            writer.endArray()
+            writer.endObject()
+        }
+
+        return HttpResponse(200, output.toString().toByteArray(StandardCharsets.UTF_8))
+    }
+
+    private fun writeTweak(
+        writer: JsonWriter,
+        tweak: TweakSnapshot,
+        includeDescriptor: Boolean,
+    ) {
+        writer.beginObject()
+        writer.name("name").value(tweak.descriptor.name)
+
+        if (includeDescriptor) {
+            writer.name("type").value(tweak.descriptor.type.wireName)
+            writer.name("default")
+            writeJsonValue(writer, tweak.descriptor.default)
+        }
+
+        writer.name("value")
+        writeJsonValue(writer, tweak.value)
+
+        if (includeDescriptor) {
+            writeConstraints(writer, tweak.descriptor)
+        }
+
+        writer.endObject()
+    }
+
+    private fun writeConstraints(writer: JsonWriter, descriptor: TweakDescriptor) {
+        descriptor.min?.let { minimum -> writer.name("min").value(minimum) }
+        descriptor.max?.let { maximum -> writer.name("max").value(maximum) }
+        descriptor.step?.let { increment -> writer.name("step").value(increment) }
+    }
+
+    private fun writeJsonValue(writer: JsonWriter, value: Any) {
+        when (value) {
+            is Boolean -> writer.value(value)
+            is Number -> writer.value(value)
+            is String -> writer.value(value)
+            else -> throw HttpFailure(500, "Unsupported tweak value.")
+        }
+    }
+
+    private fun errorResponse(
+        statusCode: Int,
+        message: String,
+        allowedMethods: String? = null,
+    ): HttpResponse {
+        val output = StringWriter()
+        JsonWriter(output).use { writer ->
+            writer.beginObject()
+            writer.name("error").value(message)
+            writer.endObject()
+        }
+
+        return HttpResponse(
+            statusCode,
+            output.toString().toByteArray(StandardCharsets.UTF_8),
+            allowedMethods,
+        )
+    }
+
+    private fun writeResponse(output: OutputStream, response: HttpResponse) {
+        val reason = reasonPhrase(response.statusCode)
+        val headers = buildString {
+            append("HTTP/1.1 ${response.statusCode} $reason\r\n")
+            append("Content-Type: ${response.contentType}\r\n")
+            append("Content-Length: ${response.body.size}\r\n")
+            if (response.allowedMethods != null) {
+                append("Allow: ${response.allowedMethods}\r\n")
+            }
+            append("Connection: close\r\n\r\n")
+        }
+
+        output.write(headers.toByteArray(StandardCharsets.US_ASCII))
+        output.write(response.body)
+        output.flush()
+    }
+
+    private fun reasonPhrase(statusCode: Int): String = when (statusCode) {
+        200 -> "OK"
+        400 -> "Bad Request"
+        404 -> "Not Found"
+        405 -> "Method Not Allowed"
+        408 -> "Request Timeout"
+        413 -> "Payload Too Large"
+        422 -> "Unprocessable Entity"
+        500 -> "Internal Server Error"
+        503 -> "Service Unavailable"
+        504 -> "Gateway Timeout"
+        else -> "Error"
+    }
+
+    private data class HttpRequest(
+        val method: String,
+        val path: String,
+        val headers: Map<String, String>,
+        val body: ByteArray,
+    )
+
+    private data class HttpResponse(
+        val statusCode: Int,
+        val body: ByteArray,
+        val allowedMethods: String? = null,
+        val contentType: String = "application/json; charset=utf-8",
+    )
+
+    private class HttpFailure(
+        val statusCode: Int,
+        override val message: String,
+        cause: Throwable? = null,
+        val allowedMethods: String? = null,
+    ) : Exception(message, cause)
+
+    private fun invalidRequest(message: String): Nothing =
+        throw HttpFailure(400, message)
+}

--- a/snapo-link-android/tweaks/src/main/java/com/openai/snapo/tweaks/internal/TweakNumbers.kt
+++ b/snapo-link-android/tweaks/src/main/java/com/openai/snapo/tweaks/internal/TweakNumbers.kt
@@ -1,0 +1,32 @@
+package com.openai.snapo.tweaks.internal
+
+import java.math.BigDecimal
+
+internal object TweakNumbers {
+    const val MAX_LITERAL_LENGTH = 128
+    const val MAX_PRECISION = 64
+    const val MAX_SCALE = 64
+
+    fun parse(literal: String): BigDecimal {
+        if (literal.length > MAX_LITERAL_LENGTH) {
+            invalidNumber()
+        }
+
+        val number = BigDecimal(literal)
+        if (!isSupported(number)) {
+            invalidNumber()
+        }
+
+        return number
+    }
+
+    fun isSupported(number: BigDecimal): Boolean =
+        number.precision() <= MAX_PRECISION &&
+            number.scale() in -MAX_SCALE..MAX_SCALE
+
+    private fun invalidNumber(): Nothing =
+        throw TweakUpdateException(
+            statusCode = 422,
+            message = "Numeric tweak value exceeds the supported precision or scale.",
+        )
+}

--- a/snapo-link-android/tweaks/src/main/java/com/openai/snapo/tweaks/internal/TweakRegistry.kt
+++ b/snapo-link-android/tweaks/src/main/java/com/openai/snapo/tweaks/internal/TweakRegistry.kt
@@ -1,0 +1,294 @@
+package com.openai.snapo.tweaks.internal
+
+import androidx.compose.runtime.MutableState
+import androidx.compose.runtime.State
+import androidx.compose.runtime.mutableStateOf
+import java.math.BigDecimal
+import java.math.BigInteger
+
+internal enum class TweakType(val wireName: String) {
+    INT("int"),
+    FLOAT("float"),
+    BOOLEAN("boolean"),
+    COLOR("color"),
+    STRING("string"),
+}
+
+internal data class TweakDescriptor(
+    val name: String,
+    val type: TweakType,
+    val default: Any,
+    val min: Number? = null,
+    val max: Number? = null,
+    val step: Number? = null,
+)
+
+internal data class TweakSnapshot(
+    val descriptor: TweakDescriptor,
+    val value: Any,
+)
+
+internal open class TweakUpdateException(
+    val statusCode: Int,
+    message: String,
+) : IllegalArgumentException(message)
+
+internal class UnknownTweakException(name: String) :
+    TweakUpdateException(404, "Unknown tweak: $name")
+
+internal class InvalidTweakValueException(name: String, reason: String) :
+    TweakUpdateException(422, "Invalid value for $name: $reason")
+
+internal object TweakRegistry {
+    private val lock = Any()
+    private val tweaks = LinkedHashMap<String, RegisteredTweak>()
+    private val colorPattern = Regex("^#[0-9a-fA-F]{6}([0-9a-fA-F]{2})?$")
+
+    fun register(descriptor: TweakDescriptor): State<Any> = synchronized(lock) {
+        validateDescriptor(descriptor)
+
+        val existing = tweaks[descriptor.name]
+        if (existing != null) {
+            require(existing.descriptor == descriptor) {
+                "Conflicting declarations for tweak: ${descriptor.name}"
+            }
+            existing.references += 1
+            existing.state
+        } else {
+            val tweak = RegisteredTweak(
+                descriptor = descriptor,
+                state = mutableStateOf(descriptor.default),
+                references = 1,
+            )
+            tweaks[descriptor.name] = tweak
+            tweak.state
+        }
+    }
+
+    fun unregister(name: String) = synchronized(lock) {
+        val tweak = tweaks[name] ?: return@synchronized
+        tweak.references -= 1
+        if (tweak.references == 0) {
+            tweaks.remove(name)
+        }
+    }
+
+    fun snapshot(): List<TweakSnapshot> = synchronized(lock) {
+        tweaks.values.map { tweak ->
+            TweakSnapshot(tweak.descriptor, tweak.state.value)
+        }
+    }
+
+    fun update(values: Map<String, Any?>): List<TweakSnapshot> = synchronized(lock) {
+        val changes = values.map { (name, value) ->
+            val tweak = tweaks[name]
+                ?: throw UnknownTweakException(name)
+            tweak to validateValue(tweak.descriptor, value)
+        }
+
+        changes.forEach { (tweak, value) ->
+            tweak.state.value = value
+        }
+
+        changes.map { (tweak, _) ->
+            TweakSnapshot(tweak.descriptor, tweak.state.value)
+        }
+    }
+
+    fun clear() = synchronized(lock) {
+        tweaks.clear()
+    }
+
+    private fun validateDescriptor(descriptor: TweakDescriptor) {
+        require(descriptor.name.isNotBlank()) { "Tweak names must not be blank." }
+
+        when (descriptor.type) {
+            TweakType.INT, TweakType.FLOAT -> validateNumericDescriptor(descriptor)
+            TweakType.BOOLEAN -> require(descriptor.default is Boolean) {
+                "Boolean tweaks must have a boolean default: ${descriptor.name}"
+            }
+
+            TweakType.COLOR -> require(
+                descriptor.default is String && colorPattern.matches(descriptor.default),
+            ) {
+                "Color tweaks must use #RRGGBB or #RRGGBBAA: ${descriptor.name}"
+            }
+
+            TweakType.STRING -> require(descriptor.default is String) {
+                "String tweaks must have a string default: ${descriptor.name}"
+            }
+        }
+
+        if (descriptor.type != TweakType.INT && descriptor.type != TweakType.FLOAT) {
+            require(
+                descriptor.min == null && descriptor.max == null && descriptor.step == null,
+            ) {
+                "Only numeric tweaks can define numeric constraints: ${descriptor.name}"
+            }
+        }
+    }
+
+    private fun validateNumericDescriptor(descriptor: TweakDescriptor) {
+        validateNumericDescriptorTypes(descriptor)
+
+        val default = descriptor.default as Number
+        val defaultDecimal = default.toTweakDecimal()
+            ?: throw IllegalArgumentException(
+                "Numeric tweak defaults must be finite: ${descriptor.name}",
+            )
+        val minimum = descriptor.min?.let { constraint ->
+            requireNotNull(constraint.toTweakDecimal()) {
+                "Numeric tweak minimums must be finite: ${descriptor.name}"
+            }
+        }
+        val maximum = descriptor.max?.let { constraint ->
+            requireNotNull(constraint.toTweakDecimal()) {
+                "Numeric tweak maximums must be finite: ${descriptor.name}"
+            }
+        }
+        val increment = descriptor.step?.let { constraint ->
+            requireNotNull(constraint.toTweakDecimal()) {
+                "Numeric tweak steps must be finite: ${descriptor.name}"
+            }
+        }
+
+        require(minimum == null || maximum == null || minimum <= maximum) {
+            "Numeric tweak minimum must not exceed its maximum: ${descriptor.name}"
+        }
+        require(minimum == null || defaultDecimal >= minimum) {
+            "Numeric tweak default is below its minimum: ${descriptor.name}"
+        }
+        require(maximum == null || defaultDecimal <= maximum) {
+            "Numeric tweak default exceeds its maximum: ${descriptor.name}"
+        }
+        require(increment == null || increment > BigDecimal.ZERO) {
+            "Numeric tweak steps must be positive: ${descriptor.name}"
+        }
+        require(
+            minimum == null || increment == null ||
+                defaultDecimal.subtract(minimum).remainder(increment)
+                    .compareTo(BigDecimal.ZERO) == 0,
+        ) {
+            "Numeric tweak default must align with its minimum and step: ${descriptor.name}"
+        }
+    }
+
+    private fun validateNumericDescriptorTypes(descriptor: TweakDescriptor) {
+        val constraints = listOf(descriptor.min, descriptor.max, descriptor.step)
+
+        when (descriptor.type) {
+            TweakType.INT -> {
+                require(descriptor.default is Int) {
+                    "Integer tweaks must have a 32-bit integer default: ${descriptor.name}"
+                }
+                require(constraints.all { constraint -> constraint == null || constraint is Int }) {
+                    "Integer tweak constraints must be 32-bit integers: ${descriptor.name}"
+                }
+            }
+
+            TweakType.FLOAT -> {
+                require(descriptor.default is Float) {
+                    "Floating-point tweaks must have a float default: ${descriptor.name}"
+                }
+                require(
+                    constraints.all { constraint -> constraint == null || constraint is Float },
+                ) {
+                    "Floating-point tweak constraints must be floats: ${descriptor.name}"
+                }
+            }
+
+            else -> error("Tweak is not numeric: ${descriptor.name}")
+        }
+    }
+
+    private fun validateValue(descriptor: TweakDescriptor, value: Any?): Any =
+        when (descriptor.type) {
+            TweakType.INT, TweakType.FLOAT -> validateNumericValue(descriptor, value)
+            TweakType.BOOLEAN -> {
+                value as? Boolean ?: invalidValue(descriptor, "Expected a boolean.")
+            }
+
+            TweakType.STRING -> {
+                value as? String ?: invalidValue(descriptor, "Expected a string.")
+            }
+
+            TweakType.COLOR -> {
+                val color = value as? String
+                    ?: invalidValue(descriptor, "Expected a color string.")
+                if (!colorPattern.matches(color)) {
+                    invalidValue(descriptor, "Expected #RRGGBB or #RRGGBBAA.")
+                }
+                color.uppercase()
+            }
+        }
+
+    private fun validateNumericValue(descriptor: TweakDescriptor, value: Any?): Number {
+        val number = value as? Number
+            ?: invalidValue(descriptor, "Expected a number.")
+        val decimal = number.toTweakDecimal()
+            ?: invalidValue(descriptor, "Expected a finite number.")
+
+        if (!TweakNumbers.isSupported(decimal)) {
+            invalidValue(descriptor, "Numeric precision or scale exceeds the supported limit.")
+        }
+
+        validateNumericConstraints(descriptor, decimal)
+
+        return normalizeNumericValue(descriptor, decimal)
+    }
+
+    private fun validateNumericConstraints(
+        descriptor: TweakDescriptor,
+        decimal: BigDecimal,
+    ) {
+        val minimum = descriptor.min?.toTweakDecimal()
+        val maximum = descriptor.max?.toTweakDecimal()
+        val increment = descriptor.step?.toTweakDecimal()
+
+        if (minimum != null && decimal < minimum) {
+            invalidValue(descriptor, "Value is below the minimum.")
+        }
+        if (maximum != null && decimal > maximum) {
+            invalidValue(descriptor, "Value exceeds the maximum.")
+        }
+        if (increment != null) {
+            val origin = minimum ?: requireNotNull(
+                (descriptor.default as Number).toTweakDecimal(),
+            )
+            if (decimal.subtract(origin).remainder(increment).compareTo(BigDecimal.ZERO) != 0) {
+                invalidValue(descriptor, "Value does not match the step.")
+            }
+        }
+    }
+
+    private fun normalizeNumericValue(
+        descriptor: TweakDescriptor,
+        decimal: BigDecimal,
+    ): Number = when (descriptor.type) {
+        TweakType.INT -> runCatching { decimal.intValueExact() }
+            .getOrElse { invalidValue(descriptor, "Expected a 32-bit integer.") }
+
+        TweakType.FLOAT -> decimal.toFloat().takeIf(Float::isFinite)
+            ?: invalidValue(descriptor, "Expected a finite floating-point number.")
+
+        else -> invalidValue(descriptor, "Unsupported numeric type.")
+    }
+
+    private fun invalidValue(descriptor: TweakDescriptor, reason: String): Nothing =
+        throw InvalidTweakValueException(descriptor.name, reason)
+
+    private fun Number.toTweakDecimal(): BigDecimal? = when (this) {
+        is BigDecimal -> this
+        is BigInteger -> BigDecimal(this)
+        is Long, is Int, is Short, is Byte -> BigDecimal.valueOf(toLong())
+        is Float -> if (isFinite()) BigDecimal(toString()) else null
+        is Double -> if (isFinite()) BigDecimal(toString()) else null
+        else -> runCatching { BigDecimal(toString()) }.getOrNull()
+    }
+
+    private data class RegisteredTweak(
+        val descriptor: TweakDescriptor,
+        val state: MutableState<Any>,
+        var references: Int,
+    )
+}

--- a/snapo-link-android/tweaks/src/test/java/com/openai/snapo/tweaks/internal/TweakRegistryLifecycleTest.kt
+++ b/snapo-link-android/tweaks/src/test/java/com/openai/snapo/tweaks/internal/TweakRegistryLifecycleTest.kt
@@ -1,0 +1,192 @@
+package com.openai.snapo.tweaks.internal
+
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertSame
+import org.junit.Assert.assertThrows
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class TweakRegistryLifecycleTest {
+
+    @After
+    fun clearRegistry() {
+        TweakRegistry.clear()
+    }
+
+    @Test
+    fun `same-name registrations share state and survive until the final unregister`() {
+        val descriptor = TweakDescriptor(
+            name = "Lifecycle shared padding",
+            type = TweakType.INT,
+            default = 16,
+            min = 0,
+            max = 48,
+            step = 1,
+        )
+
+        val first = TweakRegistry.register(descriptor)
+        val second = TweakRegistry.register(descriptor.copy())
+
+        assertSame(first, second)
+        assertEquals(1, TweakRegistry.snapshot().size)
+
+        TweakRegistry.update(mapOf(descriptor.name to 20))
+
+        assertEquals(20, first.value)
+        assertEquals(20, second.value)
+
+        TweakRegistry.unregister(descriptor.name)
+
+        assertEquals(1, TweakRegistry.snapshot().size)
+        assertEquals(20, TweakRegistry.snapshot().single().value)
+
+        TweakRegistry.unregister(descriptor.name)
+
+        assertTrue(TweakRegistry.snapshot().isEmpty())
+    }
+
+    @Test
+    fun `conflicting defaults do not replace an existing tweak`() {
+        val descriptor = TweakDescriptor(
+            name = "Lifecycle conflicting default",
+            type = TweakType.INT,
+            default = 16,
+        )
+        val original = TweakRegistry.register(descriptor)
+
+        assertThrows(IllegalArgumentException::class.java) {
+            TweakRegistry.register(descriptor.copy(default = 20))
+        }
+
+        assertEquals(16, original.value)
+        assertEquals(descriptor, TweakRegistry.snapshot().single().descriptor)
+    }
+
+    @Test
+    fun `conflicting constraints do not acquire another registration`() {
+        val descriptor = TweakDescriptor(
+            name = "Lifecycle conflicting constraints",
+            type = TweakType.INT,
+            default = 16,
+            min = 0,
+            max = 48,
+            step = 1,
+        )
+        TweakRegistry.register(descriptor)
+
+        assertThrows(IllegalArgumentException::class.java) {
+            TweakRegistry.register(descriptor.copy(max = 64))
+        }
+
+        TweakRegistry.unregister(descriptor.name)
+
+        assertTrue(TweakRegistry.snapshot().isEmpty())
+    }
+
+    @Test
+    fun `conflicting types do not replace an existing tweak`() {
+        val descriptor = TweakDescriptor(
+            name = "Lifecycle conflicting type",
+            type = TweakType.INT,
+            default = 16,
+        )
+        TweakRegistry.register(descriptor)
+
+        assertThrows(IllegalArgumentException::class.java) {
+            TweakRegistry.register(
+                TweakDescriptor(
+                    name = descriptor.name,
+                    type = TweakType.STRING,
+                    default = "16",
+                ),
+            )
+        }
+
+        assertEquals(descriptor, TweakRegistry.snapshot().single().descriptor)
+    }
+
+    @Test
+    fun `integer and floating point tweaks cannot share the same name`() {
+        val integer = TweakDescriptor(
+            name = "Lifecycle conflicting numeric types",
+            type = TweakType.INT,
+            default = 16,
+        )
+        val state = TweakRegistry.register(integer)
+
+        assertThrows(IllegalArgumentException::class.java) {
+            TweakRegistry.register(
+                TweakDescriptor(
+                    name = integer.name,
+                    type = TweakType.FLOAT,
+                    default = 16f,
+                ),
+            )
+        }
+
+        assertEquals(16, state.value)
+        assertEquals(integer, TweakRegistry.snapshot().single().descriptor)
+
+        TweakRegistry.unregister(integer.name)
+
+        assertTrue(TweakRegistry.snapshot().isEmpty())
+    }
+
+    @Test
+    fun `a removed name can register a fresh descriptor and default`() {
+        val first = TweakDescriptor(
+            name = "Lifecycle reused name",
+            type = TweakType.INT,
+            default = 16,
+        )
+        TweakRegistry.register(first)
+        TweakRegistry.update(mapOf(first.name to 20))
+        TweakRegistry.unregister(first.name)
+
+        val replacement = first.copy(default = 32)
+        val state = TweakRegistry.register(replacement)
+
+        assertEquals(32, state.value)
+        assertEquals(replacement, TweakRegistry.snapshot().single().descriptor)
+    }
+
+    @Test
+    fun `snapshots preserve registration order`() {
+        TweakRegistry.register(
+            TweakDescriptor(
+                name = "Lifecycle z tweak",
+                type = TweakType.STRING,
+                default = "last",
+            ),
+        )
+        TweakRegistry.register(
+            TweakDescriptor(
+                name = "Lifecycle a tweak",
+                type = TweakType.STRING,
+                default = "first",
+            ),
+        )
+
+        assertEquals(
+            listOf("Lifecycle z tweak", "Lifecycle a tweak"),
+            TweakRegistry.snapshot().map { it.descriptor.name },
+        )
+    }
+
+    @Test
+    fun `patching a tweak with its default resets its shared value`() {
+        val descriptor = TweakDescriptor(
+            name = "Lifecycle reset",
+            type = TweakType.INT,
+            default = 16,
+        )
+        val state = TweakRegistry.register(descriptor)
+        TweakRegistry.update(mapOf(descriptor.name to 24))
+
+        val updated = TweakRegistry.update(mapOf(descriptor.name to descriptor.default))
+
+        assertEquals(16, state.value)
+        assertEquals(16, updated.single().value)
+    }
+}

--- a/snapo-link-android/tweaks/src/test/java/com/openai/snapo/tweaks/internal/TweakValidationTest.kt
+++ b/snapo-link-android/tweaks/src/test/java/com/openai/snapo/tweaks/internal/TweakValidationTest.kt
@@ -1,0 +1,612 @@
+package com.openai.snapo.tweaks.internal
+
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertThrows
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import java.math.BigDecimal
+
+class TweakValidationTest {
+
+    @After
+    fun clearRegistry() {
+        TweakRegistry.clear()
+    }
+
+    @Test
+    fun `integer updates respect their minimum maximum and step`() {
+        val descriptor = TweakDescriptor(
+            name = "Validation numeric bounds",
+            type = TweakType.INT,
+            default = 16,
+            min = 0,
+            max = 48,
+            step = 2,
+        )
+        val state = TweakRegistry.register(descriptor)
+
+        TweakRegistry.update(mapOf(descriptor.name to 18))
+
+        assertEquals(18, state.value)
+        assertInvalidUpdate(descriptor.name, -2)
+        assertInvalidUpdate(descriptor.name, 50)
+        assertInvalidUpdate(descriptor.name, 17)
+        assertEquals(18, state.value)
+    }
+
+    @Test
+    fun `an integer step without a minimum is relative to its default`() {
+        val descriptor = TweakDescriptor(
+            name = "Validation default-relative integer step",
+            type = TweakType.INT,
+            default = 5,
+            step = 2,
+        )
+        val state = TweakRegistry.register(descriptor)
+
+        TweakRegistry.update(mapOf(descriptor.name to 7))
+
+        assertEquals(7, state.value)
+
+        TweakRegistry.update(mapOf(descriptor.name to descriptor.default))
+
+        assertEquals(5, state.value)
+        assertInvalidUpdate(descriptor.name, 6)
+        assertEquals(5, state.value)
+    }
+
+    @Test
+    fun `a floating point step without a minimum is relative to its default`() {
+        val descriptor = TweakDescriptor(
+            name = "Validation default-relative floating point step",
+            type = TweakType.FLOAT,
+            default = 0.3f,
+            step = 0.2f,
+        )
+        val state = TweakRegistry.register(descriptor)
+
+        TweakRegistry.update(mapOf(descriptor.name to 0.5))
+
+        assertEquals(0.5f, state.value)
+
+        TweakRegistry.update(mapOf(descriptor.name to descriptor.default))
+
+        assertEquals(0.3f, state.value)
+        assertInvalidUpdate(descriptor.name, 0.4)
+    }
+
+    @Test
+    fun `a step with a minimum is relative to the minimum`() {
+        val descriptor = TweakDescriptor(
+            name = "Validation minimum-relative step",
+            type = TweakType.INT,
+            default = 6,
+            min = 2,
+            max = 12,
+            step = 2,
+        )
+        val state = TweakRegistry.register(descriptor)
+
+        TweakRegistry.update(mapOf(descriptor.name to 8))
+
+        assertEquals(8, state.value)
+        assertInvalidUpdate(descriptor.name, 7)
+        assertEquals(8, state.value)
+    }
+
+    @Test
+    fun `a default must align with its minimum and step`() {
+        assertThrows(IllegalArgumentException::class.java) {
+            TweakRegistry.register(
+                TweakDescriptor(
+                    name = "Validation unaligned default",
+                    type = TweakType.INT,
+                    default = 5,
+                    min = 0,
+                    step = 2,
+                ),
+            )
+        }
+
+        assertTrue(TweakRegistry.snapshot().isEmpty())
+    }
+
+    @Test
+    fun `integer tweaks reject fractional and overflowing values`() {
+        val descriptor = TweakDescriptor(
+            name = "Validation integer type",
+            type = TweakType.INT,
+            default = 16,
+        )
+        val state = TweakRegistry.register(descriptor)
+
+        assertInvalidUpdate(descriptor.name, 16.5)
+        assertInvalidUpdate(descriptor.name, BigDecimal("16.5"))
+        assertInvalidUpdate(descriptor.name, Int.MAX_VALUE.toLong() + 1)
+        assertInvalidUpdate(descriptor.name, Int.MIN_VALUE.toLong() - 1)
+
+        assertEquals(16, state.value)
+    }
+
+    @Test
+    fun `floating point tweaks reject nonfinite values`() {
+        val descriptor = TweakDescriptor(
+            name = "Validation finite numbers",
+            type = TweakType.FLOAT,
+            default = 0f,
+        )
+        val state = TweakRegistry.register(descriptor)
+
+        assertInvalidUpdate(descriptor.name, Float.NaN)
+        assertInvalidUpdate(descriptor.name, Float.POSITIVE_INFINITY)
+        assertInvalidUpdate(descriptor.name, Float.NEGATIVE_INFINITY)
+        assertInvalidUpdate(descriptor.name, Double.NaN)
+        assertInvalidUpdate(descriptor.name, Double.POSITIVE_INFINITY)
+        assertInvalidUpdate(descriptor.name, Double.NEGATIVE_INFINITY)
+        assertInvalidUpdate(descriptor.name, BigDecimal("1e100"))
+
+        assertEquals(0f, state.value)
+    }
+
+    @Test
+    fun `numeric literals reject excessive precision and scale`() {
+        val unsupportedLiterals = listOf(
+            "0e-3000000",
+            "1e-3000000",
+            "1e3000000",
+            "9".repeat(TweakNumbers.MAX_PRECISION + 1),
+        )
+
+        unsupportedLiterals.forEach { literal ->
+            val error = assertThrows(TweakUpdateException::class.java) {
+                TweakNumbers.parse(literal)
+            }
+
+            assertEquals(422, error.statusCode)
+        }
+    }
+
+    @Test
+    fun `numeric literals reject excessive length before decimal parsing`() {
+        val literal = "1".repeat(TweakNumbers.MAX_LITERAL_LENGTH + 1)
+
+        val error = assertThrows(TweakUpdateException::class.java) {
+            TweakNumbers.parse(literal)
+        }
+
+        assertEquals(422, error.statusCode)
+    }
+
+    @Test
+    fun `numeric literals accept supported precision scale and length boundaries`() {
+        val maximumPrecision = "9".repeat(TweakNumbers.MAX_PRECISION)
+        val maximumLength = "1e+" + "0".repeat(TweakNumbers.MAX_LITERAL_LENGTH - 4) + "1"
+
+        assertEquals(BigDecimal(maximumPrecision), TweakNumbers.parse(maximumPrecision))
+        assertEquals(BigDecimal("1e-64"), TweakNumbers.parse("1e-64"))
+        assertEquals(BigDecimal("1e64"), TweakNumbers.parse("1e64"))
+        assertEquals(BigDecimal("1e1"), TweakNumbers.parse(maximumLength))
+    }
+
+    @Test
+    fun `registry rejects excessive numeric scale before validating a step`() {
+        val descriptor = TweakDescriptor(
+            name = "Validation bounded default-relative floating point step",
+            type = TweakType.FLOAT,
+            default = 0.3f,
+            step = 0.1f,
+        )
+        val state = TweakRegistry.register(descriptor)
+
+        listOf(
+            BigDecimal("0e-3000000"),
+            BigDecimal("1e-3000000"),
+            BigDecimal("1e3000000"),
+            BigDecimal("9".repeat(TweakNumbers.MAX_PRECISION + 1)),
+        ).forEach { value ->
+            assertInvalidUpdate(descriptor.name, value)
+            assertEquals(0.3f, state.value)
+        }
+    }
+
+    @Test
+    fun `floating point updates preserve the declared numeric type`() {
+        val descriptor = TweakDescriptor(
+            name = "Validation float type",
+            type = TweakType.FLOAT,
+            default = 0.25f,
+            min = 0f,
+            max = 1f,
+            step = 0.25f,
+        )
+        val state = TweakRegistry.register(descriptor)
+
+        TweakRegistry.update(mapOf(descriptor.name to 0.5))
+
+        assertTrue(state.value is Float)
+        assertEquals(0.5f, state.value)
+    }
+
+    @Test
+    fun `floating point tweaks normalize integer JSON values to floats`() {
+        val descriptor = TweakDescriptor(
+            name = "Validation floating point integer input",
+            type = TweakType.FLOAT,
+            default = 0.25f,
+            min = 0f,
+            max = 4f,
+            step = 0.25f,
+        )
+        val state = TweakRegistry.register(descriptor)
+
+        TweakRegistry.update(mapOf(descriptor.name to 2))
+
+        assertTrue(state.value is Float)
+        assertEquals(2f, state.value)
+
+        TweakRegistry.update(mapOf(descriptor.name to BigDecimal("2.5")))
+
+        assertTrue(state.value is Float)
+        assertEquals(2.5f, state.value)
+
+        TweakRegistry.update(mapOf(descriptor.name to BigDecimal("3")))
+
+        assertTrue(state.value is Float)
+        assertEquals(3f, state.value)
+    }
+
+    @Test
+    fun `boolean tweaks accept only booleans`() {
+        val descriptor = TweakDescriptor(
+            name = "Validation boolean",
+            type = TweakType.BOOLEAN,
+            default = false,
+        )
+        val state = TweakRegistry.register(descriptor)
+
+        TweakRegistry.update(mapOf(descriptor.name to true))
+
+        assertEquals(true, state.value)
+        assertInvalidUpdate(descriptor.name, "true")
+        assertInvalidUpdate(descriptor.name, 1)
+        assertEquals(true, state.value)
+    }
+
+    @Test
+    fun `string tweaks accept only strings`() {
+        val descriptor = TweakDescriptor(
+            name = "Validation string",
+            type = TweakType.STRING,
+            default = "before",
+        )
+        val state = TweakRegistry.register(descriptor)
+
+        TweakRegistry.update(mapOf(descriptor.name to "after"))
+
+        assertEquals("after", state.value)
+        assertInvalidUpdate(descriptor.name, false)
+        assertInvalidUpdate(descriptor.name, null)
+        assertEquals("after", state.value)
+    }
+
+    @Test
+    fun `colors accept rgb and rgba and normalize to uppercase`() {
+        val descriptor = TweakDescriptor(
+            name = "Validation color",
+            type = TweakType.COLOR,
+            default = "#2563EB",
+        )
+        val state = TweakRegistry.register(descriptor)
+
+        TweakRegistry.update(mapOf(descriptor.name to "#3b82f6"))
+
+        assertEquals("#3B82F6", state.value)
+
+        TweakRegistry.update(mapOf(descriptor.name to "#112233aa"))
+
+        assertEquals("#112233AA", state.value)
+    }
+
+    @Test
+    fun `colors reject malformed hexadecimal strings`() {
+        val descriptor = TweakDescriptor(
+            name = "Validation invalid color",
+            type = TweakType.COLOR,
+            default = "#2563EB",
+        )
+        val state = TweakRegistry.register(descriptor)
+
+        assertInvalidUpdate(descriptor.name, "2563EB")
+        assertInvalidUpdate(descriptor.name, "#123")
+        assertInvalidUpdate(descriptor.name, "#GGGGGG")
+        assertInvalidUpdate(descriptor.name, 0x2563EB)
+
+        assertEquals("#2563EB", state.value)
+    }
+
+    @Test
+    fun `integer and floating point tweaks expose distinct wire types`() {
+        val integer = TweakDescriptor(
+            name = "Validation integer wire type",
+            type = TweakType.INT,
+            default = 16,
+        )
+        val floatingPoint = TweakDescriptor(
+            name = "Validation floating point wire type",
+            type = TweakType.FLOAT,
+            default = 0.25f,
+        )
+        val integerState = TweakRegistry.register(integer)
+        val floatingPointState = TweakRegistry.register(floatingPoint)
+
+        TweakRegistry.update(
+            linkedMapOf(
+                integer.name to BigDecimal("24"),
+                floatingPoint.name to BigDecimal("0.5"),
+            ),
+        )
+
+        assertEquals(
+            listOf("int", "float"),
+            TweakRegistry.snapshot().map {
+                it.descriptor.type.wireName
+            },
+        )
+        assertTrue(integerState.value is Int)
+        assertEquals(24, integerState.value)
+        assertTrue(floatingPointState.value is Float)
+        assertEquals(0.5f, floatingPointState.value)
+    }
+
+    @Test
+    fun `missing tweaks return a not found error`() {
+        val error = assertThrows(TweakUpdateException::class.java) {
+            TweakRegistry.update(mapOf("Validation unknown tweak" to 16))
+        }
+
+        assertEquals(404, error.statusCode)
+        assertTrue(TweakRegistry.snapshot().isEmpty())
+    }
+
+    @Test
+    fun `invalid values do not partially apply a multi-tweak update`() {
+        val padding = TweakDescriptor(
+            name = "Validation atomic padding",
+            type = TweakType.INT,
+            default = 16,
+            min = 0,
+            max = 48,
+        )
+        val enabled = TweakDescriptor(
+            name = "Validation atomic boolean",
+            type = TweakType.BOOLEAN,
+            default = false,
+        )
+        val paddingState = TweakRegistry.register(padding)
+        val enabledState = TweakRegistry.register(enabled)
+
+        val error = assertThrows(TweakUpdateException::class.java) {
+            TweakRegistry.update(
+                linkedMapOf(
+                    padding.name to 20,
+                    enabled.name to "not a boolean",
+                ),
+            )
+        }
+
+        assertEquals(422, error.statusCode)
+        assertEquals(16, paddingState.value)
+        assertEquals(false, enabledState.value)
+    }
+
+    @Test
+    fun `fractional integer updates do not partially apply floating point changes`() {
+        val integer = TweakDescriptor(
+            name = "Validation atomic fractional integer",
+            type = TweakType.INT,
+            default = 16,
+        )
+        val floatingPoint = TweakDescriptor(
+            name = "Validation atomic floating point",
+            type = TweakType.FLOAT,
+            default = 0.25f,
+        )
+        val integerState = TweakRegistry.register(integer)
+        val floatingPointState = TweakRegistry.register(floatingPoint)
+
+        val error = assertThrows(TweakUpdateException::class.java) {
+            TweakRegistry.update(
+                linkedMapOf(
+                    floatingPoint.name to BigDecimal("2.5"),
+                    integer.name to BigDecimal("16.5"),
+                ),
+            )
+        }
+
+        assertEquals(422, error.statusCode)
+        assertTrue(integerState.value is Int)
+        assertEquals(16, integerState.value)
+        assertTrue(floatingPointState.value is Float)
+        assertEquals(0.25f, floatingPointState.value)
+    }
+
+    @Test
+    fun `unknown tweaks do not partially apply a multi-tweak update`() {
+        val descriptor = TweakDescriptor(
+            name = "Validation atomic known tweak",
+            type = TweakType.INT,
+            default = 16,
+        )
+        val state = TweakRegistry.register(descriptor)
+
+        val error = assertThrows(TweakUpdateException::class.java) {
+            TweakRegistry.update(
+                linkedMapOf(
+                    descriptor.name to 20,
+                    "Validation atomic missing tweak" to 24,
+                ),
+            )
+        }
+
+        assertEquals(404, error.statusCode)
+        assertEquals(16, state.value)
+    }
+
+    @Test
+    fun `invalid numeric descriptors are rejected before registration`() {
+        assertThrows(IllegalArgumentException::class.java) {
+            TweakRegistry.register(
+                TweakDescriptor(
+                    name = "Validation zero step",
+                    type = TweakType.INT,
+                    default = 16,
+                    step = 0,
+                ),
+            )
+        }
+        assertThrows(IllegalArgumentException::class.java) {
+            TweakRegistry.register(
+                TweakDescriptor(
+                    name = "Validation reversed bounds",
+                    type = TweakType.INT,
+                    default = 16,
+                    min = 32,
+                    max = 8,
+                ),
+            )
+        }
+        assertThrows(IllegalArgumentException::class.java) {
+            TweakRegistry.register(
+                TweakDescriptor(
+                    name = "Validation out of bounds default",
+                    type = TweakType.INT,
+                    default = 64,
+                    min = 0,
+                    max = 48,
+                ),
+            )
+        }
+
+        assertTrue(TweakRegistry.snapshot().isEmpty())
+    }
+
+    @Test
+    fun `blank tweak names are rejected before registration`() {
+        assertThrows(IllegalArgumentException::class.java) {
+            TweakRegistry.register(
+                TweakDescriptor(
+                    name = "  ",
+                    type = TweakType.STRING,
+                    default = "ignored",
+                ),
+            )
+        }
+
+        assertTrue(TweakRegistry.snapshot().isEmpty())
+    }
+
+    @Test
+    fun `integer descriptors reject non-integer defaults and constraints`() {
+        val base = TweakDescriptor(
+            name = "Validation integer descriptor primitives",
+            type = TweakType.INT,
+            default = 16,
+            min = 0,
+            max = 48,
+            step = 2,
+        )
+
+        listOf(
+            base.copy(default = 16f),
+            base.copy(default = 16L),
+            base.copy(default = BigDecimal("16")),
+            base.copy(min = 0f),
+            base.copy(max = 48f),
+            base.copy(step = 2f),
+        ).forEach { descriptor ->
+            assertThrows(IllegalArgumentException::class.java) {
+                TweakRegistry.register(descriptor)
+            }
+        }
+
+        assertTrue(TweakRegistry.snapshot().isEmpty())
+    }
+
+    @Test
+    fun `floating point descriptors reject non-float defaults and constraints`() {
+        val base = TweakDescriptor(
+            name = "Validation floating point descriptor primitives",
+            type = TweakType.FLOAT,
+            default = 0.5f,
+            min = 0f,
+            max = 1f,
+            step = 0.25f,
+        )
+
+        listOf(
+            base.copy(default = 1),
+            base.copy(default = 0.5),
+            base.copy(default = BigDecimal("0.5")),
+            base.copy(min = 0),
+            base.copy(max = 1),
+            base.copy(step = 0.25),
+        ).forEach { descriptor ->
+            assertThrows(IllegalArgumentException::class.java) {
+                TweakRegistry.register(descriptor)
+            }
+        }
+
+        assertTrue(TweakRegistry.snapshot().isEmpty())
+    }
+
+    @Test
+    fun `floating point descriptors reject nonfinite defaults and constraints`() {
+        val base = TweakDescriptor(
+            name = "Validation finite floating point descriptor",
+            type = TweakType.FLOAT,
+            default = 0.5f,
+            min = 0f,
+            max = 1f,
+            step = 0.25f,
+        )
+
+        listOf(
+            base.copy(default = Float.NaN),
+            base.copy(default = Float.POSITIVE_INFINITY),
+            base.copy(min = Float.NEGATIVE_INFINITY),
+            base.copy(max = Float.POSITIVE_INFINITY),
+            base.copy(step = Float.POSITIVE_INFINITY),
+        ).forEach { descriptor ->
+            assertThrows(IllegalArgumentException::class.java) {
+                TweakRegistry.register(descriptor)
+            }
+        }
+
+        assertTrue(TweakRegistry.snapshot().isEmpty())
+    }
+
+    @Test
+    fun `non-numeric descriptors reject numeric constraints`() {
+        assertThrows(IllegalArgumentException::class.java) {
+            TweakRegistry.register(
+                TweakDescriptor(
+                    name = "Validation constrained string",
+                    type = TweakType.STRING,
+                    default = "value",
+                    min = 0,
+                ),
+            )
+        }
+
+        assertTrue(TweakRegistry.snapshot().isEmpty())
+    }
+
+    private fun assertInvalidUpdate(name: String, value: Any?) {
+        val error = assertThrows(TweakUpdateException::class.java) {
+            TweakRegistry.update(mapOf(name to value))
+        }
+
+        assertEquals(422, error.statusCode)
+    }
+}


### PR DESCRIPTION
## Summary

- Add Snap-O Tweaks for inspecting and adjusting live Jetpack Compose values in debug builds.
- Provide `tweakInt`, `tweakFloat`, `tweakColor`, `tweakBoolean`, and `tweakString`, including shared named tweak state and atomic, validated updates.
- Expose app metadata, PNG icons, and live tweak values through `/app`, `/app/icon`, and `/tweaks` over ADB-forwarded `snapo_tweaks_<pid>` sockets.
- Add matching `tweaks` and `tweaks-noop` Android artifacts so release builds contain no tweak server, initialization provider, socket, or runtime.
- Add a standalone Compose demo and an optional, dependency-free example browser panel.
- Bound numeric literal length, precision, and scale before main-thread validation to prevent oversized-exponent denial of service.
- Enable minified sample release builds and document the complete Tweaks protocol and setup.

## Validation

- `./gradlew build validateMavenCentralRelease` — full Android repository, all existing sample apps, lint, static analysis, debug and release builds, and all seven Maven publications.
- 36 Tweaks Android unit tests, including adversarial numeric regression coverage.
- `node --test` — all 20 sample panel tests pass.
- Verified `com.openai.snapo:tweaks:3.2.0` and `com.openai.snapo:tweaks-noop:3.2.0` appear in the Maven publication manifest.
- Inspected the minified sample release APK and merged manifest to confirm the Tweaks server, provider, registry, socket, and runtime are absent.

## Scope

The browser panel is an optional demonstration of what a model or host tool can build on top of the Tweaks protocol; it is not required for application integration.