### PR TITLE
Allow App Inspector to display Network or Tweaks

### DIFF
--- a/contracts/tweaks/README.md
+++ b/contracts/tweaks/README.md
@@ -28,10 +28,12 @@ curl -fsS http://127.0.0.1:43817/tweaks
 ```
 
 Implement HTTP with Android `LocalServerSocket`, standard streams, and Android
-`JsonReader`/`JsonWriter`. Use one request per connection, JSON for app and
-tweak responses, PNG for `/app/icon`, `Content-Length`, bounded request
-sizes, a read timeout, and `Connection: close`. No server dependency, Android
-TCP port, or `INTERNET` permission is needed.
+`JsonReader`/`JsonWriter`. Use JSON for app and tweak responses, PNG for
+`/app/icon`, and server-sent events for `/tweaks/events`. Ordinary responses
+include `Content-Length` and close their connection. Event streams keep their
+connection open. Bound request sizes and concurrent connections, and apply a
+read timeout while receiving each request. No server dependency, Android TCP
+port, or `INTERNET` permission is needed.
 
 ## REST API
 
@@ -157,6 +159,35 @@ translucent.
 Numeric JSON values may contain at most 128 characters and 64 significant
 digits, with a decimal scale between -64 and 64. Reject values outside those
 limits with `422` before changing any tweaks.
+
+### GET /tweaks/events
+
+Stream the current tweaks using standard server-sent events:
+
+```bash
+curl --no-buffer http://127.0.0.1:43817/tweaks/events
+```
+
+```text
+event: tweaks
+data: {"tweaks":[{"name":"Motion/Show","type":"boolean","default":true,"value":true},{"name":"Motion/Duration","type":"int","default":400,"value":400,"min":100,"max":1500,"step":50}]}
+
+event: tweaks
+data: {"tweaks":[{"name":"Motion/Show","type":"boolean","default":true,"value":false}]}
+
+```
+
+The response uses `Content-Type: text/event-stream`. Its first event contains
+the complete current tweak list. Each later event also contains a complete,
+ordered list using exactly the `GET /tweaks` response shape. Clients replace
+their previous snapshot; a missing tweak has left composition.
+
+Changes are published after the current Android main-thread turn. Tweaks added,
+removed, or changed during the same Compose update appear together in one
+event. Value changes are streamed whether they originated from an HTTP request
+or a Compose snapshot. Idle connections receive occasional SSE comments as
+keep-alives. A slow client receives the latest complete snapshot rather than
+an unbounded queue of intermediate states.
 
 ### PATCH /tweaks
 

--- a/snapo-app-mac/Snap-O.xcodeproj/project.pbxproj
+++ b/snapo-app-mac/Snap-O.xcodeproj/project.pbxproj
@@ -205,7 +205,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "set -e\n\nCLI_SOURCE=\"${PROJECT_DIR}/../skills/snap-o-network-inspector/scripts/snapo\"\nCLI_DEST=\"${TARGET_BUILD_DIR}/${CONTENTS_FOLDER_PATH}/MacOS/snapo\"\n\nif [ ! -f \"${CLI_SOURCE}\" ]; then\n  echo \"error: snapo CLI script not found at ${CLI_SOURCE}\" >&2\n  exit 1\nfi\n\n/bin/mkdir -p \"$(/usr/bin/dirname \"${CLI_DEST}\")\"\n/usr/bin/ditto \"${CLI_SOURCE}\" \"${CLI_DEST}\"\n/bin/chmod 755 \"${CLI_DEST}\"\n";
+			shellScript = "set -e\n\nCLI_SOURCE=\"${PROJECT_DIR}/../skills/snap-o-network-inspector/scripts/snapo\"\nCLI_DEST=\"${TARGET_BUILD_DIR}/${CONTENTS_FOLDER_PATH}/MacOS/snapo\"\n\nif [ ! -f \"${CLI_SOURCE}\" ]; then\n  echo \"error: snapo CLI script not found at ${CLI_SOURCE}\" >&2\n  exit 1\nfi\n\n/bin/mkdir -p \"$(/usr/bin/dirname \"${CLI_DEST}\")\"\n/usr/bin/ditto \"${CLI_SOURCE}\" \"${CLI_DEST}\"\n/bin/chmod 755 \"${CLI_DEST}\"\n\nif [ \"${CODE_SIGNING_ALLOWED}\" != \"NO\" ]; then\n  /usr/bin/codesign --force --sign \"${EXPANDED_CODE_SIGN_IDENTITY:--}\" --timestamp=none \"${CLI_DEST}\"\nfi\n";
 			showEnvVarsInLog = 0;
 		};
 /* End PBXShellScriptBuildPhase section */

--- a/snapo-app-mac/Snap-O/App/SnapOCommands.swift
+++ b/snapo-app-mac/Snap-O/App/SnapOCommands.swift
@@ -141,7 +141,7 @@ struct SnapOCommands: Commands {
       Toggle("Record Screen as Bug Report", isOn: $settings.recordAsBugReport)
     }
     CommandMenu("Tools") {
-      Button(workspaceController?.showsNetwork == true ? "Hide Network Inspector" : "Show Network Inspector") {
+      Button(workspaceController?.showsNetwork == true ? "Hide App Inspector" : "Show App Inspector") {
         workspaceController?.toggleNetwork()
       }
       .keyboardShortcut("i", modifiers: [.command, .option])

--- a/snapo-app-mac/Snap-O/CaptureWindow/CaptureToolbar.swift
+++ b/snapo-app-mac/Snap-O/CaptureWindow/CaptureToolbar.swift
@@ -118,7 +118,7 @@ struct CaptureToolbar: View {
       if presentedLayout.showsCapture {
         HStack {
           Spacer()
-          networkToggle()
+          inspectorToggle()
             .opacity(1 - networkVisibility)
             .allowsHitTesting(networkVisibility < 0.5)
         }
@@ -138,18 +138,22 @@ struct CaptureToolbar: View {
 
         if let networkModel {
           HStack(spacing: 8) {
-            NetworkInspectorToolbarControls(
-              model: networkModel,
-              isSearchPresented: $isNetworkSearchPresented
-            )
-            NetworkInspectorServerPicker(model: networkModel)
+            if networkModel.selectedInspector?.kind == .tweaks {
+              tweaksInspectorControls(model: networkModel)
+            } else {
+              NetworkInspectorToolbarControls(
+                model: networkModel,
+                isSearchPresented: $isNetworkSearchPresented
+              )
+            }
+            AppInspectorPicker(model: networkModel)
               .padding(.leading, 4)
           }
         }
 
         Spacer()
 
-        if let networkModel {
+        if let networkModel, networkModel.selectedInspector?.kind != .tweaks {
           NetworkInspectorExportMenu(model: networkModel)
         }
 
@@ -180,7 +184,7 @@ struct CaptureToolbar: View {
     let visibility = min(captureVisibility, networkVisibility)
     let width = (SnapOToolbarStyle.singleControlSize + 8) * captureVisibility
 
-    return networkToggle()
+    return inspectorToggle()
       .opacity(visibility)
       .allowsHitTesting(visibility > 0.5)
       .frame(
@@ -269,17 +273,31 @@ struct CaptureToolbar: View {
     .disabled(!workspace.canToggleCapture)
   }
 
-  private func networkToggle() -> some View {
+  private func inspectorToggle() -> some View {
     Button {
       workspace.toggleNetwork()
     } label: {
-      toggleIcon("network")
-        .accessibilityLabel("Network Inspector")
+      toggleIcon("sidebar.right")
+        .accessibilityLabel("App Inspector")
     }
-    .help(workspace.showsNetwork ? "Hide Network Inspector (⌘⌥I)" : "Show Network Inspector (⌘⌥I)")
+    .help(workspace.showsNetwork ? "Hide App Inspector (⌘⌥I)" : "Show App Inspector (⌘⌥I)")
     .controlSize(.extraLarge)
     .snapOToolbarSingleControlStyle()
     .disabled(!workspace.canToggleNetwork)
+  }
+
+  private func tweaksInspectorControls(model: NetworkInspectorHostModel) -> some View {
+    Button {
+      model.resetTweaks()
+    } label: {
+      Label("Reset All Tweaks", systemImage: "arrow.counterclockwise")
+        .labelStyle(.iconOnly)
+        .font(.system(size: 15, weight: .medium))
+        .frame(width: 34, height: 32)
+    }
+    .help("Reset all tweaks")
+    .snapOToolbarGroupStyle()
+    .disabled(!model.isPageReady)
   }
 
   private func toggleIcon(_ systemName: String) -> some View {

--- a/snapo-app-mac/Snap-O/CaptureWindow/CaptureToolbar.swift
+++ b/snapo-app-mac/Snap-O/CaptureWindow/CaptureToolbar.swift
@@ -148,6 +148,7 @@ struct CaptureToolbar: View {
             }
             AppInspectorPicker(model: networkModel)
               .padding(.leading, 4)
+            AppInspectorViewPicker(model: networkModel)
           }
         }
 

--- a/snapo-app-mac/Snap-O/CaptureWindow/CaptureToolbar.swift
+++ b/snapo-app-mac/Snap-O/CaptureWindow/CaptureToolbar.swift
@@ -298,7 +298,7 @@ struct CaptureToolbar: View {
     }
     .help("Reset all tweaks")
     .snapOToolbarGroupStyle()
-    .disabled(!model.isPageReady)
+    .disabled(!model.isPageReady || !model.hasResettableTweaks)
   }
 
   private func toggleIcon(_ systemName: String) -> some View {

--- a/snapo-app-mac/Snap-O/NetworkInspector/NetworkInspectorBridgeModels.swift
+++ b/snapo-app-mac/Snap-O/NetworkInspector/NetworkInspectorBridgeModels.swift
@@ -84,6 +84,12 @@ struct TweakList: Codable {
   let tweaks: [TweakDescriptor]
 }
 
+struct TweakStreamEvent: Codable {
+  let streamId: String
+  let server: InspectorServerReference
+  let tweaks: [TweakDescriptor]
+}
+
 struct TweakUpdate: Codable {
   let name: String
   let value: TweakValue
@@ -185,6 +191,7 @@ struct NetworkSaveFileResult: Codable {
 enum NetworkInspectorOutput {
   case event(NetworkStreamEvent)
   case status(NetworkStreamStatus)
+  case tweaks(TweakStreamEvent)
 }
 
 extension NetworkInspectorServer: Sendable {}
@@ -194,6 +201,11 @@ extension NetworkRequestBodies: Sendable {}
 extension NetworkStreamStarted: Sendable {}
 extension NetworkStreamEvent: Sendable {}
 extension NetworkStreamStatus: Sendable {}
+extension InspectorServerReference: Sendable {}
+extension TweakValue: Sendable {}
+extension TweakDescriptor: Sendable {}
+extension TweakList: Sendable {}
+extension TweakStreamEvent: Sendable {}
 extension NetworkSaveFileInput: Sendable {}
 extension NetworkSaveFileResult: Sendable {}
 extension NetworkInspectorOutput: Sendable {}

--- a/snapo-app-mac/Snap-O/NetworkInspector/NetworkInspectorBridgeModels.swift
+++ b/snapo-app-mac/Snap-O/NetworkInspector/NetworkInspectorBridgeModels.swift
@@ -1,6 +1,107 @@
 import Foundation
 import SnapODeviceClient
 
+enum AppInspectorKind: String, Codable {
+  case network
+  case tweaks
+}
+
+struct InspectorServerReference: Codable, Hashable {
+  let deviceId: String
+  let socketName: String
+}
+
+struct AppInspectorOption: Codable, Identifiable {
+  let kind: AppInspectorKind
+  let server: InspectorServerReference
+
+  var id: String {
+    "\(kind.rawValue):\(server.deviceId):\(server.socketName)"
+  }
+}
+
+struct InspectableApp: Codable, Identifiable {
+  let id: String
+  let name: String
+  let packageName: String
+  let deviceId: String
+  let deviceDisplayTitle: String
+  let appIconBase64: String?
+  let inspectors: [AppInspectorOption]
+}
+
+struct SelectedAppInspector: Codable {
+  let appId: String
+  let kind: AppInspectorKind
+  let server: InspectorServerReference
+}
+
+enum TweakValue: Codable {
+  case bool(Bool)
+  case int(Int)
+  case double(Double)
+  case string(String)
+
+  init(from decoder: Decoder) throws {
+    let container = try decoder.singleValueContainer()
+    if let value = try? container.decode(Bool.self) {
+      self = .bool(value)
+    } else if let value = try? container.decode(Int.self) {
+      self = .int(value)
+    } else if let value = try? container.decode(Double.self) {
+      self = .double(value)
+    } else {
+      self = try .string(container.decode(String.self))
+    }
+  }
+
+  func encode(to encoder: Encoder) throws {
+    var container = encoder.singleValueContainer()
+    switch self {
+    case .bool(let value):
+      try container.encode(value)
+    case .int(let value):
+      try container.encode(value)
+    case .double(let value):
+      try container.encode(value)
+    case .string(let value):
+      try container.encode(value)
+    }
+  }
+}
+
+struct TweakDescriptor: Codable {
+  let name: String
+  let type: String
+  let `default`: TweakValue
+  let value: TweakValue
+  let min: TweakValue?
+  let max: TweakValue?
+  let step: TweakValue?
+}
+
+struct TweakList: Codable {
+  let tweaks: [TweakDescriptor]
+}
+
+struct TweakUpdate: Codable {
+  let name: String
+  let value: TweakValue
+}
+
+struct TweakUpdates: Codable {
+  let tweaks: [TweakUpdate]
+}
+
+struct TweakPatch: Codable {
+  let values: [String: TweakValue]
+}
+
+struct UpdateTweaksInput: Codable {
+  let server: InspectorServerReference
+  let values: [String: TweakValue]
+}
+
 struct NetworkInspectorServer: Codable {
   let server: String
   let deviceId: String

--- a/snapo-app-mac/Snap-O/NetworkInspector/NetworkInspectorBridgeModels.swift
+++ b/snapo-app-mac/Snap-O/NetworkInspector/NetworkInspectorBridgeModels.swift
@@ -90,6 +90,11 @@ struct TweakStreamEvent: Codable {
   let tweaks: [TweakDescriptor]
 }
 
+struct TweaksInspectorNativeState: Codable {
+  let server: InspectorServerReference
+  let hasResettableTweaks: Bool
+}
+
 struct TweakUpdate: Codable {
   let name: String
   let value: TweakValue

--- a/snapo-app-mac/Snap-O/NetworkInspector/NetworkInspectorHostModel.swift
+++ b/snapo-app-mac/Snap-O/NetworkInspector/NetworkInspectorHostModel.swift
@@ -151,6 +151,8 @@ final class NetworkInspectorHostModel {
       sendPageEvent(name: "network:event", payload: event)
     case .status(let status):
       sendPageEvent(name: "network:status", payload: status)
+    case .tweaks(let event):
+      sendPageEvent(name: "tweaks:changed", payload: event)
     }
   }
 

--- a/snapo-app-mac/Snap-O/NetworkInspector/NetworkInspectorHostModel.swift
+++ b/snapo-app-mac/Snap-O/NetworkInspector/NetworkInspectorHostModel.swift
@@ -6,6 +6,8 @@ import SnapODeviceClient
 final class NetworkInspectorHostModel {
   private(set) var servers: [NetworkInspectorServer] = []
   private(set) var selectedServer: NetworkInspectorServer?
+  private(set) var inspectorApps: [InspectableApp] = []
+  private(set) var selectedInspector: SelectedAppInspector?
   private(set) var searchText = ""
   private(set) var sortNewestFirst = false
   private(set) var hasClearableItems = false
@@ -22,6 +24,9 @@ final class NetworkInspectorHostModel {
 
     bridge.inspectorStateChangedHandler = { [weak self] state in
       self?.apply(state)
+    }
+    bridge.inspectorAppsChangedHandler = { [weak self] apps in
+      self?.applyInspectorApps(apps)
     }
     webContainer.pageReadinessChangedHandler = { [weak self] isReady in
       self?.isPageReady = isReady
@@ -44,6 +49,28 @@ final class NetworkInspectorHostModel {
       name: "network:selected-server",
       payload: NetworkServerReference(deviceId: server.deviceId, socketName: server.socketName)
     )
+  }
+
+  func selectInspector(_ app: InspectableApp, option: AppInspectorOption) {
+    let selection = SelectedAppInspector(
+      appId: app.id,
+      kind: option.kind,
+      server: option.server
+    )
+    selectedInspector = selection
+    sendPageEvent(name: "inspector:selected", payload: selection)
+
+    if option.kind == .network,
+       let server = servers.first(where: {
+         $0.deviceId == option.server.deviceId && $0.socketName == option.server.socketName
+       }) {
+      selectServer(server)
+    }
+  }
+
+  var selectedInspectorApp: InspectableApp? {
+    guard let selectedInspector else { return nil }
+    return inspectorApps.first { $0.id == selectedInspector.appId }
   }
 
   func setSearchText(_ searchText: String) {
@@ -70,6 +97,10 @@ final class NetworkInspectorHostModel {
     sendPageEvent(name: "network:export-visible-har", payload: true)
   }
 
+  func resetTweaks() {
+    sendPageEvent(name: "tweaks:reset", payload: true)
+  }
+
   private func apply(_ state: NetworkInspectorNativeState) {
     servers = state.servers
     selectedServer = state.selectedServer.flatMap { selection in
@@ -82,6 +113,36 @@ final class NetworkInspectorHostModel {
     hasClearableItems = state.hasClearableItems
     selectedRecordKind = state.selectedRecordKind
     hasVisibleRecords = state.hasVisibleRecords
+  }
+
+  private func applyInspectorApps(_ apps: [InspectableApp]) {
+    inspectorApps = apps
+
+    if let selection = selectedInspector,
+       apps.contains(where: { app in
+         app.id == selection.appId && app.inspectors.contains {
+           $0.kind == selection.kind && $0.server == selection.server
+         }
+       }) {
+      return
+    }
+
+    if let selectedServer,
+       let app = apps.first(where: {
+         $0.deviceId == selectedServer.deviceId && $0.inspectors.contains {
+           $0.kind == .network && $0.server.socketName == selectedServer.socketName
+         }
+       }),
+       let network = app.inspectors.first(where: { $0.kind == .network }) {
+      selectInspector(app, option: network)
+      return
+    }
+
+    guard let app = apps.first, let option = app.inspectors.first else {
+      selectedInspector = nil
+      return
+    }
+    selectInspector(app, option: option)
   }
 
   private func dispatch(_ output: NetworkInspectorOutput) {

--- a/snapo-app-mac/Snap-O/NetworkInspector/NetworkInspectorHostModel.swift
+++ b/snapo-app-mac/Snap-O/NetworkInspector/NetworkInspectorHostModel.swift
@@ -11,6 +11,7 @@ final class NetworkInspectorHostModel {
   private(set) var searchText = ""
   private(set) var sortNewestFirst = false
   private(set) var hasClearableItems = false
+  private(set) var hasResettableTweaks = false
   private(set) var selectedRecordKind: String?
   private(set) var hasVisibleRecords = false
   private(set) var isPageReady = false
@@ -27,6 +28,9 @@ final class NetworkInspectorHostModel {
     }
     bridge.inspectorAppsChangedHandler = { [weak self] apps in
       self?.applyInspectorApps(apps)
+    }
+    bridge.tweaksStateChangedHandler = { [weak self] state in
+      self?.apply(state)
     }
     webContainer.pageReadinessChangedHandler = { [weak self] isReady in
       self?.isPageReady = isReady
@@ -57,6 +61,9 @@ final class NetworkInspectorHostModel {
       kind: option.kind,
       server: option.server
     )
+    if selectedInspector?.kind != selection.kind || selectedInspector?.server != selection.server {
+      hasResettableTweaks = false
+    }
     selectedInspector = selection
     sendPageEvent(name: "inspector:selected", payload: selection)
 
@@ -115,6 +122,16 @@ final class NetworkInspectorHostModel {
     hasVisibleRecords = state.hasVisibleRecords
   }
 
+  private func apply(_ state: TweaksInspectorNativeState) {
+    guard selectedInspector?.kind == .tweaks,
+          selectedInspector?.server == state.server
+    else {
+      return
+    }
+
+    hasResettableTweaks = state.hasResettableTweaks
+  }
+
   private func applyInspectorApps(_ apps: [InspectableApp]) {
     inspectorApps = apps
 
@@ -140,6 +157,7 @@ final class NetworkInspectorHostModel {
 
     guard let app = apps.first, let option = app.inspectors.first else {
       selectedInspector = nil
+      hasResettableTweaks = false
       return
     }
     selectInspector(app, option: option)

--- a/snapo-app-mac/Snap-O/NetworkInspector/NetworkInspectorServerPicker.swift
+++ b/snapo-app-mac/Snap-O/NetworkInspector/NetworkInspectorServerPicker.swift
@@ -55,10 +55,7 @@ struct AppInspectorPicker: View {
       return model.inspectorApps.isEmpty ? "No Apps Found" : "Select an App"
     }
 
-    guard let kind = model.selectedInspector?.kind else {
-      return app.name
-    }
-    return "\(app.name) · \(kind.title)"
+    return app.name
   }
 
   private var deviceTitle: String {
@@ -68,6 +65,31 @@ struct AppInspectorPicker: View {
       return model.inspectorApps.isEmpty ? "No devices detected" : "Choose a device"
     }
     return title
+  }
+}
+
+struct AppInspectorViewPicker: View {
+  @Bindable var model: NetworkInspectorHostModel
+
+  var body: some View {
+    if let app = model.selectedInspectorApp, app.inspectors.count > 1 {
+      HStack(spacing: 0) {
+        ForEach(app.inspectors) { option in
+          Button {
+            model.selectInspector(app, option: option)
+          } label: {
+            Label(option.kind.title, systemImage: option.kind.systemImage)
+              .labelStyle(.iconOnly)
+              .font(.system(size: 15, weight: .medium))
+              .foregroundStyle(model.selectedInspector?.kind == option.kind ? Color.accentColor : Color.primary)
+              .frame(width: 34, height: 32)
+          }
+          .help(option.kind.title)
+        }
+      }
+      .snapOToolbarGroupStyle()
+      .accessibilityLabel("Inspector")
+    }
   }
 }
 

--- a/snapo-app-mac/Snap-O/NetworkInspector/NetworkInspectorServerPicker.swift
+++ b/snapo-app-mac/Snap-O/NetworkInspector/NetworkInspectorServerPicker.swift
@@ -2,7 +2,7 @@ import AppKit
 import Observation
 import SwiftUI
 
-struct NetworkInspectorServerPicker: View {
+struct AppInspectorPicker: View {
   private enum Metrics {
     static let iconSize: CGFloat = 32
     static let statusSize: CGFloat = 8
@@ -17,23 +17,15 @@ struct NetworkInspectorServerPicker: View {
       isPresented.toggle()
     } label: {
       HStack(spacing: 12) {
-        if let server = model.selectedServer {
-          NetworkInspectorServerIcon(
-            server,
-            size: Metrics.iconSize,
-            statusSize: Metrics.statusSize
-          )
-        } else {
-          NetworkInspectorServerIcon(
-            server: nil,
-            size: Metrics.iconSize,
-            statusSize: Metrics.statusSize
-          )
-        }
+        AppInspectorIcon(
+          app: model.selectedInspectorApp,
+          size: Metrics.iconSize,
+          statusSize: Metrics.statusSize
+        )
 
         HStack(spacing: 6) {
-          NetworkInspectorServerText(
-            appName: model.selectedServer?.displayName ?? emptyTitle,
+          AppInspectorPickerText(
+            appName: selectedTitle,
             deviceName: deviceTitle
           )
 
@@ -50,58 +42,59 @@ struct NetworkInspectorServerPicker: View {
     .buttonStyle(.plain)
     .fixedSize()
     .popover(isPresented: $isPresented, arrowEdge: .bottom) {
-      NetworkInspectorServerPickerPopover(model: model) {
-        model.selectServer($0)
+      AppInspectorPickerPopover(model: model) { app, option in
+        model.selectInspector(app, option: option)
         isPresented = false
       }
     }
-    .help("Select an app to inspect")
+    .help("Select an app and inspector")
   }
 
-  private var emptyTitle: String {
-    model.servers.isEmpty ? "No Apps Found" : "Select an App"
+  private var selectedTitle: String {
+    guard let app = model.selectedInspectorApp else {
+      return model.inspectorApps.isEmpty ? "No Apps Found" : "Select an App"
+    }
+
+    guard let kind = model.selectedInspector?.kind else {
+      return app.name
+    }
+    return "\(app.name) · \(kind.title)"
   }
 
   private var deviceTitle: String {
-    guard let title = model.selectedServer?.deviceDisplayTitle,
+    guard let title = model.selectedInspectorApp?.deviceDisplayTitle,
           !title.isEmpty
     else {
-      return model.servers.isEmpty ? "No devices detected" : "Choose a device"
+      return model.inspectorApps.isEmpty ? "No devices detected" : "Choose a device"
     }
     return title
   }
 }
 
-private struct NetworkInspectorServerPickerPopover: View {
+private struct AppInspectorPickerPopover: View {
   @Bindable var model: NetworkInspectorHostModel
-  let selectServer: (NetworkInspectorServer) -> Void
+  let selectInspector: (InspectableApp, AppInspectorOption) -> Void
 
   var body: some View {
     VStack(alignment: .leading, spacing: 0) {
-      Text("Detected servers")
-        .font(.system(size: 12, weight: .medium))
-        .foregroundStyle(.secondary)
-        .padding(.horizontal, 14)
-        .padding(.vertical, 10)
-
-      if model.servers.isEmpty {
+      if model.inspectorApps.isEmpty {
         Text("No Apps Found")
           .font(.system(size: 13))
           .foregroundStyle(.secondary)
           .frame(maxWidth: .infinity, alignment: .leading)
-          .padding(.horizontal, 14)
-          .padding(.bottom, 14)
+          .padding(14)
       } else {
         ScrollView {
-          LazyVStack(spacing: 0) {
-            ForEach(model.servers, id: \.server) { server in
-              NetworkInspectorServerPickerRow(server: server) {
-                selectServer(server)
-              }
+          LazyVStack(alignment: .leading, spacing: 0) {
+            ForEach(model.inspectorApps) { app in
+              AppInspectorPickerAppGroup(
+                app: app,
+                selection: model.selectedInspector,
+                selectInspector: selectInspector
+              )
             }
           }
-          .padding(.horizontal, 6)
-          .padding(.bottom, 6)
+          .padding(6)
         }
         .frame(maxHeight: 320)
       }
@@ -110,28 +103,77 @@ private struct NetworkInspectorServerPickerPopover: View {
   }
 }
 
-private struct NetworkInspectorServerPickerRow: View {
-  let server: NetworkInspectorServer
+private struct AppInspectorPickerAppGroup: View {
+  let app: InspectableApp
+  let selection: SelectedAppInspector?
+  let selectInspector: (InspectableApp, AppInspectorOption) -> Void
+
+  var body: some View {
+    VStack(alignment: .leading, spacing: 0) {
+      HStack(spacing: 8) {
+        AppInspectorIcon(app: app, size: 16, statusSize: 0)
+
+        Text(app.name)
+          .font(.system(size: 11, weight: .medium))
+          .lineLimit(1)
+
+        Spacer(minLength: 8)
+
+        Text(app.deviceDisplayTitle)
+          .font(.system(size: 10))
+          .foregroundStyle(.secondary)
+          .lineLimit(1)
+      }
+      .frame(height: 30)
+      .padding(.horizontal, 8)
+      .help(app.packageName)
+
+      ForEach(app.inspectors) { option in
+        AppInspectorPickerOptionRow(
+          option: option,
+          isSelected: selection?.appId == app.id
+            && selection?.kind == option.kind
+            && selection?.server == option.server
+        ) {
+          selectInspector(app, option)
+        }
+      }
+    }
+  }
+}
+
+private struct AppInspectorPickerOptionRow: View {
+  let option: AppInspectorOption
+  let isSelected: Bool
   let select: () -> Void
 
   @State private var isHovering = false
 
   var body: some View {
     Button(action: select) {
-      HStack(spacing: 12) {
-        NetworkInspectorServerIcon(server, size: 32, statusSize: 8)
-        NetworkInspectorServerText(
-          appName: server.displayName,
-          deviceName: server.deviceDisplayTitle
-        )
+      HStack(spacing: 10) {
+        Image(systemName: option.kind.systemImage)
+          .font(.system(size: 13))
+          .foregroundStyle(.secondary)
+          .frame(width: 18)
+
+        Text(option.kind.title)
+          .font(.system(size: 12))
+
+        Spacer()
+
+        Image(systemName: "checkmark")
+          .font(.system(size: 11, weight: .semibold))
+          .opacity(isSelected ? 1 : 0)
       }
-      .padding(.horizontal, 8)
-      .frame(maxWidth: .infinity, minHeight: 52, alignment: .leading)
+      .padding(.leading, 22)
+      .padding(.trailing, 8)
+      .frame(height: 38)
       .contentShape(Rectangle())
       .background {
-        if isHovering {
-          RoundedRectangle(cornerRadius: 7, style: .continuous)
-            .fill(Color.primary.opacity(0.07))
+        if isHovering || isSelected {
+          RoundedRectangle(cornerRadius: 5, style: .continuous)
+            .fill(Color.primary.opacity(isHovering ? 0.08 : 0.05))
         }
       }
     }
@@ -140,7 +182,7 @@ private struct NetworkInspectorServerPickerRow: View {
   }
 }
 
-private struct NetworkInspectorServerText: View {
+private struct AppInspectorPickerText: View {
   let appName: String
   let deviceName: String
 
@@ -159,38 +201,18 @@ private struct NetworkInspectorServerText: View {
   }
 }
 
-private struct NetworkInspectorServerIcon: View {
-  let server: NetworkInspectorServer?
+private struct AppInspectorIcon: View {
+  let app: InspectableApp?
   let size: CGFloat
   let statusSize: CGFloat
-
-  init(
-    _ server: NetworkInspectorServer,
-    size: CGFloat,
-    statusSize: CGFloat
-  ) {
-    self.server = server
-    self.size = size
-    self.statusSize = statusSize
-  }
-
-  init(
-    server: NetworkInspectorServer?,
-    size: CGFloat,
-    statusSize: CGFloat
-  ) {
-    self.server = server
-    self.size = size
-    self.statusSize = statusSize
-  }
 
   var body: some View {
     ZStack(alignment: .bottomTrailing) {
       icon
 
-      if let server {
+      if app != nil, statusSize > 0 {
         Circle()
-          .fill(server.isConnected ? Color(nsColor: .systemGreen) : Color(nsColor: .secondaryLabelColor))
+          .fill(Color(nsColor: .systemGreen))
           .frame(width: statusSize, height: statusSize)
           .overlay {
             Circle()
@@ -203,7 +225,7 @@ private struct NetworkInspectorServerIcon: View {
   }
 
   @ViewBuilder private var icon: some View {
-    if let base64 = server?.appIconBase64,
+    if let base64 = app?.appIconBase64,
        let data = Data(base64Encoded: base64),
        let image = NSImage(data: data) {
       Image(nsImage: image)
@@ -215,6 +237,22 @@ private struct NetworkInspectorServerIcon: View {
       Circle()
         .fill(Color(nsColor: .unemphasizedSelectedContentBackgroundColor))
         .frame(width: size, height: size)
+    }
+  }
+}
+
+private extension AppInspectorKind {
+  var title: String {
+    switch self {
+    case .network: "Network"
+    case .tweaks: "Tweaks"
+    }
+  }
+
+  var systemImage: String {
+    switch self {
+    case .network: "network"
+    case .tweaks: "slider.horizontal.3"
     }
   }
 }

--- a/snapo-app-mac/Snap-O/NetworkInspector/NetworkInspectorService.swift
+++ b/snapo-app-mac/Snap-O/NetworkInspector/NetworkInspectorService.swift
@@ -34,6 +34,7 @@ actor NetworkInspectorService {
   private var streams: [String: String] = [:]
   private var activeStreamConnections: [String: UUID] = [:]
   private var streamStartFlights: [String: StreamStartFlight] = [:]
+  private var tweakStreams: [String: Task<Void, Never>] = [:]
   private var outputContinuations: [UUID: AsyncStream<NetworkInspectorOutput>.Continuation] = [:]
   private var refreshFlight: RefreshFlight?
   private var isStopped = false
@@ -131,6 +132,25 @@ actor NetworkInspectorService {
     try await tweaksService.updateTweaks(input)
   }
 
+  func startTweakStream(_ reference: InspectorServerReference) async throws -> NetworkStreamStarted {
+    guard !isStopped else {
+      throw NetworkInspectorError.invalidBridgeMessage
+    }
+
+    _ = try await tweaksService.listTweaks(for: reference)
+    let streamID = UUID().uuidString
+
+    tweakStreams[streamID] = Task { [weak self] in
+      await self?.consumeTweakStream(reference, streamID: streamID)
+    }
+
+    return NetworkStreamStarted(streamId: streamID)
+  }
+
+  func stopTweakStream(_ streamID: String) {
+    tweakStreams.removeValue(forKey: streamID)?.cancel()
+  }
+
   func startStream(_ reference: NetworkServerReference) async throws -> NetworkStreamStarted {
     await refresh()
     guard !isStopped, let state = servers[reference.key] else {
@@ -201,6 +221,12 @@ actor NetworkInspectorService {
   }
 
   func stopAllStreams() async {
+    let activeTweakStreams = Array(tweakStreams.values)
+    tweakStreams.removeAll()
+    for stream in activeTweakStreams {
+      stream.cancel()
+    }
+
     let serverKeys = Set(streams.values)
     streams.removeAll()
     activeStreamConnections.removeAll()
@@ -252,6 +278,11 @@ actor NetworkInspectorService {
   func stop() async {
     guard !isStopped else { return }
     isStopped = true
+    let activeTweakStreams = Array(tweakStreams.values)
+    tweakStreams.removeAll()
+    for stream in activeTweakStreams {
+      stream.cancel()
+    }
     await tweaksService.stop()
     refreshFlight?.task.cancel()
     refreshFlight = nil
@@ -279,6 +310,41 @@ actor NetworkInspectorService {
 
   func isRunning() -> Bool {
     !isStopped
+  }
+
+  private func consumeTweakStream(
+    _ reference: InspectorServerReference,
+    streamID: String
+  ) async {
+    var retryDelay: Duration = .milliseconds(250)
+
+    while !Task.isCancelled, !isStopped {
+      do {
+        try await tweaksService.streamTweaks(for: reference) { [weak self] list in
+          Task {
+            await self?.emit(
+              .tweaks(
+                TweakStreamEvent(
+                  streamId: streamID,
+                  server: reference,
+                  tweaks: list.tweaks
+                )
+              )
+            )
+          }
+        }
+        retryDelay = .milliseconds(250)
+      } catch {
+        guard !Task.isCancelled, !isStopped else { return }
+      }
+
+      do {
+        try await Task.sleep(for: retryDelay)
+      } catch {
+        return
+      }
+      retryDelay = min(retryDelay * 2, .seconds(4))
+    }
   }
 
   private func optionalCommand(

--- a/snapo-app-mac/Snap-O/NetworkInspector/NetworkInspectorService.swift
+++ b/snapo-app-mac/Snap-O/NetworkInspector/NetworkInspectorService.swift
@@ -28,6 +28,7 @@ actor NetworkInspectorService {
 
   private let adbService: ADBService
   private let deviceTracker: DeviceTracker
+  private let tweaksService: TweaksInspectorService
 
   private var servers: [String: ServerState] = [:]
   private var streams: [String: String] = [:]
@@ -40,6 +41,10 @@ actor NetworkInspectorService {
   init(adbService: ADBService, deviceTracker: DeviceTracker) {
     self.adbService = adbService
     self.deviceTracker = deviceTracker
+    tweaksService = TweaksInspectorService(
+      adbService: adbService,
+      deviceTracker: deviceTracker
+    )
   }
 
   func outputStream() -> AsyncStream<NetworkInspectorOutput> {
@@ -60,6 +65,70 @@ actor NetworkInspectorService {
     guard !isStopped else { return [] }
     await refresh()
     return currentServers()
+  }
+
+  func listInspectorApps() async -> [InspectableApp] {
+    let networkServers = await listServers()
+    let tweakApps = await tweaksService.listApps()
+    var apps: [String: InspectableApp] = [:]
+
+    for server in networkServers {
+      let packageName = server.packageName ?? server.displayName
+      let id = "\(server.deviceId):\(packageName)"
+      let option = AppInspectorOption(
+        kind: .network,
+        server: InspectorServerReference(
+          deviceId: server.deviceId,
+          socketName: server.socketName
+        )
+      )
+      let appName = server.appName.flatMap { $0.isEmpty ? nil : $0 }
+      apps[id] = InspectableApp(
+        id: id,
+        name: appName ?? server.displayName,
+        packageName: packageName,
+        deviceId: server.deviceId,
+        deviceDisplayTitle: server.deviceDisplayTitle,
+        appIconBase64: server.appIconBase64,
+        inspectors: [option]
+      )
+    }
+
+    for app in tweakApps {
+      let id = "\(app.deviceID):\(app.packageName)"
+      let option = AppInspectorOption(
+        kind: .tweaks,
+        server: InspectorServerReference(
+          deviceId: app.deviceID,
+          socketName: app.socketName
+        )
+      )
+      let existing = apps[id]
+      apps[id] = InspectableApp(
+        id: id,
+        name: app.name,
+        packageName: app.packageName,
+        deviceId: app.deviceID,
+        deviceDisplayTitle: app.deviceDisplayTitle,
+        appIconBase64: app.appIconBase64 ?? existing?.appIconBase64,
+        inspectors: (existing?.inspectors ?? []) + [option]
+      )
+    }
+
+    return apps.values.sorted {
+      if $0.deviceDisplayTitle != $1.deviceDisplayTitle {
+        return $0.deviceDisplayTitle < $1.deviceDisplayTitle
+      }
+      return $0.name.localizedStandardCompare($1.name) == .orderedAscending
+    }
+  }
+
+  func listTweaks(for reference: InspectorServerReference) async throws -> TweakList {
+    try await tweaksService.listTweaks(for: reference)
+  }
+
+  func updateTweaks(_ input: UpdateTweaksInput) async throws -> TweakUpdates {
+    try await tweaksService.updateTweaks(input)
   }
 
   func startStream(_ reference: NetworkServerReference) async throws -> NetworkStreamStarted {
@@ -183,6 +252,7 @@ actor NetworkInspectorService {
   func stop() async {
     guard !isStopped else { return }
     isStopped = true
+    await tweaksService.stop()
     refreshFlight?.task.cancel()
     refreshFlight = nil
     streams.removeAll()

--- a/snapo-app-mac/Snap-O/NetworkInspector/NetworkInspectorWebBridge.swift
+++ b/snapo-app-mac/Snap-O/NetworkInspector/NetworkInspectorWebBridge.swift
@@ -59,6 +59,13 @@ final class NetworkInspectorWebBridge: NSObject, WKScriptMessageHandlerWithReply
     case "updateTweaks":
       let input = try Self.decode(UpdateTweaksInput.self, from: payload)
       return try await Self.jsonObject(service.updateTweaks(input))
+    case "startTweakStream":
+      let reference = try Self.decode(InspectorServerReference.self, from: payload)
+      return try await Self.jsonObject(service.startTweakStream(reference))
+    case "stopTweakStream":
+      let input = try Self.decode(StreamIdentifier.self, from: payload)
+      await service.stopTweakStream(input.streamId)
+      return nil
     case "loadBodies":
       let input = try Self.decode(NetworkLoadBodiesInput.self, from: payload)
       return try await Self.jsonObject(service.loadBodies(input))

--- a/snapo-app-mac/Snap-O/NetworkInspector/NetworkInspectorWebBridge.swift
+++ b/snapo-app-mac/Snap-O/NetworkInspector/NetworkInspectorWebBridge.swift
@@ -7,6 +7,7 @@ final class NetworkInspectorWebBridge: NSObject, WKScriptMessageHandlerWithReply
   static let messageHandlerName = "snapoNetwork"
 
   var inspectorStateChangedHandler: ((NetworkInspectorNativeState) -> Void)?
+  var inspectorAppsChangedHandler: (([InspectableApp]) -> Void)?
 
   private let service: NetworkInspectorService
 
@@ -48,6 +49,16 @@ final class NetworkInspectorWebBridge: NSObject, WKScriptMessageHandlerWithReply
       return Bundle.main.object(forInfoDictionaryKey: "CFBundleShortVersionString") as? String ?? "unknown"
     case "listServers":
       return try await Self.jsonObject(service.listServers())
+    case "listInspectorApps":
+      let apps = await service.listInspectorApps()
+      inspectorAppsChangedHandler?(apps)
+      return try Self.jsonObject(apps)
+    case "listTweaks":
+      let reference = try Self.decode(InspectorServerReference.self, from: payload)
+      return try await Self.jsonObject(service.listTweaks(for: reference))
+    case "updateTweaks":
+      let input = try Self.decode(UpdateTweaksInput.self, from: payload)
+      return try await Self.jsonObject(service.updateTweaks(input))
     case "loadBodies":
       let input = try Self.decode(NetworkLoadBodiesInput.self, from: payload)
       return try await Self.jsonObject(service.loadBodies(input))

--- a/snapo-app-mac/Snap-O/NetworkInspector/NetworkInspectorWebBridge.swift
+++ b/snapo-app-mac/Snap-O/NetworkInspector/NetworkInspectorWebBridge.swift
@@ -8,6 +8,7 @@ final class NetworkInspectorWebBridge: NSObject, WKScriptMessageHandlerWithReply
 
   var inspectorStateChangedHandler: ((NetworkInspectorNativeState) -> Void)?
   var inspectorAppsChangedHandler: (([InspectableApp]) -> Void)?
+  var tweaksStateChangedHandler: ((TweaksInspectorNativeState) -> Void)?
 
   private let service: NetworkInspectorService
 
@@ -100,6 +101,11 @@ final class NetworkInspectorWebBridge: NSObject, WKScriptMessageHandlerWithReply
     case "inspectorStateChanged":
       try inspectorStateChangedHandler?(
         Self.decode(NetworkInspectorNativeState.self, from: payload)
+      )
+      return nil
+    case "tweaksStateChanged":
+      try tweaksStateChangedHandler?(
+        Self.decode(TweaksInspectorNativeState.self, from: payload)
       )
       return nil
     default:

--- a/snapo-app-mac/Snap-O/NetworkInspector/TweaksInspectorService.swift
+++ b/snapo-app-mac/Snap-O/NetworkInspector/TweaksInspectorService.swift
@@ -91,6 +91,38 @@ actor TweaksInspectorService {
     return try JSONDecoder().decode(TweakUpdates.self, from: data)
   }
 
+  func streamTweaks(
+    for reference: InspectorServerReference,
+    onChange: @escaping @Sendable (TweakList) -> Void
+  ) async throws {
+    let connection = try connection(for: reference)
+    var request = URLRequest(url: connection.baseURL.appending(path: "tweaks/events"))
+    request.setValue("text/event-stream", forHTTPHeaderField: "Accept")
+
+    let (bytes, response) = try await URLSession.shared.bytes(for: request)
+    try Self.validate(response)
+
+    var eventName: String?
+    var dataLines: [String] = []
+
+    for try await line in bytes.lines {
+      try Task.checkCancellation()
+
+      if line.isEmpty {
+        if eventName == "tweaks", !dataLines.isEmpty {
+          let data = Data(dataLines.joined(separator: "\n").utf8)
+          try onChange(JSONDecoder().decode(TweakList.self, from: data))
+        }
+        eventName = nil
+        dataLines.removeAll(keepingCapacity: true)
+      } else if line.hasPrefix("event:") {
+        eventName = String(line.dropFirst(6)).trimmingCharacters(in: .whitespaces)
+      } else if line.hasPrefix("data:") {
+        dataLines.append(String(line.dropFirst(5)).trimmingCharacters(in: .whitespaces))
+      }
+    }
+  }
+
   func stop() async {
     let adb = await adbService.exec()
     let forwards = connections.values.map(\.forward)

--- a/snapo-app-mac/Snap-O/NetworkInspector/TweaksInspectorService.swift
+++ b/snapo-app-mac/Snap-O/NetworkInspector/TweaksInspectorService.swift
@@ -1,0 +1,202 @@
+import Foundation
+import SnapODeviceClient
+
+actor TweaksInspectorService {
+  struct App {
+    let deviceID: String
+    let deviceDisplayTitle: String
+    let socketName: String
+    let name: String
+    let packageName: String
+    let appIconBase64: String?
+  }
+
+  private struct AppInfo: Decodable {
+    let name: String
+    let packageName: String
+  }
+
+  private struct Connection {
+    let app: App
+    let forward: ADBForwardHandle
+    let baseURL: URL
+  }
+
+  private static let socketPrefix = "snapo_tweaks_"
+
+  private let adbService: ADBService
+  private let deviceTracker: DeviceTracker
+  private var connections: [String: Connection] = [:]
+
+  init(adbService: ADBService, deviceTracker: DeviceTracker) {
+    self.adbService = adbService
+    self.deviceTracker = deviceTracker
+  }
+
+  func listApps() async -> [App] {
+    let devices = await deviceTracker.latestDevices
+    let adb = await adbService.exec()
+    var activeKeys = Set<String>()
+
+    for device in devices {
+      guard let output = try? await adb.listUnixSockets(deviceID: device.id) else {
+        continue
+      }
+
+      for socketName in Self.socketNames(in: output) {
+        let key = Self.connectionKey(deviceID: device.id, socketName: socketName)
+        activeKeys.insert(key)
+
+        if connections[key] == nil {
+          await connect(
+            deviceID: device.id,
+            deviceDisplayTitle: device.displayTitle,
+            socketName: socketName,
+            using: adb
+          )
+        }
+      }
+    }
+
+    let removedKeys = connections.keys.filter { !activeKeys.contains($0) }
+    for key in removedKeys {
+      guard let connection = connections.removeValue(forKey: key) else {
+        continue
+      }
+      await adb.removeForward(connection.forward)
+    }
+
+    return connections.values.map(\.app).sorted {
+      if $0.deviceID != $1.deviceID {
+        return $0.deviceID < $1.deviceID
+      }
+      return $0.packageName < $1.packageName
+    }
+  }
+
+  func listTweaks(for reference: InspectorServerReference) async throws -> TweakList {
+    let connection = try connection(for: reference)
+    return try await load(TweakList.self, path: "tweaks", baseURL: connection.baseURL)
+  }
+
+  func updateTweaks(_ input: UpdateTweaksInput) async throws -> TweakUpdates {
+    let connection = try connection(for: input.server)
+    var request = URLRequest(url: connection.baseURL.appending(path: "tweaks"))
+    request.httpMethod = "PATCH"
+    request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+    request.httpBody = try JSONEncoder().encode(TweakPatch(values: input.values))
+
+    let (data, response) = try await URLSession.shared.data(for: request)
+    try Self.validate(response)
+    return try JSONDecoder().decode(TweakUpdates.self, from: data)
+  }
+
+  func stop() async {
+    let adb = await adbService.exec()
+    let forwards = connections.values.map(\.forward)
+    connections.removeAll()
+
+    for forward in forwards {
+      await adb.removeForward(forward)
+    }
+  }
+
+  private func connect(
+    deviceID: String,
+    deviceDisplayTitle: String,
+    socketName: String,
+    using adb: ADBClient
+  ) async {
+    var forward: ADBForwardHandle?
+
+    do {
+      let handle = try await adb.forwardLocalAbstract(
+        deviceID: deviceID,
+        abstractSocket: socketName
+      )
+      forward = handle
+
+      guard let baseURL = URL(string: "http://127.0.0.1:\(handle.port)/") else {
+        throw NetworkInspectorError.invalidBridgeMessage
+      }
+
+      let info = try await load(AppInfo.self, path: "app", baseURL: baseURL)
+      let iconData = await loadIcon(baseURL: baseURL)
+      let app = App(
+        deviceID: deviceID,
+        deviceDisplayTitle: deviceDisplayTitle,
+        socketName: socketName,
+        name: info.name,
+        packageName: info.packageName,
+        appIconBase64: iconData?.base64EncodedString()
+      )
+      let key = Self.connectionKey(deviceID: deviceID, socketName: socketName)
+      connections[key] = Connection(app: app, forward: handle, baseURL: baseURL)
+    } catch {
+      if let forward {
+        await adb.removeForward(forward)
+      }
+    }
+  }
+
+  private func loadIcon(baseURL: URL) async -> Data? {
+    guard let (data, response) = try? await URLSession.shared.data(
+      from: baseURL.appending(path: "app/icon")
+    ),
+      let httpResponse = response as? HTTPURLResponse,
+      (200 ... 299).contains(httpResponse.statusCode)
+    else {
+      return nil
+    }
+    return data
+  }
+
+  private func connection(for reference: InspectorServerReference) throws -> Connection {
+    let key = Self.connectionKey(deviceID: reference.deviceId, socketName: reference.socketName)
+    guard let connection = connections[key] else {
+      throw NetworkInspectorError.invalidBridgeMessage
+    }
+    return connection
+  }
+
+  private func load<T: Decodable>(
+    _ type: T.Type,
+    path: String,
+    baseURL: URL
+  ) async throws -> T {
+    let (data, response) = try await URLSession.shared.data(
+      from: baseURL.appending(path: path)
+    )
+    try Self.validate(response)
+    return try JSONDecoder().decode(type, from: data)
+  }
+
+  private static func validate(_ response: URLResponse) throws {
+    guard let response = response as? HTTPURLResponse,
+          (200 ... 299).contains(response.statusCode)
+    else {
+      throw NetworkInspectorError.invalidBridgeMessage
+    }
+  }
+
+  private static func socketNames(in output: String) -> [String] {
+    Array(Set(output.split(separator: "\n").compactMap { line in
+      guard let token = line.split(whereSeparator: \.isWhitespace).last else {
+        return nil
+      }
+      let socket = String(token)
+      guard socket.hasPrefix("@\(socketPrefix)") else {
+        return nil
+      }
+      let name = String(socket.dropFirst())
+      guard Int(name.dropFirst(socketPrefix.count)) != nil else {
+        return nil
+      }
+      return name
+    })).sorted()
+  }
+
+  private static func connectionKey(deviceID: String, socketName: String) -> String {
+    "\(deviceID):\(socketName)"
+  }
+}

--- a/snapo-link-android/samples/demo-tweaks/panel/README.md
+++ b/snapo-link-android/samples/demo-tweaks/panel/README.md
@@ -1,11 +1,11 @@
-# Snap-O Tweaks panel demo
+# Snap-O Tweaks inspector demo
 
-A model built this panel as one way to see and change live app values.
-The app must use Snap-O Tweaks.
+A model built this inspector as one way to find running apps and change live
+values. Each app must use Snap-O Tweaks.
 
-This is only a demo, not part of the feature. It is not the expected way to use
-Snap-O Tweaks. You do not need this panel. Any tool can use `/app` and
-`/tweaks` to build its own UI.
+This is only a demo, not part of the feature or the expected way to use it.
+You do not need this inspector. Any tool can use `/app` and `/tweaks` to build
+its own UI.
 
 ## What you need
 
@@ -24,7 +24,7 @@ From `snapo-link-android`, run:
 
 Open **Snap-O Tweaks Demo** on your device.
 
-## Run the tweaks panel
+## Run the tweaks inspector
 
 From the root of this project, run:
 
@@ -41,25 +41,57 @@ npm start
 
 Open `http://127.0.0.1:4175`.
 
