### PR TITLE
Use the native macOS color panel for Tweaks

### DIFF
--- a/snapo-app-mac/Snap-O/CaptureWindow/CaptureWindow.swift
+++ b/snapo-app-mac/Snap-O/CaptureWindow/CaptureWindow.swift
@@ -71,6 +71,7 @@ struct CaptureWindow: View {
       }
       .task(id: workspace.showsNetwork) {
         guard workspace.showsNetwork else {
+          networkSession.model?.webContainer.closeNativeColorPanel()
           // Hiding the pane is a layout change, not a session boundary. Preserve its streams and history until the window closes.
           return
         }

--- a/snapo-app-mac/Snap-O/NetworkInspector/NetworkInspectorHostModel.swift
+++ b/snapo-app-mac/Snap-O/NetworkInspector/NetworkInspectorHostModel.swift
@@ -61,6 +61,11 @@ final class NetworkInspectorHostModel {
       kind: option.kind,
       server: option.server
     )
+    if selectedInspector?.appId != selection.appId
+      || selectedInspector?.kind != selection.kind
+      || selectedInspector?.server != selection.server {
+      webContainer.closeNativeColorPanel()
+    }
     if selectedInspector?.kind != selection.kind || selectedInspector?.server != selection.server {
       hasResettableTweaks = false
     }
@@ -156,6 +161,7 @@ final class NetworkInspectorHostModel {
     }
 
     guard let app = apps.first, let option = app.inspectors.first else {
+      webContainer.closeNativeColorPanel()
       selectedInspector = nil
       hasResettableTweaks = false
       return

--- a/snapo-app-mac/Snap-O/NetworkInspector/NetworkInspectorWebBridge.swift
+++ b/snapo-app-mac/Snap-O/NetworkInspector/NetworkInspectorWebBridge.swift
@@ -11,7 +11,7 @@ final class NetworkInspectorWebBridge: NSObject, WKScriptMessageHandlerWithReply
 
   static let messageHandlerName = "snapoNetwork"
 
-  private static weak var colorPanelOwner: NetworkInspectorWebBridge?
+  private weak static var colorPanelOwner: NetworkInspectorWebBridge?
 
   var inspectorStateChangedHandler: ((NetworkInspectorNativeState) -> Void)?
   var inspectorAppsChangedHandler: (([InspectableApp]) -> Void)?

--- a/snapo-app-mac/Snap-O/NetworkInspector/NetworkInspectorWebBridge.swift
+++ b/snapo-app-mac/Snap-O/NetworkInspector/NetworkInspectorWebBridge.swift
@@ -84,6 +84,12 @@ final class NetworkInspectorWebBridge: NSObject, WKScriptMessageHandlerWithReply
     case "openNativeColorPanel":
       try openNativeColorPanel(Self.decode(NativeColorPanelInput.self, from: payload))
       return nil
+    case "closeNativeColorPanel":
+      let input = try Self.decode(NativeColorPanelSessionInput.self, from: payload)
+      if activeColorPanelSessionID == input.sessionId {
+        closeNativeColorPanel()
+      }
+      return nil
     case "startTweakStream":
       let reference = try Self.decode(InspectorServerReference.self, from: payload)
       return try await Self.jsonObject(service.startTweakStream(reference))
@@ -277,5 +283,9 @@ final class NetworkInspectorWebBridge: NSObject, WKScriptMessageHandlerWithReply
     let color: String
     let sessionId: String
     let present: Bool?
+  }
+
+  private struct NativeColorPanelSessionInput: Decodable {
+    let sessionId: String
   }
 }

--- a/snapo-app-mac/Snap-O/NetworkInspector/NetworkInspectorWebBridge.swift
+++ b/snapo-app-mac/Snap-O/NetworkInspector/NetworkInspectorWebBridge.swift
@@ -156,6 +156,9 @@ final class NetworkInspectorWebBridge: NSObject, WKScriptMessageHandlerWithReply
       alpha: alpha
     )
     let panel = NSColorPanel.shared
+    let shouldPresent = input.present ?? true
+    guard shouldPresent || (Self.colorPanelOwner === self && panel.isVisible) else { return }
+
     let presentationWindow = NSApp.mainWindow
     let shouldCenterPanel = !panel.isVisible || Self.colorPanelOwner !== self
     panel.setTarget(nil)
@@ -171,7 +174,9 @@ final class NetworkInspectorWebBridge: NSObject, WKScriptMessageHandlerWithReply
     if shouldCenterPanel {
       positionColorPanel(panel, over: presentationWindow)
     }
-    panel.makeKeyAndOrderFront(nil)
+    if shouldPresent {
+      panel.makeKeyAndOrderFront(nil)
+    }
   }
 
   private func positionColorPanel(_ panel: NSColorPanel, over window: NSWindow?) {
@@ -271,5 +276,6 @@ final class NetworkInspectorWebBridge: NSObject, WKScriptMessageHandlerWithReply
   private struct NativeColorPanelInput: Decodable {
     let color: String
     let sessionId: String
+    let present: Bool?
   }
 }

