### PR TITLE
Fix live tweak updates in Mac inspector

### DIFF
--- a/snapo-app-mac/Snap-O/NetworkInspector/NetworkInspectorService.swift
+++ b/snapo-app-mac/Snap-O/NetworkInspector/NetworkInspectorService.swift
@@ -321,17 +321,15 @@ actor NetworkInspectorService {
     while !Task.isCancelled, !isStopped {
       do {
         try await tweaksService.streamTweaks(for: reference) { [weak self] list in
-          Task {
-            await self?.emit(
-              .tweaks(
-                TweakStreamEvent(
-                  streamId: streamID,
-                  server: reference,
-                  tweaks: list.tweaks
-                )
+          await self?.emit(
+            .tweaks(
+              TweakStreamEvent(
+                streamId: streamID,
+                server: reference,
+                tweaks: list.tweaks
               )
             )
-          }
+          )
         }
         retryDelay = .milliseconds(250)
       } catch {

--- a/snapo-app-mac/Snap-O/NetworkInspector/TweakEventStreamDecoder.swift
+++ b/snapo-app-mac/Snap-O/NetworkInspector/TweakEventStreamDecoder.swift
@@ -1,0 +1,49 @@
+import Foundation
+
+struct TweakEventStreamDecoder {
+  private var lineBytes: [UInt8] = []
+  private var eventName: String?
+  private var dataLines: [String] = []
+
+  mutating func consume(_ byte: UInt8) -> Data? {
+    guard byte == 0x0A else {
+      lineBytes.append(byte)
+      return nil
+    }
+
+    let line = currentLine()
+    lineBytes.removeAll(keepingCapacity: true)
+    guard let line else { return nil }
+    return consume(line)
+  }
+
+  private mutating func currentLine() -> String? {
+    if lineBytes.last == 0x0D {
+      lineBytes.removeLast()
+    }
+    return String(bytes: lineBytes, encoding: .utf8)
+  }
+
+  private mutating func consume(_ line: String) -> Data? {
+    if line.isEmpty {
+      defer {
+        eventName = nil
+        dataLines.removeAll(keepingCapacity: true)
+      }
+
+      guard eventName == "tweaks", !dataLines.isEmpty else { return nil }
+      return Data(dataLines.joined(separator: "\n").utf8)
+    }
+
+    if line.hasPrefix("event:") {
+      eventName = Self.fieldValue(line, prefixLength: 6)
+    } else if line.hasPrefix("data:") {
+      dataLines.append(Self.fieldValue(line, prefixLength: 5))
+    }
+    return nil
+  }
+
+  private static func fieldValue(_ line: String, prefixLength: Int) -> String {
+    String(line.dropFirst(prefixLength)).trimmingCharacters(in: .whitespaces)
+  }
+}

--- a/snapo-app-mac/Snap-O/NetworkInspector/TweaksInspectorService.swift
+++ b/snapo-app-mac/Snap-O/NetworkInspector/TweaksInspectorService.swift
@@ -93,7 +93,7 @@ actor TweaksInspectorService {
 
   func streamTweaks(
     for reference: InspectorServerReference,
-    onChange: @escaping @Sendable (TweakList) -> Void
+    onChange: @escaping @Sendable (TweakList) async -> Void
   ) async throws {
     let connection = try connection(for: reference)
     var request = URLRequest(url: connection.baseURL.appending(path: "tweaks/events"))
@@ -102,24 +102,15 @@ actor TweaksInspectorService {
     let (bytes, response) = try await URLSession.shared.bytes(for: request)
     try Self.validate(response)
 
-    var eventName: String?
-    var dataLines: [String] = []
+    // SSE frames end with an empty line, which AsyncBytes.lines omits.
+    var decoder = TweakEventStreamDecoder()
 
-    for try await line in bytes.lines {
+    for try await byte in bytes {
       try Task.checkCancellation()
 
-      if line.isEmpty {
-        if eventName == "tweaks", !dataLines.isEmpty {
-          let data = Data(dataLines.joined(separator: "\n").utf8)
-          try onChange(JSONDecoder().decode(TweakList.self, from: data))
-        }
-        eventName = nil
-        dataLines.removeAll(keepingCapacity: true)
-      } else if line.hasPrefix("event:") {
-        eventName = String(line.dropFirst(6)).trimmingCharacters(in: .whitespaces)
-      } else if line.hasPrefix("data:") {
-        dataLines.append(String(line.dropFirst(5)).trimmingCharacters(in: .whitespaces))
-      }
+      guard let data = decoder.consume(byte) else { continue }
+      let tweaks = try JSONDecoder().decode(TweakList.self, from: data)
+      await onChange(tweaks)
     }
   }
 

--- a/snapo-link-android/tweaks/src/main/java/com/openai/snapo/tweaks/internal/TweakChangePublisher.kt
+++ b/snapo-link-android/tweaks/src/main/java/com/openai/snapo/tweaks/internal/TweakChangePublisher.kt
@@ -5,10 +5,17 @@ import java.util.concurrent.LinkedBlockingDeque
 
 internal class TweakChangePublisher(
     private val schedule: (Runnable) -> Boolean,
+    private val snapshot: () -> List<TweakSnapshot>,
 ) : Closeable {
+    constructor(schedule: (Runnable) -> Boolean) : this(
+        schedule = schedule,
+        snapshot = TweakRegistry::snapshot,
+    )
+
     private val lock = Any()
     private val subscriptions = LinkedHashMap<Long, LinkedBlockingDeque<List<TweakSnapshot>>>()
     private var nextSubscriptionId = 0L
+    private var changedSincePublicationStarted = false
     private var publicationScheduled = false
     private var closed = false
 
@@ -20,7 +27,7 @@ internal class TweakChangePublisher(
         subscriptions[id] = events
 
         Subscription(
-            initial = TweakRegistry.snapshot(),
+            initial = snapshot(),
             events = events,
             onClose = { synchronized(lock) { subscriptions.remove(id) } },
         )
@@ -28,7 +35,12 @@ internal class TweakChangePublisher(
 
     fun notifyChanged() {
         val shouldSchedule = synchronized(lock) {
-            if (closed || publicationScheduled || subscriptions.isEmpty()) {
+            if (closed) {
+                false
+            } else if (publicationScheduled) {
+                changedSincePublicationStarted = true
+                false
+            } else if (subscriptions.isEmpty()) {
                 false
             } else {
                 publicationScheduled = true
@@ -36,9 +48,7 @@ internal class TweakChangePublisher(
             }
         }
 
-        if (shouldSchedule && !schedule(Runnable(::publish))) {
-            synchronized(lock) { publicationScheduled = false }
-        }
+        if (shouldSchedule) schedulePublication()
     }
 
     override fun close() {
@@ -50,18 +60,43 @@ internal class TweakChangePublisher(
     }
 
     private fun publish() {
-        val snapshot = TweakRegistry.snapshot()
-
         synchronized(lock) {
-            publicationScheduled = false
-            if (closed) return
+            if (closed) {
+                publicationScheduled = false
+                return
+            }
+            changedSincePublicationStarted = false
+        }
+        val snapshot = snapshot()
 
-            subscriptions.values.forEach { events ->
-                if (!events.offer(snapshot)) {
-                    events.poll()
-                    events.offer(snapshot)
+        val shouldSchedule = synchronized(lock) {
+            if (closed) {
+                publicationScheduled = false
+                false
+            } else {
+                subscriptions.values.forEach { events ->
+                    if (!events.offer(snapshot)) {
+                        events.poll()
+                        events.offer(snapshot)
+                    }
+                }
+
+                if (changedSincePublicationStarted) {
+                    changedSincePublicationStarted = false
+                    true
+                } else {
+                    publicationScheduled = false
+                    false
                 }
             }
+        }
+
+        if (shouldSchedule) schedulePublication()
+    }
+
+    private fun schedulePublication() {
+        if (!schedule(Runnable(::publish))) {
+            synchronized(lock) { publicationScheduled = false }
         }
     }
 

--- a/snapo-link-android/tweaks/src/test/java/com/openai/snapo/tweaks/internal/TweakChangePublisherTest.kt
+++ b/snapo-link-android/tweaks/src/test/java/com/openai/snapo/tweaks/internal/TweakChangePublisherTest.kt
@@ -46,6 +46,7 @@ class TweakChangePublisherTest {
                 listOf("Motion/Duration", "Motion/Delay", "Motion/Repeat"),
                 subscription.events.poll()?.names(),
             )
+            assertTrue(scheduled.isEmpty())
             assertNull(subscription.events.poll())
         }
 
@@ -87,6 +88,95 @@ class TweakChangePublisherTest {
         }
 
         observer.close()
+    }
+
+    @Test
+    fun `changes arriving during publication are eventually published`() {
+        val tweak = descriptor("Motion/Duration", 400)
+        TweakRegistry.register(tweak)
+        val scheduled = mutableListOf<Runnable>()
+        var updateOnNextSnapshot = false
+        var updatedDuringPublication = false
+        val publisher = TweakChangePublisher(
+            schedule = { runnable -> scheduled.add(runnable) },
+            snapshot = {
+                val current = TweakRegistry.snapshot()
+                if (updateOnNextSnapshot) {
+                    updateOnNextSnapshot = false
+                    TweakRegistry.update(mapOf(tweak.name to 550))
+                    updatedDuringPublication = true
+                }
+                current
+            },
+        )
+        val observer = TweakRegistry.observeChanges(publisher::notifyChanged)
+
+        publisher.subscribe().use { subscription ->
+            TweakRegistry.update(mapOf(tweak.name to 500))
+            updateOnNextSnapshot = true
+
+            assertEquals(1, scheduled.size)
+            scheduled.removeAt(0).run()
+
+            assertTrue(updatedDuringPublication)
+            assertEquals(500, subscription.events.poll()?.single()?.value)
+            assertEquals(1, scheduled.size)
+
+            scheduled.removeAt(0).run()
+
+            assertEquals(550, subscription.events.poll()?.single()?.value)
+            assertTrue(scheduled.isEmpty())
+            assertNull(subscription.events.poll())
+        }
+
+        observer.close()
+    }
+
+    @Test
+    fun `changes during publication survive subscriber churn`() {
+        val tweak = descriptor("Motion/Duration", 400)
+        TweakRegistry.register(tweak)
+        val scheduled = mutableListOf<Runnable>()
+        var churnOnNextSnapshot = false
+        lateinit var publisher: TweakChangePublisher
+        lateinit var initialSubscription: TweakChangePublisher.Subscription
+        var replacementSubscription: TweakChangePublisher.Subscription? = null
+        publisher = TweakChangePublisher(
+            schedule = { runnable -> scheduled.add(runnable) },
+            snapshot = {
+                val current = TweakRegistry.snapshot()
+                if (churnOnNextSnapshot) {
+                    churnOnNextSnapshot = false
+                    initialSubscription.close()
+                    TweakRegistry.update(mapOf(tweak.name to 550))
+                    replacementSubscription = publisher.subscribe()
+                }
+                current
+            },
+        )
+        val observer = TweakRegistry.observeChanges(publisher::notifyChanged)
+        initialSubscription = publisher.subscribe()
+
+        try {
+            TweakRegistry.update(mapOf(tweak.name to 500))
+            churnOnNextSnapshot = true
+
+            scheduled.removeAt(0).run()
+
+            val replacement = requireNotNull(replacementSubscription)
+            assertEquals(550, replacement.initial.single().value)
+            assertEquals(1, scheduled.size)
+
+            scheduled.removeAt(0).run()
+
+            assertEquals(550, replacement.events.poll()?.single()?.value)
+            assertTrue(scheduled.isEmpty())
+            assertNull(replacement.events.poll())
+        } finally {
+            initialSubscription.close()
+            replacementSubscription?.close()
+            observer.close()
+        }
     }
 
     @Test


### PR DESCRIPTION
## Summary

- Decode tweak event-stream frames from raw bytes in the Mac inspector so overlay edits are dispatched immediately.
- Await tweak event forwarding to preserve stream ordering for rapid updates.
- Schedule a follow-up Android snapshot when a tweak changes during publication, while preserving composition add/remove batching.
- Add deterministic regression coverage for updates during publication and subscriber churn.

## Root cause

The Mac client waited for an empty SSE separator line from `URLSession.AsyncBytes.lines`, but that sequence omits blank lines, so streamed tweak events were never dispatched. The Android publisher also had a race where a snapshot could be captured before the scheduled-publication flag was cleared, allowing a concurrent update to miss a follow-up snapshot.

## Validation

- `:tweaks:testDebugUnitTest` and `:tweaks-overlay:testDebugUnitTest`
- `:tweaks:detekt`
- Android `build`
- Tweaks inspector web tests
- Mac `xcodebuild` build
- SwiftFormat and SwiftLint
- Live smoke test on a physical Android device: in-app overlay changes update the Mac inspector