### PR TITLE
Fix live preview frame flushing

### DIFF
--- a/snapo-app-mac/Snap-O/LivePreview/H264StreamDecoder.swift
+++ b/snapo-app-mac/Snap-O/LivePreview/H264StreamDecoder.swift
@@ -4,8 +4,9 @@ import VideoToolbox
 /// Decodes the live-preview H.264 byte stream into displayable samples.
 final class H264StreamDecoder: @unchecked Sendable {
   private static let frameIdleTimeout: DispatchTimeInterval = .milliseconds(50)
+  private static let startCode = Data([0, 0, 1])
 
-  private let onSample: (CMSampleBuffer) -> Void
+  private let onSample: (CMSampleBuffer, Bool) -> Void
   private let onFormat: (CMVideoFormatDescription) -> Void
   private let processingQueue = DispatchQueue(label: "com.openai.snapo.live-preview.h264-decoder")
 
@@ -20,7 +21,7 @@ final class H264StreamDecoder: @unchecked Sendable {
 
   init(
     frameRate: Int32 = 30,
-    onSampleBuffer: @escaping (CMSampleBuffer) -> Void,
+    onSampleBuffer: @escaping (CMSampleBuffer, Bool) -> Void,
     formatHandler: @escaping (CMVideoFormatDescription) -> Void
   ) {
     onSample = onSampleBuffer
@@ -58,10 +59,10 @@ final class H264StreamDecoder: @unchecked Sendable {
   }
 
   private func flushPendingNAL() {
-    let startCode = Data([0, 0, 0, 1])
+    let startCode = Self.startCode
     guard buffer.starts(with: startCode), buffer.count > startCode.count else { return }
 
-    let nal = Data(buffer.dropFirst(startCode.count))
+    let nal = normalizedNAL(Data(buffer.dropFirst(startCode.count)))
     guard let firstByte = nal.first else { return }
     let type = firstByte & 0x1F
     guard type == 1 || type == 5,
@@ -72,7 +73,7 @@ final class H264StreamDecoder: @unchecked Sendable {
   }
 
   private func parseBuffer() {
-    let startCode = Data([0, 0, 0, 1])
+    let startCode = Self.startCode
 
     while true {
       guard let startRange = buffer.range(of: startCode) else {
@@ -86,18 +87,27 @@ final class H264StreamDecoder: @unchecked Sendable {
         buffer.removeSubrange(0 ..< startRange.lowerBound)
       }
 
-      guard let nextRange = buffer.range(of: startCode, options: [], in: startRange.upperBound ..< buffer.endIndex) else {
+      let nalStart = buffer.index(buffer.startIndex, offsetBy: startCode.count)
+      guard let nextRange = buffer.range(of: startCode, options: [], in: nalStart ..< buffer.endIndex) else {
         // incomplete NAL, wait for more data
         return
       }
 
-      let nalData = buffer[startRange.upperBound ..< nextRange.lowerBound]
-      if flushedNALByteCount != nalData.count {
-        handleNAL(Data(nalData))
+      let nal = normalizedNAL(Data(buffer[nalStart ..< nextRange.lowerBound]))
+      if flushedNALByteCount != nal.count {
+        handleNAL(nal)
       }
       flushedNALByteCount = nil
       buffer.removeSubrange(0 ..< nextRange.lowerBound)
     }
+  }
+
+  private func normalizedNAL(_ nal: Data) -> Data {
+    var nal = nal
+    while nal.last == 0 {
+      nal.removeLast()
+    }
+    return nal
   }
 
   private func handleNAL(_ nal: Data) {
@@ -120,7 +130,7 @@ final class H264StreamDecoder: @unchecked Sendable {
       }
       nalUnits.append(nal)
       if let sample = makeSampleBuffer(from: nalUnits, format: formatDescription, isIDR: type == 5) {
-        onSample(sample)
+        onSample(sample, type == 5)
       }
     default:
       break
@@ -211,13 +221,15 @@ final class H264StreamDecoder: @unchecked Sendable {
     )
     guard status == noErr, let sampleBuffer else { return nil }
 
-    if isIDR,
-       let attachments = CMSampleBufferGetSampleAttachmentsArray(sampleBuffer, createIfNecessary: true) {
+    if let attachments = CMSampleBufferGetSampleAttachmentsArray(sampleBuffer, createIfNecessary: true) {
       let attachment = unsafeBitCast(CFArrayGetValueAtIndex(attachments, 0), to: CFMutableDictionary.self)
+      let notSync = isIDR
+        ? Unmanaged.passUnretained(kCFBooleanFalse).toOpaque()
+        : Unmanaged.passUnretained(kCFBooleanTrue).toOpaque()
       CFDictionarySetValue(
         attachment,
         Unmanaged.passUnretained(kCMSampleAttachmentKey_NotSync).toOpaque(),
-        Unmanaged.passUnretained(kCFBooleanFalse).toOpaque()
+        notSync
       )
     }
 

--- a/snapo-app-mac/Snap-O/LivePreview/H264StreamDecoder.swift
+++ b/snapo-app-mac/Snap-O/LivePreview/H264StreamDecoder.swift
@@ -16,6 +16,7 @@ final class H264StreamDecoder: @unchecked Sendable {
   private var frameIndex: Int64 = 0
   private let timescale: Int32
   private var pendingFrameFlush: DispatchWorkItem?
+  private var flushedNALByteCount: Int?
 
   init(
     frameRate: Int32 = 30,
@@ -63,9 +64,10 @@ final class H264StreamDecoder: @unchecked Sendable {
     let nal = Data(buffer.dropFirst(startCode.count))
     guard let firstByte = nal.first else { return }
     let type = firstByte & 0x1F
-    guard type == 1 || type == 5 else { return }
+    guard type == 1 || type == 5,
+          flushedNALByteCount != nal.count else { return }
 
-    buffer.removeAll(keepingCapacity: true)
+    flushedNALByteCount = nal.count
     handleNAL(nal)
   }
 
@@ -90,7 +92,10 @@ final class H264StreamDecoder: @unchecked Sendable {
       }
 
       let nalData = buffer[startRange.upperBound ..< nextRange.lowerBound]
-      handleNAL(Data(nalData))
+      if flushedNALByteCount != nalData.count {
+        handleNAL(Data(nalData))
+      }
+      flushedNALByteCount = nil
       buffer.removeSubrange(0 ..< nextRange.lowerBound)
     }
   }

--- a/snapo-app-mac/Snap-O/LivePreview/H264StreamDecoder.swift
+++ b/snapo-app-mac/Snap-O/LivePreview/H264StreamDecoder.swift
@@ -2,9 +2,12 @@
 import VideoToolbox
 
 /// Decodes the live-preview H.264 byte stream into displayable samples.
-final class H264StreamDecoder {
+final class H264StreamDecoder: @unchecked Sendable {
+  private static let frameIdleTimeout: DispatchTimeInterval = .milliseconds(50)
+
   private let onSample: (CMSampleBuffer) -> Void
   private let onFormat: (CMVideoFormatDescription) -> Void
+  private let processingQueue = DispatchQueue(label: "com.openai.snapo.live-preview.h264-decoder")
 
   private var buffer = Data()
   private var sps: Data?
@@ -12,6 +15,7 @@ final class H264StreamDecoder {
   private var formatDescription: CMVideoFormatDescription?
   private var frameIndex: Int64 = 0
   private let timescale: Int32
+  private var pendingFrameFlush: DispatchWorkItem?
 
   init(
     frameRate: Int32 = 30,
@@ -24,11 +28,46 @@ final class H264StreamDecoder {
   }
 
   func append(_ data: Data) {
-    buffer.append(data)
-    parseBuffer()
+    processingQueue.sync {
+      buffer.append(data)
+      parseBuffer()
+      schedulePendingFrameFlush()
+    }
+  }
+
+  func finish() {
+    processingQueue.sync {
+      pendingFrameFlush?.cancel()
+      pendingFrameFlush = nil
+      flushPendingNAL()
+    }
   }
 
   // MARK: - Parsing
+
+  private func schedulePendingFrameFlush() {
+    pendingFrameFlush?.cancel()
+    let work = DispatchWorkItem { [weak self] in
+      guard let self else { return }
+      pendingFrameFlush = nil
+      flushPendingNAL()
+    }
+    pendingFrameFlush = work
+    processingQueue.asyncAfter(deadline: .now() + Self.frameIdleTimeout, execute: work)
+  }
+
+  private func flushPendingNAL() {
+    let startCode = Data([0, 0, 0, 1])
+    guard buffer.starts(with: startCode), buffer.count > startCode.count else { return }
+
+    let nal = Data(buffer.dropFirst(startCode.count))
+    guard let firstByte = nal.first else { return }
+    let type = firstByte & 0x1F
+    guard type == 1 || type == 5 else { return }
+
+    buffer.removeAll(keepingCapacity: true)
+    handleNAL(nal)
+  }
 
   private func parseBuffer() {
     let startCode = Data([0, 0, 0, 1])

--- a/snapo-app-mac/Snap-O/LivePreview/LivePreviewSession.swift
+++ b/snapo-app-mac/Snap-O/LivePreview/LivePreviewSession.swift
@@ -5,15 +5,22 @@ import SnapODeviceClient
 /// Owns one device-side live-preview process and its decoded frame stream.
 @MainActor
 final class LivePreviewSession {
+  private static let maxPendingSampleCount = 60
+  private static let maxPendingSampleByteCount = 2 * 1024 * 1024
+
   let deviceID: String
 
   var media: Media?
   var sampleBufferHandler: ((CMSampleBuffer) -> Void)? {
     didSet {
-      guard let sampleBufferHandler else { return }
+      guard let sampleBufferHandler else {
+        discardPendingSamples()
+        needsKeyFrame = true
+        return
+      }
 
       let pendingSamples = pendingSampleBuffers
-      pendingSampleBuffers.removeAll(keepingCapacity: true)
+      discardPendingSamples()
       for sample in pendingSamples {
         sampleBufferHandler(sample)
       }
@@ -24,6 +31,8 @@ final class LivePreviewSession {
   private let screenStream: ScreenStreamSession
   private var decoder: H264StreamDecoder?
   private var pendingSampleBuffers: [CMSampleBuffer] = []
+  private var pendingSampleByteCount = 0
+  private var needsKeyFrame = true
   private var streamTask: Task<Void, Never>?
   private var hasStopped = false
 
@@ -64,21 +73,16 @@ final class LivePreviewSession {
   }
 
   private func setupDecoder() {
-    let decoder = H264StreamDecoder { [weak self] sample in
+    let decoder = H264StreamDecoder { [weak self] sample, isKeyFrame in
       guard let self else { return }
       let boxed = UnsafeSendable(value: sample)
-      Task { @MainActor in
-        guard !self.hasStopped else { return }
-        if let sampleBufferHandler = self.sampleBufferHandler {
-          sampleBufferHandler(boxed.value)
-        } else {
-          self.pendingSampleBuffers.append(boxed.value)
-        }
+      DispatchQueue.main.async {
+        self.receiveSample(boxed.value, isKeyFrame: isKeyFrame)
       }
     } formatHandler: { [weak self] format in
       guard let self else { return }
       let dims = CMVideoFormatDescriptionGetDimensions(format)
-      Task { @MainActor in
+      DispatchQueue.main.async {
         guard !self.hasStopped else { return }
         let size = CGSize(width: CGFloat(dims.width), height: CGFloat(dims.height))
         let display = DisplayInfo(size: size, densityScale: self.densityScale)
@@ -93,6 +97,40 @@ final class LivePreviewSession {
       }
     }
     self.decoder = decoder
+  }
+
+  private func receiveSample(_ sample: CMSampleBuffer, isKeyFrame: Bool) {
+    guard !hasStopped else { return }
+
+    if isKeyFrame {
+      needsKeyFrame = false
+      if sampleBufferHandler == nil {
+        discardPendingSamples()
+      }
+    }
+    guard !needsKeyFrame else { return }
+
+    if let sampleBufferHandler {
+      sampleBufferHandler(sample)
+      return
+    }
+
+    let sampleByteCount = CMSampleBufferGetTotalSampleSize(sample)
+    guard sampleByteCount <= Self.maxPendingSampleByteCount,
+          pendingSampleBuffers.count < Self.maxPendingSampleCount,
+          pendingSampleByteCount <= Self.maxPendingSampleByteCount - sampleByteCount else {
+      discardPendingSamples()
+      needsKeyFrame = true
+      return
+    }
+
+    pendingSampleBuffers.append(sample)
+    pendingSampleByteCount += sampleByteCount
+  }
+
+  private func discardPendingSamples() {
+    pendingSampleBuffers.removeAll(keepingCapacity: true)
+    pendingSampleByteCount = 0
   }
 
   private func startStreamTask() {
@@ -112,7 +150,9 @@ final class LivePreviewSession {
       }
 
       decoder.finish()
-      await finish(with: streamError)
+      DispatchQueue.main.async {
+        self.finish(with: streamError)
+      }
     }
   }
 
@@ -125,7 +165,6 @@ final class LivePreviewSession {
     screenStream.close()
     decoder?.finish()
     decoder = nil
-    pendingSampleBuffers.removeAll(keepingCapacity: false)
     sampleBufferHandler = nil
 
     stopResult = error

--- a/snapo-app-mac/Snap-O/LivePreview/LivePreviewSession.swift
+++ b/snapo-app-mac/Snap-O/LivePreview/LivePreviewSession.swift
@@ -1,32 +1,29 @@
-import AppKit
 @preconcurrency import AVFoundation
 import Foundation
-import ImageIO
 import SnapODeviceClient
 
 /// Owns one device-side live-preview process and its decoded frame stream.
 @MainActor
 final class LivePreviewSession {
-  private static let initialFrameTimeout: Duration = .seconds(2)
-
   let deviceID: String
-  private(set) var initialFrame: CGImage?
 
   var media: Media?
-  var initialFrameHandler: ((CGImage) -> Void)? {
+  var sampleBufferHandler: ((CMSampleBuffer) -> Void)? {
     didSet {
-      if let initialFrame {
-        initialFrameHandler?(initialFrame)
+      guard let sampleBufferHandler else { return }
+
+      let pendingSamples = pendingSampleBuffers
+      pendingSampleBuffers.removeAll(keepingCapacity: true)
+      for sample in pendingSamples {
+        sampleBufferHandler(sample)
       }
     }
   }
 
-  var sampleBufferHandler: ((CMSampleBuffer) -> Void)?
-
   private let densityScale: CGFloat
   private let screenStream: ScreenStreamSession
   private var decoder: H264StreamDecoder?
-  private var initialFrameTask: Task<Void, Never>?
+  private var pendingSampleBuffers: [CMSampleBuffer] = []
   private var streamTask: Task<Void, Never>?
   private var hasStopped = false
 
@@ -46,35 +43,6 @@ final class LivePreviewSession {
 
     setupDecoder()
     startStreamTask()
-    startInitialFrameTask(using: exec)
-  }
-
-  private static func captureInitialFrame(deviceID: String, using exec: ADBClient) async throws -> CGImage? {
-    let timeout = initialFrameTimeout
-    let data = try await withThrowingTaskGroup(of: Data?.self, returning: Data?.self) { group in
-      group.addTask {
-        do {
-          return try await exec.screencapPNG(deviceID: deviceID)
-        } catch {
-          try Task.checkCancellation()
-          return nil
-        }
-      }
-      group.addTask {
-        try await Task.sleep(for: timeout)
-        return nil
-      }
-
-      defer { group.cancelAll() }
-      guard let result = try await group.next() else { return nil }
-      return result
-    }
-    return data.flatMap(decodeInitialFrame)
-  }
-
-  private static func decodeInitialFrame(from data: Data) -> CGImage? {
-    guard let source = CGImageSourceCreateWithData(data as CFData, nil) else { return nil }
-    return CGImageSourceCreateImageAtIndex(source, 0, nil)
   }
 
   func waitUntilReady() async throws -> Media {
@@ -95,34 +63,17 @@ final class LivePreviewSession {
     finish(with: nil)
   }
 
-  func discardInitialFrame() {
-    initialFrame = nil
-    initialFrameHandler = nil
-  }
-
-  private func startInitialFrameTask(using exec: ADBClient) {
-    initialFrameTask = Task { [weak self] in
-      guard let self else { return }
-      defer { initialFrameTask = nil }
-
-      do {
-        guard let frame = try await Self.captureInitialFrame(deviceID: deviceID, using: exec),
-              !hasStopped else { return }
-        initialFrame = frame
-        initialFrameHandler?(frame)
-      } catch {
-        // The initial frame is best-effort; live preview continues without it.
-      }
-    }
-  }
-
   private func setupDecoder() {
     let decoder = H264StreamDecoder { [weak self] sample in
       guard let self else { return }
       let boxed = UnsafeSendable(value: sample)
       Task { @MainActor in
         guard !self.hasStopped else { return }
-        self.sampleBufferHandler?(boxed.value)
+        if let sampleBufferHandler = self.sampleBufferHandler {
+          sampleBufferHandler(boxed.value)
+        } else {
+          self.pendingSampleBuffers.append(boxed.value)
+        }
       }
     } formatHandler: { [weak self] format in
       guard let self else { return }
@@ -146,19 +97,22 @@ final class LivePreviewSession {
 
   private func startStreamTask() {
     guard let decoder else { return }
-    let decoderRef = UnsafeSendable(value: decoder)
     let session = screenStream
     streamTask = Task.detached(priority: .userInitiated) { [weak self] in
       guard let self else { return }
+      let streamError: Error?
       do {
         while !Task.isCancelled {
           guard let chunk = try session.read(maxLength: 4096), !chunk.isEmpty else { break }
-          decoderRef.value.append(chunk)
+          decoder.append(chunk)
         }
-        await finish(with: nil)
+        streamError = nil
       } catch {
-        await finish(with: error)
+        streamError = error
       }
+
+      decoder.finish()
+      await finish(with: streamError)
     }
   }
 
@@ -168,12 +122,10 @@ final class LivePreviewSession {
 
     streamTask?.cancel()
     streamTask = nil
-    initialFrameTask?.cancel()
-    initialFrameTask = nil
     screenStream.close()
+    decoder?.finish()
     decoder = nil
-    initialFrame = nil
-    initialFrameHandler = nil
+    pendingSampleBuffers.removeAll(keepingCapacity: false)
     sampleBufferHandler = nil
 
     stopResult = error

--- a/snapo-app-mac/Snap-O/LivePreview/LivePreviewView.swift
+++ b/snapo-app-mac/Snap-O/LivePreview/LivePreviewView.swift
@@ -38,9 +38,7 @@ struct LivePreviewRendererView: NSViewRepresentable {
 final class LivePreviewDisplayView: NSView {
   private var renderer: LivePreviewRenderer?
   private var trackingArea: NSTrackingArea?
-  private var readyForDisplayObserver: NSObjectProtocol?
   private let displayLayer = AVSampleBufferDisplayLayer()
-  private let initialFrameLayer = CALayer()
   private var endedLivePreviewTrace = false
 
   private var pointerState = PointerState()
@@ -84,14 +82,10 @@ final class LivePreviewDisplayView: NSView {
     guard displayLayer.superlayer == nil else { return }
     wantsLayer = true
     layer?.addSublayer(displayLayer)
-    layer?.addSublayer(initialFrameLayer)
     displayLayer.videoGravity = .resizeAspect
     updateDisplayLayerBackgroundColor()
     displayLayer.frame = bounds
     displayLayer.autoresizingMask = [.layerWidthSizable, .layerHeightSizable]
-    initialFrameLayer.contentsGravity = .resizeAspect
-    initialFrameLayer.frame = bounds
-    initialFrameLayer.autoresizingMask = [.layerWidthSizable, .layerHeightSizable]
   }
 
   override func viewDidChangeEffectiveAppearance() {
@@ -108,24 +102,17 @@ final class LivePreviewDisplayView: NSView {
   private func attachSession() {
     guard let renderer else { return }
     let session = renderer.session
-    let operationID = renderer.operation.id
-    session.initialFrameHandler = { [weak self] frame in
-      self?.displayInitialFrame(frame, operationID: operationID)
-    }
+    endedLivePreviewTrace = false
     session.sampleBufferHandler = { [weak self] sample in
       self?.enqueue(sample)
     }
-    endedLivePreviewTrace = false
   }
 
   private func detachSession() {
-    stopObservingDisplayReadiness()
-    renderer?.session.initialFrameHandler = nil
     renderer?.session.sampleBufferHandler = nil
     displayLayer.sampleBufferRenderer.stopRequestingMediaData()
     displayLayer.sampleBufferRenderer.flush(removingDisplayedImage: true, completionHandler: nil)
     displayLayer.sampleBufferRenderer.requestMediaDataWhenReady(on: .main) {}
-    setInitialFrame(nil)
     endedLivePreviewTrace = false
   }
 
@@ -137,52 +124,6 @@ final class LivePreviewDisplayView: NSView {
       Perf.end(.livePreviewStart, finalLabel: "first frame enqueued")
       Perf.end(.appFirstSnapshot, finalLabel: "first media appeared (live)")
     }
-  }
-
-  private func displayInitialFrame(_ image: CGImage, operationID: UUID) {
-    guard renderer?.operation.id == operationID else { return }
-    observeDisplayReadiness(operationID: operationID)
-    guard !displayLayer.isReadyForDisplay else {
-      hideInitialFrameIfReady(operationID: operationID)
-      return
-    }
-    setInitialFrame(image)
-    hideInitialFrameIfReady(operationID: operationID)
-  }
-
-  private func observeDisplayReadiness(operationID: UUID) {
-    stopObservingDisplayReadiness()
-    readyForDisplayObserver = NotificationCenter.default.addObserver(
-      forName: .AVSampleBufferDisplayLayerReadyForDisplayDidChange,
-      object: displayLayer,
-      queue: .main
-    ) { [weak self] _ in
-      Task { @MainActor [weak self] in
-        self?.hideInitialFrameIfReady(operationID: operationID)
-      }
-    }
-  }
-
-  private func hideInitialFrameIfReady(operationID: UUID) {
-    guard renderer?.operation.id == operationID,
-          displayLayer.isReadyForDisplay else { return }
-    renderer?.session.discardInitialFrame()
-    setInitialFrame(nil)
-    stopObservingDisplayReadiness()
-  }
-
-  private func stopObservingDisplayReadiness() {
-    guard let readyForDisplayObserver else { return }
-    NotificationCenter.default.removeObserver(readyForDisplayObserver)
-    self.readyForDisplayObserver = nil
-  }
-
-  private func setInitialFrame(_ image: CGImage?) {
-    if image == nil, initialFrameLayer.contents == nil { return }
-    CATransaction.begin()
-    CATransaction.setDisableActions(true)
-    initialFrameLayer.contents = image
-    CATransaction.commit()
   }
 
   override func updateTrackingAreas() {


### PR DESCRIPTION
## Summary

- Flush pending H.264 video frames after 50 ms without incoming data and when streaming ends.
- Buffer decoded startup samples until the live-preview renderer attaches.
- Remove the separate startup screenshot and its display overlay.

## Root cause

Android screenrecord emits an unframed Annex-B H.264 stream. The decoder previously waited for the next NAL start code before displaying the current frame, leaving the first frame on static screens and the final streamed frame buffered indefinitely.

## Validation

- macOS app build succeeds with code signing disabled.
- All 19 SnapODeviceClient tests pass.
- SwiftFormat and SwiftLint pass.
- Generated H.264 fixtures verify static-frame idle flushing, trailing P-frame delivery, immediate EOF flushing, and safe handling of parameter sets.