### PR TITLE
Improve Compose color tweaks with a visual picker

### DIFF
--- a/contracts/tweaks/README.md
+++ b/contracts/tweaks/README.md
@@ -159,6 +159,13 @@ constraints actually supplied by the app. A `step` is relative to `min`, or to
 `default` if no `min` is supplied. Colors use `#RRGGBB`, or `#RRGGBBAA` when
 translucent.
 
+Compose color defaults keep their exact in-process identity, including color
+space, component precision, and `Color.Unspecified`. The HTTP protocol still
+presents colors as sRGB hex; non-sRGB defaults are projected, and
+`Color.Unspecified` appears as `#00000000`. Patching a color with that presented
+default remains the legacy reset operation, so the same projected hex cannot
+also express a distinct sRGB edit for a non-round-trippable default.
+
 Numeric JSON values may contain at most 128 characters and 64 significant
 digits, with a decimal scale between -64 and 64. Reject values outside those
 limits with `422` before changing any tweaks.

--- a/snapo-link-android/tweaks-overlay/src/main/java/com/openai/snapo/tweaks/overlay/TweakColorPicker.kt
+++ b/snapo-link-android/tweaks-overlay/src/main/java/com/openai/snapo/tweaks/overlay/TweakColorPicker.kt
@@ -1,0 +1,517 @@
+package com.openai.snapo.tweaks.overlay
+
+import androidx.compose.foundation.Canvas
+import androidx.compose.foundation.background
+import androidx.compose.foundation.border
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.interaction.MutableInteractionSource
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Slider
+import androidx.compose.material3.SliderDefaults
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.geometry.CornerRadius
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.geometry.Size
+import androidx.compose.ui.graphics.Brush
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.colorspace.ColorSpaces
+import androidx.compose.ui.graphics.drawscope.DrawScope
+import androidx.compose.ui.graphics.drawscope.Stroke
+import androidx.compose.ui.graphics.isSpecified
+import androidx.compose.ui.graphics.toArgb
+import androidx.compose.ui.semantics.Role
+import androidx.compose.ui.semantics.contentDescription
+import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.text.font.FontFamily
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import com.openai.snapo.tweaks.SnapOTweakEntry
+import com.openai.snapo.tweaks.SnapOTweakValue
+import com.openai.snapo.tweaks.SnapOTweaks
+import kotlin.math.ceil
+import kotlin.math.max
+import kotlin.math.min
+
+private val DefaultPickerColor = PickerColor(
+    hue = 210f,
+    saturation = 0.75f,
+    brightness = 1f,
+    alpha = 1f,
+)
+
+/** HSV state used by the visual picker. Values are clamped when converted to a Compose color. */
+internal data class PickerColor(
+    val hue: Float,
+    val saturation: Float,
+    val brightness: Float,
+    val alpha: Float,
+)
+
+internal class ColorPickerState(initialColor: PickerColor) {
+    var color by mutableStateOf(initialColor)
+        private set
+
+    private var locallyEmittedColor: Color? = null
+
+    fun sync(source: Color) {
+        if (source != locallyEmittedColor) {
+            color = source.toPickerColorOrNull() ?: DefaultPickerColor
+        }
+        locallyEmittedColor = null
+    }
+
+    fun select(
+        selected: PickerColor,
+        onColorChange: (Color) -> Unit,
+    ) {
+        color = selected
+        emit(selected.toComposeColor(), onColorChange)
+    }
+
+    fun selectAlpha(
+        alpha: Float,
+        source: Color,
+        onColorChange: (Color) -> Unit,
+    ) {
+        val selected = color.copy(alpha = alpha)
+        color = selected
+        val updated = if (source.isSpecified) {
+            source.copy(alpha = alpha.coerceIn(0f, 1f))
+        } else {
+            selected.toComposeColor()
+        }
+        emit(updated, onColorChange)
+    }
+
+    private fun emit(
+        updated: Color,
+        onColorChange: (Color) -> Unit,
+    ) {
+        locallyEmittedColor = updated
+        onColorChange(updated)
+    }
+}
+
+@Composable
+private fun rememberColorPickerState(
+    name: String,
+    source: Color,
+): ColorPickerState {
+    val state = remember(name) {
+        ColorPickerState(source.toPickerColorOrNull() ?: DefaultPickerColor)
+    }
+
+    LaunchedEffect(source) {
+        state.sync(source)
+    }
+
+    return state
+}
+
+@Composable
+internal fun TweakColorField(
+    tweak: SnapOTweakEntry,
+    onClick: () -> Unit,
+) {
+    val color = (tweak.value.value as SnapOTweakValue.ColorValue).value
+    val label = color.toPickerLabel()
+
+    Row(
+        modifier = Modifier
+            .height(48.dp)
+            .clickable(
+                role = Role.Button,
+                onClick = onClick,
+            )
+            .semantics {
+                contentDescription = "Choose color for ${tweak.name}. Current value: $label"
+            }
+            .padding(start = 8.dp),
+        verticalAlignment = Alignment.CenterVertically,
+        horizontalArrangement = Arrangement.spacedBy(8.dp),
+    ) {
+        Text(
+            text = label,
+            color = TweakOverlayColors.secondary,
+            fontSize = 11.sp,
+            fontFamily = FontFamily.Monospace,
+            maxLines = 1,
+        )
+        TweakColorSwatch(
+            color = color,
+            modifier = Modifier.size(20.dp),
+        )
+    }
+}
+
+@Composable
+internal fun TweakColorChooser(
+    tweak: SnapOTweakEntry,
+    modifier: Modifier = Modifier,
+) {
+    val color = (tweak.value.value as SnapOTweakValue.ColorValue).value
+    val pickerState = rememberColorPickerState(tweak.name, color)
+    val updateColor: (Color) -> Unit = { updated ->
+        SnapOTweaks.update(
+            tweak.name,
+            SnapOTweakValue.ColorValue(updated),
+        )
+    }
+
+    Column(
+        modifier = modifier
+            .fillMaxWidth()
+            .verticalScroll(rememberScrollState())
+            .padding(horizontal = TweakOverlayLayout.contentHorizontalPadding, vertical = 4.dp),
+    ) {
+        TweakColorPreview(color)
+        HueChannel(pickerState.color) { selected -> pickerState.select(selected, updateColor) }
+        SaturationChannel(pickerState.color) { selected ->
+            pickerState.select(selected, updateColor)
+        }
+        BrightnessChannel(pickerState.color) { selected ->
+            pickerState.select(selected, updateColor)
+        }
+        OpacityChannel(pickerState.color) { alpha ->
+            pickerState.selectAlpha(alpha, color, updateColor)
+        }
+    }
+}
+
+@Composable
+private fun HueChannel(
+    color: PickerColor,
+    onColorChange: (PickerColor) -> Unit,
+) {
+    ColorChannelRow(
+        label = "Hue",
+        value = color.hue,
+        valueRange = 0f..360f,
+        trackColors = listOf(
+            Color.Red,
+            Color.Yellow,
+            Color.Green,
+            Color.Cyan,
+            Color.Blue,
+            Color.Magenta,
+            Color.Red,
+        ),
+        thumbColor = color.copy(alpha = 1f).toComposeColor(),
+        onValueChange = { hue -> onColorChange(color.copy(hue = hue)) },
+    )
+}
+
+@Composable
+private fun SaturationChannel(
+    color: PickerColor,
+    onColorChange: (PickerColor) -> Unit,
+) {
+    ColorChannelRow(
+        label = "Saturation",
+        value = color.saturation,
+        valueRange = 0f..1f,
+        trackColors = listOf(
+            color.copy(saturation = 0f, alpha = 1f).toComposeColor(),
+            color.copy(saturation = 1f, alpha = 1f).toComposeColor(),
+        ),
+        thumbColor = color.copy(alpha = 1f).toComposeColor(),
+        onValueChange = { saturation ->
+            onColorChange(color.copy(saturation = saturation))
+        },
+    )
+}
+
+@Composable
+private fun BrightnessChannel(
+    color: PickerColor,
+    onColorChange: (PickerColor) -> Unit,
+) {
+    ColorChannelRow(
+        label = "Brightness",
+        value = color.brightness,
+        valueRange = 0f..1f,
+        trackColors = listOf(
+            Color.Black,
+            color.copy(brightness = 1f, alpha = 1f).toComposeColor(),
+        ),
+        thumbColor = color.copy(alpha = 1f).toComposeColor(),
+        onValueChange = { brightness ->
+            onColorChange(color.copy(brightness = brightness))
+        },
+    )
+}
+
+@Composable
+private fun OpacityChannel(
+    color: PickerColor,
+    onAlphaChange: (Float) -> Unit,
+) {
+    ColorChannelRow(
+        label = "Opacity",
+        value = color.alpha,
+        valueRange = 0f..1f,
+        trackColors = listOf(
+            color.copy(alpha = 0f).toComposeColor(),
+            color.copy(alpha = 1f).toComposeColor(),
+        ),
+        thumbColor = color.toComposeColor(),
+        showCheckerboard = true,
+        onValueChange = onAlphaChange,
+    )
+}
+
+@Composable
+private fun TweakColorPreview(
+    color: Color,
+) {
+    val label = color.toPickerLabel()
+
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .height(48.dp)
+            .padding(horizontal = 6.dp),
+        verticalAlignment = Alignment.CenterVertically,
+        horizontalArrangement = Arrangement.spacedBy(10.dp),
+    ) {
+        TweakColorSwatch(
+            color = color,
+            modifier = Modifier
+                .size(34.dp)
+                .semantics { contentDescription = "Current color: $label" },
+        )
+        Column {
+            Text(
+                text = label,
+                color = TweakOverlayColors.foreground,
+                fontSize = 13.sp,
+                fontFamily = FontFamily.Monospace,
+                maxLines = 1,
+                overflow = TextOverflow.Ellipsis,
+            )
+            Text(
+                text = if (color.isSpecified) "Live preview" else "No color selected",
+                color = TweakOverlayColors.secondary,
+                fontSize = 11.sp,
+                maxLines = 1,
+            )
+        }
+    }
+}
+
+@Composable
+private fun ColorChannelRow(
+    label: String,
+    value: Float,
+    valueRange: ClosedFloatingPointRange<Float>,
+    trackColors: List<Color>,
+    thumbColor: Color,
+    onValueChange: (Float) -> Unit,
+    showCheckerboard: Boolean = false,
+) {
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .height(48.dp)
+            .padding(horizontal = 6.dp),
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        Text(
+            text = label,
+            modifier = Modifier.width(72.dp),
+            color = TweakOverlayColors.secondary,
+            fontSize = 11.sp,
+            maxLines = 1,
+        )
+        ColorGradientSlider(
+            label = label,
+            value = value,
+            valueRange = valueRange,
+            trackColors = trackColors,
+            thumbColor = thumbColor,
+            showCheckerboard = showCheckerboard,
+            onValueChange = onValueChange,
+            modifier = Modifier.weight(1f),
+        )
+    }
+}
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+private fun ColorGradientSlider(
+    label: String,
+    value: Float,
+    valueRange: ClosedFloatingPointRange<Float>,
+    trackColors: List<Color>,
+    thumbColor: Color,
+    showCheckerboard: Boolean,
+    onValueChange: (Float) -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    val interactionSource = remember { MutableInteractionSource() }
+    val colors = SliderDefaults.colors(
+        thumbColor = thumbColor,
+        activeTrackColor = Color.Transparent,
+        inactiveTrackColor = Color.Transparent,
+    )
+
+    Slider(
+        value = value.coerceIn(valueRange),
+        onValueChange = onValueChange,
+        modifier = modifier.semantics { contentDescription = "$label color channel" },
+        valueRange = valueRange,
+        colors = colors,
+        interactionSource = interactionSource,
+        thumb = {
+            Box(
+                modifier = Modifier
+                    .size(14.dp)
+                    .background(thumbColor.copy(alpha = 1f), CircleShape)
+                    .border(2.dp, TweakOverlayColors.surface, CircleShape),
+            )
+        },
+        track = {
+            Canvas(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .height(10.dp)
+                    .clip(RoundedCornerShape(5.dp)),
+            ) {
+                if (showCheckerboard) {
+                    drawCheckerboard()
+                }
+                drawRect(brush = Brush.horizontalGradient(trackColors))
+                drawRoundRect(
+                    color = TweakOverlayColors.outline,
+                    cornerRadius = CornerRadius(5.dp.toPx(), 5.dp.toPx()),
+                    style = Stroke(width = 1.dp.toPx()),
+                )
+            }
+        },
+    )
+}
+
+@Composable
+private fun TweakColorSwatch(
+    color: Color,
+    modifier: Modifier = Modifier,
+) {
+    Canvas(
+        modifier = modifier
+            .clip(RoundedCornerShape(4.dp))
+            .border(1.dp, TweakOverlayColors.outline, RoundedCornerShape(4.dp)),
+    ) {
+        drawCheckerboard()
+        if (color.isSpecified) {
+            drawRect(color = color)
+        } else {
+            drawLine(
+                color = TweakOverlayColors.secondary,
+                start = Offset(2.dp.toPx(), size.height - 2.dp.toPx()),
+                end = Offset(size.width - 2.dp.toPx(), 2.dp.toPx()),
+                strokeWidth = 1.5.dp.toPx(),
+            )
+        }
+    }
+}
+
+private fun DrawScope.drawCheckerboard() {
+    val cellSize = 6.dp.toPx()
+    val columns = ceil(size.width / cellSize).toInt()
+    val rows = ceil(size.height / cellSize).toInt()
+
+    for (row in 0..rows) {
+        for (column in 0..columns) {
+            val color = if ((row + column) % 2 == 0) {
+                Color.White
+            } else {
+                Color(0xFFD9DDE3)
+            }
+            val x = column * cellSize
+            val y = row * cellSize
+            drawRect(
+                color = color,
+                topLeft = Offset(x, y),
+                size = Size(
+                    width = min(cellSize, size.width - x).coerceAtLeast(0f),
+                    height = min(cellSize, size.height - y).coerceAtLeast(0f),
+                ),
+            )
+        }
+    }
+}
+
+internal fun Color.toPickerColorOrNull(): PickerColor? {
+    if (!isSpecified) return null
+
+    val srgb = runCatching { convert(ColorSpaces.Srgb) }.getOrNull() ?: return null
+    val red = srgb.red.coerceIn(0f, 1f)
+    val green = srgb.green.coerceIn(0f, 1f)
+    val blue = srgb.blue.coerceIn(0f, 1f)
+    val maximum = max(red, max(green, blue))
+    val minimum = min(red, min(green, blue))
+    val delta = maximum - minimum
+    val hue = when {
+        delta == 0f -> 0f
+        maximum == red -> 60f * (((green - blue) / delta) % 6f)
+        maximum == green -> 60f * ((blue - red) / delta + 2f)
+        else -> 60f * ((red - green) / delta + 4f)
+    }.let { computed -> if (computed < 0f) computed + 360f else computed }
+    val saturation = if (maximum == 0f) 0f else delta / maximum
+
+    return PickerColor(
+        hue = hue,
+        saturation = saturation,
+        brightness = maximum,
+        alpha = alpha.coerceIn(0f, 1f),
+    )
+}
+
+internal fun PickerColor.toComposeColor(): Color =
+    Color.hsv(
+        hue = ((hue % 360f) + 360f) % 360f,
+        saturation = saturation.coerceIn(0f, 1f),
+        value = brightness.coerceIn(0f, 1f),
+        alpha = alpha.coerceIn(0f, 1f),
+    )
+
+internal fun Color.toPickerLabel(): String {
+    if (!isSpecified) return "Unspecified"
+
+    val argb = runCatching { toArgb() }.getOrNull() ?: return "Unsupported"
+    val rgb = (argb and 0x00FF_FFFF)
+        .toString(radix = 16)
+        .padStart(length = 6, padChar = '0')
+        .uppercase()
+    val alpha = argb ushr 24
+
+    return if (alpha == 0xFF) {
+        "#$rgb"
+    } else {
+        val suffix = alpha.toString(radix = 16).padStart(length = 2, padChar = '0').uppercase()
+        "#$rgb$suffix"
+    }
+}