-There is no install or build step. The panel will set up its own `adb` port
-forward.
+To preview the app and inspector menu without a device, open
+`http://127.0.0.1:4175/?mock`. The mock stays in the browser and does not
+run `adb` or connect to an Android app. Apps appear under **Network** and
+**Tweaks**. Each row shows the app and its phone or emulator. Hover over a
+row to see the app's package name.
 
-## How it can find an app
+To compare a second layout with compact app headings and larger inspector
+rows, open `http://127.0.0.1:4175/?mock=apps`.
 
-To find an app, the panel will:
+There is no install or build step. The inspector sets up its own `adb` port
+forwards. It can also start before an Android app is open.
 
-1. List each device that `adb` can use.
-2. Put a real device before an emulator.
-3. Start with the last real device.
-4. Find a live app by its `snapo_tweaks_<pid>` name.
-5. Use or make an `adb` port forward.
-6. Use `/app` to find the app name.
+## Find and switch apps
 
-The panel can connect to any Snap-O Tweaks app. It does not depend on one app
-or process. If the app starts again, the next request will find it.
+The inspector finds every running Snap-O Tweaks app on each connected device.
+The app picker shows the app name, icon, and device. Its menu shows each app
+once, with a short app-and-device heading above a **Tweaks** row. Select that
+row to see and change the app's values. The picker becomes a menu only when
+more than one app is available.
 
-The panel can only show values from the current screen. After a screen change,
-use **Refresh** to load the new values.
+To find apps, the inspector:
+
+1. Lists the devices that `adb` can use.
+2. Puts real devices before emulators.
+3. Finds each live `snapo_tweaks_<pid>` socket.
+4. Uses or creates an `adb` port forward.
+5. Reads `/app` to get the app name and package.
+
+It checks for new apps and screen changes every few seconds. If an app starts
+again, it keeps the same app selected when possible. If no app is running, it
+shows an empty state and waits.
+
+App discovery and selection belong to this demo server. `/apps` and
+`/apps/selection` are not part of the Android Snap-O Tweaks protocol.
+
+## Group tweaks
+
+To put a tweak in a section, use a `/` in its name:
+
+```kotlin
+tweakInt("Typography/Font size", 36, min = 16, max = 72)
+tweakBoolean("Motion/Enabled", true)
+tweakInt("Motion/Duration", 400, min = 100, max = 1500)
+```
+
+The part before `/` is the section. The part after `/` is the label. A tweak
+without `/` has no section. The full name is still used for changes.
+
+Sections and tweaks keep the order in which the app first shows them. If one
+goes away and comes back, it returns to the same place. On wide screens,
+sections stack in two stable columns and do not move between them.
 
 ## Use a different device or app
 
@@ -97,9 +129,13 @@ npm start -- --port 4176
 
 ## Change a live value
 
-Move a slider or choose a color. The app will change at once. The panel will
-wait for each request before it can send the next value. You can set one value
-or all values back.
+Move a slider or choose a color. The app changes at once. The inspector waits
+for each request before it sends the next value or switches to another app.
+You can set one value or all values back.
+
+Turn off **Show** in the **Motion** section to hide the motion preview in the
+sample app. Its animation tweaks leave the composition and vanish from the
+inspector. Turn it back on to see them appear again.
 
 ## Test the panel
 

--- a/snapo-link-android/samples/demo-tweaks/panel/README.md
+++ b/snapo-link-android/samples/demo-tweaks/panel/README.md
@@ -4,8 +4,8 @@ A model built this inspector as one way to find running apps and change live
 values. Each app must use Snap-O Tweaks.
 
 This is only a demo, not part of the feature or the expected way to use it.
-You do not need this inspector. Any tool can use `/app` and `/tweaks` to build
-its own UI.
+You do not need this inspector. Any tool can use `/app`, `/tweaks`, and
+`/tweaks/events` to build its own live UI.
 
 ## What you need
 
@@ -69,9 +69,9 @@ To find apps, the inspector:
 4. Uses or creates an `adb` port forward.
 5. Reads `/app` to get the app name and package.
 
-It checks for new apps and screen changes every few seconds. If an app starts
-again, it keeps the same app selected when possible. If no app is running, it
-shows an empty state and waits.
+It checks for new apps every few seconds. Tweak and screen changes stream from
+the app as they happen. If an app starts again, the inspector keeps the same app
+selected when possible. If no app is running, it shows an empty state and waits.
 
 App discovery and selection belong to this demo server. `/apps` and
 `/apps/selection` are not part of the Android Snap-O Tweaks protocol.

--- a/snapo-link-android/samples/demo-tweaks/panel/app.js
+++ b/snapo-link-android/samples/demo-tweaks/panel/app.js
@@ -74,7 +74,6 @@ const elements = {
   empty: document.querySelector("#empty-state"),
   sections: document.querySelector("#tweak-sections"),
   reset: document.querySelector("#reset-button"),
-  refresh: document.querySelector("#refresh-button"),
 };
 
 function node(tag, className, text) {
@@ -949,7 +948,6 @@ if (typeof window !== "undefined") {
   });
 }
 
