### PR TITLE
Fix app picker popover resizing

### DIFF
--- a/snapo-app-mac/Snap-O/NetworkInspector/NetworkInspectorServerPicker.swift
+++ b/snapo-app-mac/Snap-O/NetworkInspector/NetworkInspectorServerPicker.swift
@@ -119,6 +119,7 @@ private struct AppInspectorPickerPopover: View {
           .padding(6)
         }
         .frame(maxHeight: 320)
+        .fixedSize(horizontal: false, vertical: true)
       }
     }
     .frame(width: 320)


### PR DESCRIPTION
## Summary
- Let the app picker popover size its scroll view to the actual list content while preserving the existing 320-point maximum height.
- Resize an already-open dropdown as available apps and inspectors appear, disappear, or change.

## Root cause
The vertical scroll view accepted the popover's existing proposed height, so a dropdown opened in its short empty state remained constrained after apps populated. Applying the vertical fixed-size modifier after the maximum-height frame lets SwiftUI report the content's intrinsic height without manual measurement or additional state.

## Validation
- `xcodebuild -project Snap-O.xcodeproj -scheme Snap-O -derivedDataPath /private/tmp/snap-o-b57f-picker-derived CODE_SIGNING_ALLOWED=NO CODE_SIGNING_REQUIRED=NO build`
- `swift test --disable-sandbox --scratch-path /private/tmp/snapo-device-client-regression-tests` — 19 tests passed.
- Verified a single observed macOS hosting controller resizes through empty, populated, 320-point capped, shrinking, and empty-again states.