--- a/snapo-link-android/tweaks-overlay/src/main/java/com/openai/snapo/tweaks/overlay/TweakOverlay.kt
+++ b/snapo-link-android/tweaks-overlay/src/main/java/com/openai/snapo/tweaks/overlay/TweakOverlay.kt
@@ -49,12 +49,14 @@ import androidx.compose.ui.layout.layout
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.IntOffset
 import androidx.compose.ui.unit.IntSize
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import com.openai.snapo.tweaks.SnapOTweakEntry
+import com.openai.snapo.tweaks.SnapOTweakValue
 import com.openai.snapo.tweaks.SnapOTweaks
 import kotlin.math.roundToInt
 
@@ -163,6 +165,25 @@ private fun TweakOverlayLayer(
 }
 
 @Composable
+private fun resolveSelectedColorTweak(
+    name: String?,
+    tweaks: List<SnapOTweakEntry>,
+    onMissing: () -> Unit,
+): SnapOTweakEntry? {
+    val selected = name?.let { selectedName ->
+        tweaks.firstOrNull { tweak ->
+            tweak.name == selectedName && tweak.defaultValue is SnapOTweakValue.ColorValue
+        }
+    }
+
+    LaunchedEffect(name, selected) {
+        if (name != null && selected == null) onMissing()
+    }
+
+    return selected
+}
+
+@Composable
 private fun Modifier.measureOverlaySize(
     onSizeMeasured: (IntSize) -> Unit,
 ): Modifier = layout { measurable, constraints ->
@@ -193,6 +214,14 @@ private fun ExpandedTweakOverlay(
     onMinimize: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
+    var selectedColorTweakName by rememberSaveable { mutableStateOf<String?>(null) }
+    val selectedColorTweak = resolveSelectedColorTweak(
+        name = selectedColorTweakName,
+        tweaks = tweaks,
+    ) {
+        selectedColorTweakName = null
+    }
+
     Surface(
         modifier = modifier.height(height),
         shape = RoundedCornerShape(14.dp),
@@ -202,31 +231,47 @@ private fun ExpandedTweakOverlay(
         shadowElevation = 5.dp,
     ) {
         Column {
-            TweakOverlayActions(
-                tweaks = tweaks,
-                onMinimize = onMinimize,
-                onDrag = onDrag,
-            )
-            HorizontalDivider(color = TweakOverlayColors.outline)
+            if (selectedColorTweak == null) {
+                TweakOverlayActions(
+                    tweaks = tweaks,
+                    onMinimize = onMinimize,
+                    onDrag = onDrag,
+                )
+                HorizontalDivider(color = TweakOverlayColors.outline)
 
-            LazyColumn(
-                modifier = Modifier.weight(1f),
-                verticalArrangement = Arrangement.spacedBy(TweakOverlayLayout.fieldRowSpacing),
-            ) {
-                itemsIndexed(tweaks, key = { _, tweak -> tweak.name }) { index, tweak ->
-                    val section = tweak.name.substringBefore('/', missingDelimiterValue = "")
-                    val previousSection = if (index == 0) {
-                        null
-                    } else {
-                        tweaks[index - 1].name.substringBefore('/', missingDelimiterValue = "")
+                LazyColumn(
+                    modifier = Modifier.weight(1f),
+                    verticalArrangement = Arrangement.spacedBy(TweakOverlayLayout.fieldRowSpacing),
+                ) {
+                    itemsIndexed(tweaks, key = { _, tweak -> tweak.name }) { index, tweak ->
+                        val section = tweak.name.substringBefore('/', missingDelimiterValue = "")
+                        val previousSection = if (index == 0) {
+                            null
+                        } else {
+                            tweaks[index - 1].name.substringBefore('/', missingDelimiterValue = "")
+                        }
+
+                        if (section.isNotEmpty() && section != previousSection) {
+                            TweakOverlaySection(section)
+                        }
+
+                        TweakOverlayControl(
+                            tweak = tweak,
+                            onSelectColor = { selectedColorTweakName = tweak.name },
+                        )
                     }
-
-                    if (section.isNotEmpty() && section != previousSection) {
-                        TweakOverlaySection(section)
-                    }
-
-                    TweakOverlayControl(tweak)
                 }
+            } else {
+                TweakColorOverlayActions(
+                    tweak = selectedColorTweak,
+                    onClose = { selectedColorTweakName = null },
+                    onDrag = onDrag,
+                )
+                HorizontalDivider(color = TweakOverlayColors.outline)
+                TweakColorChooser(
+                    tweak = selectedColorTweak,
+                    modifier = Modifier.weight(1f),
+                )
             }
         }
     }
@@ -245,22 +290,52 @@ private fun TweakOverlayActions(
     }
 
     TweakOverlayHeader(
+        title = "Tweaks",
         hasChanges = hasChanges,
         onReset = {
             tweaks.filter { tweak -> tweak.isChanged }.forEach { tweak ->
                 SnapOTweaks.update(tweak.name, tweak.defaultValue)
             }
         },
-        onMinimize = onMinimize,
+        resetContentDescription = "Reset all tweaks",
+        onTrailingAction = onMinimize,
+        trailingIcon = R.drawable.snapo_tweaks_close,
+        trailingContentDescription = "Minimize tweaks",
+        onDrag = onDrag,
+    )
+}
+
+@Composable
+private fun TweakColorOverlayActions(
+    tweak: SnapOTweakEntry,
+    onClose: () -> Unit,
+    onDrag: (Float) -> Unit,
+) {
+    val hasChanges by remember(tweak) {
+        derivedStateOf(structuralEqualityPolicy()) { tweak.isChanged }
+    }
+
+    TweakOverlayHeader(
+        title = tweak.name.substringAfter('/'),
+        hasChanges = hasChanges,
+        onReset = { SnapOTweaks.update(tweak.name, tweak.defaultValue) },
+        resetContentDescription = "Reset ${tweak.name}",
+        onTrailingAction = onClose,
+        trailingIcon = R.drawable.snapo_tweaks_check,
+        trailingContentDescription = "Done editing ${tweak.name}",
         onDrag = onDrag,
     )
 }
 
 @Composable
 private fun TweakOverlayHeader(
+    title: String,
     hasChanges: Boolean,
     onReset: () -> Unit,
-    onMinimize: () -> Unit,
+    resetContentDescription: String,
+    onTrailingAction: () -> Unit,
+    trailingIcon: Int,
+    trailingContentDescription: String,
     onDrag: (Float) -> Unit,
 ) {
     val currentOnDrag by rememberUpdatedState(onDrag)
@@ -291,10 +366,12 @@ private fun TweakOverlayHeader(
             horizontalArrangement = Arrangement.spacedBy(2.dp),
         ) {
             Text(
-                text = "Tweaks",
+                text = title,
                 modifier = Modifier.weight(1f),
                 fontSize = 15.sp,
                 fontWeight = FontWeight.Medium,
+                maxLines = 1,
+                overflow = TextOverflow.Ellipsis,
             )
 
             IconButton(
@@ -303,27 +380,32 @@ private fun TweakOverlayHeader(
             ) {
                 Icon(
                     painter = painterResource(R.drawable.snapo_tweaks_restart),
-                    contentDescription = "Reset all tweaks",
+                    contentDescription = resetContentDescription,
                 )
             }
 
-            IconButton(onClick = onMinimize) {
+            IconButton(onClick = onTrailingAction) {
                 Icon(
-                    painter = painterResource(R.drawable.snapo_tweaks_close),
-                    contentDescription = "Minimize tweaks",
+                    painter = painterResource(trailingIcon),
+                    contentDescription = trailingContentDescription,
                 )
             }
         }
 
-        Box(
-            modifier = Modifier
-                .align(Alignment.TopCenter)
-                .padding(top = 7.dp)
-                .width(30.dp)
-                .height(3.dp)
-                .background(TweakOverlayColors.secondary.copy(alpha = 0.35f), CircleShape),
-        )
+        TweakOverlayDragHandle()
     }
+}
+
+@Composable
+private fun BoxScope.TweakOverlayDragHandle() {
+    Box(
+        modifier = Modifier
+            .align(Alignment.TopCenter)
+            .padding(top = 7.dp)
+            .width(30.dp)
+            .height(3.dp)
+            .background(TweakOverlayColors.secondary.copy(alpha = 0.35f), CircleShape),
+    )
 }
 
 @Composable

--- a/snapo-link-android/tweaks-overlay/src/main/java/com/openai/snapo/tweaks/overlay/TweakOverlayControls.kt
+++ b/snapo-link-android/tweaks-overlay/src/main/java/com/openai/snapo/tweaks/overlay/TweakOverlayControls.kt
@@ -1,7 +1,6 @@
 package com.openai.snapo.tweaks.overlay
 
 import androidx.compose.foundation.background
-import androidx.compose.foundation.border
 import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
@@ -38,11 +37,8 @@ import androidx.compose.runtime.structuralEqualityPolicy
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.focus.onFocusChanged
-import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.graphics.toArgb
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.text.TextStyle
-import androidx.compose.ui.text.font.FontFamily
 import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.DpSize
@@ -64,6 +60,7 @@ private const val MaximumDiscreteSliderIntervals = 1_000
 @Composable
 internal fun TweakOverlayControl(
     tweak: SnapOTweakEntry,
+    onSelectColor: () -> Unit,
 ) {
     Column(
         modifier = Modifier
@@ -76,22 +73,29 @@ internal fun TweakOverlayControl(
                     TweakIntegerSlider(tweak, defaultValue, modifier)
                 }
             } else {
-                TweakOverlayLabelRow(tweak)
+                TweakOverlayLabelRow(tweak) {
+                    TweakIntegerEditor(tweak, defaultValue)
+                }
             }
             is SnapOTweakValue.Floating -> if (defaultValue.hasSliderBounds()) {
                 TweakNumericControl(tweak) { modifier ->
                     TweakFloatingSlider(tweak, defaultValue, modifier)
                 }
             } else {
-                TweakOverlayLabelRow(tweak)
+                TweakOverlayLabelRow(tweak) {
+                    TweakFloatingEditor(tweak, defaultValue)
+                }
             }
             is SnapOTweakValue.Text -> {
-                TweakOverlayLabelRow(tweak)
+                TweakOverlayLabelRow(tweak) {}
                 TweakTextEditor(tweak)
             }
-            is SnapOTweakValue.Toggle,
-            is SnapOTweakValue.ColorValue,
-            -> TweakOverlayLabelRow(tweak)
+            is SnapOTweakValue.Toggle -> TweakOverlayLabelRow(tweak) {
+                TweakToggleField(tweak)
+            }
+            is SnapOTweakValue.ColorValue -> TweakOverlayLabelRow(tweak) {
+                TweakColorField(tweak, onSelectColor)
+            }
         }
     }
 }
@@ -168,7 +172,9 @@ private fun TweakNumericControl(
         TweakOverlayLabelRow(
             tweak = tweak,
             compact = true,
-        )
+        ) {
+            TweakNumericFieldValue(tweak)
+        }
         slider(
             Modifier.requiredHeight(48.dp),
         )
@@ -180,6 +186,7 @@ private fun TweakOverlayLabelRow(
     tweak: SnapOTweakEntry,
     modifier: Modifier = Modifier,
     compact: Boolean = false,
+    field: @Composable () -> Unit,
 ) {
     val rowHeight = if (compact) 20.dp else 48.dp
     val isChanged by remember(tweak) {
@@ -233,29 +240,8 @@ private fun TweakOverlayLabelRow(
         Box(
             contentAlignment = Alignment.CenterEnd,
         ) {
-            TweakOverlayField(tweak)
+            field()
         }
-    }
-}
-
-@Composable
-private fun TweakOverlayField(
-    tweak: SnapOTweakEntry,
-) {
-    when (val defaultValue = tweak.defaultValue) {
-        is SnapOTweakValue.Integer -> if (defaultValue.hasSliderBounds()) {
-            TweakNumericFieldValue(tweak)
-        } else {
-            TweakIntegerEditor(tweak, defaultValue)
-        }
-        is SnapOTweakValue.Floating -> if (defaultValue.hasSliderBounds()) {
-            TweakNumericFieldValue(tweak)
-        } else {
-            TweakFloatingEditor(tweak, defaultValue)
-        }
-        is SnapOTweakValue.Toggle -> TweakToggleField(tweak)
-        is SnapOTweakValue.ColorValue -> TweakColorEditor(tweak)
-        is SnapOTweakValue.Text -> Unit
     }
 }
 
@@ -614,88 +600,10 @@ private fun TweakTextEditor(
 }
 
 @Composable
-private fun TweakColorEditor(
-    tweak: SnapOTweakEntry,
-) {
-    val value = tweak.value.value as SnapOTweakValue.ColorValue
-    val committed = value.value.toTweakHex()
-    var draft by rememberSaveable { mutableStateOf(committed) }
-    var isFocused by remember { mutableStateOf(false) }
-
-    LaunchedEffect(committed, isFocused) {
-        if (!isFocused) draft = committed
-    }
-
-    Row(
-        verticalAlignment = Alignment.CenterVertically,
-        horizontalArrangement = Arrangement.spacedBy(8.dp),
-    ) {
-        Box(
-            modifier = Modifier
-                .size(18.dp)
-                .background(value.value, RoundedCornerShape(4.dp))
-                .border(1.dp, TweakOverlayColors.outline, RoundedCornerShape(4.dp)),
-        )
-
-        BasicTextField(
-            value = draft,
-            onValueChange = { updated ->
-                if (updated.length <= 9) {
-                    draft = updated
-                    updated.toTweakColorOrNull()?.let { color ->
-                        SnapOTweaks.update(tweak.name, value.copy(value = color))
-                    }
-                }
-            },
-            modifier = Modifier
-                .width(78.dp)
-                .onFocusChanged { isFocused = it.isFocused },
-            textStyle = TextStyle(
-                color = TweakOverlayColors.foreground,
-                fontSize = 12.sp,
-                fontFamily = FontFamily.Monospace,
-            ),
-            keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Ascii),
-            singleLine = true,
-        )
-    }
-}
-
-@Composable
 private fun TweakFieldText(value: String) {
     Text(
         text = value,
         color = TweakOverlayColors.foreground,
         fontSize = 13.sp,
     )
-}
-
-private fun Color.toTweakHex(): String {
-    val argb = toArgb()
-    val rgb = (argb and 0x00FF_FFFF)
-        .toString(radix = 16)
-        .padStart(length = 6, padChar = '0')
-        .uppercase()
-    val alpha = argb ushr 24
-
-    return if (alpha == 0xFF) {
-        "#$rgb"
-    } else {
-        val suffix = alpha.toString(radix = 16).padStart(length = 2, padChar = '0').uppercase()
-        "#$rgb$suffix"
-    }
-}
-
-private fun String.toTweakColorOrNull(): Color? {
-    if (!Regex("^#[0-9a-fA-F]{6}([0-9a-fA-F]{2})?$").matches(this)) return null
-
-    val digits = substring(1)
-    val argb = if (digits.length == 6) {
-        0xFF00_0000L or digits.toLong(radix = 16)
-    } else {
-        val rgba = digits.toLong(radix = 16)
-        ((rgba and 0xFF) shl 24) or (rgba ushr 8)
-    }
-
-    return Color(argb.toInt())
 }

--- a/snapo-link-android/tweaks-overlay/src/main/res/drawable/snapo_tweaks_check.xml
+++ b/snapo-link-android/tweaks-overlay/src/main/res/drawable/snapo_tweaks_check.xml
@@ -1,0 +1,9 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="960"
+    android:viewportHeight="960">
+    <path
+        android:fillColor="@android:color/white"
+        android:pathData="M382,720L166,504L222,448L382,608L738,252L794,308L382,720Z" />
+</vector>

--- a/snapo-link-android/tweaks-overlay/src/test/java/com/openai/snapo/tweaks/overlay/TweakColorPickerTest.kt
+++ b/snapo-link-android/tweaks-overlay/src/test/java/com/openai/snapo/tweaks/overlay/TweakColorPickerTest.kt
@@ -1,0 +1,92 @@
+package com.openai.snapo.tweaks.overlay
+
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.colorspace.ColorSpaces
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Test
+
+class TweakColorPickerTest {
+
+    @Test
+    fun `picker converts primary hues to sRGB colors`() {
+        assertEquals(Color.Red, PickerColor(0f, 1f, 1f, 1f).toComposeColor())
+        assertEquals(Color.Green, PickerColor(120f, 1f, 1f, 1f).toComposeColor())
+        assertEquals(Color.Blue, PickerColor(240f, 1f, 1f, 1f).toComposeColor())
+    }
+
+    @Test
+    fun `picker normalizes hue and clamps channels`() {
+        val color = PickerColor(
+            hue = -120f,
+            saturation = 2f,
+            brightness = 2f,
+            alpha = -1f,
+        ).toComposeColor()
+
+        assertEquals(Color.Blue.copy(alpha = 0f), color)
+    }
+
+    @Test
+    fun `picker reads projected rgb while preserving current alpha`() {
+        val color = Color(
+            red = 0.25f,
+            green = 0.5f,
+            blue = 0.75f,
+            alpha = 0.3f,
+        )
+
+        val picker = requireNotNull(color.toPickerColorOrNull())
+
+        assertEquals(210f, picker.hue, 0.5f)
+        assertEquals(2f / 3f, picker.saturation, 0.01f)
+        assertEquals(0.75f, picker.brightness, 0.01f)
+        assertEquals(color.alpha, picker.alpha, 0f)
+    }
+
+    @Test
+    fun `unspecified colors do not initialize a concrete picker value`() {
+        assertNull(Color.Unspecified.toPickerColorOrNull())
+        assertEquals("Unspecified", Color.Unspecified.toPickerLabel())
+    }
+
+    @Test
+    fun `picker labels make alpha visible without a keyboard`() {
+        assertEquals("#11223380", Color(0x80112233).toPickerLabel())
+        assertEquals("#112233", Color(0xFF112233).toPickerLabel())
+    }
+
+    @Test
+    fun `picker keeps a staged hue when a neutral color cannot encode it`() {
+        val state = ColorPickerState(PickerColor(0f, 0f, 1f, 1f))
+        var emitted: Color? = null
+
+        state.select(state.color.copy(hue = 240f)) { updated -> emitted = updated }
+        state.sync(requireNotNull(emitted))
+
+        assertEquals(Color.White, emitted)
+        assertEquals(240f, state.color.hue, 0f)
+    }
+
+    @Test
+    fun `opacity edits preserve exact source color components and color space`() {
+        val source = Color(
+            red = 0.25f,
+            green = 0.5f,
+            blue = 0.75f,
+            alpha = 0.3f,
+            colorSpace = ColorSpaces.DisplayP3,
+        )
+        val state = ColorPickerState(requireNotNull(source.toPickerColorOrNull()))
+        var emitted: Color? = null
+
+        state.selectAlpha(0.7f, source) { updated -> emitted = updated }
+
+        val updated = requireNotNull(emitted)
+        assertEquals(source.red, updated.red, 0f)
+        assertEquals(source.green, updated.green, 0f)
+        assertEquals(source.blue, updated.blue, 0f)
+        assertEquals(0.7f, updated.alpha, 0.001f)
+        assertEquals(ColorSpaces.DisplayP3, updated.colorSpace)
+    }
+}

--- a/snapo-link-android/tweaks/src/main/java/com/openai/snapo/tweaks/SnapOTweaks.kt
+++ b/snapo-link-android/tweaks/src/main/java/com/openai/snapo/tweaks/SnapOTweaks.kt
@@ -105,7 +105,7 @@ internal fun TweakDescriptor.toSnapOTweakValue(value: Any): SnapOTweakValue = wh
     )
 
     TweakType.BOOLEAN -> SnapOTweakValue.Toggle(value as Boolean)
-    TweakType.COLOR -> SnapOTweakValue.ColorValue((value as String).toTweakColor())
+    TweakType.COLOR -> SnapOTweakValue.ColorValue((value as TweakColorValue).color)
     TweakType.STRING -> SnapOTweakValue.Text(value as String)
 }
 
@@ -113,6 +113,6 @@ private fun SnapOTweakValue.toRegistryValue(): Any = when (this) {
     is SnapOTweakValue.Integer -> value
     is SnapOTweakValue.Floating -> value
     is SnapOTweakValue.Toggle -> value
-    is SnapOTweakValue.ColorValue -> value.toTweakColor()
+    is SnapOTweakValue.ColorValue -> value.toTweakColorValue()
     is SnapOTweakValue.Text -> value
 }

--- a/snapo-link-android/tweaks/src/main/java/com/openai/snapo/tweaks/TweakColorValue.kt
+++ b/snapo-link-android/tweaks/src/main/java/com/openai/snapo/tweaks/TweakColorValue.kt
@@ -1,0 +1,83 @@
+package com.openai.snapo.tweaks
+
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.isSpecified
+import androidx.compose.ui.graphics.toArgb
+
+/**
+ * Keeps the exact Compose color separate from the lossy sRGB value shown over the wire.
+ *
+ * The wire value remains compatible with existing hosts, while [color] participates in
+ * descriptor equality and retained-state identity.
+ */
+internal data class TweakColorValue(
+    val color: Color,
+    val wireValue: String,
+)
+
+internal fun Color.toTweakColorValue(): TweakColorValue =
+    TweakColorValue(
+        color = this,
+        wireValue = toTweakColor(),
+    )
+
+internal fun String.toTweakColorValue(): TweakColorValue {
+    val normalized = uppercase()
+    return TweakColorValue(
+        color = normalized.toTweakColor(),
+        wireValue = normalized,
+    )
+}
+
+internal fun Color.toTweakColor(): String {
+    val argb = if (isSpecified) {
+        toArgbSafely()
+    } else {
+        0
+    }
+    val redGreenBlue = (argb and 0x00FF_FFFF)
+        .toString(radix = 16)
+        .padStart(length = 6, padChar = '0')
+        .uppercase()
+    val alpha = argb ushr 24
+
+    return if (alpha == 0xFF) {
+        "#$redGreenBlue"
+    } else {
+        val alphaHex = alpha
+            .toString(radix = 16)
+            .padStart(length = 2, padChar = '0')
+            .uppercase()
+        "#$redGreenBlue$alphaHex"
+    }
+}
+
+private fun Color.toArgbSafely(): Int =
+    runCatching { toArgb() }.getOrElse { error ->
+        if (error !is RuntimeException) throw error
+        unsupportedTweakColor(error)
+    }
+
+private fun unsupportedTweakColor(error: RuntimeException): Nothing =
+    throw IllegalArgumentException(
+        "Tweak colors must be Color.Unspecified or convertible to sRGB.",
+        error,
+    )
+
+internal fun String.toTweakColor(): Color {
+    require(startsWith('#')) { "Tweak colors must start with #." }
+
+    val digits = substring(startIndex = 1)
+    val argb = when (digits.length) {
+        6 -> 0xFF00_0000L or digits.toLong(radix = 16)
+        8 -> {
+            val rgba = digits.toLong(radix = 16)
+            val alpha = rgba and 0xFF
+            (alpha shl 24) or (rgba ushr 8)
+        }
+
+        else -> error("Tweak colors must use #RRGGBB or #RRGGBBAA.")
+    }
+
+    return Color(argb.toInt())
+}

--- a/snapo-link-android/tweaks/src/main/java/com/openai/snapo/tweaks/Tweaks.kt
+++ b/snapo-link-android/tweaks/src/main/java/com/openai/snapo/tweaks/Tweaks.kt
@@ -6,8 +6,6 @@ import androidx.compose.runtime.State
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberUpdatedState
 import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.graphics.isSpecified
-import androidx.compose.ui.graphics.toArgb
 import com.openai.snapo.tweaks.internal.TweakDescriptor
 import com.openai.snapo.tweaks.internal.TweakRegistry
 import com.openai.snapo.tweaks.internal.TweakType
@@ -59,17 +57,15 @@ fun tweakColor(
     name: String,
     default: Color,
 ): State<Color> {
-    val encodedDefault = default.toTweakColor()
+    val defaultValue = default.toTweakColorValue()
     return rememberTweakState(
         TweakDescriptor(
             name = name,
             type = TweakType.COLOR,
-            default = encodedDefault,
+            default = defaultValue,
         ),
         default = default,
-    ) { value ->
-        decodeTweakColor(value, default, encodedDefault)
-    }
+    ) { value -> (value as TweakColorValue).color }
 }
 
 /** Exposes a boolean tweak as observable state. */
@@ -141,55 +137,4 @@ internal class TweakRegistration<T>(
             registered = false
         }
     }