--- a/snapo-app-mac/Snap-O/NetworkInspector/NetworkInspectorWebBridge.swift
+++ b/snapo-app-mac/Snap-O/NetworkInspector/NetworkInspectorWebBridge.swift
@@ -4,6 +4,11 @@ import WebKit
 
 @MainActor
 final class NetworkInspectorWebBridge: NSObject, WKScriptMessageHandlerWithReply {
+  struct NativeColorPanelChange: Encodable {
+    let color: String
+    let sessionId: String
+  }
+
   static let messageHandlerName = "snapoNetwork"
 
   private static weak var colorPanelOwner: NetworkInspectorWebBridge?
@@ -11,9 +16,10 @@ final class NetworkInspectorWebBridge: NSObject, WKScriptMessageHandlerWithReply
   var inspectorStateChangedHandler: ((NetworkInspectorNativeState) -> Void)?
   var inspectorAppsChangedHandler: (([InspectableApp]) -> Void)?
   var tweaksStateChangedHandler: ((TweaksInspectorNativeState) -> Void)?
-  var colorPanelChangedHandler: ((String) -> Void)?
+  var colorPanelChangedHandler: ((NativeColorPanelChange) -> Void)?
 
   private let service: NetworkInspectorService
+  private var activeColorPanelSessionID: String?
 
   init(service: NetworkInspectorService) {
     self.service = service
@@ -25,6 +31,7 @@ final class NetworkInspectorWebBridge: NSObject, WKScriptMessageHandlerWithReply
   }
 
   func closeNativeColorPanel() {
+    activeColorPanelSessionID = nil
     guard Self.colorPanelOwner === self else { return }
 
     let panel = NSColorPanel.shared
@@ -133,7 +140,8 @@ final class NetworkInspectorWebBridge: NSObject, WKScriptMessageHandlerWithReply
   private func openNativeColorPanel(_ input: NativeColorPanelInput) throws {
     guard input.color.count == 7 || input.color.count == 9,
           input.color.first == "#",
-          let components = UInt32(input.color.dropFirst(), radix: 16)
+          let components = UInt32(input.color.dropFirst(), radix: 16),
+          !input.sessionId.isEmpty
     else {
       throw NetworkInspectorError.invalidBridgeMessage
     }
@@ -152,9 +160,11 @@ final class NetworkInspectorWebBridge: NSObject, WKScriptMessageHandlerWithReply
     let shouldCenterPanel = !panel.isVisible || Self.colorPanelOwner !== self
     panel.setTarget(nil)
     panel.setAction(nil)
+    Self.colorPanelOwner?.activeColorPanelSessionID = nil
     panel.showsAlpha = true
     panel.isContinuous = true
     panel.color = color
+    activeColorPanelSessionID = input.sessionId
     panel.setTarget(self)
     panel.setAction(#selector(colorPanelDidChange(_:)))
     Self.colorPanelOwner = self
@@ -190,6 +200,7 @@ final class NetworkInspectorWebBridge: NSObject, WKScriptMessageHandlerWithReply
   @objc
   private func colorPanelDidChange(_ panel: NSColorPanel) {
     guard Self.colorPanelOwner === self,
+          let sessionId = activeColorPanelSessionID,
           let color = panel.color.usingColorSpace(.sRGB)
     else {
       return
@@ -199,7 +210,12 @@ final class NetworkInspectorWebBridge: NSObject, WKScriptMessageHandlerWithReply
     let green = Int((min(max(color.greenComponent, 0), 1) * 255).rounded())
     let blue = Int((min(max(color.blueComponent, 0), 1) * 255).rounded())
     let alpha = Int((min(max(color.alphaComponent, 0), 1) * 255).rounded())
-    colorPanelChangedHandler?(String(format: "#%02X%02X%02X%02X", red, green, blue, alpha))
+    colorPanelChangedHandler?(
+      NativeColorPanelChange(
+        color: String(format: "#%02X%02X%02X%02X", red, green, blue, alpha),
+        sessionId: sessionId
+      )
+    )
   }
 
   private func saveFile(_ input: NetworkSaveFileInput) throws -> NetworkSaveFileResult {
@@ -254,5 +270,6 @@ final class NetworkInspectorWebBridge: NSObject, WKScriptMessageHandlerWithReply
 
   private struct NativeColorPanelInput: Decodable {
     let color: String
+    let sessionId: String
   }
 }

--- a/snapo-app-mac/Snap-O/NetworkInspector/NetworkInspectorWebBridge.swift
+++ b/snapo-app-mac/Snap-O/NetworkInspector/NetworkInspectorWebBridge.swift
@@ -6,9 +6,12 @@ import WebKit
 final class NetworkInspectorWebBridge: NSObject, WKScriptMessageHandlerWithReply {
   static let messageHandlerName = "snapoNetwork"
 
+  private static weak var colorPanelOwner: NetworkInspectorWebBridge?
+
   var inspectorStateChangedHandler: ((NetworkInspectorNativeState) -> Void)?
   var inspectorAppsChangedHandler: (([InspectableApp]) -> Void)?
   var tweaksStateChangedHandler: ((TweaksInspectorNativeState) -> Void)?
+  var colorPanelChangedHandler: ((String) -> Void)?
 
   private let service: NetworkInspectorService
 
@@ -17,7 +20,18 @@ final class NetworkInspectorWebBridge: NSObject, WKScriptMessageHandlerWithReply
   }
 
   func prepareForPageReload() async {
+    closeNativeColorPanel()
     await service.stopAllStreams()
+  }
+
+  func closeNativeColorPanel() {
+    guard Self.colorPanelOwner === self else { return }
+
+    let panel = NSColorPanel.shared
+    panel.setTarget(nil)
+    panel.setAction(nil)
+    Self.colorPanelOwner = nil
+    panel.orderOut(nil)
   }
 
   func userContentController(
@@ -60,6 +74,9 @@ final class NetworkInspectorWebBridge: NSObject, WKScriptMessageHandlerWithReply
     case "updateTweaks":
       let input = try Self.decode(UpdateTweaksInput.self, from: payload)
       return try await Self.jsonObject(service.updateTweaks(input))
+    case "openNativeColorPanel":
+      try openNativeColorPanel(Self.decode(NativeColorPanelInput.self, from: payload))
+      return nil
     case "startTweakStream":
       let reference = try Self.decode(InspectorServerReference.self, from: payload)
       return try await Self.jsonObject(service.startTweakStream(reference))
@@ -113,6 +130,78 @@ final class NetworkInspectorWebBridge: NSObject, WKScriptMessageHandlerWithReply
     }
   }
 
+  private func openNativeColorPanel(_ input: NativeColorPanelInput) throws {
+    guard input.color.count == 7 || input.color.count == 9,
+          input.color.first == "#",
+          let components = UInt32(input.color.dropFirst(), radix: 16)
+    else {
+      throw NetworkInspectorError.invalidBridgeMessage
+    }
+
+    let hasAlpha = input.color.count == 9
+    let rgb = hasAlpha ? components >> 8 : components
+    let alpha = hasAlpha ? CGFloat(components & 0xFF) / 255 : 1
+    let color = NSColor(
+      srgbRed: CGFloat((rgb >> 16) & 0xFF) / 255,
+      green: CGFloat((rgb >> 8) & 0xFF) / 255,
+      blue: CGFloat(rgb & 0xFF) / 255,
+      alpha: alpha
+    )
+    let panel = NSColorPanel.shared
+    let presentationWindow = NSApp.mainWindow
+    let shouldCenterPanel = !panel.isVisible || Self.colorPanelOwner !== self
+    panel.setTarget(nil)
+    panel.setAction(nil)
+    panel.showsAlpha = true
+    panel.isContinuous = true
+    panel.color = color
+    panel.setTarget(self)
+    panel.setAction(#selector(colorPanelDidChange(_:)))
+    Self.colorPanelOwner = self
+    if shouldCenterPanel {
+      positionColorPanel(panel, over: presentationWindow)
+    }
+    panel.makeKeyAndOrderFront(nil)
+  }
+
+  private func positionColorPanel(_ panel: NSColorPanel, over window: NSWindow?) {
+    guard let window else { return }
+
+    let panelSize = panel.frame.size
+    let centeredOrigin = NSPoint(
+      x: window.frame.midX - panelSize.width / 2,
+      y: window.frame.midY - panelSize.height / 2
+    )
+    guard let visibleFrame = window.screen?.visibleFrame ?? NSScreen.main?.visibleFrame else {
+      panel.setFrameOrigin(centeredOrigin)
+      return
+    }
+
+    let maximumX = max(visibleFrame.minX, visibleFrame.maxX - panelSize.width)
+    let maximumY = max(visibleFrame.minY, visibleFrame.maxY - panelSize.height)
+    panel.setFrameOrigin(
+      NSPoint(
+        x: min(max(centeredOrigin.x, visibleFrame.minX), maximumX),
+        y: min(max(centeredOrigin.y, visibleFrame.minY), maximumY)
+      )
+    )
+  }
+
+  @objc
+  private func colorPanelDidChange(_ panel: NSColorPanel) {
+    guard Self.colorPanelOwner === self,
+          let color = panel.color.usingColorSpace(.sRGB)
+    else {
+      return
+    }
+
+    let red = Int((min(max(color.redComponent, 0), 1) * 255).rounded())
+    let green = Int((min(max(color.greenComponent, 0), 1) * 255).rounded())
+    let blue = Int((min(max(color.blueComponent, 0), 1) * 255).rounded())
+    let alpha = Int((min(max(color.alphaComponent, 0), 1) * 255).rounded())
+    colorPanelChangedHandler?(String(format: "#%02X%02X%02X%02X", red, green, blue, alpha))
+  }
+
   private func saveFile(_ input: NetworkSaveFileInput) throws -> NetworkSaveFileResult {
     let data: Data
     switch input.encoding {
@@ -161,5 +250,9 @@ final class NetworkInspectorWebBridge: NSObject, WKScriptMessageHandlerWithReply
 
   private struct ClipboardText: Decodable {
     let text: String
+  }
+
+  private struct NativeColorPanelInput: Decodable {
+    let color: String
   }
 }

--- a/snapo-app-mac/Snap-O/NetworkInspector/NetworkInspectorWebContainer.swift
+++ b/snapo-app-mac/Snap-O/NetworkInspector/NetworkInspectorWebContainer.swift
@@ -43,6 +43,9 @@ final class NetworkInspectorWebContainer: NSObject, WKNavigationDelegate {
     webView = WKWebView(frame: .zero, configuration: configuration)
     super.init()
     webView.navigationDelegate = self
+    bridge.colorPanelChangedHandler = { [weak self] color in
+      self?.sendPageEvent(name: "tweaks:color-panel-changed", payload: color)
+    }
   }
 
   func start() {
@@ -52,12 +55,18 @@ final class NetworkInspectorWebContainer: NSObject, WKNavigationDelegate {
   func stop() {
     recoveryTask?.cancel()
     recoveryTask = nil
+    closeNativeColorPanel()
+    bridge.colorPanelChangedHandler = nil
     invalidatePageEventDelivery(clearPending: true)
     webView.stopLoading()
     webView.configuration.userContentController.removeScriptMessageHandler(
       forName: NetworkInspectorWebBridge.messageHandlerName,
       contentWorld: .page
     )
+  }
+
+  func closeNativeColorPanel() {
+    bridge.closeNativeColorPanel()
   }
 
   func recoverFromEventOverflow() {

--- a/snapo-app-mac/Snap-O/NetworkInspector/NetworkInspectorWebContainer.swift
+++ b/snapo-app-mac/Snap-O/NetworkInspector/NetworkInspectorWebContainer.swift
@@ -43,8 +43,8 @@ final class NetworkInspectorWebContainer: NSObject, WKNavigationDelegate {
     webView = WKWebView(frame: .zero, configuration: configuration)
     super.init()
     webView.navigationDelegate = self
-    bridge.colorPanelChangedHandler = { [weak self] color in
-      self?.sendPageEvent(name: "tweaks:color-panel-changed", payload: color)
+    bridge.colorPanelChangedHandler = { [weak self] change in
+      self?.sendPageEvent(name: "tweaks:color-panel-changed", payload: change)
     }
   }
 

--- a/snapo-network-inspector-web/src/features/tweaks-inspector/TweaksInspectorApp.test.ts
+++ b/snapo-network-inspector-web/src/features/tweaks-inspector/TweaksInspectorApp.test.ts
@@ -47,6 +47,16 @@ describe("editable tweak colors", () => {
     expect(nativePanelTweakColor({ color: "#a1b2c344", sessionId: "previous" }, "active")).toBeNull();
   });
 
+  it("keeps panel-originated changes on the current session", () => {
+    expect(nativePanelTweakColor({ color: "#11223380", sessionId: "current" }, "current")).toBe("#11223380");
+    expect(nativePanelTweakColor({ color: "#44556640", sessionId: "current" }, "current")).toBe("#44556640");
+  });
+
+  it("rejects queued panel events after an external change refreshes its session", () => {
+    expect(nativePanelTweakColor({ color: "#11223380", sessionId: "before-sync" }, "after-sync")).toBeNull();
+    expect(nativePanelTweakColor({ color: "#44556640", sessionId: "after-sync" }, "after-sync")).toBe("#44556640");
+  });
+
   it("keeps the alpha component when a native color is translucent", () => {
     expect(nativePanelTweakColor({ color: "#a1b2c380", sessionId: "active" }, "active")).toBe("#A1B2C380");
   });

--- a/snapo-network-inspector-web/src/features/tweaks-inspector/TweaksInspectorApp.test.ts
+++ b/snapo-network-inspector-web/src/features/tweaks-inspector/TweaksInspectorApp.test.ts
@@ -40,23 +40,27 @@ describe("editable tweak colors", () => {
   });
 
   it("applies native RGBA updates", () => {
-    expect(nativePanelTweakColor("#a1b2c344")).toBe("#A1B2C344");
+    expect(nativePanelTweakColor({ color: "#a1b2c344", sessionId: "active" }, "active")).toBe("#A1B2C344");
+  });
+
+  it("ignores stale native color events from a previously opened field", () => {
+    expect(nativePanelTweakColor({ color: "#a1b2c344", sessionId: "previous" }, "active")).toBeNull();
   });
 
   it("keeps the alpha component when a native color is translucent", () => {
-    expect(nativePanelTweakColor("#a1b2c380")).toBe("#A1B2C380");
+    expect(nativePanelTweakColor({ color: "#a1b2c380", sessionId: "active" }, "active")).toBe("#A1B2C380");
   });
 
   it("omits the alpha component when a native color is fully opaque", () => {
-    expect(nativePanelTweakColor("#a1b2c3ff")).toBe("#A1B2C3");
+    expect(nativePanelTweakColor({ color: "#a1b2c3ff", sessionId: "active" }, "active")).toBe("#A1B2C3");
   });
 
   it("canonicalizes originally RGBA colors to RGB when made opaque", () => {
-    expect(nativePanelTweakColor("#5468FFFF")).toBe("#5468FF");
+    expect(nativePanelTweakColor({ color: "#5468FFFF", sessionId: "active" }, "active")).toBe("#5468FF");
   });
 
   it("ignores native color updates without an alpha component", () => {
-    expect(nativePanelTweakColor("#a1b2c3")).toBeNull();
+    expect(nativePanelTweakColor({ color: "#a1b2c3", sessionId: "active" }, "active")).toBeNull();
   });
 
   it("keeps the browser-native color input when no native panel is available", () => {

--- a/snapo-network-inspector-web/src/features/tweaks-inspector/TweaksInspectorApp.test.ts
+++ b/snapo-network-inspector-web/src/features/tweaks-inspector/TweaksInspectorApp.test.ts
@@ -1,6 +1,16 @@
+import { createElement } from "react";
+import { renderToStaticMarkup } from "react-dom/server";
 import { describe, expect, it } from "vitest";
 import type { TweakDescriptor } from "../../network/bridge-types";
-import { canResetTweaks, groupTweaks, parseTweakColor, reconcileStreamedTweaks } from "./TweaksInspectorApp";
+import {
+  canResetTweaks,
+  groupTweaks,
+  nativePanelTweakColor,
+  parseTweakColor,
+  reconcileStreamedTweaks,
+  TweakColorField,
+  tweakColorWithPreservedAlpha
+} from "./TweaksInspectorApp";
 
 describe("editable tweak colors", () => {
   it("normalizes complete RGB colors", () => {
@@ -19,6 +29,61 @@ describe("editable tweak colors", () => {
 
   it("rejects invalid hexadecimal digits", () => {
     expect(parseTweakColor("#A1B2G3")).toBeNull();
+  });
+
+  it("preserves the alpha channel when the browser color input changes RGB", () => {
+    expect(tweakColorWithPreservedAlpha("#11223380", "#a1b2c3")).toBe("#A1B2C380");
+  });
+
+  it("does not add an alpha channel to RGB colors", () => {
+    expect(tweakColorWithPreservedAlpha("#112233", "#a1b2c3")).toBe("#A1B2C3");
+  });
+
+  it("applies native RGBA updates", () => {
+    expect(nativePanelTweakColor("#a1b2c344")).toBe("#A1B2C344");
+  });
+
+  it("keeps the alpha component when a native color is translucent", () => {
+    expect(nativePanelTweakColor("#a1b2c380")).toBe("#A1B2C380");
+  });
+
+  it("omits the alpha component when a native color is fully opaque", () => {
+    expect(nativePanelTweakColor("#a1b2c3ff")).toBe("#A1B2C3");
+  });
+
+  it("canonicalizes originally RGBA colors to RGB when made opaque", () => {
+    expect(nativePanelTweakColor("#5468FFFF")).toBe("#5468FF");
+  });
+
+  it("ignores native color updates without an alpha component", () => {
+    expect(nativePanelTweakColor("#a1b2c3")).toBeNull();
+  });
+
+  it("keeps the browser-native color input when no native panel is available", () => {
+    const markup = renderToStaticMarkup(
+      createElement(TweakColorField, {
+        tweak: colorTweak(),
+        onChange() {}
+      })
+    );
+
+    expect(markup).toContain('type="color"');
+    expect(markup).not.toContain("tweaks-color-button");
+  });
+
+  it("renders an accessible native-panel swatch instead of the HTML color input", () => {
+    const markup = renderToStaticMarkup(
+      createElement(TweakColorField, {
+        tweak: colorTweak(),
+        onChange() {},
+        onOpenColorPanel() {}
+      })
+    );
+
+    expect(markup).toContain('class="tweaks-color tweaks-color-button"');
+    expect(markup).toContain('aria-label="Colors/Accent color"');
+    expect(markup).toContain("background-color:#5468FF80");
+    expect(markup).not.toContain('type="color"');
   });
 });
 
@@ -144,5 +209,14 @@ function tweak(name: string): TweakDescriptor {
     type: "int",
     default: 1,
     value: 1
+  };
+}
+
+function colorTweak(): TweakDescriptor {
+  return {
+    name: "Colors/Accent",
+    type: "color",
+    default: "#5468FF80",
+    value: "#5468FF80"
   };
 }

--- a/snapo-network-inspector-web/src/features/tweaks-inspector/TweaksInspectorApp.test.ts
+++ b/snapo-network-inspector-web/src/features/tweaks-inspector/TweaksInspectorApp.test.ts
@@ -1,7 +1,8 @@
 import { createElement } from "react";
 import { renderToStaticMarkup } from "react-dom/server";
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import type { TweakDescriptor } from "../../network/bridge-types";
+import { createNetworkClient } from "../../network/client";
 import {
   canResetTweaks,
   groupTweaks,
@@ -55,6 +56,23 @@ describe("editable tweak colors", () => {
   it("rejects queued panel events after an external change refreshes its session", () => {
     expect(nativePanelTweakColor({ color: "#11223380", sessionId: "before-sync" }, "after-sync")).toBeNull();
     expect(nativePanelTweakColor({ color: "#44556640", sessionId: "after-sync" }, "after-sync")).toBe("#44556640");
+  });
+
+  it("closes only the native color-panel session that lost its tweak", async () => {
+    const postMessage = vi.fn().mockResolvedValue(undefined);
+    vi.stubGlobal("window", { webkit: { messageHandlers: { snapoNetwork: { postMessage } } } });
+
+    try {
+      const client = createNetworkClient();
+      await client.closeNativeColorPanel?.("removed-session");
+
+      expect(postMessage).toHaveBeenCalledWith({
+        command: "closeNativeColorPanel",
+        payload: { sessionId: "removed-session" }
+      });
+    } finally {
+      vi.unstubAllGlobals();
+    }
   });
 
   it("keeps the alpha component when a native color is translucent", () => {

--- a/snapo-network-inspector-web/src/features/tweaks-inspector/TweaksInspectorApp.tsx
+++ b/snapo-network-inspector-web/src/features/tweaks-inspector/TweaksInspectorApp.tsx
@@ -119,13 +119,37 @@ export function TweaksInspectorApp({
     };
   }, [client, queue, server]);
 
+  const openNativeColorPanel = useCallback(
+    (tweak: TweakDescriptor, present = true) => {
+      if (!hasNativeColorPanel || client.openNativeColorPanel === undefined) {
+        activeColorPanel.current = null;
+        return;
+      }
+
+      const sessionId = String(++nextColorPanelSession);
+      activeColorPanel.current = { tweak, sessionId };
+      void client.openNativeColorPanel(String(tweak.value), sessionId, present).catch((cause: unknown) => {
+        if (activeColorPanel.current?.sessionId !== sessionId) return;
+
+        activeColorPanel.current = null;
+        setError(cause instanceof Error ? cause.message : "Unable to open the color picker.");
+      });
+    },
+    [client, hasNativeColorPanel]
+  );
+
   const updateTweak = useCallback(
     (tweak: TweakDescriptor, value: TweakValue) => {
+      const active = activeColorPanel.current;
+      if (active?.tweak.name === tweak.name && active.tweak.value !== value) {
+        openNativeColorPanel({ ...tweak, value }, false);
+      }
+
       setTweaks((current) => current.map((item) => (item.name === tweak.name ? { ...item, value } : item)));
       queue.enqueue(tweak.name, value);
       void queue.flush();
     },
-    [queue]
+    [openNativeColorPanel, queue]
   );
 
   useEffect(() => {
@@ -133,8 +157,18 @@ export function TweaksInspectorApp({
     if (active === null) return;
 
     const tweak = tweaks.find((candidate) => candidate.name === active.tweak.name && candidate.type === "color");
-    activeColorPanel.current = tweak === undefined ? null : { ...active, tweak };
-  }, [tweaks]);
+    if (tweak === undefined) {
+      activeColorPanel.current = null;
+      return;
+    }
+
+    if (tweak.value === active.tweak.value) {
+      activeColorPanel.current = { ...active, tweak };
+      return;
+    }
+
+    openNativeColorPanel(tweak, false);
+  }, [openNativeColorPanel, tweaks]);
 
   useEffect(() => {
     if (!hasNativeColorPanel || client.onNativeColorPanelChange === undefined) return;
@@ -144,7 +178,10 @@ export function TweaksInspectorApp({
       if (active === null) return;
 
       const value = nativePanelTweakColor(event, active.sessionId);
-      if (value !== null) updateTweak(active.tweak, value);
+      if (value === null) return;
+
+      activeColorPanel.current = { ...active, tweak: { ...active.tweak, value } };
+      updateTweak(active.tweak, value);
     });
 
     return () => {
@@ -152,20 +189,6 @@ export function TweaksInspectorApp({
       unsubscribe();
     };
   }, [client, hasNativeColorPanel, updateTweak]);
-
-  const openNativeColorPanel = useCallback(
-    (tweak: TweakDescriptor) => {
-      if (!hasNativeColorPanel || client.openNativeColorPanel === undefined) return;
-
-      const sessionId = String(++nextColorPanelSession);
-      activeColorPanel.current = { tweak, sessionId };
-      void client.openNativeColorPanel(String(tweak.value), sessionId).catch((cause: unknown) => {
-        if (activeColorPanel.current?.sessionId === sessionId) activeColorPanel.current = null;
-        setError(cause instanceof Error ? cause.message : "Unable to open the color picker.");
-      });
-    },
-    [client, hasNativeColorPanel]
-  );
 
   const resetAll = useCallback(() => {
     for (const tweak of tweaks) {

--- a/snapo-network-inspector-web/src/features/tweaks-inspector/TweaksInspectorApp.tsx
+++ b/snapo-network-inspector-web/src/features/tweaks-inspector/TweaksInspectorApp.tsx
@@ -1,5 +1,5 @@
 import { RotateCcw } from "lucide-react";
-import { useCallback, useEffect, useMemo, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import type {
   AppInspectorOption,
   InspectableApp,
@@ -37,7 +37,12 @@ export function TweaksInspectorApp({
   const [error, setError] = useState<string | null>(null);
   const [saving, setSaving] = useState(false);
   const [orderByApp] = useState(() => new Map<string, TweakOrdering>());
+  const activeColorTweak = useRef<TweakDescriptor | null>(null);
   const server = selection.server;
+  const hasNativeColorPanel =
+    client.usesNativeServerPicker &&
+    typeof client.openNativeColorPanel === "function" &&
+    typeof client.onNativeColorPanelChange === "function";
   const queue = useMemo(
     () =>
       new TweakUpdateQueue(client, server, {
@@ -116,6 +121,43 @@ export function TweaksInspectorApp({
     [queue]
   );
 
+  useEffect(() => {
+    const active = activeColorTweak.current;
+    if (active === null) return;
+
+    activeColorTweak.current = tweaks.find((tweak) => tweak.name === active.name && tweak.type === "color") ?? null;
+  }, [tweaks]);
+
+  useEffect(() => {
+    if (!hasNativeColorPanel || client.onNativeColorPanelChange === undefined) return;
+
+    const unsubscribe = client.onNativeColorPanelChange((color) => {
+      const tweak = activeColorTweak.current;
+      if (tweak === null) return;
+
+      const value = nativePanelTweakColor(color);
+      if (value !== null) updateTweak(tweak, value);
+    });
+
+    return () => {
+      activeColorTweak.current = null;
+      unsubscribe();
+    };
+  }, [client, hasNativeColorPanel, updateTweak]);
+
+  const openNativeColorPanel = useCallback(
+    (tweak: TweakDescriptor) => {
+      if (!hasNativeColorPanel || client.openNativeColorPanel === undefined) return;
+
+      activeColorTweak.current = tweak;
+      void client.openNativeColorPanel(String(tweak.value)).catch((cause: unknown) => {
+        if (activeColorTweak.current?.name === tweak.name) activeColorTweak.current = null;
+        setError(cause instanceof Error ? cause.message : "Unable to open the color picker.");
+      });
+    },
+    [client, hasNativeColorPanel]
+  );
+
   const resetAll = useCallback(() => {
     for (const tweak of tweaks) {
       queue.enqueue(tweak.name, tweak.default);
@@ -173,7 +215,12 @@ export function TweaksInspectorApp({
                   {section.name ? <h2>{section.name}</h2> : null}
                   <div className="tweaks-section-list">
                     {section.tweaks.map((tweak) => (
-                      <TweakControl key={tweak.name} tweak={tweak} onChange={updateTweak} />
+                      <TweakControl
+                        key={tweak.name}
+                        tweak={tweak}
+                        onChange={updateTweak}
+                        onOpenColorPanel={hasNativeColorPanel ? openNativeColorPanel : undefined}
+                      />
                     ))}
                   </div>
                 </section>
@@ -261,10 +308,12 @@ function tweakLabel(name: string): string {
 
 function TweakControl({
   tweak,
-  onChange
+  onChange,
+  onOpenColorPanel
 }: {
   tweak: TweakDescriptor;
   onChange(tweak: TweakDescriptor, value: TweakValue): void;
+  onOpenColorPanel?(tweak: TweakDescriptor): void;
 }): JSX.Element {
   const label = tweakLabel(tweak.name);
   const changed = tweak.value !== tweak.default;
@@ -285,7 +334,7 @@ function TweakControl({
           </button>
         ) : null}
         <span className="tweaks-control-field">
-          <TweakField tweak={tweak} onChange={onChange} />
+          <TweakField tweak={tweak} onChange={onChange} onOpenColorPanel={onOpenColorPanel} />
         </span>
       </div>
 
@@ -317,10 +366,12 @@ function TweakControl({
 
 function TweakField({
   tweak,
-  onChange
+  onChange,
+  onOpenColorPanel
 }: {
   tweak: TweakDescriptor;
   onChange(tweak: TweakDescriptor, value: TweakValue): void;
+  onOpenColorPanel?(tweak: TweakDescriptor): void;
 }): JSX.Element | null {
   if (tweak.type === "boolean") {
     return (
@@ -335,7 +386,7 @@ function TweakField({
   }
 
   if (tweak.type === "color") {
-    return <TweakColorField tweak={tweak} onChange={onChange} />;
+    return <TweakColorField tweak={tweak} onChange={onChange} onOpenColorPanel={onOpenColorPanel} />;
   }
 
   if (tweak.type === "int" || tweak.type === "float") {
@@ -361,12 +412,14 @@ function TweakField({
   return null;
 }
 
-function TweakColorField({
+export function TweakColorField({
   tweak,
-  onChange
+  onChange,
+  onOpenColorPanel
 }: {
   tweak: TweakDescriptor;
   onChange(tweak: TweakDescriptor, value: TweakValue): void;
+  onOpenColorPanel?(tweak: TweakDescriptor): void;
 }): JSX.Element {
   const committed = String(tweak.value);
   const [draft, setDraft] = useState(() => ({ committed, value: committed }));
@@ -374,16 +427,26 @@ function TweakColorField({
 
   return (
     <span className="tweaks-color-fields">
-      <input
-        className="tweaks-color"
-        type="color"
-        aria-label={`${tweak.name} color`}
-        value={committed.slice(0, 7)}
-        onChange={(event) => {
-          const alpha = committed.length === 9 ? committed.slice(7) : "";
-          onChange(tweak, `${event.currentTarget.value.toUpperCase()}${alpha}`);
-        }}
-      />
+      {onOpenColorPanel ? (
+        <button
+          className="tweaks-color tweaks-color-button"
+          type="button"
+          aria-label={`${tweak.name} color`}
+          onClick={() => onOpenColorPanel(tweak)}
+        >
+          <span className="tweaks-color-swatch" style={{ backgroundColor: committed }} />
+        </button>
+      ) : (
+        <input
+          className="tweaks-color"
+          type="color"
+          aria-label={`${tweak.name} color`}
+          value={committed.slice(0, 7)}
+          onChange={(event) => {
+            onChange(tweak, tweakColorWithPreservedAlpha(committed, event.currentTarget.value));
+          }}
+        />
+      )}
       <input
         className="tweaks-hex"
         type="text"
@@ -407,4 +470,16 @@ function TweakColorField({
 
 export function parseTweakColor(value: string): string | null {
   return /^#[\da-f]{6}(?:[\da-f]{2})?$/i.test(value) ? value.toUpperCase() : null;
+}
+
+export function tweakColorWithPreservedAlpha(committed: string, color: string): string {
+  const alpha = committed.length === 9 ? committed.slice(7) : "";
+  return `${color.toUpperCase()}${alpha}`;
+}
+
+export function nativePanelTweakColor(color: string): string | null {
+  const normalized = parseTweakColor(color);
+  if (normalized === null || normalized.length !== 9) return null;
+
+  return normalized.slice(7) === "FF" ? normalized.slice(0, 7) : normalized;
 }

--- a/snapo-network-inspector-web/src/features/tweaks-inspector/TweaksInspectorApp.tsx
+++ b/snapo-network-inspector-web/src/features/tweaks-inspector/TweaksInspectorApp.tsx
@@ -159,6 +159,11 @@ export function TweaksInspectorApp({
     const tweak = tweaks.find((candidate) => candidate.name === active.tweak.name && candidate.type === "color");
     if (tweak === undefined) {
       activeColorPanel.current = null;
+      void client.closeNativeColorPanel?.(active.sessionId).catch((cause: unknown) => {
+        if (activeColorPanel.current !== null) return;
+
+        setError(cause instanceof Error ? cause.message : "Unable to close the color picker.");
+      });
       return;
     }
 
@@ -168,7 +173,7 @@ export function TweaksInspectorApp({
     }
 
     openNativeColorPanel(tweak, false);
-  }, [openNativeColorPanel, tweaks]);
+  }, [client, openNativeColorPanel, tweaks]);
 
   useEffect(() => {
     if (!hasNativeColorPanel || client.onNativeColorPanelChange === undefined) return;

--- a/snapo-network-inspector-web/src/features/tweaks-inspector/TweaksInspectorApp.tsx
+++ b/snapo-network-inspector-web/src/features/tweaks-inspector/TweaksInspectorApp.tsx
@@ -7,7 +7,7 @@ import type {
   TweakDescriptor,
   TweakValue
 } from "../../network/bridge-types";
-import type { NetworkClient } from "../../network/client";
+import type { NativeColorPanelChange, NetworkClient } from "../../network/client";
 import { AppInspectorPicker } from "../app-inspector/components/AppInspectorPicker";
 import { TweakUpdateQueue } from "./tweak-update-queue";
 
@@ -21,6 +21,13 @@ interface TweakOrdering {
   sections: Map<string, number>;
   tweaks: Map<string, number>;
 }
+
+interface ActiveColorPanelSession {
+  tweak: TweakDescriptor;
+  sessionId: string;
+}
+
+let nextColorPanelSession = 0;
 
 export function TweaksInspectorApp({
   client,
@@ -37,7 +44,7 @@ export function TweaksInspectorApp({
   const [error, setError] = useState<string | null>(null);
   const [saving, setSaving] = useState(false);
   const [orderByApp] = useState(() => new Map<string, TweakOrdering>());
-  const activeColorTweak = useRef<TweakDescriptor | null>(null);
+  const activeColorPanel = useRef<ActiveColorPanelSession | null>(null);
   const server = selection.server;
   const hasNativeColorPanel =
     client.usesNativeServerPicker &&
@@ -122,25 +129,26 @@ export function TweaksInspectorApp({
   );
 
   useEffect(() => {
-    const active = activeColorTweak.current;
+    const active = activeColorPanel.current;
     if (active === null) return;
 
-    activeColorTweak.current = tweaks.find((tweak) => tweak.name === active.name && tweak.type === "color") ?? null;
+    const tweak = tweaks.find((candidate) => candidate.name === active.tweak.name && candidate.type === "color");
+    activeColorPanel.current = tweak === undefined ? null : { ...active, tweak };
   }, [tweaks]);
 
   useEffect(() => {
     if (!hasNativeColorPanel || client.onNativeColorPanelChange === undefined) return;
 
-    const unsubscribe = client.onNativeColorPanelChange((color) => {
-      const tweak = activeColorTweak.current;
-      if (tweak === null) return;
+    const unsubscribe = client.onNativeColorPanelChange((event) => {
+      const active = activeColorPanel.current;
+      if (active === null) return;
 
-      const value = nativePanelTweakColor(color);
-      if (value !== null) updateTweak(tweak, value);
+      const value = nativePanelTweakColor(event, active.sessionId);
+      if (value !== null) updateTweak(active.tweak, value);
     });
 
     return () => {
-      activeColorTweak.current = null;
+      activeColorPanel.current = null;
       unsubscribe();
     };
   }, [client, hasNativeColorPanel, updateTweak]);
@@ -149,9 +157,10 @@ export function TweaksInspectorApp({
     (tweak: TweakDescriptor) => {
       if (!hasNativeColorPanel || client.openNativeColorPanel === undefined) return;
 
-      activeColorTweak.current = tweak;
-      void client.openNativeColorPanel(String(tweak.value)).catch((cause: unknown) => {
-        if (activeColorTweak.current?.name === tweak.name) activeColorTweak.current = null;
+      const sessionId = String(++nextColorPanelSession);
+      activeColorPanel.current = { tweak, sessionId };
+      void client.openNativeColorPanel(String(tweak.value), sessionId).catch((cause: unknown) => {
+        if (activeColorPanel.current?.sessionId === sessionId) activeColorPanel.current = null;
         setError(cause instanceof Error ? cause.message : "Unable to open the color picker.");
       });
     },
@@ -477,8 +486,10 @@ export function tweakColorWithPreservedAlpha(committed: string, color: string): 
   return `${color.toUpperCase()}${alpha}`;
 }
 
-export function nativePanelTweakColor(color: string): string | null {
-  const normalized = parseTweakColor(color);
+export function nativePanelTweakColor(event: NativeColorPanelChange, sessionId: string): string | null {
+  if (event.sessionId !== sessionId) return null;
+
+  const normalized = parseTweakColor(event.color);
   if (normalized === null || normalized.length !== 9) return null;
 
   return normalized.slice(7) === "FF" ? normalized.slice(0, 7) : normalized;

--- a/snapo-network-inspector-web/src/network/client.ts
+++ b/snapo-network-inspector-web/src/network/client.ts
@@ -30,6 +30,8 @@ export interface NetworkClient {
   startTweakStream(server: InspectorServerReference): Promise<StreamStarted>;
   stopTweakStream(streamId: string): Promise<void>;
   onTweaksChanged(callback: (event: TweakStreamEvent) => void): () => void;
+  openNativeColorPanel?(color: string): Promise<void>;
+  onNativeColorPanelChange?(callback: (color: string) => void): () => void;
   loadBodies(input: LoadBodiesInput): Promise<RequestBodies>;
   startStream(input: StartStreamInput): Promise<StreamStarted>;
   stopStream(streamId: string): Promise<void>;
@@ -104,6 +106,14 @@ class WebKitNetworkClient implements NetworkClient {
 
   onTweaksChanged(callback: (event: TweakStreamEvent) => void): () => void {
     return listenWebKitEvent<TweakStreamEvent>("tweaks:changed", callback);
+  }
+
+  openNativeColorPanel(color: string): Promise<void> {
+    return this.invoke<void>("openNativeColorPanel", { color });
+  }
+
+  onNativeColorPanelChange(callback: (color: string) => void): () => void {
+    return listenWebKitEvent<string>("tweaks:color-panel-changed", callback);
   }
 
   loadBodies(input: LoadBodiesInput): Promise<RequestBodies> {

--- a/snapo-network-inspector-web/src/network/client.ts
+++ b/snapo-network-inspector-web/src/network/client.ts
@@ -20,6 +20,11 @@ import type {
   UpdateTweaksInput
 } from "./bridge-types";
 
+export interface NativeColorPanelChange {
+  color: string;
+  sessionId: string;
+}
+
 export interface NetworkClient {
   readonly usesNativeServerPicker: boolean;
   appVersion(): Promise<string>;
@@ -30,8 +35,8 @@ export interface NetworkClient {
   startTweakStream(server: InspectorServerReference): Promise<StreamStarted>;
   stopTweakStream(streamId: string): Promise<void>;
   onTweaksChanged(callback: (event: TweakStreamEvent) => void): () => void;
-  openNativeColorPanel?(color: string): Promise<void>;
-  onNativeColorPanelChange?(callback: (color: string) => void): () => void;
+  openNativeColorPanel?(color: string, sessionId: string): Promise<void>;
+  onNativeColorPanelChange?(callback: (event: NativeColorPanelChange) => void): () => void;
   loadBodies(input: LoadBodiesInput): Promise<RequestBodies>;
   startStream(input: StartStreamInput): Promise<StreamStarted>;
   stopStream(streamId: string): Promise<void>;
@@ -108,12 +113,12 @@ class WebKitNetworkClient implements NetworkClient {
     return listenWebKitEvent<TweakStreamEvent>("tweaks:changed", callback);
   }
 
-  openNativeColorPanel(color: string): Promise<void> {
-    return this.invoke<void>("openNativeColorPanel", { color });
+  openNativeColorPanel(color: string, sessionId: string): Promise<void> {
+    return this.invoke<void>("openNativeColorPanel", { color, sessionId });
   }
 
-  onNativeColorPanelChange(callback: (color: string) => void): () => void {
-    return listenWebKitEvent<string>("tweaks:color-panel-changed", callback);
+  onNativeColorPanelChange(callback: (event: NativeColorPanelChange) => void): () => void {
+    return listenWebKitEvent<NativeColorPanelChange>("tweaks:color-panel-changed", callback);
   }
 
   loadBodies(input: LoadBodiesInput): Promise<RequestBodies> {

--- a/snapo-network-inspector-web/src/network/client.ts
+++ b/snapo-network-inspector-web/src/network/client.ts
@@ -35,7 +35,7 @@ export interface NetworkClient {
   startTweakStream(server: InspectorServerReference): Promise<StreamStarted>;
   stopTweakStream(streamId: string): Promise<void>;
   onTweaksChanged(callback: (event: TweakStreamEvent) => void): () => void;
-  openNativeColorPanel?(color: string, sessionId: string): Promise<void>;
+  openNativeColorPanel?(color: string, sessionId: string, present?: boolean): Promise<void>;
   onNativeColorPanelChange?(callback: (event: NativeColorPanelChange) => void): () => void;
   loadBodies(input: LoadBodiesInput): Promise<RequestBodies>;
   startStream(input: StartStreamInput): Promise<StreamStarted>;
@@ -113,8 +113,8 @@ class WebKitNetworkClient implements NetworkClient {
     return listenWebKitEvent<TweakStreamEvent>("tweaks:changed", callback);
   }
 
-  openNativeColorPanel(color: string, sessionId: string): Promise<void> {
-    return this.invoke<void>("openNativeColorPanel", { color, sessionId });
+  openNativeColorPanel(color: string, sessionId: string, present = true): Promise<void> {
+    return this.invoke<void>("openNativeColorPanel", { color, sessionId, present });
   }
 
   onNativeColorPanelChange(callback: (event: NativeColorPanelChange) => void): () => void {

--- a/snapo-network-inspector-web/src/network/client.ts
+++ b/snapo-network-inspector-web/src/network/client.ts
@@ -36,6 +36,7 @@ export interface NetworkClient {
   stopTweakStream(streamId: string): Promise<void>;
   onTweaksChanged(callback: (event: TweakStreamEvent) => void): () => void;
   openNativeColorPanel?(color: string, sessionId: string, present?: boolean): Promise<void>;
+  closeNativeColorPanel?(sessionId: string): Promise<void>;
   onNativeColorPanelChange?(callback: (event: NativeColorPanelChange) => void): () => void;
   loadBodies(input: LoadBodiesInput): Promise<RequestBodies>;
   startStream(input: StartStreamInput): Promise<StreamStarted>;
@@ -115,6 +116,10 @@ class WebKitNetworkClient implements NetworkClient {
 
   openNativeColorPanel(color: string, sessionId: string, present = true): Promise<void> {
     return this.invoke<void>("openNativeColorPanel", { color, sessionId, present });
+  }
+
+  closeNativeColorPanel(sessionId: string): Promise<void> {
+    return this.invoke<void>("closeNativeColorPanel", { sessionId });
   }
 
   onNativeColorPanelChange(callback: (event: NativeColorPanelChange) => void): () => void {

--- a/snapo-network-inspector-web/src/styles.css
+++ b/snapo-network-inspector-web/src/styles.css
@@ -1528,3 +1528,14 @@ pre {
   border-radius: 4px;
   padding: 2px;
 }
+
+.tweaks-color-button {
+  background: var(--surface-bright);
+}
+
+.tweaks-color-swatch {
+  display: block;
+  width: 100%;
+  height: 100%;
+  border-radius: 2px;
+}


### PR DESCRIPTION
## Summary

- Replace the misplaced WebKit color-input popover in the macOS Tweaks inspector with the native floating Colors panel.
- Center the panel over the active Snap-O window, keep it on-screen, support multiple windows, and close it when the selected inspector changes.
- Enable live RGB and opacity editing, normalize opaque/translucent colors consistently with Android, and preserve the existing browser-native color input.
- Add focused coverage for alpha handling and native-versus-browser color controls.

## Why

WebKit calculates color-picker positioning incorrectly when a macOS window's content view uses flipped coordinates, which causes the palette to appear far from the selected field in SwiftUI-hosted web views. See the public upstream report: https://bugs.webkit.org/show_bug.cgi?id=300025.

## Validation

- `npm test` — 75 tests passed across 12 files.
- `npm run typecheck`.
- `npm run lint`.
- `npm run format:check`.
- `xcodebuild -project Snap-O.xcodeproj -scheme Snap-O CODE_SIGNING_ALLOWED=NO CODE_SIGNING_REQUIRED=NO build`.
