### PR TITLE
Fix request capture when a request body can close its sink

### DIFF
--- a/snapo-link-android/network-okhttp3/src/main/java/com/openai/snapo/network/okhttp3/SnapOOkHttpInterceptor.kt
+++ b/snapo-link-android/network-okhttp3/src/main/java/com/openai/snapo/network/okhttp3/SnapOOkHttpInterceptor.kt
@@ -367,7 +367,9 @@ internal class CapturingRequestBody(
         val buffered = capturingSink.buffer()
         try {
             delegate.writeTo(buffered)
-            buffered.emit()
+            if (buffered.isOpen) {
+                buffered.emit()
+            }
         } finally {
             val snapshot = capture.snapshot()
             val completedCapture = RequestBodyCapture(

--- a/snapo-link-android/network-okhttp3/src/test/java/com/openai/snapo/network/okhttp3/BodyCaptureTest.kt
+++ b/snapo-link-android/network-okhttp3/src/test/java/com/openai/snapo/network/okhttp3/BodyCaptureTest.kt
@@ -62,6 +62,31 @@ class BodyCaptureTest {
     }
 
     @Test
+    fun `request capture succeeds when the request body closes its sink`() {
+        val delegate = object : RequestBody() {
+            override fun contentType(): MediaType? = null
+
+            override fun writeTo(sink: BufferedSink) {
+                sink.writeUtf8("request body")
+                sink.close()
+            }
+        }
+        var capture: RequestBodyCapture? = null
+        val body = CapturingRequestBody(delegate = delegate, maxBytes = 4) { value ->
+            capture = value
+        }
+        val sink = Buffer()
+
+        body.writeTo(sink)
+
+        assertEquals("request body", sink.readUtf8())
+        val captured = checkNotNull(capture)
+        assertArrayEquals("requ".encodeToByteArray(), captured.body)
+        assertEquals(12L, captured.totalBytes)
+        assertEquals(8L, captured.truncatedBytes)
+    }
+
+    @Test
     fun `request observer failure cannot break the network write`() {
         val sink = Buffer()
         val body = CapturingRequestBody(CountingRequestBody("request body"), maxBytes = 4) {


### PR DESCRIPTION
## Summary

A request body can close its sink in `writeTo()`. The next call to `emit()` can then fail with `IllegalStateException: closed`.

- Call `emit()` only when `buffered.isOpen`.
- Add a test in which a request body can write to and close its sink.
- Keep the request body and its capture correct.
- The test does not pass before the fix. It does pass after the fix.

## Testing

- `./gradlew :network-okhttp3:testDebugUnitTest`
- `./gradlew :network-okhttp3:assembleDebug :samples:demo-ktor-okhttp:assembleDebug`