-}
-
-internal fun decodeTweakColor(
-    value: Any,
-    default: Color,
-    encodedDefault: String,
-): Color {
-    val encodedValue = value as String
-
-    return if (encodedValue == encodedDefault) {
-        default
-    } else {
-        encodedValue.toTweakColor()
-    }
-}
-
-internal fun Color.toTweakColor(): String {
-    val argb = if (isSpecified) toArgb() else 0
-    val redGreenBlue = (argb and 0x00FF_FFFF)
-        .toString(radix = 16)
-        .padStart(length = 6, padChar = '0')
-        .uppercase()
-    val alpha = argb ushr 24
-
-    return if (alpha == 0xFF) {
-        "#$redGreenBlue"
-    } else {
-        val alphaHex = alpha
-            .toString(radix = 16)
-            .padStart(length = 2, padChar = '0')
-            .uppercase()
-        "#$redGreenBlue$alphaHex"
-    }
-}
-
-internal fun String.toTweakColor(): Color {
-    require(startsWith('#')) { "Tweak colors must start with #." }
-
-    val digits = substring(startIndex = 1)
-    val argb = when (digits.length) {
-        6 -> 0xFF00_0000L or digits.toLong(radix = 16)
-        8 -> {
-            val rgba = digits.toLong(radix = 16)
-            val alpha = rgba and 0xFF
-            (alpha shl 24) or (rgba ushr 8)
-        }
-
-        else -> error("Tweak colors must use #RRGGBB or #RRGGBBAA.")
-    }
-
-    return Color(argb.toInt())
 }