-elements.refresh.addEventListener("click", () => load());
 elements.reset.addEventListener("click", resetTweaks);
 
 elements.appIcon.addEventListener("error", (event) => {

--- a/snapo-link-android/samples/demo-tweaks/panel/app.js
+++ b/snapo-link-android/samples/demo-tweaks/panel/app.js
@@ -1,17 +1,78 @@
 const state = {
+  apps: [],
+  selectedAppId: undefined,
+  selectedView: "tweaks",
   tweaks: [],
   rows: new Map(),
+  orderingByApp: new Map(),
   pending: new Map(),
   timer: undefined,
+  pollTimer: undefined,
+  refreshing: false,
   saving: false,
+  switching: false,
+  menuOpen: false,
 };
 
+const isMockMode = typeof window !== "undefined" &&
+  new URLSearchParams(window.location.search).has("mock");
+
+const isAppGroupedMock = isMockMode &&
+  new URLSearchParams(window.location.search).get("mock") === "apps";
+
+const mockApps = [
+  {
+    id: "mock:chatgpt",
+    name: "ChatGPT",
+    packageName: "com.openai.chatgpt",
+    deviceName: "Pixel 9 Pro XL",
+    views: ["network", "tweaks"],
+  },
+  {
+    id: "mock:tweaks-demo",
+    name: "Snap-O Tweaks Demo",
+    packageName: "com.openai.snapo.demo.tweaks",
+    deviceName: "Pixel 9 Pro XL",
+    views: ["tweaks"],
+  },
+  {
+    id: "mock:emulator:chatgpt",
+    name: "ChatGPT",
+    packageName: "com.openai.chatgpt",
+    deviceName: "Android Emulator",
+    views: ["network"],
+  },
+];
+
+const mockTweaks = [
+  { name: "Colors/Text", type: "color", default: "#18212F", value: "#18212F" },
+  { name: "Colors/Background", type: "color", default: "#F7F8FA", value: "#F7F8FA" },
+  { name: "Colors/Accent", type: "color", default: "#5468FF", value: "#5468FF" },
+  { name: "Typography/Font size", type: "int", default: 36, value: 36, min: 16, max: 72, step: 1 },
+  { name: "Typography/Font weight", type: "int", default: 600, value: 600, min: 100, max: 900, step: 100 },
+  { name: "Typography/Preview text", type: "string", default: "Make it feel right.", value: "Make it feel right." },
+  { name: "Motion/Show", type: "boolean", default: true, value: true },
+  { name: "Motion/Duration", type: "int", default: 400, value: 400, min: 100, max: 1500, step: 50 },
+  { name: "Motion/Spring stiffness", type: "float", default: 280, value: 280, min: 80, max: 800, step: 20 },
+  { name: "Motion/Spring damping", type: "float", default: 0.7, value: 0.7, min: 0.1, max: 1, step: 0.05 },
+  { name: "Motion/Use spring", type: "boolean", default: true, value: true },
+];
+
+let mockSelectedAppId = mockApps[0].id;
+
 const elements = {
+  appPicker: document.querySelector("#app-picker"),
+  appChevron: document.querySelector("#app-chevron"),
+  appList: document.querySelector("#app-list"),
+  appIcon: document.querySelector(".app-icon"),
   appName: document.querySelector("#app-name"),
   packageName: document.querySelector("#package-name"),
+  deviceName: document.querySelector("#device-name"),
   status: document.querySelector("#connection-status"),
   statusText: document.querySelector("#status-text"),
   error: document.querySelector("#error-message"),
+  empty: document.querySelector("#empty-state"),
+  sections: document.querySelector("#tweak-sections"),
   reset: document.querySelector("#reset-button"),
   refresh: document.querySelector("#refresh-button"),
 };
@@ -36,6 +97,8 @@ function setError(message) {
 }
 
 async function request(path, options) {
+  if (isMockMode) return mockRequest(path, options);
+
   const response = await fetch(path, {
     cache: "no-store",
     ...options,
@@ -49,11 +112,261 @@ async function request(path, options) {
   return payload;
 }
 
+function mockRequest(path, options) {
+  if (path === "/apps") {
+    return { apps: structuredClone(mockApps), selectedAppId: mockSelectedAppId };
+  }
+
+  if (path === "/apps/selection") {
+    const { id } = JSON.parse(options.body);
+    const app = mockApps.find((candidate) => candidate.id === id);
+
+    if (!app) throw new Error("The selected app is not available.");
+
+    mockSelectedAppId = id;
+    return { app: structuredClone(app) };
+  }
+
+  if (path === "/app") {
+    return structuredClone(mockApps.find((app) => app.id === mockSelectedAppId));
+  }
+
+  if (path === "/tweaks" && options?.method === "PATCH") {
+    const { values } = JSON.parse(options.body);
+
+    for (const tweak of mockTweaks) {
+      if (Object.hasOwn(values, tweak.name)) tweak.value = values[tweak.name];
+    }
+
+    return {
+      tweaks: Object.entries(values).map(([name, value]) => ({ name, value })),
+    };
+  }
+
+  if (path === "/tweaks") {
+    const showMotion = mockTweaks.find((tweak) => tweak.name === "Motion/Show");
+    const tweaks = mockTweaks.filter((tweak) =>
+      showMotion.value || !tweak.name.startsWith("Motion/") || tweak.name === "Motion/Show"
+    );
+
+    return { tweaks: structuredClone(tweaks) };
+  }
+
+  throw new Error("The mock route is not available.");
+}
+
 function updateResetButton() {
   elements.reset.disabled =
     state.saving ||
+    state.switching ||
     state.tweaks.length === 0 ||
     state.tweaks.every((tweak) => tweak.value === tweak.default);
+}
+
+function setAppMenuOpen(open) {
+  const hasChoices = state.apps.length > 1 ||
+    state.apps.some((app) => (app.views?.length ?? 0) > 1);
+  state.menuOpen = open && hasChoices && !state.switching;
+  elements.appList.hidden = !state.menuOpen;
+  elements.appPicker.setAttribute("aria-expanded", String(state.menuOpen));
+}
+
+function renderApps() {
+  const multipleApps = state.apps.length > 1 ||
+    state.apps.some((app) => (app.views?.length ?? 0) > 1);
+  elements.appPicker.disabled = state.switching || !multipleApps;
+  elements.appPicker.dataset.available = String(state.apps.length > 0);
+  elements.appPicker.dataset.multiple = String(multipleApps);
+  elements.appChevron.hidden = !multipleApps;
+
+  if (isMockMode) {
+    renderMockApps();
+    return;
+  }
+
+  renderAppGroupedMenu();
+}
+
+function mockIcon(name, className = "mock-menu-icon") {
+  const namespace = "http://www.w3.org/2000/svg";
+  const icon = document.createElementNS(namespace, "svg");
+  const use = document.createElementNS(namespace, "use");
+
+  icon.setAttribute("class", className);
+  icon.setAttribute("viewBox", "0 0 24 24");
+  icon.setAttribute("aria-hidden", "true");
+  use.setAttribute("href", `#mock-icon-${name}`);
+  icon.append(use);
+  return icon;
+}
+
+function renderMockApps() {
+  if (isAppGroupedMock) {
+    renderAppGroupedMenu();
+    return;
+  }
+
+  const rows = [];
+
+  for (const view of ["network", "tweaks"]) {
+    const apps = state.apps.filter((app) => (app.views ?? ["tweaks"]).includes(view));
+
+    if (apps.length === 0) continue;
+
+    const viewName = view === "network" ? "Network" : "Tweaks";
+    const heading = node("div", "mock-menu-heading");
+
+    heading.setAttribute("role", "presentation");
+    heading.append(
+      mockIcon(view === "network" ? "network" : "tweaks", "mock-heading-icon"),
+      node("span", undefined, viewName),
+    );
+    rows.push(heading);
+
+    for (const app of apps) {
+      const selected = app.id === state.selectedAppId && view === state.selectedView;
+      const button = node("button", "mock-menu-choice");
+      const identity = node("span", "mock-choice-identity");
+
+      button.type = "button";
+      button.dataset.selected = String(selected);
+      button.setAttribute("role", "menuitemradio");
+      button.setAttribute("aria-checked", String(selected));
+      button.setAttribute("aria-label", `${app.name}, ${viewName}, ${app.deviceName}`);
+      button.setAttribute("title", app.packageName);
+
+      identity.append(
+        node("span", "mock-choice-name", app.name),
+        node("span", "mock-choice-device", app.deviceName),
+      );
+      button.append(
+        mockIcon("app", "mock-choice-app-icon"),
+        identity,
+        mockIcon("check", "mock-menu-check"),
+      );
+
+      button.addEventListener("click", async () => {
+        state.selectedView = view;
+
+        if (app.id !== state.selectedAppId) await selectApp(app.id);
+
+        elements.appName.textContent = `${app.name} · ${viewName}`;
+        renderApps();
+        setAppMenuOpen(false);
+      });
+      rows.push(button);
+    }
+  }
+
+  elements.appList.replaceChildren(...rows);
+  setAppMenuOpen(state.menuOpen);
+}
+
+function appMenuIcon(app) {
+  if (isMockMode) return mockIcon("app", "mock-app-heading-icon");
+
+  const icon = node("img", "mock-app-heading-icon");
+  icon.src = `/apps/${encodeURIComponent(app.id)}/icon`;
+  icon.alt = "";
+  icon.width = 15;
+  icon.height = 15;
+  icon.addEventListener("error", () => {
+    icon.hidden = true;
+  });
+  return icon;
+}
+
+function renderAppGroupedMenu() {
+  const rows = [];
+
+  for (const app of state.apps) {
+    if (rows.length > 0) rows.push(node("div", "mock-app-separator"));
+
+    const heading = node("div", "mock-app-heading");
+
+    heading.setAttribute("role", "presentation");
+    heading.setAttribute("title", app.packageName);
+    heading.append(
+      appMenuIcon(app),
+      node("span", "mock-app-heading-name", app.name),
+      node("span", "mock-app-heading-device", app.deviceName),
+    );
+    rows.push(heading);
+
+    for (const view of app.views ?? ["tweaks"]) {
+      const viewName = view === "network" ? "Network" : "Tweaks";
+      const selected = app.id === state.selectedAppId && view === state.selectedView;
+      const button = node("button", "mock-menu-choice mock-app-view-choice");
+
+      button.type = "button";
+      button.dataset.selected = String(selected);
+      button.disabled = state.switching;
+      button.setAttribute("role", "menuitemradio");
+      button.setAttribute("aria-checked", String(selected));
+      button.setAttribute("aria-pressed", String(selected));
+      button.setAttribute("aria-label", `${app.name}, ${viewName}, ${app.deviceName}`);
+      button.setAttribute("title", app.packageName);
+      button.append(
+        mockIcon(view === "network" ? "network" : "tweaks", "mock-app-view-icon"),
+        node("span", "mock-app-view-name", viewName),
+        mockIcon("check", "mock-menu-check"),
+      );
+
+      button.addEventListener("click", async () => {
+        state.selectedView = view;
+
+        if (app.id !== state.selectedAppId) await selectApp(app.id);
+
+        if (isMockMode) {
+          elements.appName.textContent = `${app.name} · ${viewName}`;
+        }
+        renderApps();
+        setAppMenuOpen(false);
+      });
+      rows.push(button);
+    }
+  }
+
+  elements.appList.replaceChildren(...rows);
+  setAppMenuOpen(state.menuOpen);
+}
+
+function showEmptyState() {
+  state.tweaks = [];
+  state.rows.clear();
+  elements.appName.textContent = "No app selected";
+  elements.packageName.textContent = "";
+  elements.deviceName.textContent = "";
+  elements.appIcon.hidden = true;
+  elements.appPicker.removeAttribute?.("title");
+  elements.empty.hidden = false;
+  document.title = "Tweaks · Snap-O";
+  renderTweaks();
+  setError();
+  setStatus("disconnected", "No apps found");
+}
+
+function updateAppIdentity(app) {
+  elements.appName.textContent = isMockMode
+    ? `${app.name} · ${state.selectedView === "network" ? "Network" : "Tweaks"}`
+    : app.name;
+  elements.packageName.textContent = app.packageName;
+  elements.deviceName.textContent = app.deviceName;
+  if (isMockMode) {
+    elements.appIcon.hidden = true;
+
+    const frame = elements.appIcon.parentElement;
+
+    if (frame && !frame.querySelector(".mock-toolbar-icon")) {
+      frame.prepend(mockIcon("app", "mock-toolbar-icon"));
+    }
+  } else {
+    elements.appIcon.src = `/apps/${encodeURIComponent(app.id)}/icon`;
+    elements.appIcon.hidden = false;
+  }
+  elements.appPicker.setAttribute("title", app.packageName);
+  elements.empty.hidden = true;
+  document.title = `${app.name} · Snap-O Tweaks`;
 }
 
 function updateTweakRow(tweak) {
@@ -72,22 +385,12 @@ function updateTweakRow(tweak) {
   if (fields.checkbox) fields.checkbox.checked = tweak.value;
 }
 
-function applyAccent() {
-  const accent = state.tweaks.find(
-    (tweak) => tweak.name === "Accent color" && tweak.type === "color",
-  );
-
-  if (accent) {
-    document.documentElement.style.setProperty("--accent", accent.value);
-  }
-}
-
 function updateValue(tweak, value, delay = 75) {
+  if (state.switching) return;
   tweak.value = value;
   state.pending.set(tweak.name, value);
   updateTweakRow(tweak);
   updateResetButton();
-  applyAccent();
   clearTimeout(state.timer);
   state.timer = undefined;
 
@@ -145,6 +448,7 @@ async function flushPending() {
 
 function makeTweakLine(tweak) {
   const line = node("div", "tweak-line");
+  const content = node("div", "tweak-content");
   const actions = node("div", "tweak-actions");
   const reset = node("button", "tweak-reset", "Reset");
   reset.type = "button";
@@ -154,8 +458,8 @@ function makeTweakLine(tweak) {
     updateValue(tweak, tweak.default, 0);
   });
 
-  actions.append(reset);
-  line.append(node("span", "tweak-label", tweak.name), actions);
+  content.append(node("span", "tweak-label", tweakLabel(tweak.name)), actions);
+  line.append(content, reset);
   return { line, actions, reset };
 }
 
@@ -201,12 +505,7 @@ function makeNumberTweak(tweak) {
       updateValue(tweak, value, 0);
     });
 
-    const labels = node("div", "range-labels");
-    labels.append(
-      node("span", undefined, numberText(tweak.min)),
-      node("span", undefined, numberText(tweak.max)),
-    );
-    row.append(slider, labels);
+    row.append(slider);
   }
 
   input.addEventListener("input", () => {
@@ -329,35 +628,100 @@ function makeTweak(tweak) {
   }
 }
 
-function sectionFor(tweak) {
-  if (/animation|duration|spring|damping|stiffness|motion/i.test(tweak.name)) {
-    return "motion";
+function tweakPath(name) {
+  const separator = name.indexOf("/");
+
+  if (separator <= 0 || separator === name.length - 1) {
+    return { section: undefined, label: name };
   }
 
-  if (/font|text|color|background|accent|preview/i.test(tweak.name)) {
-    return "appearance";
+  const section = name.slice(0, separator).trim();
+  const label = name.slice(separator + 1).trim();
+
+  return section && label
+    ? { section, label }
+    : { section: undefined, label: name };
+}
+
+function tweakLabel(name) {
+  return tweakPath(name).label;
+}
+
+function tweakOrdering() {
+  const appId = state.selectedAppId ?? "";
+  let ordering = state.orderingByApp.get(appId);
+
+  if (!ordering) {
+    ordering = { sections: new Map(), tweaks: new Map() };
+    state.orderingByApp.set(appId, ordering);
   }
 
-  return "other";
+  return ordering;
 }
 
 function renderTweaks() {
   state.rows.clear();
 
-  for (const name of ["appearance", "motion", "other"]) {
-    const section = document.querySelector(`#${name}-section`);
-    const list = document.querySelector(`#${name}-tweaks`);
-    const count = document.querySelector(`#${name}-count`);
-    const tweaks = state.tweaks.filter((tweak) => sectionFor(tweak) === name);
+  const ordering = tweakOrdering();
+  const activeSections = new Map();
 
-    if (count) count.textContent = String(tweaks.length);
-    list.replaceChildren(
-      ...tweaks.map(makeTweak).filter((tweak) => tweak !== null),
-    );
-    section.hidden = list.childElementCount === 0;
+  for (const tweak of state.tweaks) {
+    const { section } = tweakPath(tweak.name);
+    const sectionKey = section ?? "";
+
+    if (!ordering.sections.has(sectionKey)) {
+      ordering.sections.set(sectionKey, ordering.sections.size);
+    }
+
+    if (!ordering.tweaks.has(tweak.name)) {
+      ordering.tweaks.set(tweak.name, ordering.tweaks.size);
+    }
+
+    if (!activeSections.has(sectionKey)) activeSections.set(sectionKey, []);
+    activeSections.get(sectionKey).push(tweak);
   }
 
-  applyAccent();
+  const sections = [...activeSections.entries()]
+    .sort(([left], [right]) =>
+      ordering.sections.get(left) - ordering.sections.get(right),
+    )
+    .map(([name, tweaks]) => {
+      const section = node("section", "tweak-section");
+      section.dataset.section = name;
+      section.dataset.order = String(ordering.sections.get(name));
+
+      if (name) {
+        const heading = node("div", "section-heading");
+        heading.append(node("h2", undefined, name));
+        section.append(heading);
+      }
+
+      const list = node("div", "tweak-list");
+      list.replaceChildren(
+        ...tweaks
+          .sort((left, right) =>
+            ordering.tweaks.get(left.name) - ordering.tweaks.get(right.name),
+          )
+          .map(makeTweak)
+          .filter((tweak) => tweak !== null),
+      );
+      section.append(list);
+      return section;
+    });
+
+  const columnCount = Math.min(2, ordering.sections.size);
+  const columns = Array.from({ length: columnCount }, (_, index) => {
+    const column = node("div", "tweak-column");
+    column.dataset.column = String(index);
+    return column;
+  });
+
+  for (const section of sections) {
+    const index = ordering.sections.get(section.dataset.section) % columnCount;
+    columns[index].append(section);
+  }
+
+  elements.sections.replaceChildren(...columns);
   updateResetButton();
 }
 
@@ -367,25 +731,170 @@ async function reloadTweaks() {
   renderTweaks();
 }
 
-async function load() {
-  setStatus("connecting", "Connecting");
+function sameTweakShape(current, incoming) {
+  if (current.length !== incoming.length) return false;
+
+  return current.every((tweak, index) => {
+    const next = incoming[index];
+
+    return (
+      tweak.name === next.name &&
+      tweak.type === next.type &&
+      tweak.default === next.default &&
+      tweak.min === next.min &&
+      tweak.max === next.max &&
+      tweak.step === next.step
+    );
+  });
+}
+
+function scheduleRefresh() {
+  clearTimeout(state.pollTimer);
+  state.pollTimer = setTimeout(() => {
+    if (!document.hidden) void refreshCurrent();
+    else scheduleRefresh();
+  }, 2_500);
+  state.pollTimer.unref?.();
+}
+
+async function refreshCurrent() {
+  if (state.refreshing || state.saving || state.switching) {
+    scheduleRefresh();
+    return;
+  }
+
+  state.refreshing = true;
 
   try {
-    const [app, result] = await Promise.all([
-      request("/app"),
-      request("/tweaks"),
-    ]);
+    const result = await request("/apps");
+    const previousId = state.selectedAppId;
+    state.apps = result.apps;
+    state.selectedAppId = result.selectedAppId ?? undefined;
+    renderApps();
 
-    elements.appName.textContent = app.name;
-    elements.packageName.textContent = app.packageName;
-    document.title = `${app.name} · Snap-O Tweaks`;
-    state.tweaks = result.tweaks;
-    renderTweaks();
+    if (!state.selectedAppId) {
+      showEmptyState();
+      return;
+    }
+
+    if (previousId !== state.selectedAppId) {
+      await load({ refreshApps: false });
+      return;
+    }
+
+    const incoming = (await request("/tweaks")).tweaks;
+
+    if (!sameTweakShape(state.tweaks, incoming)) {
+      state.tweaks = incoming;
+      renderTweaks();
+    } else {
+      for (const next of incoming) {
+        if (state.pending.has(next.name)) continue;
+
+        const tweak = state.tweaks.find((candidate) => candidate.name === next.name);
+        const fields = state.rows.get(next.name);
+
+        if (
+          tweak &&
+          tweak.value !== next.value &&
+          !Object.values(fields ?? {}).includes(document.activeElement)
+        ) {
+          tweak.value = next.value;
+          updateTweakRow(tweak);
+        }
+      }
+
+      updateResetButton();
+    }
+
     setError();
     setStatus("connected", "Connected");
   } catch (error) {
     setError(error.message);
     setStatus("error", "Disconnected");
+  } finally {
+    state.refreshing = false;
+    scheduleRefresh();
+  }
+}
+
+async function load({ refreshApps = true } = {}) {
+  setStatus("connecting", "Connecting");
+
+  try {
+    if (refreshApps) {
+      const discovery = await request("/apps");
+      state.apps = discovery.apps;
+      state.selectedAppId = discovery.selectedAppId ?? undefined;
+      renderApps();
+    }
+
+    if (!state.selectedAppId) {
+      showEmptyState();
+      return;
+    }
+
+    const [app, result] = await Promise.all([
+      request("/app"),
+      request("/tweaks"),
+    ]);
+
+    const selected = state.apps.find((candidate) => candidate.id === state.selectedAppId);
+    updateAppIdentity({ ...selected, ...app });
+    state.tweaks = result.tweaks;
+    renderTweaks();
+    setError();
+    setStatus("connected", "Connected");
+
+    if (isMockMode && refreshApps) setAppMenuOpen(true);
+  } catch (error) {
+    setError(error.message);
+    setStatus("error", "Disconnected");
+  } finally {
+    scheduleRefresh();
+  }
+}
+
+async function selectApp(id) {
+  if (state.switching) return;
+
+  if (id === state.selectedAppId) {
+    setAppMenuOpen(false);
+    return;
+  }
+
+  state.switching = true;
+  setAppMenuOpen(false);
+  renderApps();
+  updateResetButton();
+
+  try {
+    clearTimeout(state.timer);
+
+    while (state.saving || state.pending.size > 0) {
+      if (!state.saving) {
+        await flushPending();
+      } else {
+        await new Promise((resolve) => setTimeout(resolve, 10));
+      }
+    }
+
+    const result = await request("/apps/selection", {
+      method: "PUT",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ id }),
+    });
+
+    state.selectedAppId = result.app.id;
+    renderApps();
+    await load({ refreshApps: false });
+  } catch (error) {
+    setError(error.message);
+    setStatus("error", "Could not switch apps");
+  } finally {
+    state.switching = false;
+    renderApps();
+    updateResetButton();
   }
 }
 
@@ -419,10 +928,31 @@ async function resetTweaks() {
   }
 }
 
-elements.refresh.addEventListener("click", load);
+elements.appPicker.addEventListener("click", () => {
+  setAppMenuOpen(!state.menuOpen);
+});
+
+if (typeof window !== "undefined") {
+  window.addEventListener("pointerdown", (event) => {
+    const picker = elements.appPicker.parentElement;
+
+    if (state.menuOpen && picker && !picker.contains(event.target)) {
+      setAppMenuOpen(false);
+    }
+  });
+
+  window.addEventListener("keydown", (event) => {
+    if (state.menuOpen && event.key === "Escape") {
+      setAppMenuOpen(false);
+      elements.appPicker.focus();
+    }
+  });
+}
+
+elements.refresh.addEventListener("click", () => load());
 elements.reset.addEventListener("click", resetTweaks);
 
-document.querySelector(".app-icon").addEventListener("error", (event) => {
+elements.appIcon.addEventListener("error", (event) => {
   event.currentTarget.hidden = true;
 });
 

--- a/snapo-link-android/samples/demo-tweaks/panel/app.js
+++ b/snapo-link-android/samples/demo-tweaks/panel/app.js
@@ -6,6 +6,8 @@ const state = {
   rows: new Map(),
   orderingByApp: new Map(),
   pending: new Map(),
+  inFlight: new Set(),
+  eventSource: undefined,
   timer: undefined,
   pollTimer: undefined,
   refreshing: false,
@@ -367,6 +369,7 @@ function renderAppGroupedMenu() {
 }
 
 function showEmptyState() {
+  closeTweakStream();
   state.tweaks = [];
   state.rows.clear();
   elements.appName.textContent = "No app selected";
@@ -442,6 +445,7 @@ async function flushPending() {
 
   const values = Object.fromEntries(state.pending);
   state.pending.clear();
+  for (const name of Object.keys(values)) state.inFlight.add(name);
   state.saving = true;
   setStatus("connected", "Saving…");
   updateResetButton();
@@ -468,6 +472,7 @@ async function flushPending() {
     setStatus("error", "Update failed");
     await reloadTweaks();
   } finally {
+    for (const name of Object.keys(values)) state.inFlight.delete(name);
     state.saving = false;
     updateResetButton();
 
@@ -483,16 +488,18 @@ function makeTweakLine(tweak) {
   const line = node("div", "tweak-line");
   const content = node("div", "tweak-content");
   const actions = node("div", "tweak-actions");
-  const reset = node("button", "tweak-reset", "Reset");
+  const reset = node("button", "tweak-reset");
   reset.type = "button";
   reset.hidden = tweak.value === tweak.default;
   reset.setAttribute("aria-label", `Reset ${tweak.name}`);
+  reset.setAttribute("title", `Reset ${tweakLabel(tweak.name)}`);
+  reset.append(mockIcon("rotate-ccw", "tweak-reset-icon"));
   reset.addEventListener("click", () => {
     updateValue(tweak, tweak.default, 0);
   });
 
-  content.append(node("span", "tweak-label", tweakLabel(tweak.name)), actions);
-  line.append(content, reset);
+  content.append(node("span", "tweak-label", tweakLabel(tweak.name)), reset, actions);
+  line.append(content);
   return { line, actions, reset };
 }
 
@@ -781,6 +788,76 @@ function sameTweakShape(current, incoming) {
   });
 }
 
+function applyTweakSnapshot(incoming) {
+  const existing = new Map(state.tweaks.map((tweak) => [tweak.name, tweak]));
+  const nextTweaks = incoming.map((next) => {
+    const current = existing.get(next.name);
+
+    if (
+      current &&
+      (state.pending.has(next.name) || state.inFlight.has(next.name))
+    ) {
+      return { ...next, value: current.value };
+    }
+
+    const fields = state.rows.get(next.name);
+    if (current && Object.values(fields ?? {}).includes(document.activeElement)) {
+      return { ...next, value: current.value };
+    }
+
+    return next;
+  });
+
+  if (!sameTweakShape(state.tweaks, nextTweaks)) {
+    state.tweaks = nextTweaks;
+    renderTweaks();
+    return;
+  }
+
+  for (const next of nextTweaks) {
+    const current = existing.get(next.name);
+    if (current && current.value !== next.value) {
+      current.value = next.value;
+      updateTweakRow(current);
+    }
+  }
+
+  updateResetButton();
+}
+
+function closeTweakStream() {
+  state.eventSource?.close();
+  state.eventSource = undefined;
+}
+
+function openTweakStream() {
+  closeTweakStream();
+
+  if (isMockMode || typeof EventSource === "undefined") return;
+
+  const source = new EventSource("/tweaks/events");
+  state.eventSource = source;
+
+  source.addEventListener("tweaks", (event) => {
+    if (state.eventSource !== source || state.switching) return;
+
+    try {
+      const result = JSON.parse(event.data);
+      applyTweakSnapshot(result.tweaks);
+      setError();
+      setStatus("connected", "Connected");
+    } catch (error) {
+      setError(error.message);
+      setStatus("error", "Invalid tweak update");
+    }
+  });
+
+  source.addEventListener("error", () => {
+    if (state.eventSource !== source || state.switching) return;
+    setStatus("connecting", "Reconnecting…");
+  });
+}
+
 function scheduleRefresh() {
   clearTimeout(state.pollTimer);
   state.pollTimer = setTimeout(() => {
@@ -815,29 +892,8 @@ async function refreshCurrent() {
       return;
     }
 
-    const incoming = (await request("/tweaks")).tweaks;
-
-    if (!sameTweakShape(state.tweaks, incoming)) {
-      state.tweaks = incoming;
-      renderTweaks();
-    } else {
-      for (const next of incoming) {
-        if (state.pending.has(next.name)) continue;
-
-        const tweak = state.tweaks.find((candidate) => candidate.name === next.name);
-        const fields = state.rows.get(next.name);
-
-        if (
-          tweak &&
-          tweak.value !== next.value &&
-          !Object.values(fields ?? {}).includes(document.activeElement)
-        ) {
-          tweak.value = next.value;
-          updateTweakRow(tweak);
-        }
-      }
-
-      updateResetButton();
+    if (!state.eventSource) {
+      applyTweakSnapshot((await request("/tweaks")).tweaks);
     }
 
     setError();
@@ -876,6 +932,7 @@ async function load({ refreshApps = true } = {}) {
     updateAppIdentity({ ...selected, ...app });
     state.tweaks = result.tweaks;
     renderTweaks();
+    openTweakStream();
     setError();
     setStatus("connected", "Connected");
 
@@ -897,6 +954,7 @@ async function selectApp(id) {
   }
 
   state.switching = true;
+  closeTweakStream();
   setAppMenuOpen(false);
   renderApps();
   updateResetButton();

--- a/snapo-link-android/samples/demo-tweaks/panel/app.js
+++ b/snapo-link-android/samples/demo-tweaks/panel/app.js
@@ -64,6 +64,7 @@ const elements = {
   appPicker: document.querySelector("#app-picker"),
   appChevron: document.querySelector("#app-chevron"),
   appList: document.querySelector("#app-list"),
+  inspectorSegments: document.querySelector("#inspector-segments"),
   appIcon: document.querySelector(".app-icon"),
   appName: document.querySelector("#app-name"),
   packageName: document.querySelector("#package-name"),
@@ -177,6 +178,7 @@ function renderApps() {
   elements.appPicker.dataset.available = String(state.apps.length > 0);
   elements.appPicker.dataset.multiple = String(multipleApps);
   elements.appChevron.hidden = !multipleApps;
+  renderInspectorViews();
 
   if (isMockMode) {
     renderMockApps();
@@ -184,6 +186,42 @@ function renderApps() {
   }
 
   renderAppGroupedMenu();
+}
+
+function renderInspectorViews() {
+  const app = state.apps.find((candidate) => candidate.id === state.selectedAppId);
+  const views = app?.views ?? (app ? ["tweaks"] : []);
+
+  elements.inspectorSegments.hidden = views.length < 2;
+
+  if (!app || views.length < 2) {
+    elements.inspectorSegments.replaceChildren();
+    return;
+  }
+
+  const segments = views.map((view) => {
+    const title = view === "network" ? "Network" : "Tweaks";
+    const selected = view === state.selectedView;
+    const button = node("button", "inspector-segment");
+
+    button.type = "button";
+    button.disabled = state.switching;
+    button.setAttribute("aria-label", `${title} inspector`);
+    button.setAttribute("aria-pressed", String(selected));
+    button.setAttribute("title", title);
+    button.append(mockIcon(view === "network" ? "network" : "tweaks", "inspector-segment-icon"));
+    button.addEventListener("click", () => {
+      if (state.switching || view === state.selectedView) return;
+
+      state.selectedView = view;
+      updateAppIdentity(app);
+      renderApps();
+      setAppMenuOpen(false);
+    });
+    return button;
+  });
+
+  elements.inspectorSegments.replaceChildren(...segments);
 }
 
 function mockIcon(name, className = "mock-menu-icon") {
@@ -249,7 +287,7 @@ function renderMockApps() {
 
         if (app.id !== state.selectedAppId) await selectApp(app.id);
 
-        elements.appName.textContent = `${app.name} · ${viewName}`;
+        elements.appName.textContent = app.name;
         renderApps();
         setAppMenuOpen(false);
       });
@@ -316,9 +354,7 @@ function renderAppGroupedMenu() {
 
         if (app.id !== state.selectedAppId) await selectApp(app.id);
 
-        if (isMockMode) {
-          elements.appName.textContent = `${app.name} · ${viewName}`;
-        }
+        if (isMockMode) elements.appName.textContent = app.name;
         renderApps();
         setAppMenuOpen(false);
       });
@@ -346,9 +382,7 @@ function showEmptyState() {
 }
 
 function updateAppIdentity(app) {
-  elements.appName.textContent = isMockMode
-    ? `${app.name} · ${state.selectedView === "network" ? "Network" : "Tweaks"}`
-    : app.name;
+  elements.appName.textContent = app.name;
   elements.packageName.textContent = app.packageName;
   elements.deviceName.textContent = app.deviceName;
   if (isMockMode) {

--- a/snapo-link-android/samples/demo-tweaks/panel/app.test.mjs
+++ b/snapo-link-android/samples/demo-tweaks/panel/app.test.mjs
@@ -224,6 +224,7 @@ function makeDocument() {
     "#app-picker",
     "#app-chevron",
     "#app-list",
+    "#inspector-segments",
     "#app-name",
     "#package-name",
     "#device-name",
@@ -348,6 +349,8 @@ test("browser panel renders, streams, validates, and resets live tweaks", async 
     assert.equal(document.querySelector("#app-list").childElementCount, 2);
     assert.ok(findAppChoice(document, demoApp));
     assert.equal(document.querySelector("#app-list").hidden, true);
+    assert.equal(document.querySelector("#inspector-segments").hidden, true);
+    assert.equal(document.querySelector("#inspector-segments").childElementCount, 0);
     assert.equal(document.querySelector("#empty-state").hidden, true);
     assert.equal(document.querySelector("#status-text").textContent, "Connected");
     assert.equal(
@@ -462,6 +465,57 @@ test("browser panel renders, streams, validates, and resets live tweaks", async 
     assert.equal(document.properties.has("--accent"), false);
     assert.equal(document.querySelector("#status-text").textContent, "Connected");
     assert.equal(document.querySelector("#error-message").hidden, true);
+  } finally {
+    globalThis.document = originalDocument;
+    globalThis.fetch = originalFetch;
+  }
+});
+
+test("switches available inspectors beside the app-only picker", async () => {
+  const document = makeDocument();
+  const app = { ...demoApp, views: ["network", "tweaks"] };
+  const originalDocument = globalThis.document;
+  const originalFetch = globalThis.fetch;
+
+  globalThis.document = document;
+  globalThis.fetch = async (pathname) => {
+    if (pathname === "/apps") {
+      return jsonResponse({ apps: [app], selectedAppId: app.id });
+    }
+
+    if (pathname === "/app") {
+      return jsonResponse({ name: app.name, packageName: app.packageName });
+    }
+
+    if (pathname === "/tweaks") {
+      return jsonResponse({ tweaks: structuredClone(descriptors) });
+    }
+
+    return jsonResponse({ error: "Not found." }, 404);
+  };
+
+  try {
+    await import(`./app.js?inspector-segments-test=${Date.now()}`);
+    await delay(0);
+
+    const group = document.querySelector("#inspector-segments");
+
+    assert.equal(group.hidden, false);
+    assert.equal(group.childElementCount, 2);
+    assert.equal(document.querySelector("#app-name").textContent, app.name);
+    assert.equal(findInput(group, "Network inspector").getAttribute("aria-pressed"), "false");
+    assert.equal(findInput(group, "Tweaks inspector").getAttribute("aria-pressed"), "true");
+    assert.equal(findInput(group, "Network inspector").textContent, "");
+    assert.equal(findInput(group, "Network inspector").children[0].tagName, "SVG");
+    assert.equal(findInput(group, "Tweaks inspector").children[0].tagName, "SVG");
+    assert.ok(findAppChoice(document, app, "Network"));
+    assert.ok(findAppChoice(document, app, "Tweaks"));
+
+    await findInput(group, "Network inspector").emit("click");
+
+    assert.equal(document.querySelector("#app-name").textContent, app.name);
+    assert.equal(findInput(group, "Network inspector").getAttribute("aria-pressed"), "true");
+    assert.equal(findInput(group, "Tweaks inspector").getAttribute("aria-pressed"), "false");
   } finally {
     globalThis.document = originalDocument;
     globalThis.fetch = originalFetch;

--- a/snapo-link-android/samples/demo-tweaks/panel/app.test.mjs
+++ b/snapo-link-android/samples/demo-tweaks/panel/app.test.mjs
@@ -232,7 +232,6 @@ function makeDocument() {
     "#error-message",
     "#empty-state",
     "#reset-button",
-    "#refresh-button",
     "#tweak-sections",
     ".app-icon",
   ];
@@ -705,12 +704,12 @@ test("restores section and tweak order as folders disappear and reappear", async
     ]);
 
     tweaks = [accent, enabled, typography];
-    await document.querySelector("#refresh-button").emit("click");
+    await delay(2_600);
     assert.deepEqual(visibleSections(document), ["Typography", "Motion", "Colors"]);
     assert.deepEqual(visibleLabels(document, "Motion"), ["Enabled"]);
 
     tweaks = [accent, typography];
-    await document.querySelector("#refresh-button").emit("click");
+    await delay(2_600);
     assert.deepEqual(visibleSections(document), ["Typography", "Colors"]);
     assert.deepEqual(visibleColumnSections(document), [
       ["Typography", "Colors"],
@@ -718,7 +717,7 @@ test("restores section and tweak order as folders disappear and reappear", async
     ]);
 
     tweaks = [accent, stiffness, duration, enabled, typography];
-    await document.querySelector("#refresh-button").emit("click");
+    await delay(2_600);
     assert.deepEqual(visibleSections(document), ["Typography", "Motion", "Colors"]);
     assert.deepEqual(visibleColumnSections(document), [
       ["Typography", "Colors"],
@@ -982,7 +981,7 @@ test("switches apps only after pending slider updates finish", async () => {
   }
 });
 
-test("refresh replaces tweaks when the app changes screens", async () => {
+test("automatic refresh replaces tweaks when the app changes screens", async () => {
   const document = makeDocument();
   const originalDocument = globalThis.document;
   const originalFetch = globalThis.fetch;
@@ -1021,7 +1020,7 @@ test("refresh replaces tweaks when the app changes screens", async () => {
         step: 50,
       },
     ];
-    await document.querySelector("#refresh-button").emit("click");
+    await delay(2_600);
 
     assert.equal(document.querySelector("#tweak-sections").childElementCount, 1);
     assert.equal(findTweakList(document).childElementCount, 1);

--- a/snapo-link-android/samples/demo-tweaks/panel/app.test.mjs
+++ b/snapo-link-android/samples/demo-tweaks/panel/app.test.mjs
@@ -80,6 +80,14 @@ const descriptors = [
   },
 ];
 
+const demoApp = {
+  id: "PIXEL123:com.openai.snapo.demo.tweaks",
+  name: "Snap-O Tweaks Demo",
+  packageName: "com.openai.snapo.demo.tweaks",
+  deviceName: "Pixel 9 Pro XL",
+  deviceSerial: "PIXEL123",
+};
+
 class FakeElement {
   constructor(tag = "div") {
     this.tagName = tag.toUpperCase();
@@ -133,6 +141,10 @@ class FakeElement {
     return this.attributes.get(name) ?? null;
   }
 
+  removeAttribute(name) {
+    this.attributes.delete(name);
+  }
+
   append(...elements) {
     this.children.push(...elements);
   }
@@ -155,6 +167,7 @@ class FakeElement {
 }
 
 function findInput(element, label) {
+  if (!element) return null;
   if (element.getAttribute("aria-label") === label) return element;
 
   for (const child of element.children) {
@@ -165,24 +178,62 @@ function findInput(element, label) {
   return null;
 }
 
+function findAppChoice(document, app, view = "Tweaks") {
+  return findInput(
+    document.querySelector("#app-list"),
+    `${app.name}, ${view}, ${app.deviceName}`,
+  );
+}
+
+function findSection(document, name = "") {
+  return document
+    .querySelector("#tweak-sections")
+    .children.flatMap((column) => column.children)
+    .find((section) => section.dataset.section === name) ?? null;
+}
+
+function findTweakList(document, name = "") {
+  const section = findSection(document, name);
+  return section?.children.at(-1) ?? null;
+}
+
+function visibleSections(document) {
+  return document
+    .querySelector("#tweak-sections")
+    .children.flatMap((column) => column.children)
+    .sort((left, right) => Number(left.dataset.order) - Number(right.dataset.order))
+    .map((section) => section.dataset.section);
+}
+
+function visibleColumnSections(document) {
+  return document
+    .querySelector("#tweak-sections")
+    .children.map((column) => column.children.map((section) => section.dataset.section));
+}
+
+function visibleLabels(document, name = "") {
+  const list = findTweakList(document, name);
+
+  return list?.children.map(
+    (row) => row.children[0].children[0].children[0].textContent,
+  ) ?? [];
+}
+
 function makeDocument() {
   const selectors = [
+    "#app-picker",
+    "#app-chevron",
+    "#app-list",
     "#app-name",
     "#package-name",
+    "#device-name",
     "#connection-status",
     "#status-text",
     "#error-message",
+    "#empty-state",
     "#reset-button",
     "#refresh-button",
-    "#appearance-section",
-    "#appearance-tweaks",
-    "#appearance-count",
-    "#motion-section",
-    "#motion-tweaks",
-    "#motion-count",
-    "#other-section",
-    "#other-tweaks",
-    "#other-count",
+    "#tweak-sections",
     ".app-icon",
   ];
   const elements = new Map(
@@ -197,10 +248,16 @@ function makeDocument() {
         setProperty(name, value) {
           properties.set(name, value);
         },
+        removeProperty(name) {
+          properties.delete(name);
+        },
       },
     },
     properties,
     createElement(tag) {
+      return new FakeElement(tag);
+    },
+    createElementNS(_namespace, tag) {
       return new FakeElement(tag);
     },
     querySelector(selector) {
@@ -228,6 +285,13 @@ test("browser panel renders, streams, validates, and resets live tweaks", async 
 
   globalThis.document = document;
   globalThis.fetch = async (pathname, options) => {
+    if (pathname === "/apps") {
+      return jsonResponse({
+        apps: [demoApp],
+        selectedAppId: demoApp.id,
+      });
+    }
+
     if (pathname === "/app") {
       return jsonResponse({
         name: "Snap-O Tweaks Demo",
@@ -273,28 +337,47 @@ test("browser panel renders, streams, validates, and resets live tweaks", async 
       document.querySelector("#package-name").textContent,
       "com.openai.snapo.demo.tweaks",
     );
+    assert.equal(document.querySelector("#device-name").textContent, "Pixel 9 Pro XL");
+    assert.equal(document.querySelector("#app-picker").disabled, true);
+    assert.equal(document.querySelector("#app-chevron").hidden, true);
+    assert.equal(document.querySelector("#app-picker").dataset.available, "true");
+    assert.equal(document.querySelector("#app-picker").dataset.multiple, "false");
+    assert.equal(
+      document.querySelector("#app-picker").getAttribute("aria-expanded"),
+      "false",
+    );
+    assert.equal(document.querySelector("#app-list").childElementCount, 2);
+    assert.ok(findAppChoice(document, demoApp));
+    assert.equal(document.querySelector("#app-list").hidden, true);
+    assert.equal(document.querySelector("#empty-state").hidden, true);
     assert.equal(document.querySelector("#status-text").textContent, "Connected");
     assert.equal(
       document.querySelector("#connection-status").getAttribute("aria-label"),
       "Connected",
     );
-    assert.equal(document.querySelector("#appearance-section").hidden, false);
-    assert.equal(document.querySelector("#motion-section").hidden, false);
-    assert.equal(document.querySelector("#other-section").hidden, true);
-    assert.equal(
-      document.querySelector("#appearance-tweaks").childElementCount,
-      6,
-    );
-    assert.equal(document.querySelector("#motion-tweaks").childElementCount, 4);
-    assert.equal(document.querySelector("#appearance-count").textContent, "6");
-    assert.equal(document.querySelector("#motion-count").textContent, "4");
-    assert.equal(document.properties.get("--accent"), "#5468FF");
+    assert.equal(document.querySelector("#tweak-sections").childElementCount, 1);
+    assert.equal(findTweakList(document).childElementCount, 10);
+    assert.equal(document.properties.has("--accent"), false);
     assert.equal(document.querySelector("#reset-button").disabled, true);
 
-    const appearance = document.querySelector("#appearance-tweaks");
-    const motion = document.querySelector("#motion-tweaks");
+    const appearance = findTweakList(document);
+    const motion = appearance;
 
     const fontSize = findInput(appearance, "Font size");
+    const fontSizeRow = appearance.children[0];
+    const fontSizeLine = fontSizeRow.children[0];
+    const fontSizeContent = fontSizeLine.children[0];
+
+    assert.equal(fontSizeRow.children.length, 2);
+    assert.equal(fontSizeContent.children[0].textContent, "Font size");
+    assert.equal(
+      fontSizeContent.children[1].children[0].getAttribute("aria-label"),
+      "Font size value",
+    );
+    assert.equal(fontSizeLine.children[1].getAttribute("aria-label"), "Reset Font size");
+    assert.equal(fontSize.min, "16");
+    assert.equal(fontSize.max, "72");
+
     fontSize.value = "48";
     await fontSize.emit("input");
     assert.equal(findInput(appearance, "Font size value").value, "48");
@@ -350,7 +433,7 @@ test("browser panel renders, streams, validates, and resets live tweaks", async 
       "Use spring": false,
       "Preview text": "A calmer direction.",
     });
-    assert.equal(document.properties.get("--accent"), "#3B82F6");
+    assert.equal(document.properties.has("--accent"), false);
     assert.equal(document.querySelector("#reset-button").disabled, false);
 
     const resetAccent = findInput(appearance, "Reset Accent color");
@@ -359,7 +442,7 @@ test("browser panel renders, streams, validates, and resets live tweaks", async 
     await delay(0);
     assert.deepEqual(patches.at(-1), { "Accent color": "#5468FF" });
     assert.equal(resetAccent.hidden, true);
-    assert.equal(document.properties.get("--accent"), "#5468FF");
+    assert.equal(document.properties.has("--accent"), false);
 
     const patchesBeforeInvalid = patches.length;
     fontWeight.value = "701";
@@ -377,7 +460,7 @@ test("browser panel renders, streams, validates, and resets live tweaks", async 
       Object.fromEntries(descriptors.map((tweak) => [tweak.name, tweak.default])),
     );
     assert.equal(document.querySelector("#reset-button").disabled, true);
-    assert.equal(document.properties.get("--accent"), "#5468FF");
+    assert.equal(document.properties.has("--accent"), false);
     assert.equal(document.querySelector("#status-text").textContent, "Connected");
     assert.equal(document.querySelector("#error-message").hidden, true);
   } finally {
@@ -398,6 +481,13 @@ test("sliders stream immediately and wait for each request before sending the la
 
   globalThis.document = document;
   globalThis.fetch = async (pathname, options) => {
+    if (pathname === "/apps") {
+      return jsonResponse({
+        apps: [demoApp],
+        selectedAppId: demoApp.id,
+      });
+    }
+
     if (pathname === "/app") {
       return jsonResponse({
         name: "Snap-O Tweaks Demo",
@@ -450,7 +540,7 @@ test("sliders stream immediately and wait for each request before sending the la
     await import(`./app.js?slider-stream-test=${Date.now()}`);
     await delay(0);
 
-    const appearance = document.querySelector("#appearance-tweaks");
+    const appearance = findTweakList(document);
     const slider = findInput(appearance, "Font size");
 
     slider.value = "37";
@@ -498,13 +588,536 @@ test("sliders stream immediately and wait for each request before sending the la
     assert.equal(maximumRequestsInFlight, 1);
     assert.equal(requestsInFlight, 0);
     assert.equal(document.querySelector("#status-text").textContent, "Connected");
-    assert.equal(document.properties.get("--accent"), "#3B82F6");
+    assert.equal(document.properties.has("--accent"), false);
   } finally {
     if (finishFirstRequest) {
       finishFirstRequest();
       await delay(0);
     }
 
+    globalThis.document = originalDocument;
+    globalThis.fetch = originalFetch;
+  }
+});
+
+test("groups tweaks only by explicit folder paths and patches their full names", async () => {
+  const document = makeDocument();
+  const tweaks = [
+    { ...descriptors[0], name: "Typography/Font size" },
+    { ...descriptors[1], name: "Typography/Font weight" },
+    { ...descriptors[2], name: "Colors/Text" },
+    { ...descriptors[5], name: "Motion/Duration" },
+    { ...descriptors[8], name: "Enabled" },
+    { ...descriptors[5], name: "Animation duration" },
+  ];
+  const patches = [];
+  const originalDocument = globalThis.document;
+  const originalFetch = globalThis.fetch;
+
+  globalThis.document = document;
+  globalThis.fetch = async (pathname, options) => {
+    if (pathname === "/apps") {
+      return jsonResponse({ apps: [demoApp], selectedAppId: demoApp.id });
+    }
+
+    if (pathname === "/app") {
+      return jsonResponse({ name: demoApp.name, packageName: demoApp.packageName });
+    }
+
+    if (pathname === "/tweaks" && options?.method === "PATCH") {
+      const { values } = JSON.parse(options.body);
+      patches.push(values);
+
+      for (const tweak of tweaks) {
+        if (Object.hasOwn(values, tweak.name)) tweak.value = values[tweak.name];
+      }
+
+      return jsonResponse({
+        tweaks: Object.entries(values).map(([name, value]) => ({ name, value })),
+      });
+    }
+
+    if (pathname === "/tweaks") return jsonResponse({ tweaks });
+    return jsonResponse({ error: "Not found." }, 404);
+  };
+
+  try {
+    await import(`./app.js?explicit-folder-test=${Date.now()}`);
+    await delay(0);
+
+    assert.deepEqual(visibleSections(document), ["Typography", "Colors", "Motion", ""]);
+    assert.deepEqual(visibleLabels(document, "Typography"), ["Font size", "Font weight"]);
+    assert.deepEqual(visibleLabels(document, "Colors"), ["Text"]);
+    assert.deepEqual(visibleLabels(document, "Motion"), ["Duration"]);
+    assert.deepEqual(visibleLabels(document), ["Enabled", "Animation duration"]);
+
+    const typography = findTweakList(document, "Typography");
+    const slider = findInput(typography, "Typography/Font size");
+    slider.value = "48";
+    await slider.emit("input");
+    await delay(0);
+
+    assert.deepEqual(patches, [{ "Typography/Font size": 48 }]);
+  } finally {
+    globalThis.document = originalDocument;
+    globalThis.fetch = originalFetch;
+  }
+});
+
+test("restores section and tweak order as folders disappear and reappear", async () => {
+  const document = makeDocument();
+  const typography = { ...descriptors[0], name: "Typography/Font size" };
+  const enabled = { ...descriptors[8], name: "Motion/Enabled" };
+  const duration = { ...descriptors[5], name: "Motion/Duration" };
+  const stiffness = { ...descriptors[6], name: "Motion/Spring stiffness" };
+  const accent = { ...descriptors[4], name: "Colors/Accent" };
+  let tweaks = [typography, enabled, duration, stiffness, accent];
+  const originalDocument = globalThis.document;
+  const originalFetch = globalThis.fetch;
+
+  globalThis.document = document;
+  globalThis.fetch = async (pathname) => {
+    if (pathname === "/apps") {
+      return jsonResponse({ apps: [demoApp], selectedAppId: demoApp.id });
+    }
+
+    if (pathname === "/app") {
+      return jsonResponse({ name: demoApp.name, packageName: demoApp.packageName });
+    }
+
+    if (pathname === "/tweaks") return jsonResponse({ tweaks });
+    return jsonResponse({ error: "Not found." }, 404);
+  };
+
+  try {
+    await import(`./app.js?stable-folder-order-test=${Date.now()}`);
+    await delay(0);
+
+    assert.deepEqual(visibleSections(document), ["Typography", "Motion", "Colors"]);
+    assert.deepEqual(visibleColumnSections(document), [
+      ["Typography", "Colors"],
+      ["Motion"],
+    ]);
+    assert.deepEqual(visibleLabels(document, "Motion"), [
+      "Enabled",
+      "Duration",
+      "Spring stiffness",
+    ]);
+
+    tweaks = [accent, enabled, typography];
+    await document.querySelector("#refresh-button").emit("click");
+    assert.deepEqual(visibleSections(document), ["Typography", "Motion", "Colors"]);
+    assert.deepEqual(visibleLabels(document, "Motion"), ["Enabled"]);
+
+    tweaks = [accent, typography];
+    await document.querySelector("#refresh-button").emit("click");
+    assert.deepEqual(visibleSections(document), ["Typography", "Colors"]);
+    assert.deepEqual(visibleColumnSections(document), [
+      ["Typography", "Colors"],
+      [],
+    ]);
+
+    tweaks = [accent, stiffness, duration, enabled, typography];
+    await document.querySelector("#refresh-button").emit("click");
+    assert.deepEqual(visibleSections(document), ["Typography", "Motion", "Colors"]);
+    assert.deepEqual(visibleColumnSections(document), [
+      ["Typography", "Colors"],
+      ["Motion"],
+    ]);
+    assert.deepEqual(visibleLabels(document, "Motion"), [
+      "Enabled",
+      "Duration",
+      "Spring stiffness",
+    ]);
+    assert.equal(document.properties.has("--accent"), false);
+  } finally {
+    globalThis.document = originalDocument;
+    globalThis.fetch = originalFetch;
+  }
+});
+
+test("remembers folder order independently for each selected app", async () => {
+  const document = makeDocument();
+  const secondApp = {
+    id: "PIXEL123:com.example.colors",
+    name: "Color Study",
+    packageName: "com.example.colors",
+    deviceName: "Pixel 9 Pro XL",
+    deviceSerial: "PIXEL123",
+  };
+  const firstFont = { ...descriptors[0], name: "Typography/Font size" };
+  const firstMotion = { ...descriptors[5], name: "Motion/Duration" };
+  const secondColor = { ...descriptors[4], name: "Colors/Accent" };
+  const secondFont = { ...descriptors[1], name: "Typography/Font weight" };
+  let firstTweaks = [firstFont, firstMotion];
+  let selectedId = demoApp.id;
+  const originalDocument = globalThis.document;
+  const originalFetch = globalThis.fetch;
+
+  globalThis.document = document;
+  globalThis.fetch = async (pathname, options) => {
+    if (pathname === "/apps") {
+      return jsonResponse({
+        apps: [demoApp, secondApp],
+        selectedAppId: selectedId,
+      });
+    }
+
+    if (pathname === "/apps/selection" && options?.method === "PUT") {
+      selectedId = JSON.parse(options.body).id;
+      return jsonResponse({
+        app: selectedId === secondApp.id ? secondApp : demoApp,
+      });
+    }
+
+    if (pathname === "/app") {
+      const selected = selectedId === secondApp.id ? secondApp : demoApp;
+      return jsonResponse({ name: selected.name, packageName: selected.packageName });
+    }
+
+    if (pathname === "/tweaks") {
+      return jsonResponse({
+        tweaks: selectedId === secondApp.id
+          ? [secondColor, secondFont]
+          : firstTweaks,
+      });
+    }
+
+    return jsonResponse({ error: "Not found." }, 404);
+  };
+
+  try {
+    await import(`./app.js?per-app-folder-order-test=${Date.now()}`);
+    await delay(0);
+    assert.deepEqual(visibleSections(document), ["Typography", "Motion"]);
+
+    await document.querySelector("#app-picker").emit("click");
+    await findAppChoice(document, secondApp).emit("click");
+    assert.deepEqual(visibleSections(document), ["Colors", "Typography"]);
+    assert.deepEqual(visibleLabels(document, "Colors"), ["Accent"]);
+
+    firstTweaks = [firstMotion, firstFont];
+    await document.querySelector("#app-picker").emit("click");
+    await findAppChoice(document, demoApp).emit("click");
+
+    assert.deepEqual(visibleSections(document), ["Typography", "Motion"]);
+    assert.deepEqual(visibleLabels(document, "Typography"), ["Font size"]);
+    assert.deepEqual(visibleLabels(document, "Motion"), ["Duration"]);
+  } finally {
+    globalThis.document = originalDocument;
+    globalThis.fetch = originalFetch;
+  }
+});
+
+test("shows an accurate empty state when no tweaks apps are running", async () => {
+  const document = makeDocument();
+  const originalDocument = globalThis.document;
+  const originalFetch = globalThis.fetch;
+
+  globalThis.document = document;
+  globalThis.fetch = async (pathname) => {
+    if (pathname === "/apps") {
+      return jsonResponse({ apps: [], selectedAppId: null });
+    }
+
+    return jsonResponse({ error: "Not found." }, 404);
+  };
+
+  try {
+    await import(`./app.js?empty-state-test=${Date.now()}`);
+    await delay(0);
+
+    assert.equal(document.querySelector("#app-picker").disabled, true);
+    assert.equal(document.querySelector("#app-list").childElementCount, 0);
+    assert.equal(document.querySelector("#empty-state").hidden, false);
+    assert.equal(document.querySelector("#app-name").textContent, "No app selected");
+    assert.equal(document.querySelector("#status-text").textContent, "No apps found");
+    assert.equal(document.querySelector("#reset-button").disabled, true);
+    assert.equal(document.querySelector("#error-message").hidden, true);
+  } finally {
+    globalThis.document = originalDocument;
+    globalThis.fetch = originalFetch;
+  }
+});
+
+test("switches apps only after pending slider updates finish", async () => {
+  const document = makeDocument();
+  const secondApp = {
+    id: "PIXEL123:com.example.motion",
+    name: "Motion Study",
+    packageName: "com.example.motion",
+    deviceName: "Pixel 9 Pro XL",
+    deviceSerial: "PIXEL123",
+  };
+  const motionTweak = {
+    name: "Transition progress",
+    type: "float",
+    default: 0.5,
+    value: 0.5,
+    min: 0,
+    max: 1,
+    step: 0.1,
+  };
+  const patches = [];
+  const selections = [];
+  const originalDocument = globalThis.document;
+  const originalFetch = globalThis.fetch;
+  let selectedId = demoApp.id;
+  let finishFirstRequest;
+
+  globalThis.document = document;
+  globalThis.fetch = async (pathname, options) => {
+    if (pathname === "/apps") {
+      return jsonResponse({
+        apps: [demoApp, secondApp],
+        selectedAppId: selectedId,
+      });
+    }
+
+    if (pathname === "/apps/selection" && options?.method === "PUT") {
+      const { id } = JSON.parse(options.body);
+      selections.push(id);
+      selectedId = id;
+      return jsonResponse({ app: id === secondApp.id ? secondApp : demoApp });
+    }
+
+    if (pathname === "/app") {
+      const app = selectedId === secondApp.id ? secondApp : demoApp;
+      return jsonResponse({ name: app.name, packageName: app.packageName });
+    }
+
+    if (pathname === "/tweaks" && options?.method === "PATCH") {
+      const { values } = JSON.parse(options.body);
+      patches.push({ appId: selectedId, values });
+
+      const result = jsonResponse({
+        tweaks: Object.entries(values).map(([name, value]) => ({ name, value })),
+      });
+
+      if (patches.length === 1) {
+        return new Promise((resolve) => {
+          finishFirstRequest = () => resolve(result);
+        });
+      }
+
+      return result;
+    }
+
+    if (pathname === "/tweaks") {
+      return jsonResponse({
+        tweaks: selectedId === secondApp.id
+          ? [motionTweak]
+          : structuredClone(descriptors),
+      });
+    }
+
+    return jsonResponse({ error: "Not found." }, 404);
+  };
+
+  try {
+    await import(`./app.js?app-switch-test=${Date.now()}`);
+    await delay(0);
+
+    const list = document.querySelector("#app-list");
+    assert.equal(list.childElementCount, 5);
+    assert.equal(list.hidden, true);
+    assert.equal(document.querySelector("#app-picker").disabled, false);
+    assert.equal(document.querySelector("#app-chevron").hidden, false);
+    assert.equal(document.querySelector("#app-picker").dataset.multiple, "true");
+
+    await document.querySelector("#app-picker").emit("click");
+    assert.equal(list.hidden, false);
+    assert.equal(
+      document.querySelector("#app-picker").getAttribute("aria-expanded"),
+      "true",
+    );
+
+    const slider = findInput(
+      findTweakList(document),
+      "Font size",
+    );
+    slider.value = "48";
+    await slider.emit("input");
+    assert.deepEqual(patches, [
+      { appId: demoApp.id, values: { "Font size": 48 } },
+    ]);
+
+    const switching = findAppChoice(document, secondApp).emit("click");
+    await delay(5);
+    assert.deepEqual(selections, []);
+    assert.equal(document.querySelector("#app-name").textContent, demoApp.name);
+
+    const finish = finishFirstRequest;
+    finishFirstRequest = undefined;
+    finish();
+    await switching;
+
+    assert.deepEqual(selections, [secondApp.id]);
+    assert.equal(document.querySelector("#app-list").hidden, true);
+    assert.equal(
+      document.querySelector("#app-picker").getAttribute("aria-expanded"),
+      "false",
+    );
+    assert.equal(document.querySelector("#app-name").textContent, secondApp.name);
+    assert.equal(document.querySelector("#package-name").textContent, secondApp.packageName);
+    assert.equal(document.querySelector("#tweak-sections").childElementCount, 1);
+    assert.equal(findTweakList(document).childElementCount, 1);
+    assert.ok(findInput(findTweakList(document), "Transition progress"));
+    assert.equal(document.properties.has("--accent"), false);
+    assert.equal(
+      findAppChoice(document, secondApp).getAttribute("aria-pressed"),
+      "true",
+    );
+    assert.deepEqual(patches, [
+      { appId: demoApp.id, values: { "Font size": 48 } },
+    ]);
+  } finally {
+    if (finishFirstRequest) {
+      finishFirstRequest();
+      await delay(0);
+    }
+
+    globalThis.document = originalDocument;
+    globalThis.fetch = originalFetch;
+  }
+});
+
+test("refresh replaces tweaks when the app changes screens", async () => {
+  const document = makeDocument();
+  const originalDocument = globalThis.document;
+  const originalFetch = globalThis.fetch;
+  let tweaks = structuredClone(descriptors);
+
+  globalThis.document = document;
+  globalThis.fetch = async (pathname) => {
+    if (pathname === "/apps") {
+      return jsonResponse({ apps: [demoApp], selectedAppId: demoApp.id });
+    }
+
+    if (pathname === "/app") {
+      return jsonResponse({ name: demoApp.name, packageName: demoApp.packageName });
+    }
+
+    if (pathname === "/tweaks") {
+      return jsonResponse({ tweaks });
+    }
+
+    return jsonResponse({ error: "Not found." }, 404);
+  };
+
+  try {
+    await import(`./app.js?screen-change-test=${Date.now()}`);
+    await delay(0);
+    assert.equal(findTweakList(document).childElementCount, 10);
+
+    tweaks = [
+      {
+        name: "Transition duration",
+        type: "int",
+        default: 300,
+        value: 450,
+        min: 100,
+        max: 1_000,
+        step: 50,
+      },
+    ];
+    await document.querySelector("#refresh-button").emit("click");
+
+    assert.equal(document.querySelector("#tweak-sections").childElementCount, 1);
+    assert.equal(findTweakList(document).childElementCount, 1);
+    assert.ok(findInput(findTweakList(document), "Transition duration"));
+    assert.equal(document.querySelector("#reset-button").disabled, false);
+  } finally {
+    globalThis.document = originalDocument;
+    globalThis.fetch = originalFetch;
+  }
+});
+
+test("motion tweaks appear and disappear as the visibility tweak changes composition", async () => {
+  const document = makeDocument();
+  const originalDocument = globalThis.document;
+  const originalFetch = globalThis.fetch;
+  const visibility = {
+    name: "Show motion",
+    type: "boolean",
+    default: true,
+    value: true,
+  };
+  const motionNames = new Set([
+    "Animation duration",
+    "Spring stiffness",
+    "Spring damping",
+    "Use spring",
+  ]);
+
+  globalThis.document = document;
+  globalThis.fetch = async (pathname, options) => {
+    if (pathname === "/apps") {
+      return jsonResponse({ apps: [demoApp], selectedAppId: demoApp.id });
+    }
+
+    if (pathname === "/app") {
+      return jsonResponse({ name: demoApp.name, packageName: demoApp.packageName });
+    }
+
+    if (pathname === "/tweaks" && options?.method === "PATCH") {
+      const { values } = JSON.parse(options.body);
+
+      if (Object.hasOwn(values, visibility.name)) {
+        visibility.value = values[visibility.name];
+      }
+
+      return jsonResponse({
+        tweaks: Object.entries(values).map(([name, value]) => ({ name, value })),
+      });
+    }
+
+    if (pathname === "/tweaks") {
+      const visibleTweaks = descriptors.filter(
+        (tweak) => visibility.value || !motionNames.has(tweak.name),
+      );
+
+      return jsonResponse({
+        tweaks: [...visibleTweaks, visibility],
+      });
+    }
+
+    return jsonResponse({ error: "Not found." }, 404);
+  };
+
+  try {
+    await import(`./app.js?composition-visibility-test=${Date.now()}`);
+    await delay(0);
+
+    let motion = findTweakList(document);
+    assert.equal(motion.childElementCount, 11);
+    assert.ok(findInput(motion, "Animation duration"));
+
+    let toggle = findInput(motion, "Show motion");
+    assert.ok(toggle);
+    toggle.checked = false;
+    await toggle.emit("change");
+    await delay(2_600);
+
+    motion = findTweakList(document);
+    assert.equal(visibility.value, false);
+    assert.equal(motion.childElementCount, 7);
+    assert.equal(findInput(motion, "Animation duration"), null);
+    assert.equal(findInput(motion, "Spring stiffness"), null);
+
+    toggle = findInput(motion, "Show motion");
+    assert.ok(toggle);
+    toggle.checked = true;
+    await toggle.emit("change");
+    await delay(2_600);
+
+    motion = findTweakList(document);
+    assert.equal(visibility.value, true);
+    assert.equal(motion.childElementCount, 11);
+    assert.ok(findInput(motion, "Animation duration"));
+    assert.ok(findInput(motion, "Spring stiffness"));
+    assert.equal(document.querySelector("#error-message").hidden, true);
+  } finally {
     globalThis.document = originalDocument;
     globalThis.fetch = originalFetch;
   }

--- a/snapo-link-android/samples/demo-tweaks/panel/app.test.mjs
+++ b/snapo-link-android/samples/demo-tweaks/panel/app.test.mjs
@@ -373,16 +373,27 @@ test("browser panel renders, streams, validates, and resets live tweaks", async 
     assert.equal(fontSizeRow.children.length, 2);
     assert.equal(fontSizeContent.children[0].textContent, "Font size");
     assert.equal(
-      fontSizeContent.children[1].children[0].getAttribute("aria-label"),
+      fontSizeContent.children[2].children[0].getAttribute("aria-label"),
       "Font size value",
     );
-    assert.equal(fontSizeLine.children[1].getAttribute("aria-label"), "Reset Font size");
+    assert.equal(fontSizeContent.children[1].getAttribute("aria-label"), "Reset Font size");
+    assert.equal(fontSizeContent.children[1].getAttribute("title"), "Reset Font size");
+    assert.equal(fontSizeContent.children[1].hidden, true);
+    assert.equal(fontSizeContent.children[1].textContent, "");
+    assert.equal(fontSizeContent.children[1].children[0].tagName, "SVG");
+    assert.equal(
+      fontSizeContent.children[1].children[0].children[0].getAttribute("href"),
+      "#mock-icon-rotate-ccw",
+    );
+    assert.equal(fontSizeRow.dataset.changed, "false");
     assert.equal(fontSize.min, "16");
     assert.equal(fontSize.max, "72");
 
     fontSize.value = "48";
     await fontSize.emit("input");
     assert.equal(findInput(appearance, "Font size value").value, "48");
+    assert.equal(fontSizeRow.dataset.changed, "true");
+    assert.equal(fontSizeContent.children[1].hidden, false);
 
     const fontWeight = findInput(appearance, "Font weight value");
     fontWeight.value = "700";
@@ -1173,5 +1184,111 @@ test("motion tweaks appear and disappear as the visibility tweak changes composi
   } finally {
     globalThis.document = originalDocument;
     globalThis.fetch = originalFetch;
+  }
+});
+
+test("streams batched composition changes without polling tweak values", async () => {
+  const document = makeDocument();
+  const originalDocument = globalThis.document;
+  const originalFetch = globalThis.fetch;
+  const originalEventSource = globalThis.EventSource;
+  const sources = [];
+  let tweakRequests = 0;
+
+  class FakeEventSource {
+    constructor(url) {
+      this.url = url;
+      this.listeners = new Map();
+      this.closed = false;
+      sources.push(this);
+    }
+
+    addEventListener(name, listener) {
+      this.listeners.set(name, listener);
+    }
+
+    emitTweaks(tweaks) {
+      this.listeners.get("tweaks")?.({
+        data: JSON.stringify({ tweaks }),
+      });
+    }
+
+    close() {
+      this.closed = true;
+    }
+  }
+
+  globalThis.document = document;
+  globalThis.EventSource = FakeEventSource;
+  globalThis.fetch = async (pathname) => {
+    if (pathname === "/apps") {
+      return jsonResponse({ apps: [demoApp], selectedAppId: demoApp.id });
+    }
+
+    if (pathname === "/app") {
+      return jsonResponse({ name: demoApp.name, packageName: demoApp.packageName });
+    }
+
+    if (pathname === "/tweaks") {
+      tweakRequests += 1;
+      return jsonResponse({ tweaks: structuredClone(descriptors) });
+    }
+
+    return jsonResponse({ error: "Not found." }, 404);
+  };
+
+  try {
+    await import(`./app.js?event-stream-test=${Date.now()}`);
+    await delay(0);
+
+    assert.equal(sources.length, 1);
+    assert.equal(sources[0].url, "/tweaks/events");
+    assert.equal(tweakRequests, 1);
+
+    const typography = {
+      name: "Typography/Font size",
+      type: "int",
+      default: 36,
+      value: 48,
+      min: 16,
+      max: 72,
+      step: 1,
+    };
+    const motion = {
+      name: "Motion/Duration",
+      type: "int",
+      default: 400,
+      value: 550,
+      min: 100,
+      max: 1500,
+      step: 50,
+    };
+
+    sources[0].emitTweaks([typography, motion]);
+
+    assert.deepEqual(visibleSections(document), ["Typography", "Motion"]);
+    assert.equal(
+      findInput(findTweakList(document, "Typography"), "Typography/Font size").value,
+      "48",
+    );
+    assert.equal(
+      findInput(findTweakList(document, "Motion"), "Motion/Duration").value,
+      "550",
+    );
+
+    sources[0].emitTweaks([typography]);
+
+    assert.deepEqual(visibleSections(document), ["Typography"]);
+    assert.equal(findTweakList(document, "Motion"), null);
+    assert.equal(tweakRequests, 1);
+  } finally {
+    sources.forEach((source) => source.close());
+    globalThis.document = originalDocument;
+    globalThis.fetch = originalFetch;
+    if (originalEventSource === undefined) {
+      delete globalThis.EventSource;
+    } else {
+      globalThis.EventSource = originalEventSource;
+    }
   }
 });

--- a/snapo-link-android/samples/demo-tweaks/panel/icons/chevron-down.svg
+++ b/snapo-link-android/samples/demo-tweaks/panel/icons/chevron-down.svg
@@ -1,0 +1,13 @@
+<svg
+  xmlns="http://www.w3.org/2000/svg"
+  width="24"
+  height="24"
+  viewBox="0 0 24 24"
+  fill="none"
+  stroke="currentColor"
+  stroke-width="2"
+  stroke-linecap="round"
+  stroke-linejoin="round"
+>
+  <path d="m6 9 6 6 6-6" />
+</svg>

--- a/snapo-link-android/samples/demo-tweaks/panel/index.html
+++ b/snapo-link-android/samples/demo-tweaks/panel/index.html
@@ -6,40 +6,91 @@
     <meta name="color-scheme" content="light dark" />
     <meta
       name="description"
-      content="Optional browser panel for the Snap-O Tweaks sample."
+      content="An example inspector for running Snap-O Tweaks apps."
     />
-    <meta name="theme-color" content="#fafaf9" />
-    <title>Snap-O Tweaks</title>
+    <meta name="theme-color" content="#ffffff" />
+    <title>Tweaks · Snap-O</title>
     <link rel="stylesheet" href="/styles.css" />
     <script type="module" src="/app.js"></script>
   </head>
   <body>
-    <main class="panel">
-      <header class="app-header">
-        <div class="app-bar">
-          <div class="app-identity">
-            <div class="app-icon-frame">
-              <img
-                class="app-icon"
-                src="/app/icon"
-                alt=""
-                width="38"
-                height="38"
-              />
-              <span
-                id="connection-status"
-                class="connection-status"
-                role="status"
-                aria-label="Connecting"
-              >
-                <span class="status-dot"></span>
-                <span id="status-text" class="visually-hidden">Connecting</span>
+    <svg class="visually-hidden" aria-hidden="true" focusable="false">
+      <symbol id="mock-icon-app" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round">
+        <rect x="3" y="3" width="18" height="18" rx="3" />
+        <path d="M3 9h18" />
+        <path d="M8 3v6" />
+      </symbol>
+      <symbol id="mock-icon-network" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round">
+        <rect x="16" y="16" width="6" height="6" rx="1" />
+        <rect x="2" y="16" width="6" height="6" rx="1" />
+        <rect x="9" y="2" width="6" height="6" rx="1" />
+        <path d="M5 16v-3a1 1 0 0 1 1-1h12a1 1 0 0 1 1 1v3" />
+        <path d="M12 12V8" />
+      </symbol>
+      <symbol id="mock-icon-tweaks" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round">
+        <path d="M10 5H3" />
+        <path d="M12 19H3" />
+        <path d="M14 3v4" />
+        <path d="M16 17v4" />
+        <path d="M21 12h-9" />
+        <path d="M21 19h-5" />
+        <path d="M21 5h-7" />
+        <path d="M8 10v4" />
+        <path d="M8 12H3" />
+      </symbol>
+      <symbol id="mock-icon-check" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round">
+        <path d="m20 6-11 11-5-5" />
+      </symbol>
+    </svg>
+    <main class="inspector">
+      <header class="inspector-toolbar">
+        <div class="toolbar-content">
+          <div class="server-select">
+            <button
+              id="app-picker"
+              class="server-picker-button"
+              type="button"
+              aria-label="Select a tweaks-enabled app"
+              aria-haspopup="menu"
+              aria-expanded="false"
+              aria-controls="app-list"
+              disabled
+            >
+              <span class="server-app-icon">
+                <img class="app-icon" alt="" width="32" height="32" hidden />
+                <span
+                  id="connection-status"
+                  class="connection-status"
+                  role="status"
+                  aria-label="Connecting"
+                >
+                  <span class="status-dot"></span>
+                  <span id="status-text" class="visually-hidden">Connecting</span>
+                </span>
               </span>
-            </div>
-            <div class="app-heading">
-              <p id="app-name" class="app-name">Connecting…</p>
-              <p id="package-name" class="package-name"></p>
-            </div>
+              <span class="server-picker-text">
+                <span id="app-name" class="server-name">Select an app</span>
+                <span id="device-name" class="server-device"></span>
+                <span id="package-name" class="visually-hidden"></span>
+              </span>
+              <img
+                id="app-chevron"
+                class="server-chevron"
+                src="/icons/chevron-down.svg"
+                alt=""
+                width="18"
+                height="18"
+                hidden
+              />
+            </button>
+
+            <div
+              id="app-list"
+              class="server-picker-menu"
+              role="menu"
+              aria-label="Detected apps"
+              hidden
+            ></div>
           </div>
 
           <div class="toolbar">
@@ -53,30 +104,17 @@
         </div>
       </header>
 
-      <p id="error-message" class="error-message" role="alert" hidden></p>
+      <section class="detail" aria-label="App tweaks">
+        <div class="detail-content">
+          <p id="error-message" class="error-message" role="alert" hidden></p>
 
-      <section id="appearance-section" class="tweak-section" hidden>
-        <div class="section-heading">
-          <h2>Appearance</h2>
-          <span id="appearance-count" class="section-count"></span>
-        </div>
-        <div id="appearance-tweaks" class="tweak-list"></div>
-      </section>
+          <section id="empty-state" class="empty-state" hidden>
+            <h1>No apps found</h1>
+            <p>Open an app with Snap-O Tweaks on a connected Android device.</p>
+          </section>
 
-      <section id="motion-section" class="tweak-section" hidden>
-        <div class="section-heading">
-          <h2>Motion</h2>
-          <span id="motion-count" class="section-count"></span>
+          <div id="tweak-sections" class="tweak-sections"></div>
         </div>
-        <div id="motion-tweaks" class="tweak-list"></div>
-      </section>
-
-      <section id="other-section" class="tweak-section" hidden>
-        <div class="section-heading">
-          <h2>Other</h2>
-          <span id="other-count" class="section-count"></span>
-        </div>
-        <div id="other-tweaks" class="tweak-list"></div>
       </section>
     </main>
   </body>

--- a/snapo-link-android/samples/demo-tweaks/panel/index.html
+++ b/snapo-link-android/samples/demo-tweaks/panel/index.html
@@ -41,10 +41,29 @@
       <symbol id="mock-icon-check" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round">
         <path d="m20 6-11 11-5-5" />
       </symbol>
+      <symbol id="mock-icon-rotate-ccw" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round">
+        <path d="M3 12a9 9 0 1 0 9-9 9.75 9.75 0 0 0-6.74 2.74L3 8" />
+        <path d="M3 3v5h5" />
+      </symbol>
     </svg>
     <main class="inspector">
       <header class="inspector-toolbar">
         <div class="toolbar-content">
+          <div class="toolbar">
+            <button
+              id="reset-button"
+              class="toolbar-button"
+              type="button"
+              aria-label="Reset all tweaks"
+              title="Reset all tweaks"
+              disabled
+            >
+              <svg class="toolbar-icon" width="16" height="16" aria-hidden="true">
+                <use href="#mock-icon-rotate-ccw"></use>
+              </svg>
+            </button>
+          </div>
+
           <div class="server-select">
             <button
               id="app-picker"
@@ -91,15 +110,6 @@
               aria-label="Detected apps"
               hidden
             ></div>
-          </div>
-
-          <div class="toolbar">
-            <button id="refresh-button" class="toolbar-button" type="button">
-              Refresh
-            </button>
-            <button id="reset-button" class="toolbar-button" type="button" disabled>
-              Reset all
-            </button>
           </div>
         </div>
       </header>

--- a/snapo-link-android/samples/demo-tweaks/panel/index.html
+++ b/snapo-link-android/samples/demo-tweaks/panel/index.html
@@ -111,6 +111,14 @@
               hidden
             ></div>
           </div>
+
+          <div
+            id="inspector-segments"
+            class="inspector-segments"
+            role="group"
+            aria-label="Inspector"
+            hidden
+          ></div>
         </div>
       </header>
 

--- a/snapo-link-android/samples/demo-tweaks/panel/server.mjs
+++ b/snapo-link-android/samples/demo-tweaks/panel/server.mjs
@@ -14,6 +14,10 @@ const staticFiles = new Map([
   ["/", { name: "index.html", type: "text/html; charset=utf-8" }],
   ["/app.js", { name: "app.js", type: "text/javascript; charset=utf-8" }],
   ["/styles.css", { name: "styles.css", type: "text/css; charset=utf-8" }],
+  [
+    "/icons/chevron-down.svg",
+    { name: "icons/chevron-down.svg", type: "image/svg+xml" },
+  ],
 ]);
 
 const tweakRoutes = new Set(["/app", "/app/icon", "/tweaks"]);
@@ -97,17 +101,29 @@ async function probeTweakTarget(target, packageName, fetcher) {
       signal: AbortSignal.timeout(1_500),
     });
 
-    if (!response.ok) return false;
+    if (!response.ok) return null;
 
     const app = await response.json();
     if (typeof app.name !== "string" || typeof app.packageName !== "string") {
-      return false;
+      return null;
     }
 
-    return !packageName || app.packageName === packageName;
+    return !packageName || app.packageName === packageName ? app : null;
   } catch {
-    return false;
+    return null;
   }
+}
+
+function describeTweakApp(app, device, socket, target) {
+  return {
+    id: `${device.serial}:${app.packageName}`,
+    name: app.name,
+    packageName: app.packageName,
+    deviceName: device.model,
+    deviceSerial: device.serial,
+    pid: socket?.pid,
+    target: validateTarget(target),
+  };
 }
 
 async function createDeviceForward(adb, serial, socket, run) {
@@ -194,6 +210,139 @@ async function discoverOnDevice({
   }
 
   return null;
+}
+
+async function discoverAppsOnDevice({
+  adb,
+  device,
+  forwards,
+  packageName,
+  run,
+  fetcher,
+}) {
+  let sockets = [];
+
+  try {
+    const { stdout } = await run(
+      adb,
+      ["-s", device.serial, "shell", "cat", "/proc/net/unix"],
+      { timeout: 4_000 },
+    );
+    sockets = parseTweakSockets(stdout);
+  } catch {
+    // Existing forwards may remain usable if socket inspection is unavailable.
+  }
+
+  const deviceForwards = forwards.filter(
+    (forward) => forward.serial === device.serial,
+  );
+  const apps = new Map();
+  const checkedPorts = new Set();
+
+  async function checkForward(target, socket) {
+    const normalized = validateTarget(target);
+    if (checkedPorts.has(normalized.href)) return false;
+    checkedPorts.add(normalized.href);
+
+    const app = await probeTweakTarget(normalized, packageName, fetcher);
+    if (!app) return false;
+
+    const description = describeTweakApp(app, device, socket, normalized);
+    if (!apps.has(description.id)) apps.set(description.id, description);
+    return true;
+  }
+
+  for (const socket of sockets) {
+    const existing = deviceForwards.filter(
+      (forward) => forward.socket === `localabstract:${socket.name}`,
+    );
+    let found = false;
+
+    for (const forward of existing) {
+      found = await checkForward(
+        new URL(`http://127.0.0.1:${forward.port}`),
+        socket,
+      );
+      if (found) break;
+    }
+
+    if (found) continue;
+
+    let created;
+
+    try {
+      created = await createDeviceForward(adb, device.serial, socket.name, run);
+      if (await checkForward(created.target, socket)) continue;
+    } catch {
+      if (!created) continue;
+    }
+
+    if (created) {
+      try {
+        await run(
+          adb,
+          ["-s", device.serial, "forward", "--remove", `tcp:${created.port}`],
+          { timeout: 4_000 },
+        );
+      } catch {
+        // A rejected temporary forward may already have disappeared.
+      }
+    }
+  }
+
+  for (const forward of deviceForwards) {
+    const match = forward.socket.match(/snapo_tweaks_(\d+)$/);
+    const socket = match
+      ? { name: `snapo_tweaks_${match[1]}`, pid: Number(match[1]) }
+      : undefined;
+
+    await checkForward(new URL(`http://127.0.0.1:${forward.port}`), socket);
+  }
+
+  return [...apps.values()];
+}
+
+export async function discoverTweakApps({
+  serial,
+  packageName,
+  adb,
+  run = runFile,
+  fetcher = fetch,
+} = {}) {
+  for (const executable of adb ? [adb] : adbCandidates()) {
+    let devices;
+    let forwards;
+
+    try {
+      const [deviceResult, forwardResult] = await Promise.all([
+        run(executable, ["devices", "-l"], { timeout: 4_000 }),
+        run(executable, ["forward", "--list"], { timeout: 4_000 }),
+      ]);
+      devices = parseAdbDevices(deviceResult.stdout);
+      forwards = parseAdbForwards(forwardResult.stdout);
+    } catch {
+      continue;
+    }
+
+    if (serial) devices = devices.filter((device) => device.serial === serial);
+
+    const discovered = await Promise.all(
+      devices.map((device) =>
+        discoverAppsOnDevice({
+          adb: executable,
+          device,
+          forwards,
+          packageName,
+          run,
+          fetcher,
+        }),
+      ),
+    );
+
+    return discovered.flat();
+  }
+
+  return [];
 }
 
 export async function discoverTweakTarget({
@@ -311,7 +460,7 @@ async function serveStatic(request, response, file) {
   response.end(request.method === "HEAD" ? undefined : data);
 }
 
-async function proxyTweak(request, response, connection, pathname) {
+async function proxyTweak(request, response, connection, pathname, target) {
   const headers = {};
   let body;
 
@@ -320,7 +469,7 @@ async function proxyTweak(request, response, connection, pathname) {
     body = await readRequestBody(request);
   }
 
-  const performRequest = () => fetch(new URL(pathname, connection.target), {
+  const performRequest = () => fetch(new URL(pathname, target ?? connection.target), {
     method: request.method,
     headers,
     body,
@@ -332,7 +481,7 @@ async function proxyTweak(request, response, connection, pathname) {
   try {
     upstream = await performRequest();
   } catch (error) {
-    if (connection.fixed) throw error;
+    if (connection.fixed || target) throw error;
 
     await connection.reconnect();
     upstream = await performRequest();
@@ -354,6 +503,97 @@ async function proxyTweak(request, response, connection, pathname) {
   response.end(data);
 }
 
+function publicApp(app) {
+  return {
+    id: app.id,
+    name: app.name,
+    packageName: app.packageName,
+    deviceName: app.deviceName,
+    deviceSerial: app.deviceSerial,
+  };
+}
+
+async function handleApps(request, response, connection, pathname) {
+  if (pathname === "/apps") {
+    if (request.method !== "GET") {
+      jsonResponse(response, 405, { error: "Method not allowed." }, {
+        Allow: "GET",
+      });
+      return;
+    }
+
+    await connection.refreshApps();
+    jsonResponse(response, 200, {
+      apps: connection.apps.map(publicApp),
+      selectedAppId: connection.selectedAppId ?? null,
+    });
+    return;
+  }
+
+  if (pathname === "/apps/selection") {
+    if (request.method !== "PUT") {
+      jsonResponse(response, 405, { error: "Method not allowed." }, {
+        Allow: "PUT",
+      });
+      return;
+    }
+
+    let payload;
+
+    try {
+      payload = JSON.parse((await readRequestBody(request)).toString("utf8"));
+    } catch (error) {
+      if (error.status === 413) throw error;
+      jsonResponse(response, 400, { error: "Expected a JSON app selection." });
+      return;
+    }
+
+    const selected = connection.apps.find((app) => app.id === payload?.id);
+
+    if (!selected) {
+      jsonResponse(response, 404, { error: "The selected app is not available." });
+      return;
+    }
+
+    connection.selectedAppId = selected.id;
+    connection.target = selected.target;
+    jsonResponse(response, 200, { app: publicApp(selected) });
+    return;
+  }
+
+  const iconMatch = pathname.match(/^\/apps\/([^/]+)\/icon$/);
+
+  if (iconMatch) {
+    if (request.method !== "GET") {
+      jsonResponse(response, 405, { error: "Method not allowed." }, {
+        Allow: "GET",
+      });
+      return;
+    }
+
+    let id;
+
+    try {
+      id = decodeURIComponent(iconMatch[1]);
+    } catch {
+      jsonResponse(response, 400, { error: "Invalid app identifier." });
+      return;
+    }
+
+    const app = connection.apps.find((candidate) => candidate.id === id);
+
+    if (!app) {
+      jsonResponse(response, 404, { error: "The selected app is not available." });
+      return;
+    }
+
+    await proxyTweak(request, response, connection, "/app/icon", app.target);
+    return;
+  }
+
+  jsonResponse(response, 404, { error: "Not found." });
+}
+
 function createHandler(connection) {
   return async (request, response) => {
     try {
@@ -365,7 +605,23 @@ function createHandler(connection) {
         return;
       }
 
+      if (pathname === "/apps" || pathname.startsWith("/apps/")) {
+        await handleApps(request, response, connection, pathname);
+        return;
+      }
+
       if (tweakRoutes.has(pathname)) {
+        if (!connection.target) {
+          await connection.refreshApps();
+        }
+
+        if (!connection.target) {
+          jsonResponse(response, 503, {
+            error: "No running Snap-O Tweaks app found.",
+          });
+          return;
+        }
+
         await proxyTweak(request, response, connection, pathname);
         return;
       }
@@ -391,22 +647,77 @@ export async function createTweakPanelServer({
   serial,
   packageName,
   discoverTarget = discoverTweakTarget,
+  discoverApps = discoverTweakApps,
   hostname = "127.0.0.1",
   port = 0,
 } = {}) {
   const configuredTarget = target ?? process.env.SNAPO_TWEAKS_URL;
+  const legacyDiscovery =
+    !configuredTarget && discoverTarget !== discoverTweakTarget;
   const connection = {
-    target: validateTarget(
-      configuredTarget ?? (await discoverTarget({ serial, packageName })),
-    ),
+    target: configuredTarget
+      ? validateTarget(configuredTarget)
+      : legacyDiscovery
+        ? validateTarget(await discoverTarget({ serial, packageName }))
+        : undefined,
     fixed: Boolean(configuredTarget),
+    apps: [],
+    selectedAppId: undefined,
+    refreshing: undefined,
     reconnecting: undefined,
+    async refreshApps() {
+      if (!this.refreshing) {
+        this.refreshing = Promise.resolve()
+          .then(async () => {
+            if (this.fixed || legacyDiscovery) {
+              const identity = await probeTweakTarget(this.target, packageName, fetch);
+
+              if (!identity) {
+                this.apps = [];
+                return;
+              }
+
+              const device = {
+                serial: serial ?? "local",
+                model: serial ?? "Local endpoint",
+              };
+              const app = describeTweakApp(identity, device, undefined, this.target);
+              this.apps = [app];
+              this.selectedAppId = app.id;
+              return;
+            }
+
+            this.apps = await discoverApps({ serial, packageName });
+            const selected =
+              this.apps.find((app) => app.id === this.selectedAppId) ??
+              this.apps[0];
+            this.selectedAppId = selected?.id;
+            this.target = selected ? validateTarget(selected.target) : undefined;
+          })
+          .finally(() => {
+            this.refreshing = undefined;
+          });
+      }
+
+      return this.refreshing;
+    },
     async reconnect() {
       if (!this.reconnecting) {
         this.reconnecting = Promise.resolve()
-          .then(() => discoverTarget({ serial, packageName }))
-          .then((next) => {
-            this.target = validateTarget(next);
+          .then(async () => {
+            if (legacyDiscovery) {
+              this.target = validateTarget(
+                await discoverTarget({ serial, packageName }),
+              );
+              return;
+            }
+
+            const selectedId = this.selectedAppId;
+            await this.refreshApps();
+
+            if (!this.target || (selectedId && this.selectedAppId !== selectedId)) {
+              throw new Error("The selected Android tweaks app is not available.");
+            }
           })
           .finally(() => {
             this.reconnecting = undefined;
@@ -416,6 +727,8 @@ export async function createTweakPanelServer({
       return this.reconnecting;
     },
   };
+
+  if (!configuredTarget && !legacyDiscovery) await connection.refreshApps();
   const server = createServer(createHandler(connection));
 
   await new Promise((resolve, reject) => {
@@ -491,7 +804,11 @@ export function parseArguments(args) {
 async function main() {
   const panel = await createTweakPanelServer(parseArguments(process.argv.slice(2)));
   console.log(`Snap-O Tweaks panel: ${panel.url}`);
-  console.log(`Android tweaks endpoint: ${panel.target}`);
+  console.log(
+    panel.target
+      ? `Android tweaks endpoint: ${panel.target}`
+      : "Waiting for a running Snap-O Tweaks app.",
+  );
 
   for (const signal of ["SIGINT", "SIGTERM"]) {
     process.once(signal, async () => {

--- a/snapo-link-android/samples/demo-tweaks/panel/server.mjs
+++ b/snapo-link-android/samples/demo-tweaks/panel/server.mjs
@@ -3,6 +3,8 @@ import { createServer } from "node:http";
 import { homedir } from "node:os";
 import path from "node:path";
 import { readFile } from "node:fs/promises";
+import { Readable } from "node:stream";
+import { pipeline } from "node:stream/promises";
 import { fileURLToPath, pathToFileURL } from "node:url";
 import { promisify } from "node:util";
 
@@ -20,7 +22,7 @@ const staticFiles = new Map([
   ],
 ]);
 
-const tweakRoutes = new Set(["/app", "/app/icon", "/tweaks"]);
+const tweakRoutes = new Set(["/app", "/app/icon", "/tweaks", "/tweaks/events"]);
 
 export function parseAdbDevices(output) {
   return output
@@ -461,6 +463,11 @@ async function serveStatic(request, response, file) {
 }
 
 async function proxyTweak(request, response, connection, pathname, target) {
+  if (pathname === "/tweaks/events" && request.method === "GET") {
+    await proxyTweakEvents(request, response, connection, target);
+    return;
+  }
+
   const headers = {};
   let body;
 
@@ -501,6 +508,57 @@ async function proxyTweak(request, response, connection, pathname, target) {
 
   response.writeHead(upstream.status, responseHeaders);
   response.end(data);
+}
+
+async function proxyTweakEvents(request, response, connection, target) {
+  const controller = new AbortController();
+  const abort = () => controller.abort();
+  response.once("close", abort);
+
+  try {
+    const performRequest = () => fetch(
+      new URL("/tweaks/events", target ?? connection.target),
+      {
+        method: request.method,
+        headers: { Accept: "text/event-stream" },
+        signal: controller.signal,
+      },
+    );
+
+    let upstream;
+
+    try {
+      upstream = await performRequest();
+    } catch (error) {
+      if (connection.fixed || target || controller.signal.aborted) throw error;
+
+      await connection.reconnect();
+      upstream = await performRequest();
+    }
+
+    if (!upstream.ok || !upstream.body) {
+      const data = Buffer.from(await upstream.arrayBuffer());
+      response.writeHead(upstream.status, {
+        "Cache-Control": "no-store",
+        "Content-Type": upstream.headers.get("content-type") ?? "application/json",
+        "Content-Length": data.length,
+        "X-Content-Type-Options": "nosniff",
+      });
+      response.end(data);
+      return;
+    }
+
+    response.writeHead(upstream.status, {
+      "Cache-Control": "no-cache",
+      "Content-Type": "text/event-stream; charset=utf-8",
+      "X-Content-Type-Options": "nosniff",
+    });
+
+    await pipeline(Readable.fromWeb(upstream.body), response);
+  } finally {
+    response.removeListener("close", abort);
+    controller.abort();
+  }
 }
 
 function publicApp(app) {

--- a/snapo-link-android/samples/demo-tweaks/panel/server.test.mjs
+++ b/snapo-link-android/samples/demo-tweaks/panel/server.test.mjs
@@ -137,6 +137,10 @@ test("serves the host-side tweaks panel", async () => {
   assert.match(html, /id="app-chevron"/);
   assert.match(html, /id="app-list"/);
   assert.match(html, /id="tweak-sections"/);
+  assert.match(html, /id="reset-button"/);
+  assert.match(html, /href="#mock-icon-rotate-ccw"/);
+  assert.match(html, /id="reset-button"[\s\S]*?id="app-picker"/);
+  assert.doesNotMatch(html, /id="refresh-button"/);
 });
 
 test("serves the browser application and stylesheet", async () => {
@@ -161,7 +165,8 @@ test("anchors the app and actions to the Mac-style full-width toolbar", async ()
 
   assert.ok(toolbar);
   assert.match(toolbar, /width:\s*100%/);
-  assert.match(toolbar, /justify-content:\s*space-between/);
+  assert.match(toolbar, /justify-content:\s*flex-start/);
+  assert.match(toolbar, /gap:\s*8px/);
   assert.match(toolbar, /padding:\s*8px\s+12px/);
   assert.doesNotMatch(toolbar, /margin-inline:\s*auto/);
 

--- a/snapo-link-android/samples/demo-tweaks/panel/server.test.mjs
+++ b/snapo-link-android/samples/demo-tweaks/panel/server.test.mjs
@@ -81,6 +81,15 @@ before(async () => {
       return;
     }
 
+    if (request.url === "/tweaks/events" && request.method === "GET") {
+      response.writeHead(200, {
+        "Cache-Control": "no-cache",
+        "Content-Type": "text/event-stream; charset=utf-8",
+      });
+      response.write(`event: tweaks\ndata: ${JSON.stringify({ tweaks: initialTweaks })}\n\n`);
+      return;
+    }
+
     if (request.url === "/tweaks" && request.method === "PATCH") {
       const chunks = [];
       for await (const chunk of request) chunks.push(chunk);
@@ -185,11 +194,29 @@ test("keeps tweak values beside their labels without visible slider bounds", asy
   const response = await fetch(new URL("/styles.css", panel.url));
   const styles = await response.text();
   const content = styles.match(/\.tweak-content\s*\{([^}]*)\}/)?.[1];
+  const actions = styles.match(/\.tweak-actions\s*\{([^}]*)\}/)?.[1];
 
   assert.ok(content);
   assert.match(content, /display:\s*flex/);
   assert.match(content, /gap:\s*10px/);
+  assert.ok(actions);
+  assert.match(actions, /margin-left:\s*auto/);
   assert.doesNotMatch(styles, /\.range-labels\b/);
+});
+
+test("shows an icon reset only for changed tweaks", async () => {
+  const response = await fetch(new URL("/styles.css", panel.url));
+  const styles = await response.text();
+  const reset = styles.match(/\.tweak-reset\s*\{\s*display:\s*inline-flex;([^}]*)\}/)?.[0];
+  const hidden = styles.match(/\.tweak-reset\[hidden\]\s*\{([^}]*)\}/)?.[1];
+  const icon = styles.match(/\.tweak-reset-icon\s*\{([^}]*)\}/)?.[1];
+  assert.ok(reset);
+  assert.match(reset, /display:\s*inline-flex/);
+  assert.ok(hidden);
+  assert.match(hidden, /display:\s*none/);
+  assert.ok(icon);
+  assert.match(icon, /width:\s*13px/);
+  assert.doesNotMatch(styles, /\.tweak-row\[data-changed="true"\]\s+\.tweak-label/);
 });
 
 test("uses a responsive, monochrome inspector dashboard", async () => {
@@ -417,6 +444,42 @@ test("proxies the original flat tweak descriptors", async () => {
 
   assert.equal(response.status, 200);
   assert.deepEqual(await response.json(), { tweaks: initialTweaks });
+});
+
+test("streams complete tweak snapshots while allowing concurrent patches", async () => {
+  const controller = new AbortController();
+
+  try {
+    const response = await fetch(new URL("/tweaks/events", panel.url), {
+      signal: controller.signal,
+    });
+
+    assert.equal(response.status, 200);
+    assert.match(response.headers.get("content-type"), /text\/event-stream/);
+
+    const reader = response.body.getReader();
+    const first = await reader.read();
+    const event = new TextDecoder().decode(first.value);
+
+    assert.match(event, /^event: tweaks\ndata: /);
+    assert.deepEqual(
+      JSON.parse(event.match(/^event: tweaks\ndata: (.+)\n\n$/s)[1]),
+      { tweaks: initialTweaks },
+    );
+
+    const patch = await fetch(new URL("/tweaks", panel.url), {
+      method: "PATCH",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ values: { "Font size": 48 } }),
+    });
+
+    assert.equal(patch.status, 200);
+    assert.deepEqual(await patch.json(), {
+      tweaks: [{ name: "Font size", value: 48 }],
+    });
+  } finally {
+    controller.abort();
+  }
 });
 
 test("forwards live tweak patches", async () => {

--- a/snapo-link-android/samples/demo-tweaks/panel/server.test.mjs
+++ b/snapo-link-android/samples/demo-tweaks/panel/server.test.mjs
@@ -136,10 +136,12 @@ test("serves the host-side tweaks panel", async () => {
   assert.match(html, /id="app-picker"/);
   assert.match(html, /id="app-chevron"/);
   assert.match(html, /id="app-list"/);
+  assert.match(html, /id="inspector-segments"/);
   assert.match(html, /id="tweak-sections"/);
   assert.match(html, /id="reset-button"/);
   assert.match(html, /href="#mock-icon-rotate-ccw"/);
   assert.match(html, /id="reset-button"[\s\S]*?id="app-picker"/);
+  assert.match(html, /id="app-picker"[\s\S]*?id="inspector-segments"/);
   assert.doesNotMatch(html, /id="refresh-button"/);
 });
 

--- a/snapo-link-android/samples/demo-tweaks/panel/server.test.mjs
+++ b/snapo-link-android/samples/demo-tweaks/panel/server.test.mjs
@@ -4,6 +4,7 @@ import { after, before, test } from "node:test";
 
 import {
   createTweakPanelServer,
+  discoverTweakApps,
   discoverTweakTarget,
   parseAdbDevices,
   parseAdbForwards,
@@ -123,16 +124,26 @@ test("serves the host-side tweaks panel", async () => {
   assert.match(html, /\/styles\.css/);
   assert.match(
     html,
-    /class="app-icon-frame">[\s\S]*?class="app-icon"[\s\S]*?id="connection-status"/,
+    /class="server-app-icon">[\s\S]*?class="app-icon"[\s\S]*?id="connection-status"/,
   );
   assert.doesNotMatch(html, /class="masthead"/);
-  assert.doesNotMatch(html, /<h1\b/);
+  assert.doesNotMatch(html, /<aside\b/);
+  assert.doesNotMatch(html, /class="sidebar"/);
+  assert.doesNotMatch(html, /class="sidebar-heading"/);
+  assert.doesNotMatch(html, /class="app-header"/);
+  assert.doesNotMatch(html, /id="app-count"/);
+  assert.match(html, /class="inspector-toolbar"/);
+  assert.match(html, /id="app-picker"/);
+  assert.match(html, /id="app-chevron"/);
+  assert.match(html, /id="app-list"/);
+  assert.match(html, /id="tweak-sections"/);
 });
 
 test("serves the browser application and stylesheet", async () => {
   for (const [pathname, type] of [
     ["/app.js", /text\/javascript/],
     ["/styles.css", /text\/css/],
+    ["/icons/chevron-down.svg", /image\/svg\+xml/],
   ]) {
     const response = await fetch(new URL(pathname, panel.url));
     assert.equal(response.status, 200);
@@ -141,10 +152,248 @@ test("serves the browser application and stylesheet", async () => {
   }
 });
 
+test("anchors the app and actions to the Mac-style full-width toolbar", async () => {
+  const response = await fetch(new URL("/styles.css", panel.url));
+  const styles = await response.text();
+  const toolbar = styles.match(/\.toolbar-content\s*\{([^}]*)\}/)?.[1];
+  const picker = styles.match(/\.server-select\s*\{([^}]*)\}/)?.[1];
+  const content = styles.match(/\.detail-content\s*\{([^}]*)\}/)?.[1];
+
+  assert.ok(toolbar);
+  assert.match(toolbar, /width:\s*100%/);
+  assert.match(toolbar, /justify-content:\s*space-between/);
+  assert.match(toolbar, /padding:\s*8px\s+12px/);
+  assert.doesNotMatch(toolbar, /margin-inline:\s*auto/);
+
+  assert.ok(picker);
+  assert.match(picker, /width:\s*min\(100%,\s*244px\)/);
+  assert.match(picker, /flex:\s*0\s+1\s+244px/);
+
+  assert.ok(content);
+  assert.match(content, /width:\s*min\(100%,\s*var\(--content-width\)\)/);
+  assert.match(content, /margin-inline:\s*auto/);
+});
+
+test("keeps tweak values beside their labels without visible slider bounds", async () => {
+  const response = await fetch(new URL("/styles.css", panel.url));
+  const styles = await response.text();
+  const content = styles.match(/\.tweak-content\s*\{([^}]*)\}/)?.[1];
+
+  assert.ok(content);
+  assert.match(content, /display:\s*flex/);
+  assert.match(content, /gap:\s*10px/);
+  assert.doesNotMatch(styles, /\.range-labels\b/);
+});
+
+test("uses a responsive, monochrome inspector dashboard", async () => {
+  const response = await fetch(new URL("/styles.css", panel.url));
+  const styles = await response.text();
+  const sections = styles.match(/\.tweak-sections\s*\{([^}]*)\}/)?.[1];
+  const column = styles.match(/\.tweak-column\s*\{([^}]*)\}/)?.[1];
+  const section = styles.match(/\.tweak-section\s*\{([^}]*)\}/)?.[1];
+  const ungrouped = styles.match(
+    /\.tweak-section\[data-section=""\]\s+\.tweak-list\s*\{([^}]*)\}/,
+  )?.[1];
+  const slider = styles.match(/\.range-input\s*\{([^}]*)\}/)?.[1];
+  const checkbox = styles.match(/\.boolean-input\s*\{([^}]*)\}/)?.[1];
+
+  assert.match(styles, /--control-accent:\s*var\(--text\)/);
+  assert.doesNotMatch(styles, /--accent:\s*#[\da-f]+/i);
+  assert.ok(sections);
+  assert.match(sections, /grid-template-columns:\s*repeat\(auto-fit/);
+  assert.ok(column);
+  assert.match(column, /display:\s*grid/);
+  assert.match(column, /align-content:\s*start/);
+  assert.ok(section);
+  assert.doesNotMatch(section, /border-top/);
+  assert.ok(ungrouped);
+  assert.match(ungrouped, /grid-template-columns:\s*repeat\(auto-fit/);
+  assert.ok(slider);
+  assert.match(slider, /accent-color:\s*var\(--control-accent\)/);
+  assert.ok(checkbox);
+  assert.match(checkbox, /accent-color:\s*var\(--control-accent\)/);
+});
+
+test("serves Network Inspector's official Lucide app-picker chevron", async () => {
+  const response = await fetch(new URL("/icons/chevron-down.svg", panel.url));
+
+  assert.equal(response.status, 200);
+  assert.match(response.headers.get("content-type"), /image\/svg\+xml/);
+  assert.match(await response.text(), /<path d="m6 9 6 6 6-6"\s*\/>/);
+});
+
 test("proxies app metadata without adding an icon URL", async () => {
   const response = await fetch(new URL("/app", panel.url));
   assert.equal(response.status, 200);
   assert.deepEqual(await response.json(), app);
+});
+
+test("lists a fixed-target app without exposing its local upstream", async () => {
+  const response = await fetch(new URL("/apps", panel.url));
+
+  assert.equal(response.status, 200);
+  assert.deepEqual(await response.json(), {
+    apps: [
+      {
+        id: `local:${app.packageName}`,
+        name: app.name,
+        packageName: app.packageName,
+        deviceName: "Local endpoint",
+        deviceSerial: "local",
+      },
+    ],
+    selectedAppId: `local:${app.packageName}`,
+  });
+});
+
+test("serves an app-list icon as an unchanged PNG", async () => {
+  await fetch(new URL("/apps", panel.url));
+
+  const pathname = `/apps/${encodeURIComponent(`local:${app.packageName}`)}/icon`;
+  const response = await fetch(new URL(pathname, panel.url));
+
+  assert.equal(response.status, 200);
+  assert.equal(response.headers.get("content-type"), "image/png");
+  assert.deepEqual(Buffer.from(await response.arrayBuffer()), icon);
+});
+
+test("starts without an Android app and exposes an honest empty state", async () => {
+  const emptyPanel = await createTweakPanelServer({
+    discoverApps: async () => [],
+  });
+
+  try {
+    const apps = await fetch(new URL("/apps", emptyPanel.url));
+    assert.equal(apps.status, 200);
+    assert.deepEqual(await apps.json(), { apps: [], selectedAppId: null });
+
+    const tweaks = await fetch(new URL("/tweaks", emptyPanel.url));
+    assert.equal(tweaks.status, 503);
+    assert.deepEqual(await tweaks.json(), {
+      error: "No running Snap-O Tweaks app found.",
+    });
+  } finally {
+    await emptyPanel.close();
+  }
+});
+
+test("switches only to a discovered app and routes its tweaks and icon", async () => {
+  const first = {
+    ...app,
+    name: "First Tweaks App",
+    packageName: "com.example.first",
+  };
+  const second = {
+    ...app,
+    name: "Second Tweaks App",
+    packageName: "com.example.second",
+  };
+  const secondIcon = Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x33, 0x44]);
+  const patches = [];
+
+  function makeAppServer(identity, image) {
+    return createServer(async (request, response) => {
+      if (request.url === "/app" && request.method === "GET") {
+        reply(response, 200, identity);
+      } else if (request.url === "/app/icon" && request.method === "GET") {
+        reply(response, 200, image);
+      } else if (request.url === "/tweaks" && request.method === "GET") {
+        reply(response, 200, { tweaks: initialTweaks });
+      } else if (request.url === "/tweaks" && request.method === "PATCH") {
+        const chunks = [];
+        for await (const chunk of request) chunks.push(chunk);
+        const payload = JSON.parse(Buffer.concat(chunks).toString("utf8"));
+        patches.push({ packageName: identity.packageName, values: payload.values });
+        reply(response, 200, {
+          tweaks: Object.entries(payload.values).map(([name, value]) => ({
+            name,
+            value,
+          })),
+        });
+      } else {
+        reply(response, 404, { error: "Not found." });
+      }
+    });
+  }
+
+  const firstServer = makeAppServer(first, icon);
+  const secondServer = makeAppServer(second, secondIcon);
+  await Promise.all([
+    new Promise((resolve) => firstServer.listen(0, "127.0.0.1", resolve)),
+    new Promise((resolve) => secondServer.listen(0, "127.0.0.1", resolve)),
+  ]);
+
+  const discovered = [
+    {
+      id: `PIXEL123:${first.packageName}`,
+      ...first,
+      deviceName: "Pixel 9 Pro XL",
+      deviceSerial: "PIXEL123",
+      target: new URL(`http://127.0.0.1:${firstServer.address().port}`),
+    },
+    {
+      id: `PIXEL123:${second.packageName}`,
+      ...second,
+      deviceName: "Pixel 9 Pro XL",
+      deviceSerial: "PIXEL123",
+      target: new URL(`http://127.0.0.1:${secondServer.address().port}`),
+    },
+  ];
+  const multiPanel = await createTweakPanelServer({
+    discoverApps: async () => discovered,
+  });
+
+  try {
+    const apps = await fetch(new URL("/apps", multiPanel.url));
+    const listing = await apps.json();
+    assert.equal(listing.apps.length, 2);
+    assert.equal(listing.selectedAppId, discovered[0].id);
+    assert.equal(Object.hasOwn(listing.apps[0], "target"), false);
+
+    const selection = await fetch(new URL("/apps/selection", multiPanel.url), {
+      method: "PUT",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ id: discovered[1].id }),
+    });
+    assert.equal(selection.status, 200);
+    assert.equal((await selection.json()).app.name, second.name);
+
+    const metadata = await fetch(new URL("/app", multiPanel.url));
+    assert.deepEqual(await metadata.json(), second);
+
+    const image = await fetch(
+      new URL(`/apps/${encodeURIComponent(discovered[1].id)}/icon`, multiPanel.url),
+    );
+    assert.deepEqual(Buffer.from(await image.arrayBuffer()), secondIcon);
+
+    const patch = await fetch(new URL("/tweaks", multiPanel.url), {
+      method: "PATCH",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ values: { "Font size": 44 } }),
+    });
+    assert.equal(patch.status, 200);
+    assert.deepEqual(patches, [
+      { packageName: second.packageName, values: { "Font size": 44 } },
+    ]);
+
+    const unknown = await fetch(new URL("/apps/selection", multiPanel.url), {
+      method: "PUT",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ id: "PIXEL123:com.example.unknown" }),
+    });
+    assert.equal(unknown.status, 404);
+
+    const current = await fetch(new URL("/app", multiPanel.url));
+    assert.deepEqual(await current.json(), second);
+  } finally {
+    await multiPanel.close();
+    firstServer.closeAllConnections();
+    secondServer.closeAllConnections();
+    await Promise.all([
+      new Promise((resolve) => firstServer.close(resolve)),
+      new Promise((resolve) => secondServer.close(resolve)),
+    ]);
+  }
 });
 
 test("proxies the application icon as an unchanged PNG", async () => {
@@ -267,6 +516,79 @@ test("discovers only live Snap-O Tweaks app sockets", () => {
     { name: "snapo_tweaks_6976", pid: 6976 },
     { name: "snapo_tweaks_4312", pid: 4312 },
   ]);
+});
+
+test("discovers every running tweaks app across connected Android devices", async () => {
+  const identities = new Map([
+    [49231, { name: "Design Preview", packageName: "com.example.design" }],
+    [49232, { name: "Motion Study", packageName: "com.example.motion" }],
+    [49233, { name: "Tablet Preview", packageName: "com.example.tablet" }],
+  ]);
+  const run = async (_executable, args) => {
+    if (args[0] === "devices") {
+      return {
+        stdout: [
+          "List of devices attached",
+          "PHONE123 device model:Pixel_9_Pro_XL transport_id:9",
+          "TABLET456 device model:Pixel_Tablet transport_id:5",
+        ].join("\n"),
+      };
+    }
+
+    if (args[0] === "forward") {
+      return {
+        stdout: [
+          "PHONE123 tcp:49231 localabstract:snapo_tweaks_7001",
+          "PHONE123 tcp:49232 localabstract:snapo_tweaks_7002",
+          "TABLET456 tcp:49233 localabstract:snapo_tweaks_8101",
+        ].join("\n"),
+      };
+    }
+
+    if (args.includes("/proc/net/unix")) {
+      return {
+        stdout: args.includes("PHONE123")
+          ? "@snapo_tweaks_7002\n@snapo_tweaks_7001\n"
+          : "@snapo_tweaks_8101\n",
+      };
+    }
+
+    throw new Error(`Unexpected ADB arguments: ${args.join(" ")}`);
+  };
+  const apps = await discoverTweakApps({
+    adb: "sample-adb",
+    run,
+    fetcher: async (url) => {
+      const identity = identities.get(Number(url.port));
+      return identity
+        ? new Response(JSON.stringify(identity))
+        : new Response(null, { status: 404 });
+    },
+  });
+
+  assert.deepEqual(
+    apps.map(({ id, name, deviceName, pid }) => ({ id, name, deviceName, pid })),
+    [
+      {
+        id: "PHONE123:com.example.motion",
+        name: "Motion Study",
+        deviceName: "Pixel 9 Pro XL",
+        pid: 7002,
+      },
+      {
+        id: "PHONE123:com.example.design",
+        name: "Design Preview",
+        deviceName: "Pixel 9 Pro XL",
+        pid: 7001,
+      },
+      {
+        id: "TABLET456:com.example.tablet",
+        name: "Tablet Preview",
+        deviceName: "Pixel Tablet",
+        pid: 8101,
+      },
+    ],
+  );
 });
 
 test("creates its own ADB forward for a running app", async () => {

--- a/snapo-link-android/samples/demo-tweaks/panel/styles.css
+++ b/snapo-link-android/samples/demo-tweaks/panel/styles.css
@@ -86,8 +86,8 @@ button {
   width: 100%;
   min-height: 66px;
   align-items: center;
-  justify-content: space-between;
-  gap: 16px;
+  justify-content: flex-start;
+  gap: 8px;
   padding: 8px 12px;
 }
 
@@ -460,6 +460,10 @@ button {
 
 .toolbar-button:disabled {
   color: var(--subtle);
+}
+
+.toolbar-icon {
+  display: block;
 }
 
 .error-message {

--- a/snapo-link-android/samples/demo-tweaks/panel/styles.css
+++ b/snapo-link-android/samples/demo-tweaks/panel/styles.css
@@ -498,6 +498,24 @@ button {
   color: var(--text);
 }
 
+.tweak-reset {
+  display: inline-flex;
+  width: 20px;
+  height: 20px;
+  align-items: center;
+  justify-content: center;
+  padding: 0;
+}
+
+.tweak-reset[hidden] {
+  display: none;
+}
+
+.tweak-reset-icon {
+  width: 13px;
+  height: 13px;
+}
+
 .toolbar-button:disabled {
   color: var(--subtle);
 }
@@ -601,6 +619,7 @@ button {
   flex: 0 0 auto;
   align-items: center;
   gap: 9px;
+  margin-left: auto;
 }
 
 .number-input,

--- a/snapo-link-android/samples/demo-tweaks/panel/styles.css
+++ b/snapo-link-android/samples/demo-tweaks/panel/styles.css
@@ -2,6 +2,7 @@
   color-scheme: light dark;
   font-family:
     ui-sans-serif,
+    system-ui,
     -apple-system,
     BlinkMacSystemFont,
     "Segoe UI",
@@ -11,27 +12,34 @@
   -webkit-font-smoothing: antialiased;
 
   --background: #f7f7f7;
+  --surface: #fdfdfd;
+  --surface-bright: #fff;
   --text: #151515;
   --muted: #6b6b6b;
   --subtle: #929292;
+  --outline: #d0d0d0;
   --line: #e3e3e3;
-  --input-background: #ebebea;
-  --input-hover: #e4e4e3;
-  --accent: #5468ff;
+  --input-background: #f6f6f6;
+  --input-hover: #e8e8e8;
+  --selection: color-mix(in srgb, var(--text) 8%, var(--surface-bright));
+  --control-accent: var(--text);
   --success: #23a84a;
   --error: #d04a3c;
+  --content-width: 1040px;
 }
 
 @media (prefers-color-scheme: dark) {
   :root {
-    --background: #111;
+    --background: #0f0f0f;
+    --surface: #111;
+    --surface-bright: #1a1a1a;
     --text: #f1f1f1;
     --muted: #b5b5b5;
     --subtle: #858585;
-    --line: #292929;
+    --outline: #3a3a3a;
+    --line: #242424;
     --input-background: #212121;
-    --input-hover: #292929;
-    --accent: #8390ff;
+    --input-hover: #2a2a2a;
     --success: #5bcf8b;
     --error: #ff7b6d;
   }
@@ -41,14 +49,13 @@
   box-sizing: border-box;
 }
 
-html {
-  min-width: 320px;
-  min-height: 100%;
-  background: var(--background);
-}
-
+html,
 body {
+  width: 100%;
+  min-width: 340px;
+  min-height: 100%;
   margin: 0;
+  background: var(--surface-bright);
   color: var(--text);
 }
 
@@ -58,75 +65,353 @@ input {
 }
 
 button {
+  appearance: none;
   color: inherit;
 }
 
-.panel {
-  width: min(100%, 560px);
-  margin-inline: auto;
-  padding: 24px clamp(20px, 5vw, 34px) 52px;
+.inspector {
+  display: grid;
+  min-height: 100dvh;
+  grid-template-rows: auto minmax(0, 1fr);
+  background: var(--surface-bright);
 }
 
-.app-header {
-  padding-bottom: 19px;
+.inspector-toolbar {
+  border-bottom: 1px solid var(--line);
+  background: var(--surface-bright);
 }
 
-.app-bar {
+.toolbar-content {
   display: flex;
+  width: 100%;
+  min-height: 66px;
   align-items: center;
   justify-content: space-between;
-  gap: 14px;
-  min-height: 40px;
+  gap: 16px;
+  padding: 8px 12px;
 }
 
-.app-identity {
-  display: flex;
-  flex: 1;
-  align-items: center;
-  gap: 11px;
-  min-width: 0;
-}
-
-.app-icon-frame {
+.server-select {
   position: relative;
-  flex: 0 0 38px;
-  width: 38px;
-  height: 38px;
+  width: min(100%, 244px);
+  min-width: 0;
+  flex: 0 1 244px;
 }
 
-.app-icon {
+.server-picker-button {
+  display: flex;
+  width: 100%;
+  min-height: 50px;
+  align-items: center;
+  border: 1px solid var(--outline);
+  border-radius: 0;
+  background: var(--surface-bright);
+  padding: 8px 12px;
+  text-align: left;
+}
+
+.server-picker-button:disabled {
+  color: var(--text);
+}
+
+.server-picker-button[data-available="false"] .server-name {
+  color: var(--muted);
+}
+
+.server-app-icon {
+  position: relative;
+  display: inline-flex;
+  width: 32px;
+  height: 32px;
+  flex: 0 0 32px;
+}
+
+.app-icon,
+.menu-app-icon {
   display: block;
-  width: 38px;
-  height: 38px;
+  width: 32px;
+  height: 32px;
   object-fit: contain;
 }
 
-.connection-status {
+.app-icon[hidden],
+.menu-app-icon[hidden] {
+  display: none;
+}
+
+.connection-status,
+.menu-status-dot {
   position: absolute;
-  right: -2px;
-  bottom: -2px;
+  right: 1px;
+  bottom: 1px;
   display: grid;
-  width: 13px;
-  height: 13px;
+  width: 10px;
+  height: 10px;
   place-items: center;
-  border: 2px solid var(--background);
+  border: 1px solid var(--surface-bright);
   border-radius: 50%;
-  background: var(--background);
+  background: var(--surface-bright);
 }
 
 .status-dot {
-  width: 9px;
-  height: 9px;
+  width: 8px;
+  height: 8px;
   border-radius: 50%;
   background: var(--subtle);
 }
 
-.connection-status[data-state="connected"] .status-dot {
+.connection-status[data-state="connected"] .status-dot,
+.menu-status-dot {
   background: var(--success);
 }
 
 .connection-status[data-state="error"] .status-dot {
   background: var(--error);
+}
+
+.server-picker-text,
+.server-picker-menu-text {
+  display: flex;
+  min-width: 0;
+  flex: 1;
+  flex-direction: column;
+}
+
+.server-picker-text {
+  margin-left: 12px;
+}
+
+.server-name,
+.server-device,
+.server-picker-menu-name,
+.server-picker-menu-device {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.server-name,
+.server-picker-menu-name {
+  font-size: 12px;
+  font-weight: 500;
+  line-height: 16px;
+}
+
+.server-device,
+.server-picker-menu-device {
+  margin-top: 1px;
+  color: var(--muted);
+  font-size: 12px;
+  font-weight: 400;
+  line-height: 16px;
+}
+
+.server-chevron {
+  width: 18px;
+  height: 18px;
+  flex: 0 0 18px;
+  margin-left: 10px;
+  opacity: 0.65;
+  transition: transform 120ms ease;
+}
+
+.server-chevron[hidden] {
+  display: none;
+}
+
+.server-picker-button[aria-expanded="true"] .server-chevron {
+  transform: rotate(180deg);
+}
+
+.server-picker-menu {
+  position: absolute;
+  z-index: 20;
+  top: 100%;
+  left: 0;
+  width: 100%;
+  max-height: 320px;
+  overflow-y: auto;
+  border: 1px solid var(--outline);
+  background: var(--surface-bright);
+}
+
+.server-picker-menu[hidden] {
+  display: none;
+}
+
+.server-picker-menu-item {
+  display: flex;
+  width: 100%;
+  min-height: 48px;
+  align-items: center;
+  gap: 12px;
+  border: 0;
+  border-radius: 0;
+  background: transparent;
+  padding: 8px 12px;
+  text-align: left;
+}
+
+.server-picker-menu-item:hover:not(:disabled),
+.server-picker-menu-item:focus-visible {
+  background: color-mix(in srgb, var(--text) 8%, transparent);
+}
+
+.server-picker-menu-item[data-selected="true"] {
+  background: var(--selection);
+}
+
+.server-picker-menu:has(.mock-menu-choice) {
+  width: min(320px, calc(100vw - 24px));
+}
+
+.mock-menu-choice {
+  display: flex;
+  width: 100%;
+  height: 48px;
+  align-items: center;
+  gap: 10px;
+  border: 0;
+  border-radius: 0;
+  background: transparent;
+  padding: 6px 10px;
+  color: var(--text);
+  text-align: left;
+}
+
+.mock-menu-choice:hover,
+.mock-menu-choice:focus-visible,
+.mock-menu-choice[data-selected="true"] {
+  background: var(--selection);
+}
+
+.mock-menu-heading {
+  display: flex;
+  height: 28px;
+  align-items: center;
+  gap: 7px;
+  padding: 0 10px;
+  color: var(--muted);
+  font-size: 11px;
+  font-weight: 500;
+  line-height: 16px;
+}
+
+.mock-heading-icon {
+  width: 14px;
+  height: 14px;
+  flex: 0 0 14px;
+}
+
+.mock-choice-app-icon {
+  width: 22px;
+  height: 22px;
+  flex: 0 0 22px;
+}
+
+.mock-choice-identity {
+  display: grid;
+  min-width: 0;
+  flex: 1 1 auto;
+  gap: 2px;
+}
+
+.mock-choice-name {
+  min-width: 0;
+  overflow: hidden;
+  font-size: 12px;
+  font-weight: 500;
+  line-height: 16px;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.mock-choice-device {
+  min-width: 0;
+  overflow: hidden;
+  color: var(--muted);
+  font-size: 11px;
+  line-height: 16px;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.mock-menu-check {
+  width: 16px;
+  height: 16px;
+  flex: 0 0 16px;
+  opacity: 0;
+}
+
+.mock-menu-choice[data-selected="true"] .mock-menu-check {
+  opacity: 1;
+}
+
+.mock-app-heading {
+  display: flex;
+  height: 30px;
+  align-items: center;
+  gap: 7px;
+  padding: 0 10px;
+}
+
+.mock-app-heading-icon {
+  width: 15px;
+  height: 15px;
+  flex: 0 0 15px;
+  color: var(--muted);
+}
+
+.mock-app-heading-name {
+  min-width: 0;
+  overflow: hidden;
+  font-size: 11px;
+  font-weight: 500;
+  line-height: 16px;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.mock-app-heading-device {
+  min-width: 0;
+  overflow: hidden;
+  margin-left: auto;
+  color: var(--muted);
+  font-size: 10px;
+  line-height: 16px;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.mock-app-view-choice {
+  height: 40px;
+  gap: 10px;
+  padding-left: 24px;
+}
+
+.mock-app-view-icon {
+  width: 17px;
+  height: 17px;
+  flex: 0 0 17px;
+  color: var(--muted);
+}
+
+.mock-app-view-name {
+  flex: 1 1 auto;
+  font-size: 12px;
+  line-height: 16px;
+}
+
+.mock-app-separator {
+  height: 1px;
+  margin: 4px 10px;
+  background: var(--line);
+}
+
+.mock-toolbar-icon {
+  width: 24px;
+  height: 24px;
+  align-self: center;
 }
 
 .visually-hidden {
@@ -138,41 +423,31 @@ button {
   white-space: nowrap;
 }
 
-.app-heading {
+.detail {
   min-width: 0;
+  min-height: 0;
+  background: var(--surface-bright);
 }
 
-.app-name {
-  overflow: hidden;
-  margin: 0;
-  font-size: 13px;
-  font-weight: 590;
-  line-height: 1.35;
-  text-overflow: ellipsis;
-  white-space: nowrap;
-}
-
-.package-name {
-  overflow: hidden;
-  margin: 3px 0 0;
-  color: var(--muted);
-  font-size: 11px;
-  text-overflow: ellipsis;
-  white-space: nowrap;
+.detail-content {
+  width: min(100%, var(--content-width));
+  margin-inline: auto;
+  padding: 24px clamp(18px, 4vw, 36px) 56px;
 }
 
 .toolbar {
   display: flex;
-  flex: 0 0 auto;
+  min-height: 30px;
   align-items: center;
-  gap: 13px;
+  justify-content: flex-end;
+  gap: 14px;
 }
 
 .toolbar-button,
 .tweak-reset {
   border: 0;
   background: transparent;
-  padding: 4px 0;
+  padding: 5px 0;
   color: var(--muted);
   font-size: 11px;
   white-space: nowrap;
@@ -188,61 +463,93 @@ button {
 }
 
 .error-message {
-  margin: 0 0 16px;
+  margin: 12px 0;
   color: var(--error);
   font-size: 12px;
   line-height: 1.5;
 }
 
+.empty-state {
+  padding-block: 22px;
+}
+
+.empty-state h1 {
+  margin: 0;
+  font-size: 13px;
+  font-weight: 590;
+}
+
+.empty-state p {
+  margin: 7px 0 0;
+  color: var(--muted);
+  font-size: 12px;
+  line-height: 1.6;
+}
+
+.tweak-sections {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(min(100%, 320px), 1fr));
+  align-items: start;
+  column-gap: 44px;
+}
+
+.tweak-column {
+  display: grid;
+  min-width: 0;
+  align-content: start;
+}
+
 .tweak-section {
-  border-top: 1px solid var(--line);
-  padding-block: 19px 21px;
+  padding-block: 15px 24px;
 }
 
 .section-heading {
-  display: flex;
-  align-items: baseline;
-  justify-content: space-between;
-  gap: 12px;
-  margin-bottom: 18px;
+  margin-bottom: 15px;
 }
 
 .section-heading h2 {
   margin: 0;
   font-size: 12px;
-  font-weight: 640;
-  letter-spacing: -0.01em;
-}
-
-.section-count {
-  color: var(--subtle);
-  font-size: 11px;
-  font-variant-numeric: tabular-nums;
+  font-weight: 560;
+  line-height: 16px;
 }
 
 .tweak-list {
   display: grid;
-  gap: 17px;
+  gap: 15px;
+}
+
+.tweak-section[data-section=""] .tweak-list {
+  grid-template-columns: repeat(auto-fit, minmax(min(100%, 280px), 1fr));
+  gap: 17px 36px;
 }
 
 .tweak-row {
   display: grid;
-  gap: 8px;
+  gap: 7px;
 }
 
 .tweak-line {
   display: flex;
+  min-height: 27px;
   align-items: center;
   justify-content: space-between;
   gap: 12px;
-  min-height: 28px;
+}
+
+.tweak-content {
+  display: flex;
+  min-width: 0;
+  flex: 1 1 auto;
+  align-items: center;
+  gap: 10px;
 }
 
 .tweak-label {
   overflow: hidden;
-  color: var(--text);
   font-size: 12px;
   text-overflow: ellipsis;
+  white-space: nowrap;
 }
 
 .tweak-actions {
@@ -266,12 +573,13 @@ button {
 }
 
 .number-input:hover,
-.hex-input:hover {
+.hex-input:hover,
+.string-input:hover {
   background: var(--input-hover);
 }
 
 .number-input {
-  width: 68px;
+  width: 60px;
   text-align: right;
 }
 
@@ -289,16 +597,7 @@ button {
   width: 100%;
   height: 17px;
   margin: 0;
-  accent-color: var(--accent);
-}
-
-.range-labels {
-  display: flex;
-  justify-content: space-between;
-  margin-top: -3px;
-  color: var(--subtle);
-  font-size: 10px;
-  font-variant-numeric: tabular-nums;
+  accent-color: var(--control-accent);
 }
 
 .color-inputs {
@@ -320,7 +619,7 @@ button {
   width: 16px;
   height: 16px;
   margin: 0;
-  accent-color: var(--accent);
+  accent-color: var(--control-accent);
 }
 
 .string-input {
@@ -335,27 +634,34 @@ button {
   transition: background-color 120ms ease;
 }
 
-.string-input:hover {
-  background: var(--input-hover);
-}
-
 .string-input::placeholder {
   color: var(--subtle);
 }
 
 button:focus-visible,
 input:focus-visible {
-  outline: 2px solid var(--accent);
+  outline: 2px solid var(--control-accent);
   outline-offset: 2px;
 }
 
-@media (max-width: 390px) {
-  .panel {
-    padding: 20px 18px 42px;
+@media (prefers-color-scheme: dark) {
+  .server-chevron {
+    filter: invert(1);
+  }
+}
+
+@media (max-width: 460px) {
+  .toolbar-content {
+    gap: 10px;
+    padding-inline: 10px;
   }
 
   .toolbar {
-    gap: 10px;
+    gap: 9px;
+  }
+
+  .detail-content {
+    padding-inline: 14px;
   }
 }
 

--- a/snapo-link-android/samples/demo-tweaks/panel/styles.css
+++ b/snapo-link-android/samples/demo-tweaks/panel/styles.css
@@ -23,6 +23,7 @@
   --input-hover: #e8e8e8;
   --selection: color-mix(in srgb, var(--text) 8%, var(--surface-bright));
   --control-accent: var(--text);
+  --accent-blue: #2778db;
   --success: #23a84a;
   --error: #d04a3c;
   --content-width: 1040px;
@@ -40,6 +41,7 @@
     --line: #242424;
     --input-background: #212121;
     --input-hover: #2a2a2a;
+    --accent-blue: #5aa4e8;
     --success: #5bcf8b;
     --error: #ff7b6d;
   }
@@ -96,6 +98,44 @@ button {
   width: min(100%, 244px);
   min-width: 0;
   flex: 0 1 244px;
+}
+
+.inspector-segments {
+  display: flex;
+  flex: none;
+  align-items: center;
+  border: 1px solid var(--line);
+  border-radius: 16px;
+  background: var(--surface-bright);
+  padding: 2px 4px;
+}
+
+.inspector-segments[hidden] {
+  display: none;
+}
+
+.inspector-segment {
+  display: grid;
+  width: 30px;
+  height: 28px;
+  place-items: center;
+  border: 0;
+  background: transparent;
+  padding: 0;
+  color: var(--muted);
+}
+
+.inspector-segment-icon {
+  width: 16px;
+  height: 16px;
+}
+
+.inspector-segment[aria-pressed="true"] {
+  color: var(--accent-blue);
+}
+
+.inspector-segment:disabled {
+  opacity: 0.45;
 }
 
 .server-picker-button {

--- a/snapo-link-android/samples/demo-tweaks/src/main/java/com/openai/snapo/demo/tweaks/MainActivity.kt
+++ b/snapo-link-android/samples/demo-tweaks/src/main/java/com/openai/snapo/demo/tweaks/MainActivity.kt
@@ -68,9 +68,9 @@ class MainActivity : ComponentActivity() {
 
 @Composable
 private fun TweakDemo() {
-    val textColor = tweakColor("Text color", Color(0xFF18212F))
-    val backgroundColor = tweakColor("Background color", Color(0xFFF7F8FA))
-    val accentColor = tweakColor("Accent color", Color(0xFF5468FF))
+    val textColor = tweakColor("Colors/Text", Color(0xFF18212F))
+    val backgroundColor = tweakColor("Colors/Background", Color(0xFFF7F8FA))
+    val accentColor = tweakColor("Colors/Accent", Color(0xFF5468FF))
 
     MaterialTheme(
         colorScheme = lightColorScheme(
@@ -95,6 +95,7 @@ private fun TweakDemo() {
 @Composable
 private fun TweakDemoContent() {
     val dividerColor = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.12f)
+    val showMotion = tweakBoolean("Motion/Show", true)
 
     Column(
         modifier = Modifier
@@ -107,8 +108,11 @@ private fun TweakDemoContent() {
         DemoHeader()
         HorizontalDivider(color = dividerColor)
         TypographyPreview()
-        HorizontalDivider(color = dividerColor)
-        MotionPreview()
+
+        if (showMotion) {
+            HorizontalDivider(color = dividerColor)
+            MotionPreview()
+        }
     }
 }
 
@@ -135,9 +139,9 @@ private fun DemoHeader() {
 
 @Composable
 private fun TypographyPreview() {
-    val fontSize = tweakInt("Font size", 36, min = 16, max = 72, step = 1)
-    val fontWeight = tweakInt("Font weight", 600, min = 100, max = 900, step = 100)
-    val previewText = tweakString("Preview text", "Make it feel right.")
+    val fontSize = tweakInt("Typography/Font size", 36, min = 16, max = 72, step = 1)
+    val fontWeight = tweakInt("Typography/Font weight", 600, min = 100, max = 900, step = 100)
+    val previewText = tweakString("Typography/Preview text", "Make it feel right.")
 
     Column(verticalArrangement = Arrangement.spacedBy(12.dp)) {
         Text(
@@ -158,8 +162,8 @@ private fun TypographyPreview() {
 
 @Composable
 private fun TypographyDetails() {
-    val fontSize = tweakInt("Font size", 36, min = 16, max = 72, step = 1)
-    val fontWeight = tweakInt("Font weight", 600, min = 100, max = 900, step = 100)
+    val fontSize = tweakInt("Typography/Font size", 36, min = 16, max = 72, step = 1)
+    val fontWeight = tweakInt("Typography/Font weight", 600, min = 100, max = 900, step = 100)
 
     Text(
         text = "$fontSize sp · $fontWeight",
@@ -171,10 +175,10 @@ private fun TypographyDetails() {
 @Composable
 private fun MotionPreview() {
     var isStateB by rememberSaveable { mutableStateOf(false) }
-    val duration = tweakInt("Animation duration", 400, min = 100, max = 1500, step = 50)
-    val stiffness = tweakFloat("Spring stiffness", 280f, min = 80f, max = 800f, step = 20f)
-    val damping = tweakFloat("Spring damping", 0.7f, min = 0.1f, max = 1f, step = 0.05f)
-    val useSpring = tweakBoolean("Use spring", true)
+    val duration = tweakInt("Motion/Duration", 400, min = 100, max = 1500, step = 50)
+    val stiffness = tweakFloat("Motion/Spring stiffness", 280f, min = 80f, max = 800f, step = 20f)
+    val damping = tweakFloat("Motion/Spring damping", 0.7f, min = 0.1f, max = 1f, step = 0.05f)
+    val useSpring = tweakBoolean("Motion/Use spring", true)
 
     val animationSpec: FiniteAnimationSpec<Float> = if (useSpring) {
         spring(
@@ -266,14 +270,14 @@ private fun MotionTrack(
 private fun AnimationDetails(
     isStateB: Boolean,
 ) {
-    val useSpring = tweakBoolean("Use spring", true)
+    val useSpring = tweakBoolean("Motion/Use spring", true)
     val description = if (useSpring) {
-        val stiffness = tweakFloat("Spring stiffness", 280f, min = 80f, max = 800f, step = 20f)
-        val damping = tweakFloat("Spring damping", 0.7f, min = 0.1f, max = 1f, step = 0.05f)
+        val stiffness = tweakFloat("Motion/Spring stiffness", 280f, min = 80f, max = 800f, step = 20f)
+        val damping = tweakFloat("Motion/Spring damping", 0.7f, min = 0.1f, max = 1f, step = 0.05f)
 
         "Spring · $stiffness stiffness · $damping damping"
     } else {
-        val duration = tweakInt("Animation duration", 400, min = 100, max = 1500, step = 50)
+        val duration = tweakInt("Motion/Duration", 400, min = 100, max = 1500, step = 50)
 
         "Tween · $duration ms"
     }

--- a/snapo-link-android/tweaks/src/main/java/com/openai/snapo/tweaks/internal/TweakChangePublisher.kt
+++ b/snapo-link-android/tweaks/src/main/java/com/openai/snapo/tweaks/internal/TweakChangePublisher.kt
@@ -1,0 +1,75 @@
+package com.openai.snapo.tweaks.internal
+
+import java.io.Closeable
+import java.util.concurrent.LinkedBlockingDeque
+
+internal class TweakChangePublisher(
+    private val schedule: (Runnable) -> Boolean,
+) : Closeable {
+    private val lock = Any()
+    private val subscriptions = LinkedHashMap<Long, LinkedBlockingDeque<List<TweakSnapshot>>>()
+    private var nextSubscriptionId = 0L
+    private var publicationScheduled = false
+    private var closed = false
+
+    fun subscribe(): Subscription = synchronized(lock) {
+        check(!closed) { "The tweak change publisher is closed." }
+
+        val id = nextSubscriptionId++
+        val events = LinkedBlockingDeque<List<TweakSnapshot>>(1)
+        subscriptions[id] = events
+
+        Subscription(
+            initial = TweakRegistry.snapshot(),
+            events = events,
+            onClose = { synchronized(lock) { subscriptions.remove(id) } },
+        )
+    }
+
+    fun notifyChanged() {
+        val shouldSchedule = synchronized(lock) {
+            if (closed || publicationScheduled || subscriptions.isEmpty()) {
+                false
+            } else {
+                publicationScheduled = true
+                true
+            }
+        }
+
+        if (shouldSchedule && !schedule(Runnable(::publish))) {
+            synchronized(lock) { publicationScheduled = false }
+        }
+    }
+
+    override fun close() {
+        synchronized(lock) {
+            closed = true
+            publicationScheduled = false
+            subscriptions.clear()
+        }
+    }
+
+    private fun publish() {
+        val snapshot = TweakRegistry.snapshot()
+
+        synchronized(lock) {
+            publicationScheduled = false
+            if (closed) return
+
+            subscriptions.values.forEach { events ->
+                if (!events.offer(snapshot)) {
+                    events.poll()
+                    events.offer(snapshot)
+                }
+            }
+        }
+    }
+
+    internal class Subscription(
+        val initial: List<TweakSnapshot>,
+        val events: LinkedBlockingDeque<List<TweakSnapshot>>,
+        private val onClose: () -> Unit,
+    ) : Closeable {
+        override fun close() = onClose()
+    }
+}

--- a/snapo-link-android/tweaks/src/main/java/com/openai/snapo/tweaks/internal/TweakHttpServer.kt
+++ b/snapo-link-android/tweaks/src/main/java/com/openai/snapo/tweaks/internal/TweakHttpServer.kt
@@ -8,6 +8,7 @@ import android.os.Process
 import android.util.JsonReader
 import android.util.JsonToken
 import android.util.JsonWriter
+import androidx.compose.runtime.snapshots.Snapshot
 import java.io.ByteArrayInputStream
 import java.io.ByteArrayOutputStream
 import java.io.Closeable
@@ -21,6 +22,7 @@ import java.nio.charset.StandardCharsets
 import java.util.Locale
 import java.util.concurrent.ExecutionException
 import java.util.concurrent.FutureTask
+import java.util.concurrent.Semaphore
 import java.util.concurrent.TimeUnit
 import java.util.concurrent.TimeoutException
 import kotlin.concurrent.thread
@@ -29,6 +31,8 @@ private const val MaxHeaderBytes = 16 * 1024
 private const val MaxBodyBytes = 64 * 1024
 private const val SocketTimeoutMillis = 5_000
 private const val MainThreadTimeoutMillis = 5_000L
+private const val MaximumConcurrentConnections = 32
+private const val EventHeartbeatSeconds = 15L
 
 internal class TweakHttpServer(
     private val appInfoProvider: TweakAppInfoProvider,
@@ -36,12 +40,17 @@ internal class TweakHttpServer(
     private val mainHandler: Handler = Handler(Looper.getMainLooper()),
 ) : Closeable {
     private val lifecycleLock = Any()
+    private val connectionPermits = Semaphore(MaximumConcurrentConnections)
+    private val activeSockets = LinkedHashSet<LocalSocket>()
+    private val changePublisher = TweakChangePublisher(mainHandler::post)
 
     @Volatile
     private var running = false
 
     private var server: LocalServerSocket? = null
     private var acceptThread: Thread? = null
+    private var registryObserver: Closeable? = null
+    private var disposeSnapshotObserver: (() -> Unit)? = null
 
     fun start() {
         synchronized(lifecycleLock) {
@@ -50,6 +59,13 @@ internal class TweakHttpServer(
             val localServer = LocalServerSocket(socketName)
             server = localServer
             running = true
+            registryObserver = TweakRegistry.observeChanges(changePublisher::notifyChanged)
+            val snapshotObserver = Snapshot.registerApplyObserver { changed, _ ->
+                if (TweakRegistry.containsChangedState(changed)) {
+                    changePublisher.notifyChanged()
+                }
+            }
+            disposeSnapshotObserver = snapshotObserver::dispose
             acceptThread = thread(
                 isDaemon = true,
                 name = "Snap-O Tweaks",
@@ -60,13 +76,20 @@ internal class TweakHttpServer(
     }
 
     override fun close() {
-        synchronized(lifecycleLock) {
+        val sockets = synchronized(lifecycleLock) {
             running = false
             runCatching { server?.close() }
             server = null
             acceptThread?.interrupt()
             acceptThread = null
+            registryObserver?.close()
+            registryObserver = null
+            disposeSnapshotObserver?.invoke()
+            disposeSnapshotObserver = null
+            changePublisher.close()
+            activeSockets.toList().also { activeSockets.clear() }
         }
+        sockets.forEach { socket -> runCatching { socket.close() } }
     }
 
     private fun acceptConnections(localServer: LocalServerSocket) {
@@ -78,8 +101,30 @@ internal class TweakHttpServer(
                 continue
             }
 
+            handleAcceptedConnection(socket)
+        }
+    }
+
+    private fun handleAcceptedConnection(socket: LocalSocket) {
+        if (!connectionPermits.tryAcquire()) {
             runCatching {
-                socket.use(::handleConnection)
+                socket.use {
+                    writeResponse(
+                        it.outputStream,
+                        errorResponse(503, "Too many active tweak connections."),
+                    )
+                }
+            }
+            return
+        }
+
+        synchronized(lifecycleLock) { activeSockets.add(socket) }
+        thread(isDaemon = true, name = "Snap-O Tweaks connection") {
+            try {
+                runCatching { socket.use(::handleConnection) }
+            } finally {
+                synchronized(lifecycleLock) { activeSockets.remove(socket) }
+                connectionPermits.release()
             }
         }
     }
@@ -88,7 +133,12 @@ internal class TweakHttpServer(
         socket.soTimeout = SocketTimeoutMillis
 
         val response = try {
-            route(readRequest(socket.inputStream))
+            val request = readRequest(socket.inputStream)
+            if (request.path == "/tweaks/events" && request.method == "GET") {
+                streamTweaks(socket.outputStream)
+                return
+            }
+            route(request)
         } catch (error: TweakUpdateException) {
             errorResponse(error.statusCode, error.message ?: "Invalid tweak update.")
         } catch (error: HttpFailure) {
@@ -110,7 +160,49 @@ internal class TweakHttpServer(
         "/app" -> routeApp(request)
         "/app/icon" -> routeAppIcon(request)
         "/tweaks" -> routeTweaks(request)
+        "/tweaks/events" -> throw HttpFailure(
+            statusCode = 405,
+            message = "Unsupported method: ${request.method}",
+            allowedMethods = "GET",
+        )
         else -> throw HttpFailure(404, "Unknown endpoint: ${request.path}")
+    }
+
+    private fun streamTweaks(output: OutputStream) {
+        changePublisher.subscribe().use { subscription ->
+            output.write(
+                (
+                    "HTTP/1.1 200 OK\r\n" +
+                        "Content-Type: text/event-stream; charset=utf-8\r\n" +
+                        "Cache-Control: no-cache\r\n" +
+                        "Connection: close\r\n\r\n"
+                    ).toByteArray(StandardCharsets.US_ASCII),
+            )
+            writeTweakEvent(output, subscription.initial)
+
+            while (running) {
+                val snapshot = try {
+                    subscription.events.poll(EventHeartbeatSeconds, TimeUnit.SECONDS)
+                } catch (_: InterruptedException) {
+                    Thread.currentThread().interrupt()
+                    return
+                }
+
+                if (snapshot == null) {
+                    output.write(": keep-alive\n\n".toByteArray(StandardCharsets.US_ASCII))
+                    output.flush()
+                } else {
+                    writeTweakEvent(output, snapshot)
+                }
+            }
+        }
+    }
+
+    private fun writeTweakEvent(output: OutputStream, tweaks: List<TweakSnapshot>) {
+        output.write("event: tweaks\ndata: ".toByteArray(StandardCharsets.US_ASCII))
+        output.write(tweaksResponse(tweaks, includeDescriptors = true).body)
+        output.write("\n\n".toByteArray(StandardCharsets.US_ASCII))
+        output.flush()
     }
 
     private fun routeApp(request: HttpRequest): HttpResponse {

--- a/snapo-link-android/tweaks/src/main/java/com/openai/snapo/tweaks/internal/TweakRegistry.kt
+++ b/snapo-link-android/tweaks/src/main/java/com/openai/snapo/tweaks/internal/TweakRegistry.kt
@@ -3,6 +3,7 @@ package com.openai.snapo.tweaks.internal
 import androidx.compose.runtime.MutableState
 import androidx.compose.runtime.State
 import androidx.compose.runtime.mutableStateOf
+import java.io.Closeable
 import java.math.BigDecimal
 import java.math.BigInteger
 
@@ -42,35 +43,49 @@ internal class InvalidTweakValueException(name: String, reason: String) :
 internal object TweakRegistry {
     private val lock = Any()
     private val tweaks = LinkedHashMap<String, RegisteredTweak>()
+    private val observers = LinkedHashMap<Long, () -> Unit>()
+    private var nextObserverId = 0L
     private val colorPattern = Regex("^#[0-9a-fA-F]{6}([0-9a-fA-F]{2})?$")
 
-    fun register(descriptor: TweakDescriptor): State<Any> = synchronized(lock) {
-        validateDescriptor(descriptor)
+    fun register(descriptor: TweakDescriptor): State<Any> {
+        var changed = false
+        val state = synchronized(lock) {
+            validateDescriptor(descriptor)
 
-        val existing = tweaks[descriptor.name]
-        if (existing != null) {
-            require(existing.descriptor == descriptor) {
-                "Conflicting declarations for tweak: ${descriptor.name}"
+            val existing = tweaks[descriptor.name]
+            if (existing != null) {
+                require(existing.descriptor == descriptor) {
+                    "Conflicting declarations for tweak: ${descriptor.name}"
+                }
+                existing.references += 1
+                existing.state
+            } else {
+                val tweak = RegisteredTweak(
+                    descriptor = descriptor,
+                    state = mutableStateOf(descriptor.default),
+                    references = 1,
+                )
+                tweaks[descriptor.name] = tweak
+                changed = true
+                tweak.state
             }
-            existing.references += 1
-            existing.state
-        } else {
-            val tweak = RegisteredTweak(
-                descriptor = descriptor,
-                state = mutableStateOf(descriptor.default),
-                references = 1,
-            )
-            tweaks[descriptor.name] = tweak
-            tweak.state
         }
+        if (changed) notifyObservers()
+        return state
     }
 
-    fun unregister(name: String) = synchronized(lock) {
-        val tweak = tweaks[name] ?: return@synchronized
-        tweak.references -= 1
-        if (tweak.references == 0) {
-            tweaks.remove(name)
+    fun unregister(name: String) {
+        val changed = synchronized(lock) {
+            val tweak = tweaks[name] ?: return@synchronized false
+            tweak.references -= 1
+            if (tweak.references == 0) {
+                tweaks.remove(name)
+                true
+            } else {
+                false
+            }
         }
+        if (changed) notifyObservers()
     }
 
     fun snapshot(): List<TweakSnapshot> = synchronized(lock) {
@@ -79,24 +94,58 @@ internal object TweakRegistry {
         }
     }
 
-    fun update(values: Map<String, Any?>): List<TweakSnapshot> = synchronized(lock) {
-        val changes = values.map { (name, value) ->
-            val tweak = tweaks[name]
-                ?: throw UnknownTweakException(name)
-            tweak to validateValue(tweak.descriptor, value)
-        }
+    fun update(values: Map<String, Any?>): List<TweakSnapshot> {
+        var changed = false
+        val snapshots = synchronized(lock) {
+            val changes = values.map { (name, value) ->
+                val tweak = tweaks[name]
+                    ?: throw UnknownTweakException(name)
+                tweak to validateValue(tweak.descriptor, value)
+            }
 
-        changes.forEach { (tweak, value) ->
-            tweak.state.value = value
-        }
+            changes.forEach { (tweak, value) ->
+                if (tweak.state.value != value) {
+                    tweak.state.value = value
+                    changed = true
+                }
+            }
 
-        changes.map { (tweak, _) ->
-            TweakSnapshot(tweak.descriptor, tweak.state.value)
+            changes.map { (tweak, _) ->
+                TweakSnapshot(tweak.descriptor, tweak.state.value)
+            }
         }
+        if (changed) notifyObservers()
+        return snapshots
     }
 
-    fun clear() = synchronized(lock) {
-        tweaks.clear()
+    fun observeChanges(observer: () -> Unit): Closeable {
+        val id = synchronized(lock) {
+            val nextId = nextObserverId++
+            observers[nextId] = observer
+            nextId
+        }
+        return Closeable { synchronized(lock) { observers.remove(id) } }
+    }
+
+    fun containsChangedState(changed: Set<Any>): Boolean = synchronized(lock) {
+        tweaks.values.any { it.state in changed }
+    }
+
+    fun clear() {
+        val changed = synchronized(lock) {
+            if (tweaks.isEmpty()) {
+                false
+            } else {
+                tweaks.clear()
+                true
+            }
+        }
+        if (changed) notifyObservers()
+    }
+
+    private fun notifyObservers() {
+        val current = synchronized(lock) { observers.values.toList() }
+        current.forEach { it() }
     }
 
     private fun validateDescriptor(descriptor: TweakDescriptor) {

--- a/snapo-link-android/tweaks/src/test/java/com/openai/snapo/tweaks/internal/TweakChangePublisherTest.kt
+++ b/snapo-link-android/tweaks/src/test/java/com/openai/snapo/tweaks/internal/TweakChangePublisherTest.kt
@@ -1,0 +1,165 @@
+package com.openai.snapo.tweaks.internal
+
+import androidx.compose.runtime.MutableState
+import androidx.compose.runtime.snapshots.Snapshot
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class TweakChangePublisherTest {
+
+    @After
+    fun clearRegistry() {
+        TweakRegistry.clear()
+    }
+
+    @Test
+    fun `subscription begins with the complete current snapshot`() {
+        TweakRegistry.register(descriptor("Typography/Size", 16))
+        val publisher = TweakChangePublisher { true }
+
+        publisher.subscribe().use { subscription ->
+            assertEquals(listOf("Typography/Size"), subscription.initial.names())
+            assertNull(subscription.events.poll())
+        }
+    }
+
+    @Test
+    fun `composition changes are published together after the scheduled turn`() {
+        val scheduled = mutableListOf<Runnable>()
+        val publisher = TweakChangePublisher { runnable -> scheduled.add(runnable) }
+        val observer = TweakRegistry.observeChanges(publisher::notifyChanged)
+
+        publisher.subscribe().use { subscription ->
+            TweakRegistry.register(descriptor("Motion/Duration", 400))
+            TweakRegistry.register(descriptor("Motion/Delay", 100))
+            TweakRegistry.register(descriptor("Motion/Repeat", 2))
+
+            assertEquals(1, scheduled.size)
+            assertNull(subscription.events.poll())
+
+            scheduled.removeAt(0).run()
+
+            assertEquals(
+                listOf("Motion/Duration", "Motion/Delay", "Motion/Repeat"),
+                subscription.events.poll()?.names(),
+            )
+            assertNull(subscription.events.poll())
+        }
+
+        observer.close()
+    }
+
+    @Test
+    fun `added and removed tweaks are reconciled in one snapshot`() {
+        TweakRegistry.register(descriptor("Motion/Old", 100))
+        val scheduled = mutableListOf<Runnable>()
+        val publisher = TweakChangePublisher { runnable -> scheduled.add(runnable) }
+        val observer = TweakRegistry.observeChanges(publisher::notifyChanged)
+
+        publisher.subscribe().use { subscription ->
+            TweakRegistry.unregister("Motion/Old")
+            TweakRegistry.register(descriptor("Motion/New", 200))
+
+            assertEquals(1, scheduled.size)
+            scheduled.single().run()
+
+            assertEquals(listOf("Motion/New"), subscription.events.poll()?.names())
+        }
+
+        observer.close()
+    }
+
+    @Test
+    fun `value changes appear in the streamed snapshot`() {
+        TweakRegistry.register(descriptor("Motion/Duration", 400))
+        val scheduled = mutableListOf<Runnable>()
+        val publisher = TweakChangePublisher { runnable -> scheduled.add(runnable) }
+        val observer = TweakRegistry.observeChanges(publisher::notifyChanged)
+
+        publisher.subscribe().use { subscription ->
+            TweakRegistry.update(mapOf("Motion/Duration" to 550))
+            scheduled.single().run()
+
+            assertEquals(550, subscription.events.poll()?.single()?.value)
+        }
+
+        observer.close()
+    }
+
+    @Test
+    fun `reference count changes and unchanged values do not publish`() {
+        val tweak = descriptor("Motion/Duration", 400)
+        TweakRegistry.register(tweak)
+        val scheduled = mutableListOf<Runnable>()
+        val publisher = TweakChangePublisher { runnable -> scheduled.add(runnable) }
+        val observer = TweakRegistry.observeChanges(publisher::notifyChanged)
+
+        publisher.subscribe().use {
+            TweakRegistry.register(tweak)
+            TweakRegistry.unregister(tweak.name)
+            TweakRegistry.update(mapOf(tweak.name to 400))
+
+            assertTrue(scheduled.isEmpty())
+        }
+
+        observer.close()
+    }
+
+    @Test
+    fun `slow subscribers keep only the latest complete snapshot`() {
+        val scheduled = mutableListOf<Runnable>()
+        val publisher = TweakChangePublisher { runnable -> scheduled.add(runnable) }
+        val observer = TweakRegistry.observeChanges(publisher::notifyChanged)
+
+        publisher.subscribe().use { subscription ->
+            TweakRegistry.register(descriptor("Motion/First", 1))
+            scheduled.removeAt(0).run()
+            TweakRegistry.register(descriptor("Motion/Second", 2))
+            scheduled.removeAt(0).run()
+
+            assertEquals(
+                listOf("Motion/First", "Motion/Second"),
+                subscription.events.poll()?.names(),
+            )
+            assertNull(subscription.events.poll())
+        }
+
+        observer.close()
+    }
+
+    @Test
+    fun `compose snapshot state changes are recognized`() {
+        val state = TweakRegistry.register(descriptor("Motion/Duration", 400))
+        var observed = false
+        val observer = Snapshot.registerApplyObserver { changed, _ ->
+            if (TweakRegistry.containsChangedState(changed)) {
+                observed = true
+            }
+        }
+
+        try {
+            Snapshot.withMutableSnapshot {
+                (state as MutableState<Any>).value = 550
+            }
+
+            assertTrue(observed)
+            assertEquals(550, TweakRegistry.snapshot().single().value)
+            assertTrue(TweakRegistry.containsChangedState(setOf(state)))
+            assertFalse(TweakRegistry.containsChangedState(setOf(Any())))
+        } finally {
+            observer.dispose()
+        }
+    }
+
+    private fun descriptor(name: String, default: Int) = TweakDescriptor(
+        name = name,
+        type = TweakType.INT,
+        default = default,
+    )
+
+    private fun List<TweakSnapshot>.names(): List<String> = map { it.descriptor.name }
+}

--- a/snapo-network-inspector-web/README.md
+++ b/snapo-network-inspector-web/README.md
@@ -1,6 +1,9 @@
-# Snap-O Network Inspector Web UI
+# Snap-O App Inspector Web UI
 
-This project contains the React renderer embedded in Snap-O's native macOS app. The Swift app hosts the built files in a `WKWebView` and provides device and network operations through the WebKit message bridge in `src/network/client.ts`.
+This project contains the App Inspector renderer embedded in Snap-O's native
+macOS app. The Swift app hosts the built files in a `WKWebView` and provides
+device, Network Inspector, and Snap-O Tweaks operations through the WebKit
+message bridge in `src/network/client.ts`.
 
 The renderer also retains its HTTP transport so it can run in a browser-hosted environment. It contains only portable web UI code.
 
@@ -16,7 +19,9 @@ npm install --registry=https://openai.firewall.socket.dev/npm/
 npm run dev
 ```
 
-Running the renderer by itself uses the HTTP endpoints under `/api/network/...`. To use the native WebKit bridge and inspect a connected device, build and run the Swift app in `snapo-app-mac`.
+Running the renderer by itself uses the HTTP endpoints under `/api/network/...`
+and `/api/inspector/...`. To use the native WebKit bridge and inspect a connected
+device, build and run the Swift app in `snapo-app-mac`.
 
 ## Validation
 

--- a/snapo-network-inspector-web/src/App.tsx
+++ b/snapo-network-inspector-web/src/App.tsx
@@ -1,9 +1,73 @@
+import { useCallback, useEffect, useMemo, useState } from "react";
+import type { AppInspectorOption, InspectableApp, SelectedAppInspector } from "./network/bridge-types";
+import { createNetworkClient } from "./network/client";
 import { NetworkInspectorApp } from "./features/network-inspector/NetworkInspectorApp";
+import { TweaksInspectorApp } from "./features/tweaks-inspector/TweaksInspectorApp";
 
 export function App(): JSX.Element {
+  const client = useMemo(() => createNetworkClient(), []);
+  const [apps, setApps] = useState<InspectableApp[]>([]);
+  const [selection, setSelection] = useState<SelectedAppInspector | null>(null);
+
+  const selectInspector = useCallback((app: InspectableApp, option: AppInspectorOption) => {
+    setSelection({ appId: app.id, kind: option.kind, server: option.server });
+  }, []);
+
+  useEffect(() => {
+    let disposed = false;
+
+    const refresh = async () => {
+      try {
+        const discovered = await client.listInspectorApps();
+        if (disposed) return;
+
+        setApps(discovered);
+        setSelection((current) => {
+          if (
+            current &&
+            discovered.some(
+              (app) =>
+                app.id === current.appId &&
+                app.inspectors.some(
+                  (option) =>
+                    option.kind === current.kind &&
+                    option.server.deviceId === current.server.deviceId &&
+                    option.server.socketName === current.server.socketName
+                )
+            )
+          ) {
+            return current;
+          }
+
+          const app = discovered[0];
+          const option = app?.inspectors[0];
+          return app && option ? { appId: app.id, kind: option.kind, server: option.server } : null;
+        });
+      } catch {
+        if (!disposed) setApps([]);
+      }
+    };
+
+    void refresh();
+    const interval = window.setInterval(() => {
+      if (!document.hidden) void refresh();
+    }, 2_500);
+    const unsubscribe = client.onNativeSelectedInspector(setSelection);
+
+    return () => {
+      disposed = true;
+      window.clearInterval(interval);
+      unsubscribe();
+    };
+  }, [client]);
+
   return (
     <div className="window-frame">
-      <NetworkInspectorApp />
+      {selection?.kind === "tweaks" ? (
+        <TweaksInspectorApp client={client} apps={apps} selection={selection} onSelect={selectInspector} />
+      ) : (
+        <NetworkInspectorApp inspectorApps={apps} inspectorSelection={selection} onInspectorSelect={selectInspector} />
+      )}
     </div>
   );
 }

--- a/snapo-network-inspector-web/src/features/app-inspector/components/AppInspectorPicker.test.tsx
+++ b/snapo-network-inspector-web/src/features/app-inspector/components/AppInspectorPicker.test.tsx
@@ -1,7 +1,7 @@
 import { renderToStaticMarkup } from "react-dom/server";
 import { describe, expect, it, vi } from "vitest";
 import type { InspectableApp, SelectedAppInspector } from "../../../network/bridge-types";
-import { AppInspectorMenu } from "./AppInspectorPicker";
+import { AppInspectorMenu, AppInspectorPicker, AppInspectorViewPicker } from "./AppInspectorPicker";
 
 describe("app-first inspector menu", () => {
   it("shows an app once and includes only the inspectors it exposes", () => {
@@ -23,6 +23,35 @@ describe("app-first inspector menu", () => {
 
     expect(markup.match(/aria-checked="true"/g)).toHaveLength(1);
     expect(markup.match(/aria-checked="false"/g)).toHaveLength(2);
+  });
+
+  it("shows only the app name in the picker button", () => {
+    const markup = renderToStaticMarkup(<AppInspectorPicker apps={apps} selection={selection} onSelect={vi.fn()} />);
+
+    expect(markup).toContain('class="inspector-app-picker-name">ChatGPT</span>');
+    expect(markup).not.toContain("ChatGPT · Tweaks");
+    expect(markup).not.toContain("ChatGPT · Network");
+  });
+
+  it("shows a selectable icon group when an app exposes both inspectors", () => {
+    const markup = renderToStaticMarkup(
+      <AppInspectorViewPicker app={apps[0]} selection={selection} onSelect={vi.fn()} />
+    );
+
+    expect(markup).toContain('role="radiogroup"');
+    expect(markup.match(/class="inspector-app-segment"/g)).toHaveLength(2);
+    expect(markup).toMatch(/aria-label="Network" aria-checked="false"/);
+    expect(markup).toMatch(/aria-label="Tweaks" aria-checked="true"/);
+    expect(markup).not.toContain(">Network</button>");
+    expect(markup).not.toContain(">Tweaks</button>");
+  });
+
+  it("hides the icon group when only one inspector is available", () => {
+    const markup = renderToStaticMarkup(
+      <AppInspectorViewPicker app={apps[1]} selection={selection} onSelect={vi.fn()} />
+    );
+
+    expect(markup).toBe("");
   });
 });
 

--- a/snapo-network-inspector-web/src/features/app-inspector/components/AppInspectorPicker.test.tsx
+++ b/snapo-network-inspector-web/src/features/app-inspector/components/AppInspectorPicker.test.tsx
@@ -1,0 +1,55 @@
+import { renderToStaticMarkup } from "react-dom/server";
+import { describe, expect, it, vi } from "vitest";
+import type { InspectableApp, SelectedAppInspector } from "../../../network/bridge-types";
+import { AppInspectorMenu } from "./AppInspectorPicker";
+
+describe("app-first inspector menu", () => {
+  it("shows an app once and includes only the inspectors it exposes", () => {
+    const markup = renderToStaticMarkup(<AppInspectorMenu apps={apps} selection={selection} onSelect={vi.fn()} />);
+
+    expect(markup.match(/class="inspector-app-heading"/g)).toHaveLength(2);
+    expect(markup.match(/class="inspector-app-option"/g)).toHaveLength(3);
+    expect(markup).toContain("Pixel 9 Pro XL");
+    expect(markup).toContain("Android Emulator");
+    expect(markup).toContain('title="com.openai.chatgpt"');
+    expect(markup).toContain('aria-label="ChatGPT, Network, Pixel 9 Pro XL"');
+    expect(markup).toContain('aria-label="ChatGPT, Tweaks, Pixel 9 Pro XL"');
+    expect(markup).toContain('aria-label="Snap-O Tweaks Demo, Tweaks, Android Emulator"');
+    expect(markup).not.toContain('aria-label="Snap-O Tweaks Demo, Network');
+  });
+
+  it("checks only the selected app and inspector", () => {
+    const markup = renderToStaticMarkup(<AppInspectorMenu apps={apps} selection={selection} onSelect={vi.fn()} />);
+
+    expect(markup.match(/aria-checked="true"/g)).toHaveLength(1);
+    expect(markup.match(/aria-checked="false"/g)).toHaveLength(2);
+  });
+});
+
+const apps: InspectableApp[] = [
+  {
+    id: "pixel:com.openai.chatgpt",
+    name: "ChatGPT",
+    packageName: "com.openai.chatgpt",
+    deviceId: "pixel",
+    deviceDisplayTitle: "Pixel 9 Pro XL",
+    inspectors: [
+      { kind: "network", server: { deviceId: "pixel", socketName: "snapo_network_10" } },
+      { kind: "tweaks", server: { deviceId: "pixel", socketName: "snapo_tweaks_10" } }
+    ]
+  },
+  {
+    id: "emulator:com.openai.snapo.demo.tweaks",
+    name: "Snap-O Tweaks Demo",
+    packageName: "com.openai.snapo.demo.tweaks",
+    deviceId: "emulator",
+    deviceDisplayTitle: "Android Emulator",
+    inspectors: [{ kind: "tweaks", server: { deviceId: "emulator", socketName: "snapo_tweaks_20" } }]
+  }
+];
+
+const selection: SelectedAppInspector = {
+  appId: "pixel:com.openai.chatgpt",
+  kind: "tweaks",
+  server: { deviceId: "pixel", socketName: "snapo_tweaks_10" }
+};

--- a/snapo-network-inspector-web/src/features/app-inspector/components/AppInspectorPicker.tsx
+++ b/snapo-network-inspector-web/src/features/app-inspector/components/AppInspectorPicker.tsx
@@ -35,42 +35,79 @@ export function AppInspectorPicker({
   }, [expanded]);
 
   return (
-    <div className="inspector-app-select" ref={rootRef}>
-      <button
-        className="inspector-app-picker-button"
-        type="button"
-        aria-label="Select an app and inspector"
-        aria-haspopup="menu"
-        aria-expanded={expanded}
-        aria-controls={menuId}
-        disabled={apps.length === 0}
-        onClick={() => setExpanded((value) => !value)}
-      >
-        <AppIcon app={selectedApp} size={28} />
-        <span className="inspector-app-picker-text">
-          <span className="inspector-app-picker-name">
-            {selectedApp == null
-              ? "No Apps Found"
-              : `${selectedApp.name} · ${selection?.kind === "tweaks" ? "Tweaks" : "Network"}`}
+    <div className="inspector-app-toolbar">
+      <div className="inspector-app-select" ref={rootRef}>
+        <button
+          className="inspector-app-picker-button"
+          type="button"
+          aria-label="Select an app and inspector"
+          aria-haspopup="menu"
+          aria-expanded={expanded}
+          aria-controls={menuId}
+          disabled={apps.length === 0}
+          onClick={() => setExpanded((value) => !value)}
+        >
+          <AppIcon app={selectedApp} size={28} />
+          <span className="inspector-app-picker-text">
+            <span className="inspector-app-picker-name">{selectedApp?.name ?? "No Apps Found"}</span>
+            <span className="inspector-app-picker-device">
+              {selectedApp?.deviceDisplayTitle ?? "No devices detected"}
+            </span>
           </span>
-          <span className="inspector-app-picker-device">
-            {selectedApp?.deviceDisplayTitle ?? "No devices detected"}
-          </span>
-        </span>
-        <ChevronDown size={16} aria-hidden="true" />
-      </button>
+          <ChevronDown size={16} aria-hidden="true" />
+        </button>
 
-      {expanded ? (
-        <AppInspectorMenu
-          id={menuId}
-          apps={apps}
-          selection={selection}
-          onSelect={(app, option) => {
-            onSelect(app, option);
-            setExpanded(false);
-          }}
-        />
-      ) : null}
+        {expanded ? (
+          <AppInspectorMenu
+            id={menuId}
+            apps={apps}
+            selection={selection}
+            onSelect={(app, option) => {
+              onSelect(app, option);
+              setExpanded(false);
+            }}
+          />
+        ) : null}
+      </div>
+
+      {selectedApp ? <AppInspectorViewPicker app={selectedApp} selection={selection} onSelect={onSelect} /> : null}
+    </div>
+  );
+}
+
+export function AppInspectorViewPicker({
+  app,
+  selection,
+  onSelect
+}: {
+  app: InspectableApp;
+  selection: SelectedAppInspector | null;
+  onSelect(app: InspectableApp, option: AppInspectorOption): void;
+}): JSX.Element | null {
+  if (app.inspectors.length < 2) return null;
+
+  return (
+    <div className="inspector-app-segments" role="radiogroup" aria-label="Inspector">
+      {app.inspectors.map((option) => {
+        const selected = selection?.appId === app.id && selection.kind === option.kind;
+        const title = option.kind === "network" ? "Network" : "Tweaks";
+        const Icon = option.kind === "network" ? Network : SlidersHorizontal;
+
+        return (
+          <button
+            className="inspector-app-segment"
+            key={`${option.kind}:${option.server.socketName}`}
+            type="button"
+            role="radio"
+            aria-label={title}
+            aria-checked={selected}
+            title={title}
+            onClick={() => onSelect(app, option)}
+          >
+            <Icon size={16} aria-hidden="true" />
+          </button>
+        );
+      })}
     </div>
   );
 }

--- a/snapo-network-inspector-web/src/features/app-inspector/components/AppInspectorPicker.tsx
+++ b/snapo-network-inspector-web/src/features/app-inspector/components/AppInspectorPicker.tsx
@@ -1,0 +1,137 @@
+import { Check, ChevronDown, Network, SlidersHorizontal } from "lucide-react";
+import { useEffect, useId, useRef, useState } from "react";
+import type { AppInspectorOption, InspectableApp, SelectedAppInspector } from "../../../network/bridge-types";
+
+export function AppInspectorPicker({
+  apps,
+  selection,
+  onSelect
+}: {
+  apps: InspectableApp[];
+  selection: SelectedAppInspector | null;
+  onSelect(app: InspectableApp, option: AppInspectorOption): void;
+}): JSX.Element {
+  const [expanded, setExpanded] = useState(false);
+  const rootRef = useRef<HTMLDivElement>(null);
+  const menuId = useId();
+  const selectedApp = apps.find((app) => app.id === selection?.appId);
+
+  useEffect(() => {
+    if (!expanded) return;
+
+    const closeOnOutsidePointer = (event: PointerEvent) => {
+      if (!rootRef.current?.contains(event.target as Node)) setExpanded(false);
+    };
+    const closeOnEscape = (event: KeyboardEvent) => {
+      if (event.key === "Escape") setExpanded(false);
+    };
+
+    window.addEventListener("pointerdown", closeOnOutsidePointer);
+    window.addEventListener("keydown", closeOnEscape);
+    return () => {
+      window.removeEventListener("pointerdown", closeOnOutsidePointer);
+      window.removeEventListener("keydown", closeOnEscape);
+    };
+  }, [expanded]);
+
+  return (
+    <div className="inspector-app-select" ref={rootRef}>
+      <button
+        className="inspector-app-picker-button"
+        type="button"
+        aria-label="Select an app and inspector"
+        aria-haspopup="menu"
+        aria-expanded={expanded}
+        aria-controls={menuId}
+        disabled={apps.length === 0}
+        onClick={() => setExpanded((value) => !value)}
+      >
+        <AppIcon app={selectedApp} size={28} />
+        <span className="inspector-app-picker-text">
+          <span className="inspector-app-picker-name">
+            {selectedApp == null
+              ? "No Apps Found"
+              : `${selectedApp.name} · ${selection?.kind === "tweaks" ? "Tweaks" : "Network"}`}
+          </span>
+          <span className="inspector-app-picker-device">
+            {selectedApp?.deviceDisplayTitle ?? "No devices detected"}
+          </span>
+        </span>
+        <ChevronDown size={16} aria-hidden="true" />
+      </button>
+
+      {expanded ? (
+        <AppInspectorMenu
+          id={menuId}
+          apps={apps}
+          selection={selection}
+          onSelect={(app, option) => {
+            onSelect(app, option);
+            setExpanded(false);
+          }}
+        />
+      ) : null}
+    </div>
+  );
+}
+
+export function AppInspectorMenu({
+  id,
+  apps,
+  selection,
+  onSelect
+}: {
+  id?: string;
+  apps: InspectableApp[];
+  selection: SelectedAppInspector | null;
+  onSelect(app: InspectableApp, option: AppInspectorOption): void;
+}): JSX.Element {
+  return (
+    <div className="inspector-app-menu" id={id} role="menu" aria-label="Apps and inspectors">
+      {apps.map((app) => (
+        <div className="inspector-app-group" key={app.id}>
+          <div className="inspector-app-heading" title={app.packageName}>
+            <AppIcon app={app} size={16} />
+            <span className="inspector-app-heading-name">{app.name}</span>
+            <span className="inspector-app-heading-device">{app.deviceDisplayTitle}</span>
+          </div>
+
+          {app.inspectors.map((option) => {
+            const selected =
+              selection?.appId === app.id &&
+              selection.kind === option.kind &&
+              selection.server.deviceId === option.server.deviceId &&
+              selection.server.socketName === option.server.socketName;
+            const Icon = option.kind === "network" ? Network : SlidersHorizontal;
+            const title = option.kind === "network" ? "Network" : "Tweaks";
+
+            return (
+              <button
+                className="inspector-app-option"
+                data-selected={selected}
+                key={`${option.kind}:${option.server.socketName}`}
+                type="button"
+                role="menuitemradio"
+                aria-checked={selected}
+                aria-label={`${app.name}, ${title}, ${app.deviceDisplayTitle}`}
+                onClick={() => onSelect(app, option)}
+              >
+                <Icon size={16} aria-hidden="true" />
+                <span>{title}</span>
+                <Check className="inspector-app-option-check" size={15} aria-hidden="true" />
+              </button>
+            );
+          })}
+        </div>
+      ))}
+    </div>
+  );
+}
+
+function AppIcon({ app, size }: { app?: InspectableApp; size: number }): JSX.Element {
+  return (
+    <span className="inspector-app-icon" style={{ width: size, height: size }}>
+      {app?.appIconBase64 ? <img src={`data:image/png;base64,${app.appIconBase64}`} alt="" /> : null}
+    </span>
+  );
+}

--- a/snapo-network-inspector-web/src/features/network-inspector/NetworkInspectorApp.tsx
+++ b/snapo-network-inspector-web/src/features/network-inspector/NetworkInspectorApp.tsx
@@ -1,12 +1,22 @@
-import type { CSSProperties } from "react";
+import { useEffect, type CSSProperties } from "react";
+import type { AppInspectorOption, InspectableApp, SelectedAppInspector } from "../../network/bridge-types";
 import { DetailContent } from "./components/DetailPane";
 import { Sidebar } from "./components/Sidebar";
 import { useNetworkInspectorModel } from "./hooks/useNetworkInspectorModel";
 import { usePersistentSplitPane } from "./hooks/usePersistentSplitPane";
 import { useSearchHighlights } from "./hooks/useSearchHighlights";
 
-export function NetworkInspectorApp(): JSX.Element {
+export function NetworkInspectorApp({
+  inspectorApps = [],
+  inspectorSelection = null,
+  onInspectorSelect
+}: {
+  inspectorApps?: InspectableApp[];
+  inspectorSelection?: SelectedAppInspector | null;
+  onInspectorSelect?(app: InspectableApp, option: AppInspectorOption): void;
+}): JSX.Element {
   const model = useNetworkInspectorModel();
+  const { selectServer } = model;
   const {
     containerRef,
     sidebarWidth,
@@ -18,6 +28,11 @@ export function NetworkInspectorApp(): JSX.Element {
     resizeWithKeyboard
   } = usePersistentSplitPane();
   useSearchHighlights(containerRef, model.searchText);
+
+  useEffect(() => {
+    if (inspectorSelection?.kind !== "network") return;
+    selectServer(inspectorSelection.server);
+  }, [inspectorSelection, selectServer]);
 
   return (
     <div className="app-shell" ref={containerRef} style={{ "--sidebar-width": `${sidebarWidth}px` } as CSSProperties}>
@@ -36,6 +51,9 @@ export function NetworkInspectorApp(): JSX.Element {
         showsServerPicker={!model.client.usesNativeServerPicker}
         showsInlineToolbar={!model.client.usesNativeServerPicker}
         onServerChange={model.selectServer}
+        inspectorApps={inspectorApps}
+        inspectorSelection={inspectorSelection}
+        onInspectorSelect={onInspectorSelect}
         onReplacementServerClick={model.selectReplacementServer}
         onSearchTextChange={model.setSearchText}
         onToggleSortOrder={model.toggleSortOrder}

--- a/snapo-network-inspector-web/src/features/network-inspector/components/Sidebar.tsx
+++ b/snapo-network-inspector-web/src/features/network-inspector/components/Sidebar.tsx
@@ -2,7 +2,13 @@ import { RefreshCw, SortAsc, SortDesc, Trash2 } from "lucide-react";
 import { memo } from "react";
 import type { NetworkClient } from "../../../network/client";
 import type { InspectorRecord, ServerId } from "../../../network/cdp";
-import type { SnapOServer } from "../../../network/bridge-types";
+import type {
+  AppInspectorOption,
+  InspectableApp,
+  SelectedAppInspector,
+  SnapOServer
+} from "../../../network/bridge-types";
+import { AppInspectorPicker } from "../../app-inspector/components/AppInspectorPicker";
 import { serverHasProtocolWarning } from "../lib/protocol";
 import { RecordList } from "./RecordList";
 import { ServerSelect } from "./ServerPicker";
@@ -19,9 +25,12 @@ export const Sidebar = memo(function Sidebar({
   placeholder,
   selectedRecordId,
   client,
+  inspectorApps,
+  inspectorSelection,
   showsServerPicker,
   showsInlineToolbar,
   onServerChange,
+  onInspectorSelect,
   onReplacementServerClick,
   onSearchTextChange,
   onToggleSortOrder,
@@ -39,9 +48,12 @@ export const Sidebar = memo(function Sidebar({
   placeholder: string | null;
   selectedRecordId: string | null;
   client: NetworkClient;
+  inspectorApps?: InspectableApp[];
+  inspectorSelection?: SelectedAppInspector | null;
   showsServerPicker: boolean;
   showsInlineToolbar: boolean;
   onServerChange(server: ServerId | null): void;
+  onInspectorSelect?(app: InspectableApp, option: AppInspectorOption): void;
   onReplacementServerClick(server: SnapOServer): void;
   onSearchTextChange(value: string): void;
   onToggleSortOrder(): void;
@@ -56,7 +68,15 @@ export const Sidebar = memo(function Sidebar({
       {showsServerPicker || replacementServer != null ? (
         <div className="server-picker-frame">
           {showsServerPicker ? (
-            <ServerSelect servers={servers} selectedServer={selectedServer} onChange={onServerChange} />
+            inspectorApps && onInspectorSelect ? (
+              <AppInspectorPicker
+                apps={inspectorApps}
+                selection={inspectorSelection ?? null}
+                onSelect={onInspectorSelect}
+              />
+            ) : (
+              <ServerSelect servers={servers} selectedServer={selectedServer} onChange={onServerChange} />
+            )
           ) : null}
           {replacementServer == null ? null : (
             <button

--- a/snapo-network-inspector-web/src/features/tweaks-inspector/TweaksInspectorApp.test.ts
+++ b/snapo-network-inspector-web/src/features/tweaks-inspector/TweaksInspectorApp.test.ts
@@ -1,6 +1,26 @@
 import { describe, expect, it } from "vitest";
 import type { TweakDescriptor } from "../../network/bridge-types";
-import { canResetTweaks, groupTweaks, reconcileStreamedTweaks } from "./TweaksInspectorApp";
+import { canResetTweaks, groupTweaks, parseTweakColor, reconcileStreamedTweaks } from "./TweaksInspectorApp";
+
+describe("editable tweak colors", () => {
+  it("normalizes complete RGB colors", () => {
+    expect(parseTweakColor("#a1b2c3")).toBe("#A1B2C3");
+  });
+
+  it("normalizes complete RGBA colors", () => {
+    expect(parseTweakColor("#a1b2c380")).toBe("#A1B2C380");
+  });
+
+  it("does not commit an incomplete color while it is being edited", () => {
+    expect(parseTweakColor("#A1B2")).toBeNull();
+    expect(parseTweakColor("#A1B2C3F")).toBeNull();
+    expect(parseTweakColor("")).toBeNull();
+  });
+
+  it("rejects invalid hexadecimal digits", () => {
+    expect(parseTweakColor("#A1B2G3")).toBeNull();
+  });
+});
 
 describe("native reset toolbar state", () => {
   it("disables reset when no tweaks exist", () => {

--- a/snapo-network-inspector-web/src/features/tweaks-inspector/TweaksInspectorApp.test.ts
+++ b/snapo-network-inspector-web/src/features/tweaks-inspector/TweaksInspectorApp.test.ts
@@ -1,0 +1,68 @@
+import { describe, expect, it } from "vitest";
+import type { TweakDescriptor } from "../../network/bridge-types";
+import { groupTweaks } from "./TweaksInspectorApp";
+
+describe("stable tweak section columns", () => {
+  it("assigns sections alternately as they first appear", () => {
+    const ordering = new Map();
+    const columns = groupTweaks(
+      [tweak("Colors/Text"), tweak("Motion/Duration"), tweak("Typography/Font size")],
+      "pixel:chatgpt",
+      ordering
+    );
+
+    expect(columns.map((column) => column.map((section) => section.name))).toEqual([
+      ["Colors", "Typography"],
+      ["Motion"]
+    ]);
+  });
+
+  it("keeps sections in their original columns when another section disappears", () => {
+    const ordering = new Map();
+    const app = "pixel:chatgpt";
+
+    groupTweaks([tweak("Colors/Text"), tweak("Motion/Duration"), tweak("Typography/Font size")], app, ordering);
+
+    const columns = groupTweaks([tweak("Typography/Font size"), tweak("Colors/Text")], app, ordering);
+
+    expect(columns.map((column) => column.map((section) => section.name))).toEqual([["Colors", "Typography"], []]);
+  });
+
+  it("restores a returning section to its original column", () => {
+    const ordering = new Map();
+    const app = "pixel:chatgpt";
+
+    groupTweaks([tweak("Colors/Text"), tweak("Motion/Duration"), tweak("Typography/Font size")], app, ordering);
+    groupTweaks([tweak("Colors/Text"), tweak("Typography/Font size")], app, ordering);
+
+    const columns = groupTweaks(
+      [tweak("Motion/Duration"), tweak("Typography/Font size"), tweak("Colors/Text")],
+      app,
+      ordering
+    );
+
+    expect(columns.map((column) => column.map((section) => section.name))).toEqual([
+      ["Colors", "Typography"],
+      ["Motion"]
+    ]);
+  });
+
+  it("remembers section order independently for each app", () => {
+    const ordering = new Map();
+
+    groupTweaks([tweak("Colors/Text"), tweak("Motion/Duration")], "pixel:chatgpt", ordering);
+
+    const columns = groupTweaks([tweak("Motion/Duration"), tweak("Colors/Text")], "pixel:demo", ordering);
+
+    expect(columns.map((column) => column.map((section) => section.name))).toEqual([["Motion"], ["Colors"]]);
+  });
+});
+
+function tweak(name: string): TweakDescriptor {
+  return {
+    name,
+    type: "int",
+    default: 1,
+    value: 1
+  };
+}

--- a/snapo-network-inspector-web/src/features/tweaks-inspector/TweaksInspectorApp.test.ts
+++ b/snapo-network-inspector-web/src/features/tweaks-inspector/TweaksInspectorApp.test.ts
@@ -1,6 +1,45 @@
 import { describe, expect, it } from "vitest";
 import type { TweakDescriptor } from "../../network/bridge-types";
-import { groupTweaks } from "./TweaksInspectorApp";
+import { groupTweaks, reconcileStreamedTweaks } from "./TweaksInspectorApp";
+
+describe("streamed tweak snapshots", () => {
+  it("adds and removes a section in one update", () => {
+    const current = [tweak("Typography/Font size"), tweak("Motion/Duration")];
+    const incoming = [tweak("Typography/Font size"), tweak("Colors/Accent")];
+
+    expect(reconcileStreamedTweaks(current, incoming, new Map(), new Set())).toEqual(incoming);
+  });
+
+  it("applies values changed by the Android app", () => {
+    const current = [{ ...tweak("Motion/Duration"), value: 400 }];
+    const incoming = [{ ...tweak("Motion/Duration"), value: 550 }];
+
+    expect(reconcileStreamedTweaks(current, incoming, new Map(), new Set())).toEqual(incoming);
+  });
+
+  it("preserves a locally queued slider value", () => {
+    const current = [{ ...tweak("Motion/Duration"), value: 700 }];
+    const incoming = [{ ...tweak("Motion/Duration"), value: 550 }];
+
+    expect(reconcileStreamedTweaks(current, incoming, new Map([["Motion/Duration", 700]]), new Set())).toEqual(current);
+  });
+
+  it("preserves a slider value while its request is in flight", () => {
+    const current = [{ ...tweak("Motion/Duration"), value: 700 }];
+    const incoming = [{ ...tweak("Motion/Duration"), value: 550 }];
+
+    expect(reconcileStreamedTweaks(current, incoming, new Map(), new Set(["Motion/Duration"]))).toEqual(current);
+  });
+
+  it("preserves new descriptor metadata while keeping a pending local value", () => {
+    const current = [{ ...tweak("Motion/Duration"), value: 700 }];
+    const incoming: TweakDescriptor[] = [{ ...tweak("Motion/Duration"), value: 550, max: 1500 }];
+
+    expect(reconcileStreamedTweaks(current, incoming, new Map([["Motion/Duration", 700]]), new Set())).toEqual([
+      { ...incoming[0], value: 700 }
+    ]);
+  });
+});
 
 describe("stable tweak section columns", () => {
   it("assigns sections alternately as they first appear", () => {

--- a/snapo-network-inspector-web/src/features/tweaks-inspector/TweaksInspectorApp.test.ts
+++ b/snapo-network-inspector-web/src/features/tweaks-inspector/TweaksInspectorApp.test.ts
@@ -1,6 +1,27 @@
 import { describe, expect, it } from "vitest";
 import type { TweakDescriptor } from "../../network/bridge-types";
-import { groupTweaks, reconcileStreamedTweaks } from "./TweaksInspectorApp";
+import { canResetTweaks, groupTweaks, reconcileStreamedTweaks } from "./TweaksInspectorApp";
+
+describe("native reset toolbar state", () => {
+  it("disables reset when no tweaks exist", () => {
+    expect(canResetTweaks([])).toBe(false);
+  });
+
+  it("disables reset when all tweaks are at their defaults", () => {
+    expect(canResetTweaks([tweak("Typography/Font size"), tweak("Motion/Duration")])).toBe(false);
+  });
+
+  it("enables reset immediately when a tweak changes", () => {
+    expect(canResetTweaks([{ ...tweak("Typography/Font size"), value: 2 }])).toBe(true);
+  });
+
+  it("disables reset when every changed tweak returns to its default", () => {
+    const fontSize = tweak("Typography/Font size");
+
+    expect(canResetTweaks([{ ...fontSize, value: 2 }])).toBe(true);
+    expect(canResetTweaks([fontSize])).toBe(false);
+  });
+});
 
 describe("streamed tweak snapshots", () => {
   it("adds and removes a section in one update", () => {

--- a/snapo-network-inspector-web/src/features/tweaks-inspector/TweaksInspectorApp.tsx
+++ b/snapo-network-inspector-web/src/features/tweaks-inspector/TweaksInspectorApp.tsx
@@ -1,0 +1,350 @@
+import { RotateCcw } from "lucide-react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import type {
+  AppInspectorOption,
+  InspectableApp,
+  SelectedAppInspector,
+  TweakDescriptor,
+  TweakValue
+} from "../../network/bridge-types";
+import type { NetworkClient } from "../../network/client";
+import { AppInspectorPicker } from "../app-inspector/components/AppInspectorPicker";
+
+interface TweakSection {
+  name: string;
+  order: number;
+  tweaks: TweakDescriptor[];
+}
+
+interface TweakOrdering {
+  sections: Map<string, number>;
+  tweaks: Map<string, number>;
+}
+
+export function TweaksInspectorApp({
+  client,
+  apps,
+  selection,
+  onSelect
+}: {
+  client: NetworkClient;
+  apps: InspectableApp[];
+  selection: SelectedAppInspector;
+  onSelect(app: InspectableApp, option: AppInspectorOption): void;
+}): JSX.Element {
+  const [tweaks, setTweaks] = useState<TweakDescriptor[]>([]);
+  const [error, setError] = useState<string | null>(null);
+  const [saving, setSaving] = useState(false);
+  const pending = useRef(new Map<string, TweakValue>());
+  const savingRef = useRef(false);
+  const [orderByApp] = useState(() => new Map<string, TweakOrdering>());
+  const server = selection.server;
+
+  useEffect(() => {
+    let disposed = false;
+    pending.current.clear();
+
+    const reload = () => {
+      void client
+        .listTweaks(server)
+        .then((response) => {
+          if (disposed) return;
+          setTweaks(response.tweaks);
+          setError(null);
+        })
+        .catch((cause: unknown) => {
+          if (disposed) return;
+          setError(cause instanceof Error ? cause.message : "Unable to load tweaks.");
+        });
+    };
+
+    reload();
+
+    const interval = window.setInterval(() => {
+      if (!document.hidden) reload();
+    }, 2_500);
+
+    return () => {
+      disposed = true;
+      window.clearInterval(interval);
+    };
+  }, [client, server]);
+
+  const flush = useCallback(async () => {
+    if (savingRef.current || pending.current.size === 0) return;
+
+    savingRef.current = true;
+    setSaving(true);
+
+    try {
+      while (pending.current.size > 0) {
+        const values = Object.fromEntries(pending.current);
+        pending.current.clear();
+        const result = await client.updateTweaks({ server, values });
+
+        setTweaks((current) =>
+          current.map((tweak) => {
+            const update = result.tweaks.find((candidate) => candidate.name === tweak.name);
+            return update && !pending.current.has(tweak.name) ? { ...tweak, value: update.value } : tweak;
+          })
+        );
+      }
+      setError(null);
+    } catch (cause) {
+      pending.current.clear();
+      setError(cause instanceof Error ? cause.message : "Unable to update tweaks.");
+    } finally {
+      savingRef.current = false;
+      setSaving(false);
+    }
+  }, [client, server]);
+
+  const updateTweak = useCallback(
+    (tweak: TweakDescriptor, value: TweakValue) => {
+      setTweaks((current) => current.map((item) => (item.name === tweak.name ? { ...item, value } : item)));
+      pending.current.set(tweak.name, value);
+      void flush();
+    },
+    [flush]
+  );
+
+  const resetAll = useCallback(() => {
+    for (const tweak of tweaks) {
+      pending.current.set(tweak.name, tweak.default);
+    }
+    setTweaks((current) => current.map((tweak) => ({ ...tweak, value: tweak.default })));
+    void flush();
+  }, [flush, tweaks]);
+
+  useEffect(() => client.onNativeTweaksReset(resetAll), [client, resetAll]);
+
+  const sections = useMemo(
+    () => groupTweaks(tweaks, selection.appId, orderByApp),
+    [orderByApp, selection.appId, tweaks]
+  );
+  const hasChanges = tweaks.some((tweak) => tweak.value !== tweak.default);
+
+  return (
+    <main className="tweaks-inspector">
+      {!client.usesNativeServerPicker ? (
+        <header className="tweaks-inspector-toolbar">
+          <div className="tweaks-inspector-actions">
+            <button
+              className="tweaks-action"
+              type="button"
+              title="Reset all tweaks"
+              aria-label="Reset all tweaks"
+              disabled={!hasChanges || saving}
+              onClick={resetAll}
+            >
+              <RotateCcw size={16} aria-hidden="true" />
+            </button>
+          </div>
+          <AppInspectorPicker apps={apps} selection={selection} onSelect={onSelect} />
+        </header>
+      ) : null}
+
+      <div className="tweaks-inspector-content">
+        {error ? (
+          <p className="tweaks-error" role="alert">
+            {error}
+          </p>
+        ) : null}
+        <div className="tweaks-columns">
+          {sections.map((column, index) => (
+            <div className="tweaks-column" key={index}>
+              {column.map((section) => (
+                <section className="tweaks-section" key={section.name}>
+                  {section.name ? <h2>{section.name}</h2> : null}
+                  <div className="tweaks-section-list">
+                    {section.tweaks.map((tweak) => (
+                      <TweakControl key={tweak.name} tweak={tweak} onChange={updateTweak} />
+                    ))}
+                  </div>
+                </section>
+              ))}
+            </div>
+          ))}
+        </div>
+      </div>
+    </main>
+  );
+}
+
+export function groupTweaks(
+  tweaks: TweakDescriptor[],
+  appId: string,
+  saved: Map<string, TweakOrdering>
+): TweakSection[][] {
+  let ordering = saved.get(appId);
+  if (!ordering) {
+    ordering = { sections: new Map(), tweaks: new Map() };
+    saved.set(appId, ordering);
+  }
+
+  const active = new Map<string, TweakDescriptor[]>();
+
+  for (const tweak of tweaks) {
+    const name = tweakSection(tweak.name);
+    if (!ordering.sections.has(name)) ordering.sections.set(name, ordering.sections.size);
+    if (!ordering.tweaks.has(tweak.name)) ordering.tweaks.set(tweak.name, ordering.tweaks.size);
+    const items = active.get(name) ?? [];
+    items.push(tweak);
+    active.set(name, items);
+  }
+
+  const count = Math.min(2, ordering.sections.size);
+  const columns: TweakSection[][] = Array.from({ length: count }, () => []);
+
+  for (const [name, items] of active) {
+    const order = ordering.sections.get(name) ?? 0;
+    const section: TweakSection = {
+      name,
+      order,
+      tweaks: items.sort(
+        (left, right) => (ordering.tweaks.get(left.name) ?? 0) - (ordering.tweaks.get(right.name) ?? 0)
+      )
+    };
+    columns[order % count].push(section);
+  }
+
+  for (const column of columns) column.sort((left, right) => left.order - right.order);
+  return columns;
+}
+
+function tweakSection(name: string): string {
+  const separator = name.indexOf("/");
+  if (separator <= 0 || separator === name.length - 1) return "";
+  return name.slice(0, separator).trim();
+}
+
+function tweakLabel(name: string): string {
+  const section = tweakSection(name);
+  return section ? name.slice(name.indexOf("/") + 1).trim() : name;
+}
+
+function TweakControl({
+  tweak,
+  onChange
+}: {
+  tweak: TweakDescriptor;
+  onChange(tweak: TweakDescriptor, value: TweakValue): void;
+}): JSX.Element {
+  const label = tweakLabel(tweak.name);
+  const changed = tweak.value !== tweak.default;
+
+  return (
+    <div className="tweaks-control">
+      <div className="tweaks-control-line">
+        <span className="tweaks-control-label">{label}</span>
+        <TweakField tweak={tweak} onChange={onChange} />
+        {changed ? (
+          <button
+            className="tweaks-reset"
+            type="button"
+            aria-label={`Reset ${tweak.name}`}
+            onClick={() => onChange(tweak, tweak.default)}
+          >
+            Reset
+          </button>
+        ) : null}
+      </div>
+
+      {(tweak.type === "int" || tweak.type === "float") && tweak.min !== undefined && tweak.max !== undefined ? (
+        <input
+          className="tweaks-range"
+          type="range"
+          aria-label={tweak.name}
+          min={tweak.min}
+          max={tweak.max}
+          step={tweak.step ?? (tweak.type === "int" ? 1 : 0.01)}
+          value={Number(tweak.value)}
+          onChange={(event) => onChange(tweak, Number(event.currentTarget.value))}
+        />
+      ) : null}
+
+      {tweak.type === "string" ? (
+        <input
+          className="tweaks-string"
+          type="text"
+          aria-label={tweak.name}
+          value={String(tweak.value)}
+          onChange={(event) => onChange(tweak, event.currentTarget.value)}
+        />
+      ) : null}
+    </div>
+  );
+}
+
+function TweakField({
+  tweak,
+  onChange
+}: {
+  tweak: TweakDescriptor;
+  onChange(tweak: TweakDescriptor, value: TweakValue): void;
+}): JSX.Element | null {
+  if (tweak.type === "boolean") {
+    return (
+      <input
+        className="tweaks-checkbox"
+        type="checkbox"
+        aria-label={tweak.name}
+        checked={Boolean(tweak.value)}
+        onChange={(event) => onChange(tweak, event.currentTarget.checked)}
+      />
+    );
+  }
+
+  if (tweak.type === "color") {
+    return (
+      <span className="tweaks-color-fields">
+        <input
+          className="tweaks-color"
+          type="color"
+          aria-label={`${tweak.name} color`}
+          value={String(tweak.value).slice(0, 7)}
+          onChange={(event) => {
+            const previous = String(tweak.value);
+            const alpha = previous.length === 9 ? previous.slice(7) : "";
+            onChange(tweak, `${event.currentTarget.value.toUpperCase()}${alpha}`);
+          }}
+        />
+        <input
+          className="tweaks-hex"
+          type="text"
+          aria-label={`${tweak.name} hex`}
+          maxLength={9}
+          value={String(tweak.value)}
+          onChange={(event) => {
+            const value = event.currentTarget.value;
+            if (/^#[\da-f]{6}(?:[\da-f]{2})?$/i.test(value)) {
+              onChange(tweak, value.toUpperCase());
+            }
+          }}
+        />
+      </span>
+    );
+  }
+
+  if (tweak.type === "int" || tweak.type === "float") {
+    return (
+      <input
+        className="tweaks-number"
+        type="number"
+        aria-label={`${tweak.name} value`}
+        min={tweak.min}
+        max={tweak.max}
+        step={tweak.step ?? (tweak.type === "int" ? 1 : 0.01)}
+        value={Number(tweak.value)}
+        onChange={(event) => {
+          const value = Number(event.currentTarget.value);
+          if (event.currentTarget.validity.valid && Number.isFinite(value)) {
+            onChange(tweak, value);
+          }
+        }}
+      />
+    );
+  }
+
+  return null;
+}

--- a/snapo-network-inspector-web/src/features/tweaks-inspector/TweaksInspectorApp.tsx
+++ b/snapo-network-inspector-web/src/features/tweaks-inspector/TweaksInspectorApp.tsx
@@ -1,5 +1,5 @@
 import { RotateCcw } from "lucide-react";
-import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { useCallback, useEffect, useMemo, useState } from "react";
 import type {
   AppInspectorOption,
   InspectableApp,
@@ -9,6 +9,7 @@ import type {
 } from "../../network/bridge-types";
 import type { NetworkClient } from "../../network/client";
 import { AppInspectorPicker } from "../app-inspector/components/AppInspectorPicker";
+import { TweakUpdateQueue } from "./tweak-update-queue";
 
 interface TweakSection {
   name: string;
@@ -35,17 +36,28 @@ export function TweaksInspectorApp({
   const [tweaks, setTweaks] = useState<TweakDescriptor[]>([]);
   const [error, setError] = useState<string | null>(null);
   const [saving, setSaving] = useState(false);
-  const pending = useRef(new Map<string, TweakValue>());
-  const inFlight = useRef(new Set<string>());
-  const savingRef = useRef(false);
   const [orderByApp] = useState(() => new Map<string, TweakOrdering>());
   const server = selection.server;
+  const queue = useMemo(
+    () =>
+      new TweakUpdateQueue(client, server, {
+        onUpdate(updates, pending) {
+          setTweaks((current) =>
+            current.map((tweak) => {
+              const update = updates.find((candidate) => candidate.name === tweak.name);
+              return update && !pending.has(tweak.name) ? { ...tweak, value: update.value } : tweak;
+            })
+          );
+        },
+        onError: setError,
+        onSavingChange: setSaving
+      }),
+    [client, server]
+  );
 
   useEffect(() => {
     let disposed = false;
     let streamId: string | undefined;
-    pending.current.clear();
-    inFlight.current.clear();
 
     const unsubscribe = client.onTweaksChanged((event) => {
       if (
@@ -57,7 +69,7 @@ export function TweaksInspectorApp({
         return;
       }
 
-      setTweaks((current) => reconcileStreamedTweaks(current, event.tweaks, pending.current, inFlight.current));
+      setTweaks((current) => reconcileStreamedTweaks(current, event.tweaks, queue.pending, queue.inFlight));
       setError(null);
     });
 
@@ -65,7 +77,7 @@ export function TweaksInspectorApp({
       .listTweaks(server)
       .then((response) => {
         if (disposed) return;
-        setTweaks((current) => reconcileStreamedTweaks(current, response.tweaks, pending.current, inFlight.current));
+        setTweaks((current) => reconcileStreamedTweaks(current, response.tweaks, queue.pending, queue.inFlight));
         setError(null);
       })
       .catch((cause: unknown) => {
@@ -89,64 +101,28 @@ export function TweaksInspectorApp({
 
     return () => {
       disposed = true;
+      queue.cancel();
       unsubscribe();
       if (streamId !== undefined) void client.stopTweakStream(streamId);
     };
-  }, [client, server]);
-
-  const flush = useCallback(async () => {
-    if (savingRef.current || pending.current.size === 0) return;
-
-    savingRef.current = true;
-    setSaving(true);
-
-    try {
-      while (pending.current.size > 0) {
-        const values = Object.fromEntries(pending.current);
-        const names = Object.keys(values);
-        pending.current.clear();
-        for (const name of names) inFlight.current.add(name);
-
-        let result;
-        try {
-          result = await client.updateTweaks({ server, values });
-        } finally {
-          for (const name of names) inFlight.current.delete(name);
-        }
-
-        setTweaks((current) =>
-          current.map((tweak) => {
-            const update = result.tweaks.find((candidate) => candidate.name === tweak.name);
-            return update && !pending.current.has(tweak.name) ? { ...tweak, value: update.value } : tweak;
-          })
-        );
-      }
-      setError(null);
-    } catch (cause) {
-      pending.current.clear();
-      setError(cause instanceof Error ? cause.message : "Unable to update tweaks.");
-    } finally {
-      savingRef.current = false;
-      setSaving(false);
-    }
-  }, [client, server]);
+  }, [client, queue, server]);
 
   const updateTweak = useCallback(
     (tweak: TweakDescriptor, value: TweakValue) => {
       setTweaks((current) => current.map((item) => (item.name === tweak.name ? { ...item, value } : item)));
-      pending.current.set(tweak.name, value);
-      void flush();
+      queue.enqueue(tweak.name, value);
+      void queue.flush();
     },
-    [flush]
+    [queue]
   );
 
   const resetAll = useCallback(() => {
     for (const tweak of tweaks) {
-      pending.current.set(tweak.name, tweak.default);
+      queue.enqueue(tweak.name, tweak.default);
     }
     setTweaks((current) => current.map((tweak) => ({ ...tweak, value: tweak.default })));
-    void flush();
-  }, [flush, tweaks]);
+    void queue.flush();
+  }, [queue, tweaks]);
 
   useEffect(() => client.onNativeTweaksReset(resetAll), [client, resetAll]);
 
@@ -359,34 +335,7 @@ function TweakField({
   }
 
   if (tweak.type === "color") {
-    return (
-      <span className="tweaks-color-fields">
-        <input
-          className="tweaks-color"
-          type="color"
-          aria-label={`${tweak.name} color`}
-          value={String(tweak.value).slice(0, 7)}
-          onChange={(event) => {
-            const previous = String(tweak.value);
-            const alpha = previous.length === 9 ? previous.slice(7) : "";
-            onChange(tweak, `${event.currentTarget.value.toUpperCase()}${alpha}`);
-          }}
-        />
-        <input
-          className="tweaks-hex"
-          type="text"
-          aria-label={`${tweak.name} hex`}
-          maxLength={9}
-          value={String(tweak.value)}
-          onChange={(event) => {
-            const value = event.currentTarget.value;
-            if (/^#[\da-f]{6}(?:[\da-f]{2})?$/i.test(value)) {
-              onChange(tweak, value.toUpperCase());
-            }
-          }}
-        />
-      </span>
-    );
+    return <TweakColorField tweak={tweak} onChange={onChange} />;
   }
 
   if (tweak.type === "int" || tweak.type === "float") {
@@ -410,4 +359,52 @@ function TweakField({
   }
 
   return null;
+}
+
+function TweakColorField({
+  tweak,
+  onChange
+}: {
+  tweak: TweakDescriptor;
+  onChange(tweak: TweakDescriptor, value: TweakValue): void;
+}): JSX.Element {
+  const committed = String(tweak.value);
+  const [draft, setDraft] = useState(() => ({ committed, value: committed }));
+  const value = draft.committed === committed ? draft.value : committed;
+
+  return (
+    <span className="tweaks-color-fields">
+      <input
+        className="tweaks-color"
+        type="color"
+        aria-label={`${tweak.name} color`}
+        value={committed.slice(0, 7)}
+        onChange={(event) => {
+          const alpha = committed.length === 9 ? committed.slice(7) : "";
+          onChange(tweak, `${event.currentTarget.value.toUpperCase()}${alpha}`);
+        }}
+      />
+      <input
+        className="tweaks-hex"
+        type="text"
+        aria-label={`${tweak.name} hex`}
+        maxLength={9}
+        value={value}
+        onChange={(event) => {
+          const next = event.currentTarget.value;
+          setDraft({ committed, value: next });
+
+          const color = parseTweakColor(next);
+          if (color !== null) onChange(tweak, color);
+        }}
+        onBlur={() => {
+          if (parseTweakColor(value) === null) setDraft({ committed, value: committed });
+        }}
+      />
+    </span>
+  );
+}
+
+export function parseTweakColor(value: string): string | null {
+  return /^#[\da-f]{6}(?:[\da-f]{2})?$/i.test(value) ? value.toUpperCase() : null;
 }

--- a/snapo-network-inspector-web/src/features/tweaks-inspector/TweaksInspectorApp.tsx
+++ b/snapo-network-inspector-web/src/features/tweaks-inspector/TweaksInspectorApp.tsx
@@ -154,7 +154,14 @@ export function TweaksInspectorApp({
     () => groupTweaks(tweaks, selection.appId, orderByApp),
     [orderByApp, selection.appId, tweaks]
   );
-  const hasChanges = tweaks.some((tweak) => tweak.value !== tweak.default);
+  const hasChanges = canResetTweaks(tweaks);
+
+  useEffect(() => {
+    client.nativeTweaksStateChanged({
+      server,
+      hasResettableTweaks: hasChanges && !saving
+    });
+  }, [client, hasChanges, saving, server]);
 
   return (
     <main className="tweaks-inspector">
@@ -201,6 +208,10 @@ export function TweaksInspectorApp({
       </div>
     </main>
   );
+}
+
+export function canResetTweaks(tweaks: TweakDescriptor[]): boolean {
+  return tweaks.some((tweak) => tweak.value !== tweak.default);
 }
 
 export function reconcileStreamedTweaks(

--- a/snapo-network-inspector-web/src/features/tweaks-inspector/TweaksInspectorApp.tsx
+++ b/snapo-network-inspector-web/src/features/tweaks-inspector/TweaksInspectorApp.tsx
@@ -36,37 +36,61 @@ export function TweaksInspectorApp({
   const [error, setError] = useState<string | null>(null);
   const [saving, setSaving] = useState(false);
   const pending = useRef(new Map<string, TweakValue>());
+  const inFlight = useRef(new Set<string>());
   const savingRef = useRef(false);
   const [orderByApp] = useState(() => new Map<string, TweakOrdering>());
   const server = selection.server;
 
   useEffect(() => {
     let disposed = false;
+    let streamId: string | undefined;
     pending.current.clear();
+    inFlight.current.clear();
 
-    const reload = () => {
-      void client
-        .listTweaks(server)
-        .then((response) => {
-          if (disposed) return;
-          setTweaks(response.tweaks);
-          setError(null);
-        })
-        .catch((cause: unknown) => {
-          if (disposed) return;
-          setError(cause instanceof Error ? cause.message : "Unable to load tweaks.");
-        });
-    };
+    const unsubscribe = client.onTweaksChanged((event) => {
+      if (
+        disposed ||
+        event.server.deviceId !== server.deviceId ||
+        event.server.socketName !== server.socketName ||
+        (streamId !== undefined && event.streamId !== streamId)
+      ) {
+        return;
+      }
 
-    reload();
+      setTweaks((current) => reconcileStreamedTweaks(current, event.tweaks, pending.current, inFlight.current));
+      setError(null);
+    });
 
-    const interval = window.setInterval(() => {
-      if (!document.hidden) reload();
-    }, 2_500);
+    void client
+      .listTweaks(server)
+      .then((response) => {
+        if (disposed) return;
+        setTweaks((current) => reconcileStreamedTweaks(current, response.tweaks, pending.current, inFlight.current));
+        setError(null);
+      })
+      .catch((cause: unknown) => {
+        if (disposed) return;
+        setError(cause instanceof Error ? cause.message : "Unable to load tweaks.");
+      });
+
+    void client
+      .startTweakStream(server)
+      .then((started) => {
+        if (disposed) {
+          void client.stopTweakStream(started.streamId);
+          return;
+        }
+        streamId = started.streamId;
+      })
+      .catch((cause: unknown) => {
+        if (disposed) return;
+        setError(cause instanceof Error ? cause.message : "Unable to stream tweaks.");
+      });
 
     return () => {
       disposed = true;
-      window.clearInterval(interval);
+      unsubscribe();
+      if (streamId !== undefined) void client.stopTweakStream(streamId);
     };
   }, [client, server]);
 
@@ -79,8 +103,16 @@ export function TweaksInspectorApp({
     try {
       while (pending.current.size > 0) {
         const values = Object.fromEntries(pending.current);
+        const names = Object.keys(values);
         pending.current.clear();
-        const result = await client.updateTweaks({ server, values });
+        for (const name of names) inFlight.current.add(name);
+
+        let result;
+        try {
+          result = await client.updateTweaks({ server, values });
+        } finally {
+          for (const name of names) inFlight.current.delete(name);
+        }
 
         setTweaks((current) =>
           current.map((tweak) => {
@@ -171,6 +203,23 @@ export function TweaksInspectorApp({
   );
 }
 
+export function reconcileStreamedTweaks(
+  current: TweakDescriptor[],
+  incoming: TweakDescriptor[],
+  pending: ReadonlyMap<string, TweakValue>,
+  inFlight: ReadonlySet<string>
+): TweakDescriptor[] {
+  const currentByName = new Map(current.map((tweak) => [tweak.name, tweak]));
+
+  return incoming.map((tweak) => {
+    const existing = currentByName.get(tweak.name);
+    if (existing && (pending.has(tweak.name) || inFlight.has(tweak.name))) {
+      return { ...tweak, value: existing.value };
+    }
+    return tweak;
+  });
+}
+
 export function groupTweaks(
   tweaks: TweakDescriptor[],
   appId: string,
@@ -237,17 +286,20 @@ function TweakControl({
     <div className="tweaks-control">
       <div className="tweaks-control-line">
         <span className="tweaks-control-label">{label}</span>
-        <TweakField tweak={tweak} onChange={onChange} />
         {changed ? (
           <button
             className="tweaks-reset"
             type="button"
             aria-label={`Reset ${tweak.name}`}
+            title={`Reset ${label}`}
             onClick={() => onChange(tweak, tweak.default)}
           >
-            Reset
+            <RotateCcw size={13} aria-hidden="true" />
           </button>
         ) : null}
+        <span className="tweaks-control-field">
+          <TweakField tweak={tweak} onChange={onChange} />
+        </span>
       </div>
 
       {(tweak.type === "int" || tweak.type === "float") && tweak.min !== undefined && tweak.max !== undefined ? (

--- a/snapo-network-inspector-web/src/features/tweaks-inspector/tweak-update-queue.test.ts
+++ b/snapo-network-inspector-web/src/features/tweaks-inspector/tweak-update-queue.test.ts
@@ -1,0 +1,111 @@
+import { describe, expect, it, vi } from "vitest";
+import type { TweakUpdates } from "../../network/bridge-types";
+import { TweakUpdateQueue } from "./tweak-update-queue";
+
+describe("app-scoped tweak updates", () => {
+  it("never sends a second app's pending edits to the first app", async () => {
+    const firstRequest = deferred<TweakUpdates>();
+    const secondRequest = deferred<TweakUpdates>();
+    const client = {
+      updateTweaks: vi.fn().mockReturnValueOnce(firstRequest.promise).mockReturnValueOnce(secondRequest.promise)
+    };
+    const firstCallbacks = callbacks();
+    const secondCallbacks = callbacks();
+    const firstServer = { deviceId: "pixel", socketName: "snapo_tweaks_first" };
+    const secondServer = { deviceId: "pixel", socketName: "snapo_tweaks_second" };
+    const firstQueue = new TweakUpdateQueue(client, firstServer, firstCallbacks);
+    const secondQueue = new TweakUpdateQueue(client, secondServer, secondCallbacks);
+
+    firstQueue.enqueue("Typography/Font size", 24);
+    const firstFlush = firstQueue.flush();
+    firstQueue.cancel();
+
+    secondQueue.enqueue("Typography/Font size", 36);
+    const secondFlush = secondQueue.flush();
+
+    expect(client.updateTweaks).toHaveBeenNthCalledWith(1, {
+      server: firstServer,
+      values: { "Typography/Font size": 24 }
+    });
+    expect(client.updateTweaks).toHaveBeenNthCalledWith(2, {
+      server: secondServer,
+      values: { "Typography/Font size": 36 }
+    });
+
+    secondRequest.resolve({ tweaks: [{ name: "Typography/Font size", value: 36 }] });
+    await secondFlush;
+
+    firstRequest.resolve({ tweaks: [{ name: "Typography/Font size", value: 24 }] });
+    await firstFlush;
+
+    expect(client.updateTweaks).toHaveBeenCalledTimes(2);
+    expect(firstCallbacks.onUpdate).not.toHaveBeenCalled();
+    expect(secondCallbacks.onUpdate).toHaveBeenCalledOnce();
+  });
+
+  it("waits for the current request before sending coalesced slider updates", async () => {
+    const firstRequest = deferred<TweakUpdates>();
+    const secondRequest = deferred<TweakUpdates>();
+    const client = {
+      updateTweaks: vi.fn().mockReturnValueOnce(firstRequest.promise).mockReturnValueOnce(secondRequest.promise)
+    };
+    const server = { deviceId: "pixel", socketName: "snapo_tweaks_demo" };
+    const queue = new TweakUpdateQueue(client, server, callbacks());
+
+    queue.enqueue("Motion/Duration", 400);
+    const flush = queue.flush();
+    queue.enqueue("Motion/Duration", 450);
+    queue.enqueue("Motion/Duration", 500);
+    void queue.flush();
+
+    expect(client.updateTweaks).toHaveBeenCalledTimes(1);
+
+    firstRequest.resolve({ tweaks: [{ name: "Motion/Duration", value: 400 }] });
+    await vi.waitFor(() => {
+      expect(client.updateTweaks).toHaveBeenCalledTimes(2);
+    });
+
+    expect(client.updateTweaks).toHaveBeenNthCalledWith(2, {
+      server,
+      values: { "Motion/Duration": 500 }
+    });
+
+    secondRequest.resolve({ tweaks: [{ name: "Motion/Duration", value: 500 }] });
+    await flush;
+  });
+
+  it("does not report an old app's request failure after switching apps", async () => {
+    const request = deferred<TweakUpdates>();
+    const client = { updateTweaks: vi.fn().mockReturnValue(request.promise) };
+    const handlers = callbacks();
+    const queue = new TweakUpdateQueue(client, { deviceId: "pixel", socketName: "snapo_tweaks_first" }, handlers);
+
+    queue.enqueue("Motion/Duration", 400);
+    const flush = queue.flush();
+    queue.cancel();
+    request.reject(new Error("The previous app disconnected."));
+    await flush;
+
+    expect(handlers.onError).not.toHaveBeenCalled();
+    expect(handlers.onUpdate).not.toHaveBeenCalled();
+  });
+});
+
+function callbacks() {
+  return {
+    onUpdate: vi.fn(),
+    onError: vi.fn(),
+    onSavingChange: vi.fn()
+  };
+}
+
+function deferred<T>() {
+  let resolve!: (value: T) => void;
+  let reject!: (reason: Error) => void;
+  const promise = new Promise<T>((complete, fail) => {
+    resolve = complete;
+    reject = fail;
+  });
+
+  return { promise, resolve, reject };
+}

--- a/snapo-network-inspector-web/src/features/tweaks-inspector/tweak-update-queue.ts
+++ b/snapo-network-inspector-web/src/features/tweaks-inspector/tweak-update-queue.ts
@@ -1,0 +1,73 @@
+import type { InspectorServerReference, TweakUpdate, TweakValue } from "../../network/bridge-types";
+import type { NetworkClient } from "../../network/client";
+
+interface TweakUpdateQueueCallbacks {
+  onUpdate(tweaks: TweakUpdate[], pending: ReadonlyMap<string, TweakValue>): void;
+  onError(error: string | null): void;
+  onSavingChange(saving: boolean): void;
+}
+
+export class TweakUpdateQueue {
+  readonly pending = new Map<string, TweakValue>();
+  readonly inFlight = new Set<string>();
+
+  private saving = false;
+  private generation = 0;
+
+  constructor(
+    private readonly client: Pick<NetworkClient, "updateTweaks">,
+    private readonly server: InspectorServerReference,
+    private readonly callbacks: TweakUpdateQueueCallbacks
+  ) {}
+
+  enqueue(name: string, value: TweakValue): void {
+    this.pending.set(name, value);
+  }
+
+  cancel(): void {
+    this.generation += 1;
+    this.pending.clear();
+    this.inFlight.clear();
+  }
+
+  async flush(): Promise<void> {
+    if (this.saving || this.pending.size === 0) return;
+
+    const generation = this.generation;
+    this.saving = true;
+    this.callbacks.onSavingChange(true);
+
+    try {
+      while (generation === this.generation && this.pending.size > 0) {
+        const values = Object.fromEntries(this.pending);
+        const names = Object.keys(values);
+        this.pending.clear();
+        for (const name of names) this.inFlight.add(name);
+
+        let result;
+        try {
+          result = await this.client.updateTweaks({ server: this.server, values });
+        } finally {
+          for (const name of names) this.inFlight.delete(name);
+        }
+
+        if (generation !== this.generation) return;
+        this.callbacks.onUpdate(result.tweaks, this.pending);
+      }
+
+      if (generation === this.generation) this.callbacks.onError(null);
+    } catch (cause: unknown) {
+      if (generation !== this.generation) return;
+      this.pending.clear();
+      this.callbacks.onError(cause instanceof Error ? cause.message : "Unable to update tweaks.");
+    } finally {
+      this.saving = false;
+
+      if (generation === this.generation) {
+        this.callbacks.onSavingChange(false);
+      } else if (this.pending.size > 0) {
+        void this.flush();
+      }
+    }
+  }
+}

--- a/snapo-network-inspector-web/src/network/bridge-types.ts
+++ b/snapo-network-inspector-web/src/network/bridge-types.ts
@@ -60,6 +60,11 @@ export interface TweakList {
   tweaks: TweakDescriptor[];
 }
 
+export interface TweakStreamEvent extends TweakList {
+  streamId: string;
+  server: InspectorServerReference;
+}
+
 export interface TweakUpdate {
   name: string;
   value: TweakValue;

--- a/snapo-network-inspector-web/src/network/bridge-types.ts
+++ b/snapo-network-inspector-web/src/network/bridge-types.ts
@@ -16,6 +16,64 @@ export interface SnapOServer {
   appName?: string | null;
 }
 
+export type AppInspectorKind = "network" | "tweaks";
+
+export interface InspectorServerReference {
+  deviceId: string;
+  socketName: string;
+}
+
+export interface AppInspectorOption {
+  kind: AppInspectorKind;
+  server: InspectorServerReference;
+}
+
+export interface InspectableApp {
+  id: string;
+  name: string;
+  packageName: string;
+  deviceId: string;
+  deviceDisplayTitle: string;
+  appIconBase64?: string | null;
+  inspectors: AppInspectorOption[];
+}
+
+export interface SelectedAppInspector {
+  appId: string;
+  kind: AppInspectorKind;
+  server: InspectorServerReference;
+}
+
+export type TweakValue = boolean | number | string;
+
+export interface TweakDescriptor {
+  name: string;
+  type: "int" | "float" | "boolean" | "color" | "string";
+  default: TweakValue;
+  value: TweakValue;
+  min?: number;
+  max?: number;
+  step?: number;
+}
+
+export interface TweakList {
+  tweaks: TweakDescriptor[];
+}
+
+export interface TweakUpdate {
+  name: string;
+  value: TweakValue;
+}
+
+export interface TweakUpdates {
+  tweaks: TweakUpdate[];
+}
+
+export interface UpdateTweaksInput {
+  server: InspectorServerReference;
+  values: Record<string, TweakValue>;
+}
+
 export interface NativeInspectorState {
   servers: SnapOServer[];
   selectedServer: StartStreamInput | null;

--- a/snapo-network-inspector-web/src/network/bridge-types.ts
+++ b/snapo-network-inspector-web/src/network/bridge-types.ts
@@ -65,6 +65,11 @@ export interface TweakStreamEvent extends TweakList {
   server: InspectorServerReference;
 }
 
+export interface NativeTweaksState {
+  server: InspectorServerReference;
+  hasResettableTweaks: boolean;
+}
+
 export interface TweakUpdate {
   name: string;
   value: TweakValue;

--- a/snapo-network-inspector-web/src/network/client.ts
+++ b/snapo-network-inspector-web/src/network/client.ts
@@ -4,6 +4,7 @@ import type {
   InspectorServerReference,
   LoadBodiesInput,
   NativeInspectorState,
+  NativeTweaksState,
   RequestBodies,
   SaveFileInput,
   SaveFileResult,
@@ -42,6 +43,7 @@ export interface NetworkClient {
   selectedDeviceChanged(deviceId: string): void;
   onPreferredDevice(callback: (deviceId: string) => void): () => void;
   nativeInspectorStateChanged(state: NativeInspectorState): void;
+  nativeTweaksStateChanged(state: NativeTweaksState): void;
   onNativeSelectedServer(callback: (server: StartStreamInput) => void): () => void;
   onNativeSelectedInspector(callback: (selection: SelectedAppInspector) => void): () => void;
   onNativeTweaksReset(callback: () => void): () => void;
@@ -154,6 +156,10 @@ class WebKitNetworkClient implements NetworkClient {
 
   nativeInspectorStateChanged(state: NativeInspectorState): void {
     void this.invoke<void>("inspectorStateChanged", state);
+  }
+
+  nativeTweaksStateChanged(state: NativeTweaksState): void {
+    void this.invoke<void>("tweaksStateChanged", state);
   }
 
   onNativeSelectedServer(callback: (server: StartStreamInput) => void): () => void {
@@ -374,6 +380,10 @@ class HttpNetworkClient implements NetworkClient {
   }
 
   nativeInspectorStateChanged(state: NativeInspectorState): void {
+    void state;
+  }
+
+  nativeTweaksStateChanged(state: NativeTweaksState): void {
     void state;
   }
 

--- a/snapo-network-inspector-web/src/network/client.ts
+++ b/snapo-network-inspector-web/src/network/client.ts
@@ -1,21 +1,30 @@
 import type {
   DebugInspectorPreset,
+  InspectableApp,
+  InspectorServerReference,
   LoadBodiesInput,
   NativeInspectorState,
   RequestBodies,
   SaveFileInput,
   SaveFileResult,
+  SelectedAppInspector,
   SnapOServer,
   StartStreamInput,
   StreamEvent,
   StreamStarted,
-  StreamStatus
+  StreamStatus,
+  TweakList,
+  TweakUpdates,
+  UpdateTweaksInput
 } from "./bridge-types";
 
 export interface NetworkClient {
   readonly usesNativeServerPicker: boolean;
   appVersion(): Promise<string>;
+  listInspectorApps(): Promise<InspectableApp[]>;
   listServers(): Promise<SnapOServer[]>;
+  listTweaks(server: InspectorServerReference): Promise<TweakList>;
+  updateTweaks(input: UpdateTweaksInput): Promise<TweakUpdates>;
   loadBodies(input: LoadBodiesInput): Promise<RequestBodies>;
   startStream(input: StartStreamInput): Promise<StreamStarted>;
   stopStream(streamId: string): Promise<void>;
@@ -30,6 +39,8 @@ export interface NetworkClient {
   onPreferredDevice(callback: (deviceId: string) => void): () => void;
   nativeInspectorStateChanged(state: NativeInspectorState): void;
   onNativeSelectedServer(callback: (server: StartStreamInput) => void): () => void;
+  onNativeSelectedInspector(callback: (selection: SelectedAppInspector) => void): () => void;
+  onNativeTweaksReset(callback: () => void): () => void;
   onNativeSearchText(callback: (searchText: string) => void): () => void;
   onNativeSortOrder(callback: (sortNewestFirst: boolean) => void): () => void;
   onNativeClearCompleted(callback: () => void): () => void;
@@ -61,8 +72,20 @@ class WebKitNetworkClient implements NetworkClient {
     return this.invoke<string>("appVersion");
   }
 
+  listInspectorApps(): Promise<InspectableApp[]> {
+    return this.invoke<InspectableApp[]>("listInspectorApps");
+  }
+
   listServers(): Promise<SnapOServer[]> {
     return this.invoke<SnapOServer[]>("listServers");
+  }
+
+  listTweaks(server: InspectorServerReference): Promise<TweakList> {
+    return this.invoke<TweakList>("listTweaks", server);
+  }
+
+  updateTweaks(input: UpdateTweaksInput): Promise<TweakUpdates> {
+    return this.invoke<TweakUpdates>("updateTweaks", input);
   }
 
   loadBodies(input: LoadBodiesInput): Promise<RequestBodies> {
@@ -121,6 +144,14 @@ class WebKitNetworkClient implements NetworkClient {
     return listenWebKitEvent<StartStreamInput>("network:selected-server", callback);
   }
 
+  onNativeSelectedInspector(callback: (selection: SelectedAppInspector) => void): () => void {
+    return listenWebKitEvent<SelectedAppInspector>("inspector:selected", callback);
+  }
+
+  onNativeTweaksReset(callback: () => void): () => void {
+    return listenWebKitEvent<boolean>("tweaks:reset", () => callback());
+  }
+
   onNativeSearchText(callback: (searchText: string) => void): () => void {
     return listenWebKitEvent<string>("network:search-text", callback);
   }
@@ -169,8 +200,46 @@ class HttpNetworkClient implements NetworkClient {
     return "web";
   }
 
+  async listInspectorApps(): Promise<InspectableApp[]> {
+    try {
+      return await fetchJson<InspectableApp[]>("/api/inspector/apps");
+    } catch {
+      const servers = await this.listServers();
+      return servers.map((server) => ({
+        id: `${server.deviceId}:${server.packageName ?? server.displayName}`,
+        name: server.appName || server.displayName,
+        packageName: server.packageName ?? server.displayName,
+        deviceId: server.deviceId,
+        deviceDisplayTitle: server.deviceDisplayTitle,
+        appIconBase64: server.appIconBase64,
+        inspectors: [
+          {
+            kind: "network" as const,
+            server: { deviceId: server.deviceId, socketName: server.socketName }
+          }
+        ]
+      }));
+    }
+  }
+
   async listServers(): Promise<SnapOServer[]> {
     return fetchJson("/api/network/servers");
+  }
+
+  async listTweaks(server: InspectorServerReference): Promise<TweakList> {
+    return fetchJson("/api/inspector/tweaks", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(server)
+    });
+  }
+
+  async updateTweaks(input: UpdateTweaksInput): Promise<TweakUpdates> {
+    return fetchJson("/api/inspector/tweaks", {
+      method: "PATCH",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(input)
+    });
   }
 
   async loadBodies(input: LoadBodiesInput): Promise<RequestBodies> {
@@ -263,6 +332,16 @@ class HttpNetworkClient implements NetworkClient {
   }
 
   onNativeSelectedServer(callback: (server: StartStreamInput) => void): () => void {
+    void callback;
+    return () => {};
+  }
+
+  onNativeSelectedInspector(callback: (selection: SelectedAppInspector) => void): () => void {
+    void callback;
+    return () => {};
+  }
+
+  onNativeTweaksReset(callback: () => void): () => void {
     void callback;
     return () => {};
   }

--- a/snapo-network-inspector-web/src/network/client.ts
+++ b/snapo-network-inspector-web/src/network/client.ts
@@ -14,6 +14,7 @@ import type {
   StreamStarted,
   StreamStatus,
   TweakList,
+  TweakStreamEvent,
   TweakUpdates,
   UpdateTweaksInput
 } from "./bridge-types";
@@ -25,6 +26,9 @@ export interface NetworkClient {
   listServers(): Promise<SnapOServer[]>;
   listTweaks(server: InspectorServerReference): Promise<TweakList>;
   updateTweaks(input: UpdateTweaksInput): Promise<TweakUpdates>;
+  startTweakStream(server: InspectorServerReference): Promise<StreamStarted>;
+  stopTweakStream(streamId: string): Promise<void>;
+  onTweaksChanged(callback: (event: TweakStreamEvent) => void): () => void;
   loadBodies(input: LoadBodiesInput): Promise<RequestBodies>;
   startStream(input: StartStreamInput): Promise<StreamStarted>;
   stopStream(streamId: string): Promise<void>;
@@ -86,6 +90,18 @@ class WebKitNetworkClient implements NetworkClient {
 
   updateTweaks(input: UpdateTweaksInput): Promise<TweakUpdates> {
     return this.invoke<TweakUpdates>("updateTweaks", input);
+  }
+
+  startTweakStream(server: InspectorServerReference): Promise<StreamStarted> {
+    return this.invoke<StreamStarted>("startTweakStream", server);
+  }
+
+  stopTweakStream(streamId: string): Promise<void> {
+    return this.invoke<void>("stopTweakStream", { streamId });
+  }
+
+  onTweaksChanged(callback: (event: TweakStreamEvent) => void): () => void {
+    return listenWebKitEvent<TweakStreamEvent>("tweaks:changed", callback);
   }
 
   loadBodies(input: LoadBodiesInput): Promise<RequestBodies> {
@@ -195,6 +211,8 @@ class HttpNetworkClient implements NetworkClient {
   private eventSource: EventSource | null = null;
   private statusCallbacks = new Set<(status: StreamStatus) => void>();
   private eventCallbacks = new Set<(event: StreamEvent) => void>();
+  private tweakCallbacks = new Set<(event: TweakStreamEvent) => void>();
+  private tweakEventSources = new Map<string, EventSource>();
 
   async appVersion(): Promise<string> {
     return "web";
@@ -240,6 +258,34 @@ class HttpNetworkClient implements NetworkClient {
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify(input)
     });
+  }
+
+  async startTweakStream(server: InspectorServerReference): Promise<StreamStarted> {
+    const streamId = crypto.randomUUID();
+    const query = new URLSearchParams({
+      deviceId: server.deviceId,
+      socketName: server.socketName
+    });
+    const source = new EventSource(`/api/inspector/tweaks/events?${query.toString()}`);
+
+    source.addEventListener("tweaks", (event) => {
+      const payload = JSON.parse(event.data) as TweakList;
+      const update: TweakStreamEvent = { streamId, server, tweaks: payload.tweaks };
+      for (const callback of this.tweakCallbacks) callback(update);
+    });
+
+    this.tweakEventSources.set(streamId, source);
+    return { streamId };
+  }
+
+  async stopTweakStream(streamId: string): Promise<void> {
+    this.tweakEventSources.get(streamId)?.close();
+    this.tweakEventSources.delete(streamId);
+  }
+
+  onTweaksChanged(callback: (event: TweakStreamEvent) => void): () => void {
+    this.tweakCallbacks.add(callback);
+    return () => this.tweakCallbacks.delete(callback);
   }
 
   async loadBodies(input: LoadBodiesInput): Promise<RequestBodies> {

--- a/snapo-network-inspector-web/src/styles.css
+++ b/snapo-network-inspector-web/src/styles.css
@@ -1385,7 +1385,12 @@ pre {
 }
 
 .tweaks-reset {
-  margin-left: auto;
+  display: inline-flex;
+  width: 20px;
+  height: 20px;
+  align-items: center;
+  justify-content: center;
+  padding: 0;
 }
 
 .tweaks-action:disabled {
@@ -1458,6 +1463,14 @@ pre {
   font-size: 12px;
   text-overflow: ellipsis;
   white-space: nowrap;
+}
+
+.tweaks-control-field {
+  display: flex;
+  min-width: 0;
+  align-items: center;
+  justify-content: flex-end;
+  margin-left: auto;
 }
 
 .tweaks-number,

--- a/snapo-network-inspector-web/src/styles.css
+++ b/snapo-network-inspector-web/src/styles.css
@@ -1185,3 +1185,299 @@ pre {
 .text-button:hover {
   background: var(--surface-container-low);
 }
+
+.inspector-app-select {
+  position: relative;
+  width: min(100%, 280px);
+}
+
+.inspector-app-picker-button {
+  display: flex;
+  width: 100%;
+  min-height: 48px;
+  align-items: center;
+  gap: 10px;
+  border: 1px solid var(--outline);
+  background: var(--surface-bright);
+  padding: 7px 10px;
+  text-align: left;
+}
+
+.inspector-app-picker-text {
+  display: grid;
+  min-width: 0;
+  flex: 1;
+  gap: 1px;
+}
+
+.inspector-app-picker-name,
+.inspector-app-picker-device,
+.inspector-app-heading-name,
+.inspector-app-heading-device {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.inspector-app-picker-name {
+  font-size: 12px;
+  font-weight: 500;
+  line-height: 16px;
+}
+
+.inspector-app-picker-device {
+  color: var(--on-surface-variant);
+  font-size: 11px;
+  line-height: 15px;
+}
+
+.inspector-app-icon {
+  display: block;
+  flex: none;
+  overflow: hidden;
+  border-radius: 4px;
+  background: var(--surface-container-high);
+}
+
+.inspector-app-icon img {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+}
+
+.inspector-app-menu {
+  position: absolute;
+  z-index: 20;
+  top: 100%;
+  left: 0;
+  width: min(320px, calc(100vw - 24px));
+  max-height: 320px;
+  overflow-y: auto;
+  border: 1px solid var(--outline);
+  background: var(--surface-bright);
+  padding: 4px;
+}
+
+.inspector-app-group + .inspector-app-group {
+  border-top: 1px solid var(--outline-variant);
+  margin-top: 4px;
+  padding-top: 4px;
+}
+
+.inspector-app-heading {
+  display: flex;
+  height: 30px;
+  align-items: center;
+  gap: 8px;
+  padding: 0 7px;
+}
+
+.inspector-app-heading-name {
+  min-width: 0;
+  font-size: 11px;
+  font-weight: 500;
+  line-height: 16px;
+}
+
+.inspector-app-heading-device {
+  min-width: 0;
+  margin-left: auto;
+  color: var(--on-surface-variant);
+  font-size: 10px;
+  line-height: 16px;
+}
+
+.inspector-app-option {
+  display: flex;
+  width: 100%;
+  height: 38px;
+  align-items: center;
+  gap: 9px;
+  border: 0;
+  border-radius: 4px;
+  background: transparent;
+  padding: 0 8px 0 24px;
+  color: var(--on-surface);
+  text-align: left;
+  font-size: 12px;
+}
+
+.inspector-app-option:hover,
+.inspector-app-option:focus-visible,
+.inspector-app-option[data-selected="true"] {
+  background: color-mix(in srgb, var(--on-surface) 7%, transparent);
+}
+
+.inspector-app-option-check {
+  margin-left: auto;
+  opacity: 0;
+}
+
+.inspector-app-option[data-selected="true"] .inspector-app-option-check {
+  opacity: 1;
+}
+
+.tweaks-inspector {
+  display: grid;
+  min-width: 0;
+  min-height: 0;
+  grid-template-rows: auto minmax(0, 1fr);
+  overflow: hidden;
+  background: var(--surface-bright);
+}
+
+.tweaks-inspector-toolbar {
+  display: flex;
+  min-height: 64px;
+  align-items: center;
+  gap: 8px;
+  border-bottom: 1px solid var(--outline-variant);
+  padding: 7px 12px;
+}
+
+.tweaks-inspector-actions {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+}
+
+.tweaks-action,
+.tweaks-reset {
+  border: 0;
+  background: transparent;
+  padding: 5px 0;
+  color: var(--on-surface-variant);
+  font-size: 11px;
+}
+
+.tweaks-reset {
+  margin-left: auto;
+}
+
+.tweaks-action:disabled {
+  opacity: 0.5;
+}
+
+.tweaks-action:hover:not(:disabled),
+.tweaks-reset:hover {
+  color: var(--on-surface);
+}
+
+.tweaks-inspector-content {
+  width: min(100%, 1040px);
+  min-height: 0;
+  overflow-y: auto;
+  margin-inline: auto;
+  padding: 20px clamp(18px, 4vw, 36px) 48px;
+}
+
+.tweaks-error {
+  margin: 0 0 14px;
+  color: var(--error);
+  font-size: 12px;
+}
+
+.tweaks-columns {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(min(100%, 320px), 1fr));
+  align-items: start;
+  gap: 0 44px;
+}
+
+.tweaks-column {
+  display: grid;
+  min-width: 0;
+  align-content: start;
+}
+
+.tweaks-section {
+  padding-block: 14px 22px;
+}
+
+.tweaks-section h2 {
+  margin: 0 0 14px;
+  font-size: 12px;
+  font-weight: 560;
+  line-height: 16px;
+}
+
+.tweaks-section-list {
+  display: grid;
+  gap: 14px;
+}
+
+.tweaks-control {
+  display: grid;
+  gap: 7px;
+}
+
+.tweaks-control-line {
+  display: flex;
+  min-height: 27px;
+  align-items: center;
+  gap: 9px;
+}
+
+.tweaks-control-label {
+  min-width: 0;
+  overflow: hidden;
+  font-size: 12px;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.tweaks-number,
+.tweaks-hex,
+.tweaks-string {
+  min-width: 0;
+  border: 1px solid transparent;
+  border-radius: 4px;
+  background: var(--surface-container-high);
+  padding: 5px 8px;
+  color: var(--on-surface);
+  font-size: 11px;
+  font-variant-numeric: tabular-nums;
+}
+
+.tweaks-number {
+  width: 60px;
+  text-align: right;
+}
+
+.tweaks-hex {
+  width: 88px;
+  text-transform: uppercase;
+}
+
+.tweaks-string {
+  width: 100%;
+  min-height: 32px;
+}
+
+.tweaks-range {
+  width: 100%;
+  height: 17px;
+  margin: 0;
+  accent-color: var(--on-surface);
+}
+
+.tweaks-checkbox {
+  width: 16px;
+  height: 16px;
+  margin: 0;
+  accent-color: var(--on-surface);
+}
+
+.tweaks-color-fields {
+  display: flex;
+  align-items: center;
+  gap: 7px;
+}
+
+.tweaks-color {
+  width: 26px;
+  height: 26px;
+  border: 1px solid var(--outline-variant);
+  border-radius: 4px;
+  padding: 2px;
+}

--- a/snapo-network-inspector-web/src/styles.css
+++ b/snapo-network-inspector-web/src/styles.css
@@ -1186,9 +1186,18 @@ pre {
   background: var(--surface-container-low);
 }
 
+.inspector-app-toolbar {
+  display: flex;
+  min-width: 0;
+  align-items: center;
+  gap: 8px;
+}
+
 .inspector-app-select {
   position: relative;
   width: min(100%, 280px);
+  min-width: 0;
+  flex: 0 1 280px;
 }
 
 .inspector-app-picker-button {
@@ -1243,6 +1252,31 @@ pre {
   width: 100%;
   height: 100%;
   object-fit: cover;
+}
+
+.inspector-app-segments {
+  display: flex;
+  flex: none;
+  align-items: center;
+  border: 1px solid var(--outline-variant);
+  border-radius: 16px;
+  background: var(--surface-bright);
+  padding: 2px 4px;
+}
+
+.inspector-app-segment {
+  display: grid;
+  width: 30px;
+  height: 28px;
+  place-items: center;
+  border: 0;
+  background: transparent;
+  padding: 0;
+  color: var(--on-surface-variant);
+}
+
+.inspector-app-segment[aria-checked="true"] {
+  color: var(--accent-blue);
 }
 
 .inspector-app-menu {


### PR DESCRIPTION
Allows automatic inspection and editing of Tweaks if an app defines them.

The Network Inspector now becomes an App Inspector, where you can select from different inspectors for any app.

This also includes a new "live stream" of tweak events, via a new SSE endpoint.

## Validation

- Android Tweaks unit tests, Detekt, and Android lint.
- Debug and minified release sample builds.
- 59 App Inspector web tests.
- 40 sample panel tests.
- Signed macOS app build, SwiftLint, SwiftFormat, TypeScript, ESLint, Stylelint, and Prettier.