### PR TITLE
Simplify Compose tweaks with value-first overloads

### DIFF
--- a/contracts/tweaks/README.md
+++ b/contracts/tweaks/README.md
@@ -268,8 +268,8 @@ fun TweakSpecimen() {
 fun TypographySpecimen() {
     Text(
         text = tweak("Make it feel right.", name = "Preview text").value,
-        fontSize = tweak(36, "Font size", min = 16, max = 72, step = 1).value.sp,
-        fontWeight = FontWeight(tweak(600, "Font weight", min = 100, max = 900, step = 100).value),
+        fontSize = tweak(36, "Font size", 16..72, step = 1).value.sp,
+        fontWeight = FontWeight(tweak(600, "Font weight", 100..900, step = 100).value),
         color = MaterialTheme.colorScheme.onSurface,
     )
 
@@ -278,7 +278,7 @@ fun TypographySpecimen() {
 
 @Composable
 fun SpecimenAccessory() {
-    val fontSize by tweak(36, "Font size", min = 16, max = 72, step = 1)
+    val fontSize by tweak(36, "Font size", 16..72, step = 1)
 
     Text(text = "$fontSize sp")
 }
@@ -288,12 +288,12 @@ fun MotionSpecimen() {
     val useSpring by tweak(true, "Use spring")
 
     val animationSpec = if (useSpring) {
-        val stiffness by tweak(280f, "Spring stiffness", min = 80f, max = 800f, step = 20f)
-        val dampingRatio by tweak(0.7f, "Spring damping", min = 0.1f, max = 1f, step = 0.05f)
+        val stiffness by tweak(280f, "Spring stiffness", 80f..800f, step = 20f)
+        val dampingRatio by tweak(0.7f, "Spring damping", 0.1f..1f, step = 0.05f)
 
         spring<Float>(dampingRatio = dampingRatio, stiffness = stiffness)
     } else {
-        val durationMillis by tweak(400, "Animation duration", min = 100, max = 1_500, step = 50)
+        val durationMillis by tweak(400, "Animation duration", 100..1_500, step = 50)
 
         tween<Float>(durationMillis = durationMillis)
     }
@@ -312,7 +312,7 @@ read the delegated value inside the corresponding callback instead of
 composition:
 
 ```kotlin
-val horizontalOffset by tweak(0, "Horizontal offset", min = 0, max = 200)
+val horizontalOffset by tweak(0, "Horizontal offset", 0..200)
 
 Box(
     modifier = Modifier.offset {
@@ -330,9 +330,9 @@ Provide overloaded `tweak(default, name)` functions for `Int`, `Float`,
 `Color`, `Boolean`, and `String` defaults; each returns its corresponding
 `State<T>`. For strings, name the second argument to distinguish the label from
 the default, as in `tweak("Hello", name = "Greeting")`. Numeric tweaks accept
-optional `min`, `max`, and `step` values of the same type. Convert delegated
-integer values into Compose units at the call site, such as `fontSize.sp`.
-The real and no-op artifacts expose the same package and public Compose API.
+an optional range and `step` of the same type. Convert delegated integer values
+into Compose units at the call site, such as `fontSize.sp`. The real and no-op
+artifacts expose the same package and public Compose API.
 
 ## Setup
 

--- a/contracts/tweaks/README.md
+++ b/contracts/tweaks/README.md
@@ -242,28 +242,13 @@ any tweaks in that request. Reset a value by patching it with its default.
 
 ```kotlin
 import androidx.compose.runtime.getValue
-import com.openai.snapo.tweaks.tweakBoolean
-import com.openai.snapo.tweaks.tweakColor
-import com.openai.snapo.tweaks.tweakFloat
-import com.openai.snapo.tweaks.tweakInt
-import com.openai.snapo.tweaks.tweakString
+import com.openai.snapo.tweaks.tweak
 
 @Composable
 fun TweakSpecimen() {
-    val textColor by tweakColor(
-        name = "Text color",
-        default = Color(0xFF18212F),
-    )
-
-    val backgroundColor by tweakColor(
-        name = "Background color",
-        default = Color(0xFFF7F8FA),
-    )
-
-    val accentColor by tweakColor(
-        name = "Accent color",
-        default = Color(0xFF5468FF),
-    )
+    val textColor by tweak(Color(0xFF18212F), "Text color")
+    val backgroundColor by tweak(Color(0xFFF7F8FA), "Background color")
+    val accentColor by tweak(Color(0xFF5468FF), "Accent color")
 
     MaterialTheme(
         colorScheme = lightColorScheme(
@@ -281,28 +266,10 @@ fun TweakSpecimen() {
 
 @Composable
 fun TypographySpecimen() {
-    val fontSize by tweakInt(
-        name = "Font size",
-        default = 36,
-        min = 16,
-        max = 72,
-        step = 1,
-    )
-
-    val fontWeight by tweakInt(
-        name = "Font weight",
-        default = 600,
-        min = 100,
-        max = 900,
-        step = 100,
-    )
-
-    val previewText by tweakString("Preview text", "Make it feel right.")
-
     Text(
-        text = previewText,
-        fontSize = fontSize.sp,
-        fontWeight = FontWeight(fontWeight),
+        text = tweak("Make it feel right.", name = "Preview text").value,
+        fontSize = tweak(36, "Font size", min = 16, max = 72, step = 1).value.sp,
+        fontWeight = FontWeight(tweak(600, "Font weight", min = 100, max = 900, step = 100).value),
         color = MaterialTheme.colorScheme.onSurface,
     )
 
@@ -311,45 +278,23 @@ fun TypographySpecimen() {
 
 @Composable
 fun SpecimenAccessory() {
-    val fontSize by tweakInt("Font size", 36, min = 16, max = 72, step = 1)
+    val fontSize by tweak(36, "Font size", min = 16, max = 72, step = 1)
 
     Text(text = "$fontSize sp")
 }
 
 @Composable
 fun MotionSpecimen() {
-    val durationMillis by tweakInt(
-        name = "Animation duration",
-        default = 400,
-        min = 100,
-        max = 1_500,
-        step = 50,
-    )
-
-    val springStiffness by tweakFloat(
-        name = "Spring stiffness",
-        default = 280f,
-        min = 80f,
-        max = 800f,
-        step = 20f,
-    )
-
-    val springDamping by tweakFloat(
-        name = "Spring damping",
-        default = 0.7f,
-        min = 0.1f,
-        max = 1f,
-        step = 0.05f,
-    )
-
-    val useSpring by tweakBoolean(
-        name = "Use spring",
-        default = true,
-    )
+    val useSpring by tweak(true, "Use spring")
 
     val animationSpec = if (useSpring) {
-        spring<Float>(dampingRatio = springDamping, stiffness = springStiffness)
+        val stiffness by tweak(280f, "Spring stiffness", min = 80f, max = 800f, step = 20f)
+        val dampingRatio by tweak(0.7f, "Spring damping", min = 0.1f, max = 1f, step = 0.05f)
+
+        spring<Float>(dampingRatio = dampingRatio, stiffness = stiffness)
     } else {
+        val durationMillis by tweak(400, "Animation duration", min = 100, max = 1_500, step = 50)
+
         tween<Float>(durationMillis = durationMillis)
     }
 
@@ -357,16 +302,17 @@ fun MotionSpecimen() {
 }
 ```
 
-Each tweak function returns `State<T>`. Delegate it with `by` where the value is
-used; `androidx.compose.runtime.getValue` supplies the delegate operator. Theme
-colors are intentionally read at the theme boundary; font, text, and animation
-changes recompose their respective leaf composables rather than the entire
-screen. Both typography composables read the same Font size state, so one host
-update changes both. When a value only affects layout or drawing, read the
-delegated value inside the corresponding callback instead of composition:
+Each tweak function returns `State<T>`. Read it with `.value`, or delegate it
+with `by`; `androidx.compose.runtime.getValue` supplies the delegate operator.
+Theme colors are intentionally read at the theme boundary; font, text, and
+animation changes recompose their respective leaf composables rather than the
+entire screen. Both typography composables read the same Font size state, so
+one host update changes both. When a value only affects layout or drawing,
+read the delegated value inside the corresponding callback instead of
+composition:
 
 ```kotlin
-val horizontalOffset by tweakInt("Horizontal offset", 0, min = 0, max = 200)
+val horizontalOffset by tweak(0, "Horizontal offset", min = 0, max = 200)
 
 Box(
     modifier = Modifier.offset {
@@ -380,11 +326,13 @@ the active list only after its final usage leaves. Returning declarations
 restore their previously edited values. Screen navigation therefore determines
 what appears in the response without discarding edits.
 
-Provide `tweakInt`, `tweakFloat`, `tweakColor`, `tweakBoolean`, and
-`tweakString`; each returns its corresponding `State<T>`. Numeric tweaks accept
+Provide overloaded `tweak(default, name)` functions for `Int`, `Float`,
+`Color`, `Boolean`, and `String` defaults; each returns its corresponding
+`State<T>`. For strings, name the second argument to distinguish the label from
+the default, as in `tweak("Hello", name = "Greeting")`. Numeric tweaks accept
 optional `min`, `max`, and `step` values of the same type. Convert delegated
-integer values into Compose units at the call site, such as `fontSize.sp`. The
-real and no-op artifacts expose the same package and public Compose API.
+integer values into Compose units at the call site, such as `fontSize.sp`.
+The real and no-op artifacts expose the same package and public Compose API.
 
 ## Setup
 

--- a/snapo-link-android/samples/demo-tweaks/panel/README.md
+++ b/snapo-link-android/samples/demo-tweaks/panel/README.md
@@ -81,9 +81,9 @@ App discovery and selection belong to this demo server. `/apps` and
 To put a tweak in a section, use a `/` in its name:
 
 ```kotlin
-val fontSize by tweak(36, "Typography/Font size", min = 16, max = 72)
+val fontSize by tweak(36, "Typography/Font size", 16..72)
 val isMotionEnabled by tweak(true, "Motion/Enabled")
-val animationDuration by tweak(400, "Motion/Duration", min = 100, max = 1500)
+val animationDuration by tweak(400, "Motion/Duration", 100..1500)
 ```
 
 The part before `/` is the section. The part after `/` is the label. A tweak

--- a/snapo-link-android/samples/demo-tweaks/panel/README.md
+++ b/snapo-link-android/samples/demo-tweaks/panel/README.md
@@ -81,9 +81,9 @@ App discovery and selection belong to this demo server. `/apps` and
 To put a tweak in a section, use a `/` in its name:
 
 ```kotlin
-val fontSize by tweakInt("Typography/Font size", 36, min = 16, max = 72)
-val isMotionEnabled by tweakBoolean("Motion/Enabled", true)
-val animationDuration by tweakInt("Motion/Duration", 400, min = 100, max = 1500)
+val fontSize by tweak(36, "Typography/Font size", min = 16, max = 72)
+val isMotionEnabled by tweak(true, "Motion/Enabled")
+val animationDuration by tweak(400, "Motion/Duration", min = 100, max = 1500)
 ```
 
 The part before `/` is the section. The part after `/` is the label. A tweak

--- a/snapo-link-android/samples/demo-tweaks/src/main/java/com/openai/snapo/demo/tweaks/MainActivity.kt
+++ b/snapo-link-android/samples/demo-tweaks/src/main/java/com/openai/snapo/demo/tweaks/MainActivity.kt
@@ -232,8 +232,8 @@ private fun TypographyPreview() {
 
 @Composable
 private fun TweakableTypographyPreview() {
-    val fontSize by tweak(36, "Typography/Font size", min = 16, max = 72, step = 1)
-    val fontWeight by tweak(600, "Typography/Font weight", min = 100, max = 900, step = 100)
+    val fontSize by tweak(36, "Typography/Font size", 16..72, step = 1)
+    val fontWeight by tweak(600, "Typography/Font weight", 100..900, step = 100)
     val previewText by tweak("Make it feel right.", name = "Typography/Preview text")
 
     Text(
@@ -247,8 +247,8 @@ private fun TweakableTypographyPreview() {
 
 @Composable
 private fun TypographyDetails() {
-    val fontSize by tweak(36, "Typography/Font size", min = 16, max = 72, step = 1)
-    val fontWeight by tweak(600, "Typography/Font weight", min = 100, max = 900, step = 100)
+    val fontSize by tweak(36, "Typography/Font size", 16..72, step = 1)
+    val fontWeight by tweak(600, "Typography/Font weight", 100..900, step = 100)
 
     Text(
         text = "$fontSize sp · $fontWeight",
@@ -263,8 +263,8 @@ private fun MotionPreview() {
     val useSpring by tweak(true, "Motion/Use spring")
 
     val animationSpec: FiniteAnimationSpec<Float> = if (useSpring) {
-        val stiffness by tweak(280f, "Motion/Spring stiffness", min = 80f, max = 800f, step = 20f)
-        val dampingRatio by tweak(0.7f, "Motion/Spring damping", min = 0.1f, max = 1f, step = 0.05f)
+        val stiffness by tweak(280f, "Motion/Spring stiffness", 80f..800f, step = 20f)
+        val dampingRatio by tweak(0.7f, "Motion/Spring damping", 0.1f..1f, step = 0.05f)
 
         spring(
             dampingRatio = dampingRatio,
@@ -272,7 +272,7 @@ private fun MotionPreview() {
             visibilityThreshold = 0.001f,
         )
     } else {
-        val durationMillis by tweak(400, "Motion/Duration", min = 100, max = 1500, step = 50)
+        val durationMillis by tweak(400, "Motion/Duration", 100..1500, step = 50)
 
         tween(
             durationMillis = durationMillis,
@@ -314,7 +314,7 @@ private fun MotionTrack(
     val accentColor = MaterialTheme.colorScheme.primary
     val mutedColor = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.55f)
     val trackColor = accentColor.copy(alpha = 0.22f)
-    val trackThickness by tweak(2f, "Motion/Track thickness", min = 1f, max = 8f, step = 0.5f)
+    val trackThickness by tweak(2f, "Motion/Track thickness", 1f..8f, step = 0.5f)
 
     Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
         Row(
@@ -371,12 +371,12 @@ private fun AnimationDetails(
 ) {
     val useSpring by tweak(true, "Motion/Use spring")
     val description = if (useSpring) {
-        val stiffness by tweak(280f, "Motion/Spring stiffness", min = 80f, max = 800f, step = 20f)
-        val dampingRatio by tweak(0.7f, "Motion/Spring damping", min = 0.1f, max = 1f, step = 0.05f)
+        val stiffness by tweak(280f, "Motion/Spring stiffness", 80f..800f, step = 20f)
+        val dampingRatio by tweak(0.7f, "Motion/Spring damping", 0.1f..1f, step = 0.05f)
 
         "Spring · $stiffness stiffness · $dampingRatio damping"
     } else {
-        val durationMillis by tweak(400, "Motion/Duration", min = 100, max = 1500, step = 50)
+        val durationMillis by tweak(400, "Motion/Duration", 100..1500, step = 50)
 
         "Tween · $durationMillis ms"
     }

--- a/snapo-link-android/samples/demo-tweaks/src/main/java/com/openai/snapo/demo/tweaks/MainActivity.kt
+++ b/snapo-link-android/samples/demo-tweaks/src/main/java/com/openai/snapo/demo/tweaks/MainActivity.kt
@@ -51,11 +51,7 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import com.openai.snapo.tweaks.overlay.SnapOTweakOverlay
 import com.openai.snapo.tweaks.overlay.SnapOTweakOverlaySettings
-import com.openai.snapo.tweaks.tweakBoolean
-import com.openai.snapo.tweaks.tweakColor
-import com.openai.snapo.tweaks.tweakFloat
-import com.openai.snapo.tweaks.tweakInt
-import com.openai.snapo.tweaks.tweakString
+import com.openai.snapo.tweaks.tweak
 import kotlin.math.roundToInt
 
 private val DefaultTextColor = Color(0xFF18212F)
@@ -111,9 +107,9 @@ private fun TweakDemo() {
 private fun TweakDemoContent(
     onToggleTweakableContent: () -> Unit,
 ) {
-    val textColor = tweakColor("Colors/Text", DefaultTextColor).value
-    val backgroundColor = tweakColor("Colors/Background", DefaultBackgroundColor).value
-    val accentColor = tweakColor("Colors/Accent", DefaultAccentColor).value
+    val textColor by tweak(DefaultTextColor, "Colors/Text")
+    val backgroundColor by tweak(DefaultBackgroundColor, "Colors/Background")
+    val accentColor by tweak(DefaultAccentColor, "Colors/Accent")
 
     MaterialTheme(
         colorScheme = lightColorScheme(
@@ -175,7 +171,7 @@ private fun TweakDemoScreen(
 
 @Composable
 private fun MotionSection(dividerColor: Color) {
-    val isVisible by tweakBoolean("Motion/Show", true)
+    val isVisible by tweak(true, "Motion/Show")
     if (isVisible) {
         HorizontalDivider(color = dividerColor)
         MotionPreview()
@@ -236,9 +232,9 @@ private fun TypographyPreview() {
 
 @Composable
 private fun TweakableTypographyPreview() {
-    val fontSize by tweakInt("Typography/Font size", 36, min = 16, max = 72, step = 1)
-    val fontWeight by tweakInt("Typography/Font weight", 600, min = 100, max = 900, step = 100)
-    val previewText by tweakString("Typography/Preview text", "Make it feel right.")
+    val fontSize by tweak(36, "Typography/Font size", min = 16, max = 72, step = 1)
+    val fontWeight by tweak(600, "Typography/Font weight", min = 100, max = 900, step = 100)
+    val previewText by tweak("Make it feel right.", name = "Typography/Preview text")
 
     Text(
         text = previewText,
@@ -251,8 +247,8 @@ private fun TweakableTypographyPreview() {
 
 @Composable
 private fun TypographyDetails() {
-    val fontSize by tweakInt("Typography/Font size", 36, min = 16, max = 72, step = 1)
-    val fontWeight by tweakInt("Typography/Font weight", 600, min = 100, max = 900, step = 100)
+    val fontSize by tweak(36, "Typography/Font size", min = 16, max = 72, step = 1)
+    val fontWeight by tweak(600, "Typography/Font weight", min = 100, max = 900, step = 100)
 
     Text(
         text = "$fontSize sp · $fontWeight",
@@ -264,22 +260,22 @@ private fun TypographyDetails() {
 @Composable
 private fun MotionPreview() {
     var isStateB by rememberSaveable { mutableStateOf(false) }
-    val useSpring by tweakBoolean("Motion/Use spring", true)
+    val useSpring by tweak(true, "Motion/Use spring")
 
     val animationSpec: FiniteAnimationSpec<Float> = if (useSpring) {
-        val stiffness by tweakFloat("Motion/Spring stiffness", 280f, min = 80f, max = 800f, step = 20f)
-        val damping by tweakFloat("Motion/Spring damping", 0.7f, min = 0.1f, max = 1f, step = 0.05f)
+        val stiffness by tweak(280f, "Motion/Spring stiffness", min = 80f, max = 800f, step = 20f)
+        val dampingRatio by tweak(0.7f, "Motion/Spring damping", min = 0.1f, max = 1f, step = 0.05f)
 
         spring(
-            dampingRatio = damping,
+            dampingRatio = dampingRatio,
             stiffness = stiffness,
             visibilityThreshold = 0.001f,
         )
     } else {
-        val duration by tweakInt("Motion/Duration", 400, min = 100, max = 1500, step = 50)
+        val durationMillis by tweak(400, "Motion/Duration", min = 100, max = 1500, step = 50)
 
         tween(
-            durationMillis = duration,
+            durationMillis = durationMillis,
             easing = FastOutSlowInEasing,
         )
     }
@@ -318,13 +314,7 @@ private fun MotionTrack(
     val accentColor = MaterialTheme.colorScheme.primary
     val mutedColor = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.55f)
     val trackColor = accentColor.copy(alpha = 0.22f)
-    val trackThickness = tweakFloat(
-        name = "Motion/Track thickness",
-        default = 2f,
-        min = 1f,
-        max = 8f,
-        step = 0.5f,
-    )
+    val trackThickness by tweak(2f, "Motion/Track thickness", min = 1f, max = 8f, step = 0.5f)
 
     Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
         Row(
@@ -344,7 +334,7 @@ private fun MotionTrack(
                         color = trackColor,
                         start = Offset(x = 0f, y = center.y),
                         end = Offset(x = size.width, y = center.y),
-                        strokeWidth = trackThickness.value.dp.toPx(),
+                        strokeWidth = trackThickness.dp.toPx(),
                     )
                 },
             contentAlignment = Alignment.CenterStart,
@@ -379,16 +369,16 @@ private fun Modifier.motionMarkerOffset(progress: State<Float>): Modifier =
 private fun AnimationDetails(
     isStateB: Boolean,
 ) {
-    val useSpring by tweakBoolean("Motion/Use spring", true)
+    val useSpring by tweak(true, "Motion/Use spring")
     val description = if (useSpring) {
-        val stiffness by tweakFloat("Motion/Spring stiffness", 280f, min = 80f, max = 800f, step = 20f)
-        val damping by tweakFloat("Motion/Spring damping", 0.7f, min = 0.1f, max = 1f, step = 0.05f)
+        val stiffness by tweak(280f, "Motion/Spring stiffness", min = 80f, max = 800f, step = 20f)
+        val dampingRatio by tweak(0.7f, "Motion/Spring damping", min = 0.1f, max = 1f, step = 0.05f)
 
-        "Spring · $stiffness stiffness · $damping damping"
+        "Spring · $stiffness stiffness · $dampingRatio damping"
     } else {
-        val duration by tweakInt("Motion/Duration", 400, min = 100, max = 1500, step = 50)
+        val durationMillis by tweak(400, "Motion/Duration", min = 100, max = 1500, step = 50)
 
-        "Tween · $duration ms"
+        "Tween · $durationMillis ms"
     }
     val selectedState = if (isStateB) "State B" else "State A"
 

--- a/snapo-link-android/tweaks-noop/src/main/java/com/openai/snapo/tweaks/Tweaks.kt
+++ b/snapo-link-android/tweaks-noop/src/main/java/com/openai/snapo/tweaks/Tweaks.kt
@@ -9,9 +9,9 @@ import androidx.compose.ui.graphics.Color
 
 /** Returns observable release-build state for the current floating-point default. */
 @Composable
-fun tweakFloat(
-    name: String,
+fun tweak(
     default: Float,
+    name: String,
     min: Float? = null,
     max: Float? = null,
     step: Float? = null,
@@ -19,9 +19,9 @@ fun tweakFloat(
 
 /** Returns observable release-build state for the current integer default. */
 @Composable
-fun tweakInt(
-    name: String,
+fun tweak(
     default: Int,
+    name: String,
     min: Int? = null,
     max: Int? = null,
     step: Int? = null,
@@ -29,21 +29,21 @@ fun tweakInt(
 
 /** Returns observable release-build state for the current color default. */
 @Composable
-fun tweakColor(
-    name: String,
+fun tweak(
     default: Color,
+    name: String,
 ): State<Color> = rememberUpdatedState(default)
 
 /** Returns observable release-build state for the current boolean default. */
 @Composable
-fun tweakBoolean(
-    name: String,
+fun tweak(
     default: Boolean,
+    name: String,
 ): State<Boolean> = rememberUpdatedState(default)
 
 /** Returns observable release-build state for the current text default. */
 @Composable
-fun tweakString(
-    name: String,
+fun tweak(
     default: String,
+    name: String,
 ): State<String> = rememberUpdatedState(default)

--- a/snapo-link-android/tweaks-noop/src/main/java/com/openai/snapo/tweaks/Tweaks.kt
+++ b/snapo-link-android/tweaks-noop/src/main/java/com/openai/snapo/tweaks/Tweaks.kt
@@ -12,8 +12,7 @@ import androidx.compose.ui.graphics.Color
 fun tweak(
     default: Float,
     name: String,
-    min: Float? = null,
-    max: Float? = null,
+    range: ClosedFloatingPointRange<Float>? = null,
     step: Float? = null,
 ): State<Float> = rememberUpdatedState(default)
 
@@ -22,8 +21,7 @@ fun tweak(
 fun tweak(
     default: Int,
     name: String,
-    min: Int? = null,
-    max: Int? = null,
+    range: IntRange? = null,
     step: Int? = null,
 ): State<Int> = rememberUpdatedState(default)
 

--- a/snapo-link-android/tweaks/src/main/java/com/openai/snapo/tweaks/Tweaks.kt
+++ b/snapo-link-android/tweaks/src/main/java/com/openai/snapo/tweaks/Tweaks.kt
@@ -15,9 +15,9 @@ import com.openai.snapo.tweaks.internal.TweaksRuntimePolicy
 
 /** Exposes a floating-point tweak as observable state. */
 @Composable
-fun tweakFloat(
-    name: String,
+fun tweak(
     default: Float,
+    name: String,
     min: Float? = null,
     max: Float? = null,
     step: Float? = null,
@@ -35,9 +35,9 @@ fun tweakFloat(
 
 /** Exposes an integer tweak as observable state. */
 @Composable
-fun tweakInt(
-    name: String,
+fun tweak(
     default: Int,
+    name: String,
     min: Int? = null,
     max: Int? = null,
     step: Int? = null,
@@ -55,9 +55,9 @@ fun tweakInt(
 
 /** Exposes a color tweak as observable state. */
 @Composable
-fun tweakColor(
-    name: String,
+fun tweak(
     default: Color,
+    name: String,
 ): State<Color> {
     val encodedDefault = default.toTweakColor()
     return rememberTweakState(
@@ -74,9 +74,9 @@ fun tweakColor(
 
 /** Exposes a boolean tweak as observable state. */
 @Composable
-fun tweakBoolean(
-    name: String,
+fun tweak(
     default: Boolean,
+    name: String,
 ): State<Boolean> = rememberTweakState(
     TweakDescriptor(
         name = name,
@@ -88,9 +88,9 @@ fun tweakBoolean(
 
 /** Exposes a text tweak as observable state. */
 @Composable
-fun tweakString(
-    name: String,
+fun tweak(
     default: String,
+    name: String,
 ): State<String> = rememberTweakState(
     TweakDescriptor(
         name = name,

--- a/snapo-link-android/tweaks/src/main/java/com/openai/snapo/tweaks/Tweaks.kt
+++ b/snapo-link-android/tweaks/src/main/java/com/openai/snapo/tweaks/Tweaks.kt
@@ -18,16 +18,15 @@ import com.openai.snapo.tweaks.internal.TweaksRuntimePolicy
 fun tweak(
     default: Float,
     name: String,
-    min: Float? = null,
-    max: Float? = null,
+    range: ClosedFloatingPointRange<Float>? = null,
     step: Float? = null,
 ): State<Float> = rememberTweakState(
     TweakDescriptor(
         name = name,
         type = TweakType.FLOAT,
         default = default,
-        min = min,
-        max = max,
+        min = range?.start,
+        max = range?.endInclusive,
         step = step,
     ),
     default = default,
@@ -38,16 +37,15 @@ fun tweak(
 fun tweak(
     default: Int,
     name: String,
-    min: Int? = null,
-    max: Int? = null,
+    range: IntRange? = null,
     step: Int? = null,
 ): State<Int> = rememberTweakState(
     TweakDescriptor(
         name = name,
         type = TweakType.INT,
         default = default,
-        min = min,
-        max = max,
+        min = range?.start,
+        max = range?.endInclusive,
         step = step,
     ),
     default = default,


### PR DESCRIPTION
## Summary
- Replace the type-specific Compose tweak helpers with overloaded, value-first `tweak(default, name, ...)` APIs for `Int`, `Float`, `Color`, `Boolean`, and `String`.
- Represent numeric bounds with optional typed Kotlin ranges, such as `tweak(36, "Font size", 16..72, step = 1)`, while preserving the inspector's existing `min`/`max` wire format.
- Keep the live and no-op artifacts aligned, migrate the sample application and inspector documentation, and use explicit `name =` arguments for string tweaks.
- Register spring stiffness/damping or tween duration only while their corresponding animation branch is active.

## Compatibility
- This intentionally removes `tweakInt`, `tweakFloat`, `tweakColor`, `tweakBoolean`, and `tweakString`; existing consumers must migrate to the new `tweak(default, name, ...)` overloads.
- Numeric tweak bounds are now provided as `IntRange` or `ClosedFloatingPointRange<Float>` instead of separate `min` and `max` arguments.

## Validation
- `./gradlew :tweaks:testDebugUnitTest :samples:demo-tweaks:assembleDebug :samples:demo-tweaks:assembleRelease`
- All 86 tweak unit tests pass; both live/debug and no-op/release demo builds succeed.