--- a/snapo-link-android/tweaks/src/main/java/com/openai/snapo/tweaks/internal/TweakHttpServer.kt
+++ b/snapo-link-android/tweaks/src/main/java/com/openai/snapo/tweaks/internal/TweakHttpServer.kt
@@ -8,6 +8,7 @@ import android.os.Process
 import android.util.JsonReader
 import android.util.JsonToken
 import android.util.JsonWriter
+import com.openai.snapo.tweaks.TweakColorValue
 import java.io.ByteArrayInputStream
 import java.io.ByteArrayOutputStream
 import java.io.Closeable
@@ -504,6 +505,7 @@ internal class TweakHttpServer(
             is Boolean -> writer.value(value)
             is Number -> writer.value(value)
             is String -> writer.value(value)
+            is TweakColorValue -> writer.value(value.wireValue)
             else -> throw HttpFailure(500, "Unsupported tweak value.")
         }
     }

--- a/snapo-link-android/tweaks/src/main/java/com/openai/snapo/tweaks/internal/TweakRegistry.kt
+++ b/snapo-link-android/tweaks/src/main/java/com/openai/snapo/tweaks/internal/TweakRegistry.kt
@@ -6,7 +6,9 @@ import androidx.compose.runtime.derivedStateOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.snapshots.Snapshot
 import com.openai.snapo.tweaks.SnapOTweakEntry
+import com.openai.snapo.tweaks.TweakColorValue
 import com.openai.snapo.tweaks.toSnapOTweakValue
+import com.openai.snapo.tweaks.toTweakColorValue
 import java.io.Closeable
 import java.math.BigDecimal
 import java.math.BigInteger
@@ -200,7 +202,8 @@ internal object TweakRegistry {
             }
 
             TweakType.COLOR -> require(
-                descriptor.default is String && colorPattern.matches(descriptor.default),
+                descriptor.default is TweakColorValue &&
+                    colorPattern.matches(descriptor.default.wireValue),
             ) {
                 "Color tweaks must use #RRGGBB or #RRGGBBAA: ${descriptor.name}"
             }
@@ -304,12 +307,36 @@ internal object TweakRegistry {
             }
 
             TweakType.COLOR -> {
-                val color = value as? String
-                    ?: invalidValue(descriptor, "Expected a color string.")
-                if (!colorPattern.matches(color)) {
-                    invalidValue(descriptor, "Expected #RRGGBB or #RRGGBBAA.")
+                val defaultColor = descriptor.default as TweakColorValue
+
+                when (value) {
+                    is TweakColorValue -> {
+                        val color = try {
+                            value.color.toTweakColorValue()
+                        } catch (_: IllegalArgumentException) {
+                            invalidValue(descriptor, "Expected a supported color.")
+                        }
+                        if (color.color == defaultColor.color) {
+                            defaultColor
+                        } else {
+                            color
+                        }
+                    }
+
+                    is String -> {
+                        if (!colorPattern.matches(value)) {
+                            invalidValue(descriptor, "Expected #RRGGBB or #RRGGBBAA.")
+                        }
+                        val normalized = value.uppercase()
+                        if (normalized == defaultColor.wireValue) {
+                            defaultColor
+                        } else {
+                            normalized.toTweakColorValue()
+                        }
+                    }
+
+                    else -> invalidValue(descriptor, "Expected a color string.")
                 }
-                color.uppercase()
             }
         }
 

--- a/snapo-link-android/tweaks/src/test/java/com/openai/snapo/tweaks/SnapOTweaksTest.kt
+++ b/snapo-link-android/tweaks/src/test/java/com/openai/snapo/tweaks/SnapOTweaksTest.kt
@@ -1,12 +1,14 @@
 package com.openai.snapo.tweaks
 
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.colorspace.ColorSpaces
 import com.openai.snapo.tweaks.internal.TweakDescriptor
 import com.openai.snapo.tweaks.internal.TweakRegistry
 import com.openai.snapo.tweaks.internal.TweakType
 import com.openai.snapo.tweaks.internal.TweaksRuntimePolicy
 import org.junit.After
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotEquals
 import org.junit.Assert.assertSame
 import org.junit.Assert.assertTrue
 import org.junit.Before
@@ -182,7 +184,7 @@ class SnapOTweaksTest {
         val descriptor = TweakDescriptor(
             name = "Colors/Accent",
             type = TweakType.COLOR,
-            default = "#5468FF",
+            default = "#5468FF".toTweakColorValue(),
         )
         val state = TweakRegistry.register(descriptor)
 
@@ -196,7 +198,58 @@ class SnapOTweaksTest {
             SnapOTweakValue.ColorValue(Color(0xFF112233)),
         )
 
-        assertEquals("#112233", state.value)
+        assertEquals("#112233", (state.value as TweakColorValue).wireValue)
+    }
+
+    @Test
+    fun `color entries preserve exact defaults and overlay resets`() {
+        val default = Color(
+            red = 0.25f,
+            green = 0.5f,
+            blue = 0.75f,
+            alpha = 0.3f,
+            colorSpace = ColorSpaces.DisplayP3,
+        )
+        val descriptor = TweakDescriptor(
+            name = "Colors/Exact accent",
+            type = TweakType.COLOR,
+            default = default.toTweakColorValue(),
+        )
+        val state = TweakRegistry.register(descriptor)
+        val entry = SnapOTweaks.activeTweakEntries().value.single()
+        val projectedSrgb = default.toTweakColor().toTweakColor()
+        val edited = Color(
+            red = 0.9f,
+            green = 0.1f,
+            blue = 0.2f,
+            alpha = 0.7f,
+            colorSpace = ColorSpaces.DisplayP3,
+        )
+
+        assertEquals(SnapOTweakValue.ColorValue(default), entry.value.value)
+        assertEquals(SnapOTweakValue.ColorValue(default), entry.defaultValue)
+
+        SnapOTweaks.update(
+            descriptor.name,
+            SnapOTweakValue.ColorValue(projectedSrgb),
+        )
+
+        assertNotEquals(default, projectedSrgb)
+        assertEquals(projectedSrgb, (state.value as TweakColorValue).color)
+        assertEquals(SnapOTweakValue.ColorValue(projectedSrgb), entry.value.value)
+
+        SnapOTweaks.update(
+            descriptor.name,
+            SnapOTweakValue.ColorValue(edited),
+        )
+
+        assertEquals(edited, (state.value as TweakColorValue).color)
+        assertEquals(SnapOTweakValue.ColorValue(edited), entry.value.value)
+
+        SnapOTweaks.update(descriptor.name, entry.defaultValue)
+
+        assertEquals(default, (state.value as TweakColorValue).color)
+        assertEquals(SnapOTweakValue.ColorValue(default), entry.value.value)
     }
 
     @Test

--- a/snapo-link-android/tweaks/src/test/java/com/openai/snapo/tweaks/TweakRegistrationTest.kt
+++ b/snapo-link-android/tweaks/src/test/java/com/openai/snapo/tweaks/TweakRegistrationTest.kt
@@ -8,6 +8,9 @@ import com.openai.snapo.tweaks.internal.TweakRegistry
 import com.openai.snapo.tweaks.internal.TweakType
 import org.junit.After
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotEquals
+import org.junit.Assert.assertNotSame
+import org.junit.Assert.assertSame
 import org.junit.Assert.assertThrows
 import org.junit.Assert.assertTrue
 import org.junit.Test
@@ -222,13 +225,21 @@ class TweakRegistrationTest {
             colorSpace = ColorSpaces.DisplayP3,
         )
         val encodedDefault = default.toTweakColor()
-        val descriptor = colorDescriptor(encodedDefault)
+        val descriptor = colorDescriptor(default)
         val state = TweakRegistration(descriptor) { value ->
-            decodeTweakColor(value, default, encodedDefault)
+            (value as TweakColorValue).color
         }
         state.onRemembered()
 
         assertEquals(default, state.value)
+        assertEquals(
+            SnapOTweakValue.ColorValue(default),
+            SnapOTweaks.activeTweakEntries().value.single().defaultValue,
+        )
+        assertEquals(
+            SnapOTweakValue.ColorValue(default),
+            SnapOTweaks.activeTweakEntries().value.single().value.value,
+        )
 
         TweakRegistry.update(mapOf(descriptor.name to "#112233"))
         assertEquals(Color(0xFF112233), state.value)
@@ -242,9 +253,9 @@ class TweakRegistrationTest {
     @Test
     fun `unspecified color defaults remain unspecified until edited`() {
         val encodedDefault = Color.Unspecified.toTweakColor()
-        val descriptor = colorDescriptor(encodedDefault)
+        val descriptor = colorDescriptor(Color.Unspecified)
         val state = TweakRegistration(descriptor) { value ->
-            decodeTweakColor(value, Color.Unspecified, encodedDefault)
+            (value as TweakColorValue).color
         }
         state.onRemembered()
 
@@ -260,6 +271,96 @@ class TweakRegistrationTest {
         state.onForgotten()
     }
 
+    @Test
+    fun `same exact color defaults share retained state`() {
+        val default = Color(
+            red = 0.25f,
+            green = 0.5f,
+            blue = 0.75f,
+            alpha = 0.3f,
+            colorSpace = ColorSpaces.DisplayP3,
+        )
+        val firstDescriptor = colorDescriptor(
+            default = default,
+            name = "Lifecycle shared exact color",
+        )
+        val secondDescriptor = colorDescriptor(
+            default = default,
+            name = firstDescriptor.name,
+        )
+
+        val first = TweakRegistry.register(firstDescriptor)
+        val second = TweakRegistry.register(secondDescriptor)
+
+        assertSame(first, second)
+        assertEquals(default, (first.value as TweakColorValue).color)
+
+        TweakRegistry.unregister(firstDescriptor.name)
+        TweakRegistry.unregister(firstDescriptor.name)
+    }
+
+    @Test
+    fun `unspecified and transparent defaults retain independent histories`() {
+        assertIndependentColorHistories(
+            firstDefault = Color.Unspecified,
+            secondDefault = Color.Transparent,
+            name = "Lifecycle unspecified and transparent colors",
+        )
+    }
+
+    @Test
+    fun `color-space collisions retain independent histories`() {
+        val displayP3 = Color(
+            red = 0.25f,
+            green = 0.5f,
+            blue = 0.75f,
+            alpha = 1f,
+            colorSpace = ColorSpaces.DisplayP3,
+        )
+        val projectedSrgb = displayP3.toTweakColor().toTweakColor()
+
+        assertIndependentColorHistories(
+            firstDefault = displayP3,
+            secondDefault = projectedSrgb,
+            name = "Lifecycle color-space collisions",
+        )
+    }
+
+    @Test
+    fun `quantized alpha collisions retain independent histories`() {
+        val first = Color(
+            red = 0.25f,
+            green = 0.5f,
+            blue = 0.75f,
+            alpha = 0.5f,
+            colorSpace = ColorSpaces.DisplayP3,
+        )
+        val second = Color(
+            red = 0.25f,
+            green = 0.5f,
+            blue = 0.75f,
+            alpha = 0.5015f,
+            colorSpace = ColorSpaces.DisplayP3,
+        )
+
+        assertIndependentColorHistories(
+            firstDefault = first,
+            secondDefault = second,
+            name = "Lifecycle quantized alpha collisions",
+        )
+    }
+
+    @Test
+    fun `unsupported packed colors fail with a clear error`() {
+        val unsupported = Color(value = ULong.MAX_VALUE)
+
+        val error = assertThrows(IllegalArgumentException::class.java) {
+            unsupported.toTweakColorValue()
+        }
+
+        assertTrue(error.message.orEmpty().contains("convertible to sRGB"))
+    }
+
     private fun registration(descriptor: TweakDescriptor) =
         TweakRegistration(descriptor) { value -> value as Int }
 
@@ -270,10 +371,49 @@ class TweakRegistrationTest {
         assertTrue(SnapOTweaks.activeTweakEntries().value.isEmpty())
     }
 
-    private fun colorDescriptor(default: String) = TweakDescriptor(
-        name = "Lifecycle remembered color tweak",
+    private fun assertIndependentColorHistories(
+        firstDefault: Color,
+        secondDefault: Color,
+        name: String,
+    ) {
+        val firstDescriptor = colorDescriptor(firstDefault, name)
+        val secondDescriptor = colorDescriptor(secondDefault, name)
+
+        assertNotEquals(firstDefault, secondDefault)
+        assertEquals(
+            (firstDescriptor.default as TweakColorValue).wireValue,
+            (secondDescriptor.default as TweakColorValue).wireValue,
+        )
+        assertNotEquals(firstDescriptor, secondDescriptor)
+
+        val firstState = TweakRegistry.register(firstDescriptor)
+        TweakRegistry.update(mapOf(name to "#112233"))
+        TweakRegistry.unregister(name)
+
+        val secondState = TweakRegistry.register(secondDescriptor)
+        assertNotSame(firstState, secondState)
+        assertEquals(secondDefault, (secondState.value as TweakColorValue).color)
+        TweakRegistry.update(mapOf(name to "#445566"))
+        TweakRegistry.unregister(name)
+
+        val restoredFirst = TweakRegistry.register(firstDescriptor)
+        assertSame(firstState, restoredFirst)
+        assertEquals(Color(0xFF112233), (restoredFirst.value as TweakColorValue).color)
+        TweakRegistry.unregister(name)
+
+        val restoredSecond = TweakRegistry.register(secondDescriptor)
+        assertSame(secondState, restoredSecond)
+        assertEquals(Color(0xFF445566), (restoredSecond.value as TweakColorValue).color)
+        TweakRegistry.unregister(name)
+    }
+
+    private fun colorDescriptor(
+        default: Color,
+        name: String = "Lifecycle remembered color tweak",
+    ) = TweakDescriptor(
+        name = name,
         type = TweakType.COLOR,
-        default = default,
+        default = default.toTweakColorValue(),
     )
 
     private fun descriptor() = TweakDescriptor(

--- a/snapo-link-android/tweaks/src/test/java/com/openai/snapo/tweaks/internal/TweakValidationTest.kt
+++ b/snapo-link-android/tweaks/src/test/java/com/openai/snapo/tweaks/internal/TweakValidationTest.kt
@@ -1,5 +1,7 @@
 package com.openai.snapo.tweaks.internal
 
+import com.openai.snapo.tweaks.TweakColorValue
+import com.openai.snapo.tweaks.toTweakColorValue
 import org.junit.After
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertThrows
@@ -295,17 +297,17 @@ class TweakValidationTest {
         val descriptor = TweakDescriptor(
             name = "Validation color",
             type = TweakType.COLOR,
-            default = "#2563EB",
+            default = "#2563EB".toTweakColorValue(),
         )
         val state = TweakRegistry.register(descriptor)
 
         TweakRegistry.update(mapOf(descriptor.name to "#3b82f6"))
 
-        assertEquals("#3B82F6", state.value)
+        assertEquals("#3B82F6", (state.value as TweakColorValue).wireValue)
 
         TweakRegistry.update(mapOf(descriptor.name to "#112233aa"))
 
-        assertEquals("#112233AA", state.value)
+        assertEquals("#112233AA", (state.value as TweakColorValue).wireValue)
     }
 
     @Test
@@ -313,7 +315,7 @@ class TweakValidationTest {
         val descriptor = TweakDescriptor(
             name = "Validation invalid color",
             type = TweakType.COLOR,
-            default = "#2563EB",
+            default = "#2563EB".toTweakColorValue(),
         )
         val state = TweakRegistry.register(descriptor)
 
@@ -322,7 +324,7 @@ class TweakValidationTest {
         assertInvalidUpdate(descriptor.name, "#GGGGGG")
         assertInvalidUpdate(descriptor.name, 0x2563EB)
 
-        assertEquals("#2563EB", state.value)
+        assertEquals("#2563EB", (state.value as TweakColorValue).wireValue)
     }
 
     @Test


### PR DESCRIPTION
## Summary

- Preserve exact Compose color identities, including color spaces, component precision, alpha values, and `Color.Unspecified`, while keeping the existing name-addressed sRGB HTTP protocol and reset behavior compatible.
- Replace keyboard-dependent color editing with an accessible in-panel HSV and opacity picker, live preview, field-scoped reset, and ready/done navigation.
- Add regression coverage for color identity collisions, wide-gamut defaults, host edits, resets, picker conversion, and exact alpha handling; document the unavoidable wire-format projection tradeoff.

## Verification

- `./gradlew --console=plain --no-daemon build detekt` — full Android CI-equivalent build, debug/release builds, lint, and Detekt; 1,146 Gradle tasks succeeded.
- 139 Android unit tests passed across the affected modules.
- `node --test` in `snapo-link-android/samples/demo-tweaks/panel` — 40 host-panel compatibility tests passed.
- `git diff --check` passed.