### PR TITLE
Add Snap-O tweaks support to the CLI

### DIFF
--- a/.github/workflows/snapo-cli.yml
+++ b/.github/workflows/snapo-cli.yml
@@ -1,4 +1,4 @@
-name: Network CLI
+name: Snap-O CLI
 
 on:
   push:
@@ -10,7 +10,8 @@ on:
       - 'skills/snap-o-network-inspector/**'
       - 'tests/snapo_cli/**'
       - 'contracts/network/**'
-      - '.github/workflows/network-cli.yml'
+      - 'contracts/tweaks/**'
+      - '.github/workflows/snapo-cli.yml'
   pull_request:
     branches: [main, master]
     paths:
@@ -20,7 +21,8 @@ on:
       - 'skills/snap-o-network-inspector/**'
       - 'tests/snapo_cli/**'
       - 'contracts/network/**'
-      - '.github/workflows/network-cli.yml'
+      - 'contracts/tweaks/**'
+      - '.github/workflows/snapo-cli.yml'
 
 permissions:
   contents: read
@@ -49,3 +51,9 @@ jobs:
           "$SNAPO_CLI" network list --help
           "$SNAPO_CLI" network requests --help
           "$SNAPO_CLI" network show --help
+          "$SNAPO_CLI" tweaks apps --help
+          "$SNAPO_CLI" tweaks list --help
+          "$SNAPO_CLI" tweaks get --help
+          "$SNAPO_CLI" tweaks set --help
+          "$SNAPO_CLI" tweaks reset --help
+          "$SNAPO_CLI" tweaks watch --help

--- a/skills/snap-o-network-inspector/scripts/snapo
+++ b/skills/snap-o-network-inspector/scripts/snapo
@@ -1,12 +1,14 @@
 #!/usr/bin/env python3
-"""Inspect Snap-O network traffic through the configured adb command."""
+"""Inspect Snap-O-enabled apps through the configured adb command."""
 
 import argparse
 import base64
 import gzip
+import http.client
 import json
 import math
 import os
+import re
 import shutil
 import signal
 import socket
@@ -17,6 +19,7 @@ from dataclasses import dataclass, field
 
 
 SOCKET_PREFIX = "snapo_network_"
+TWEAK_SOCKET_PREFIX = "snapo_tweaks_"
 MAX_RECORD_BYTES = 16 * 1024 * 1024
 REDACTED = "[REDACTED]"
 REQUEST_HEADERS = {"authorization", "cookie"}
@@ -39,7 +42,7 @@ class Server:
 
     @property
     def pid(self):
-        suffix = self.socket_name[len(SOCKET_PREFIX) :]
+        suffix = self.socket_name.rsplit("_", 1)[-1]
         return int(suffix) if suffix.isdigit() else None
 
 
@@ -118,6 +121,10 @@ class ADB:
         output = self.command("shell", "cat /proc/net/unix", serial=serial)
         return parse_sockets(output)
 
+    def tweak_sockets(self, serial):
+        output = self.command("shell", "cat /proc/net/unix", serial=serial)
+        return parse_tweak_sockets(output)
+
     def package_hint(self, server):
         if server.pid is None:
             return None
@@ -142,16 +149,24 @@ def parse_devices(output):
     return devices
 
 
-def parse_sockets(output):
+def parse_sockets(output, prefix=SOCKET_PREFIX):
     sockets = set()
     for line in output.splitlines():
         fields = line.split()
         if not fields:
             continue
         name = fields[-1]
-        if name.startswith("@" + SOCKET_PREFIX):
+        if name.startswith("@" + prefix):
             sockets.add(name[1:])
     return sorted(sockets)
+
+
+def parse_tweak_sockets(output):
+    return [
+        name
+        for name in parse_sockets(output, TWEAK_SOCKET_PREFIX)
+        if name[len(TWEAK_SOCKET_PREFIX) :].isdigit()
+    ]
 
 
 def select_devices(devices, serial=None, usb=False, emulator=False):
@@ -194,9 +209,27 @@ def discover(adb, options):
     return sorted(servers, key=lambda server: (server.device_id, server.socket_name))
 
 
-def choose_server(servers, requested):
+def discover_tweaks(adb, options):
+    devices = select_devices(
+        adb.devices(),
+        serial=options.serial,
+        usb=options.usb,
+        emulator=options.emulator,
+    )
+    if not devices:
+        raise SnapOError("No connected devices found")
+    servers = []
+    for device in devices:
+        try:
+            servers.extend(Server(device, name) for name in adb.tweak_sockets(device))
+        except SnapOError:
+            continue
+    return sorted(servers, key=lambda server: (server.device_id, server.socket_name))
+
+
+def choose_server(servers, requested, feature="network"):
     if not servers:
-        raise SnapOError("No Snap-O network servers found for selected device(s)")
+        raise SnapOError(f"No Snap-O {feature} servers found for selected device(s)")
     if not requested:
         if len(servers) == 1:
             return servers[0]
@@ -213,7 +246,7 @@ def choose_server(servers, requested):
     else:
         matches = [server for server in servers if server.socket_name == requested]
     if not matches:
-        raise SnapOError(f"No Snap-O network server named '{requested}' found")
+        raise SnapOError(f"No Snap-O {feature} server named '{requested}' found")
     if len(matches) > 1:
         choices = ", ".join(server.identifier for server in matches)
         raise SnapOError(f"Socket '{requested}' exists on multiple devices. Available: {choices}")
@@ -464,6 +497,149 @@ class ConnectedSession:
         if getattr(self.forward.adb, "has_explicit_endpoint", False):
             return False
         return self.forward.__exit__(error_type, error, traceback)
+
+
+class TweakConnection:
+    def __init__(self, adb, server, timeout=10):
+        self.adb = adb
+        self.server = server
+        self.timeout = timeout
+        self.forward = None
+        self.socket = None
+        self.response = None
+
+    def __enter__(self):
+        if not getattr(self.adb, "has_explicit_endpoint", False):
+            self.forward = Forward(self.adb, self.server)
+            self.forward.__enter__()
+        return self
+
+    def __exit__(self, error_type, error, traceback):
+        self.close()
+        if self.forward is not None:
+            return self.forward.__exit__(error_type, error, traceback)
+        return False
+
+    def close(self):
+        if self.response is not None:
+            self.response.close()
+            self.response = None
+        if self.socket is not None:
+            self.socket.close()
+            self.socket = None
+
+    def _read_exact(self, count):
+        received = bytearray()
+        while len(received) < count:
+            try:
+                chunk = self.socket.recv(count - len(received))
+            except OSError as error:
+                raise SnapOError(f"Failed to read from ADB server: {error}") from error
+            if not chunk:
+                raise SnapOError("ADB server closed the connection unexpectedly")
+            received.extend(chunk)
+        return bytes(received)
+
+    def _adb_request(self, request):
+        payload = request.encode("utf-8")
+        if len(payload) > 0xFFFF:
+            raise SnapOError("ADB request is too large")
+        try:
+            self.socket.sendall(f"{len(payload):04X}".encode("ascii") + payload)
+        except OSError as error:
+            raise SnapOError(f"Failed to write to ADB server: {error}") from error
+        status = self._read_exact(4)
+        if status == b"OKAY":
+            return
+        if status == b"FAIL":
+            try:
+                length = int(self._read_exact(4), 16)
+            except ValueError as error:
+                raise SnapOError("ADB returned an invalid failure response") from error
+            message = self._read_exact(length).decode("utf-8", errors="replace")
+            raise SnapOError(f"ADB rejected the tweaks connection: {message}")
+        raise SnapOError("ADB returned an invalid status response")
+
+    def _open_socket(self):
+        explicit_endpoint = getattr(self.adb, "has_explicit_endpoint", False)
+        endpoint = self.adb.endpoint if explicit_endpoint else ("127.0.0.1", self.forward.port)
+        try:
+            self.socket = socket.create_connection(endpoint, timeout=self.timeout)
+        except OSError as error:
+            target = "ADB server" if explicit_endpoint else "forwarded Snap-O tweaks socket"
+            raise SnapOError(f"Failed to connect to {target}: {error}") from error
+        if explicit_endpoint:
+            self._adb_request(f"host:transport:{self.server.device_id}")
+            self._adb_request(f"localabstract:{self.server.socket_name}")
+
+    def request(self, method, path, payload=None, stream=False):
+        self.close()
+        keep_open = False
+        try:
+            self._open_socket()
+            try:
+                body = (
+                    json.dumps(payload, separators=(",", ":"), ensure_ascii=False, allow_nan=False)
+                    .encode("utf-8")
+                    if payload is not None
+                    else b""
+                )
+            except (TypeError, ValueError) as error:
+                raise SnapOError(f"Invalid tweaks request body: {error}") from error
+            route = path if path.startswith("/") else f"/{path}"
+            headers = [
+                f"{method} {route} HTTP/1.1",
+                "Host: localhost",
+                f"Accept: {'text/event-stream' if stream else 'application/json'}",
+                "Connection: close",
+            ]
+            if payload is not None:
+                headers.extend(["Content-Type: application/json", f"Content-Length: {len(body)}"])
+            request = ("\r\n".join(headers) + "\r\n\r\n").encode("ascii") + body
+            try:
+                self.socket.sendall(request)
+                self.response = http.client.HTTPResponse(self.socket)
+                self.response.begin()
+            except (OSError, http.client.HTTPException) as error:
+                raise SnapOError(f"Failed to communicate with Snap-O tweaks server: {error}") from error
+
+            if not 200 <= self.response.status < 300:
+                data = self._read_response()
+                detail = self.response.reason or "Request failed"
+                try:
+                    document = json.loads(data)
+                    if isinstance(document, dict) and isinstance(document.get("error"), str):
+                        detail = document["error"]
+                except (UnicodeDecodeError, ValueError):
+                    pass
+                raise SnapOError(f"Snap-O tweaks server returned HTTP {self.response.status}: {detail}")
+
+            if stream:
+                self.socket.settimeout(None)
+                keep_open = True
+                return self.response
+
+            try:
+                document = json.loads(self._read_response())
+            except (UnicodeDecodeError, ValueError) as error:
+                raise SnapOError("Snap-O tweaks server returned invalid JSON") from error
+            if not isinstance(document, dict):
+                raise SnapOError("Snap-O tweaks server returned an invalid response")
+            return document
+        finally:
+            if not keep_open:
+                self.close()
+
+    def _read_response(self):
+        if self.response.length is not None and self.response.length > MAX_RECORD_BYTES:
+            raise SnapOError("Snap-O tweaks server returned an oversized response")
+        try:
+            data = self.response.read(MAX_RECORD_BYTES + 1)
+        except (OSError, http.client.HTTPException) as error:
+            raise SnapOError(f"Failed to read Snap-O tweaks response: {error}") from error
+        if len(data) > MAX_RECORD_BYTES:
+            raise SnapOError("Snap-O tweaks server returned an oversized response")
+        return data
 
 
 def redact_headers(headers, sensitive):
@@ -887,6 +1063,244 @@ def run_show(adb, options):
     return 0
 
 
+def choose_tweak_server(adb, options):
+    return choose_server(discover_tweaks(adb, options), options.socket, feature="tweaks")
+
+
+def tweak_descriptors(document):
+    descriptors = document.get("tweaks")
+    if not isinstance(descriptors, list) or any(
+        not isinstance(tweak, dict)
+        or not isinstance(tweak.get("name"), str)
+        or not isinstance(tweak.get("type"), str)
+        for tweak in descriptors
+    ):
+        raise SnapOError("Snap-O tweaks server returned an invalid tweak list")
+    return descriptors
+
+
+def find_tweak(descriptors, name):
+    for descriptor in descriptors:
+        if descriptor["name"] == name:
+            return descriptor
+    raise SnapOError(f"Unknown tweak: {name}")
+
+
+def parse_tweak_value(descriptor, raw):
+    kind = descriptor.get("type")
+    if kind == "string":
+        return raw
+    if kind == "boolean":
+        value = raw.lower()
+        if value in {"true", "yes", "on", "1"}:
+            return True
+        if value in {"false", "no", "off", "0"}:
+            return False
+        raise SnapOError(f"Tweak '{descriptor.get('name', '')}' requires a boolean value")
+    if kind == "int":
+        if not re.fullmatch(r"[+-]?\d+", raw, flags=re.ASCII):
+            raise SnapOError(f"Tweak '{descriptor.get('name', '')}' requires a whole-number value")
+        try:
+            return int(raw)
+        except ValueError as error:
+            raise SnapOError(f"Tweak '{descriptor.get('name', '')}' requires a whole-number value") from error
+    if kind == "float":
+        try:
+            value = float(raw)
+        except ValueError as error:
+            raise SnapOError(f"Tweak '{descriptor.get('name', '')}' requires a numeric value") from error
+        if not math.isfinite(value):
+            raise SnapOError(f"Tweak '{descriptor.get('name', '')}' requires a finite numeric value")
+        return value
+    if kind == "color":
+        if not re.fullmatch(r"#[0-9a-fA-F]{6}(?:[0-9a-fA-F]{2})?", raw):
+            raise SnapOError(f"Tweak '{descriptor.get('name', '')}' requires a #RRGGBB or #RRGGBBAA color")
+        return raw
+    raise SnapOError(f"Tweak '{descriptor.get('name', '')}' has unsupported type '{kind}'")
+
+
+def validate_tweak_json_value(descriptor, value):
+    kind = descriptor["type"]
+    valid = {
+        "int": lambda item: isinstance(item, int) and not isinstance(item, bool),
+        "float": lambda item: (
+            isinstance(item, (int, float))
+            and not isinstance(item, bool)
+            and math.isfinite(item)
+        ),
+        "boolean": lambda item: isinstance(item, bool),
+        "color": lambda item: (
+            isinstance(item, str)
+            and re.fullmatch(r"#[0-9a-fA-F]{6}(?:[0-9a-fA-F]{2})?", item) is not None
+        ),
+        "string": lambda item: isinstance(item, str),
+    }.get(kind)
+    if valid is None:
+        raise SnapOError(f"Tweak '{descriptor['name']}' has unsupported type '{kind}'")
+    try:
+        is_valid = valid(value)
+    except (OverflowError, TypeError, ValueError):
+        is_valid = False
+    if not is_valid:
+        raise SnapOError(f"Tweak '{descriptor['name']}' requires a {kind} value")
+
+
+def emit_tweak_document(document, as_json):
+    if as_json:
+        print_json(document)
+        return
+    tweaks = document.get("tweaks") if isinstance(document.get("tweaks"), list) else [document]
+    for tweak in tweaks:
+        value = json.dumps(tweak.get("value"), ensure_ascii=False, allow_nan=False)
+        kind = f" [{tweak['type']}]" if isinstance(tweak.get("type"), str) else ""
+        print(f"{tweak.get('name', 'unknown')} = {value}{kind}", flush=True)
+
+
+def run_tweak_apps(adb, options):
+    servers = discover_tweaks(adb, options)
+    if not servers:
+        raise SnapOError("No Snap-O tweaks servers found")
+    found = False
+    current_device = None
+    for server in servers:
+        try:
+            with TweakConnection(adb, server) as connection:
+                info = connection.request("GET", "/app")
+        except SnapOError:
+            continue
+        name = info.get("name")
+        package = info.get("packageName")
+        if not isinstance(name, str) or not isinstance(package, str):
+            continue
+        found = True
+        if options.json:
+            print_json(
+                {
+                    "server": server.identifier,
+                    "deviceId": server.device_id,
+                    "socketName": server.socket_name,
+                    "packageName": package,
+                    "appName": name,
+                }
+            )
+        else:
+            if current_device != server.device_id:
+                current_device = server.device_id
+                print(f"{current_device}:")
+            print(f"    {server.socket_name}  {name}  pkg:{package}")
+    if not found:
+        raise SnapOError("No reachable Snap-O tweaks apps found")
+    return 0
+
+
+def run_tweak_list(adb, options):
+    server = choose_tweak_server(adb, options)
+    with TweakConnection(adb, server) as connection:
+        document = connection.request("GET", "/tweaks")
+    tweak_descriptors(document)
+    emit_tweak_document(document, options.json)
+    return 0
+
+
+def run_tweak_get(adb, options):
+    server = choose_tweak_server(adb, options)
+    with TweakConnection(adb, server) as connection:
+        descriptors = tweak_descriptors(connection.request("GET", "/tweaks"))
+    emit_tweak_document(find_tweak(descriptors, options.name), options.json)
+    return 0
+
+
+def tweak_json_values(raw):
+    try:
+        values = json.loads(raw, parse_constant=lambda value: (_ for _ in ()).throw(ValueError(value)))
+    except (TypeError, ValueError) as error:
+        raise SnapOError(f"--values-json must contain a valid JSON object: {error}") from error
+    if not isinstance(values, dict) or not values:
+        raise SnapOError("--values-json must contain a nonempty JSON object")
+    return values
+
+
+def run_tweak_set(adb, options):
+    server = choose_tweak_server(adb, options)
+    with TweakConnection(adb, server) as connection:
+        descriptors = tweak_descriptors(connection.request("GET", "/tweaks"))
+        if options.values_json is not None:
+            values = tweak_json_values(options.values_json)
+            for name, value in values.items():
+                validate_tweak_json_value(find_tweak(descriptors, name), value)
+        else:
+            descriptor = find_tweak(descriptors, options.name)
+            values = {options.name: parse_tweak_value(descriptor, options.value)}
+        document = connection.request("PATCH", "/tweaks", {"values": values})
+    emit_tweak_document(document, options.json)
+    return 0
+
+
+def run_tweak_reset(adb, options):
+    server = choose_tweak_server(adb, options)
+    with TweakConnection(adb, server) as connection:
+        descriptors = tweak_descriptors(connection.request("GET", "/tweaks"))
+        selected = descriptors if options.all else [find_tweak(descriptors, options.name)]
+        values = {}
+        for descriptor in selected:
+            if "default" not in descriptor:
+                raise SnapOError(f"Tweak '{descriptor['name']}' does not provide a default value")
+            values[descriptor["name"]] = descriptor["default"]
+        document = (
+            connection.request("PATCH", "/tweaks", {"values": values})
+            if values
+            else {"tweaks": []}
+        )
+    emit_tweak_document(document, options.json)
+    return 0
+
+
+def tweak_events(response):
+    event_name = "message"
+    data = []
+    while True:
+        try:
+            line = response.readline(MAX_RECORD_BYTES + 1)
+        except (OSError, http.client.HTTPException) as error:
+            raise SnapOError(f"Failed to read Snap-O tweaks event stream: {error}") from error
+        if len(line) > MAX_RECORD_BYTES:
+            raise SnapOError("Snap-O tweaks server returned an oversized event")
+        if not line:
+            raise SnapOError("Snap-O tweaks event stream closed unexpectedly")
+        try:
+            text = line.decode("utf-8").rstrip("\r\n")
+        except UnicodeDecodeError as error:
+            raise SnapOError("Snap-O tweaks server returned an invalid event") from error
+        if not text:
+            if data and event_name == "tweaks":
+                try:
+                    document = json.loads("\n".join(data))
+                except ValueError as error:
+                    raise SnapOError("Snap-O tweaks server returned an invalid event") from error
+                if not isinstance(document, dict):
+                    raise SnapOError("Snap-O tweaks server returned an invalid event")
+                tweak_descriptors(document)
+                yield document
+            event_name = "message"
+            data = []
+        elif text.startswith(":"):
+            continue
+        elif text.startswith("event:"):
+            event_name = text.partition(":")[2].lstrip(" ")
+        elif text.startswith("data:"):
+            data.append(text.partition(":")[2].lstrip(" "))
+
+
+def run_tweak_watch(adb, options):
+    server = choose_tweak_server(adb, options)
+    with TweakConnection(adb, server) as connection:
+        response = connection.request("GET", "/tweaks/events", stream=True)
+        for document in tweak_events(response):
+            emit_tweak_document(document, options.json)
+            if options.once:
+                return 0
+
+
 def add_common_options(parser, socket_option=False):
     selection = parser.add_mutually_exclusive_group()
     selection.add_argument("-s", "--serial")
@@ -922,6 +1336,16 @@ class SnapOArgumentParser(argparse.ArgumentParser):
         options = super().parse_args(arguments, namespace)
         if hasattr(options, "adb_host") and (options.adb_host is None) != (options.adb_port is None):
             self.error("--adb-host and --adb-port must be used together")
+        if getattr(options, "root_command", None) == "tweaks":
+            command = getattr(options, "tweaks_command", None)
+            if command == "set":
+                if options.values_json is not None:
+                    if options.name is not None or options.value is not None:
+                        self.error("set accepts either NAME VALUE or --values-json, not both")
+                elif options.name is None or options.value is None:
+                    self.error("set requires NAME VALUE or --values-json")
+            elif command == "reset" and (options.name is None) == (not options.all):
+                self.error("reset requires either NAME or --all")
         return options
 
 
@@ -946,6 +1370,40 @@ def parser():
     add_common_options(show, socket_option=True)
     show.add_argument("-r", "--request-id", required=True)
     show.set_defaults(handler=run_show)
+
+    tweaks = root_commands.add_parser("tweaks", help="inspect and update Snap-O live tweaks")
+    tweaks_commands = tweaks.add_subparsers(dest="tweaks_command")
+
+    apps = tweaks_commands.add_parser("apps", help="list available Snap-O tweaks apps")
+    add_common_options(apps)
+    apps.set_defaults(handler=run_tweak_apps)
+
+    tweak_list = tweaks_commands.add_parser("list", help="list available tweaks and their values")
+    add_common_options(tweak_list, socket_option=True)
+    tweak_list.set_defaults(handler=run_tweak_list)
+
+    get = tweaks_commands.add_parser("get", help="show one tweak and its current value")
+    add_common_options(get, socket_option=True)
+    get.add_argument("name", metavar="NAME")
+    get.set_defaults(handler=run_tweak_get)
+
+    set_tweak = tweaks_commands.add_parser("set", help="update one tweak or an atomic JSON batch")
+    add_common_options(set_tweak, socket_option=True)
+    set_tweak.add_argument("name", metavar="NAME", nargs="?")
+    set_tweak.add_argument("value", metavar="VALUE", nargs="?")
+    set_tweak.add_argument("--values-json", help="JSON object containing an atomic batch of tweak values")
+    set_tweak.set_defaults(handler=run_tweak_set)
+
+    reset = tweaks_commands.add_parser("reset", help="reset one tweak or all tweaks to their defaults")
+    add_common_options(reset, socket_option=True)
+    reset.add_argument("name", metavar="NAME", nargs="?")
+    reset.add_argument("--all", action="store_true", help="reset every currently registered tweak")
+    reset.set_defaults(handler=run_tweak_reset)
+
+    watch = tweaks_commands.add_parser("watch", help="stream current tweak snapshots")
+    add_common_options(watch, socket_option=True)
+    watch.add_argument("--once", action="store_true", help="stop after the first tweak snapshot")
+    watch.set_defaults(handler=run_tweak_watch)
     return root
 
 
@@ -959,8 +1417,8 @@ def main(arguments=None):
     if options.root_command is None:
         cli.print_help()
         return 0
-    if options.network_command is None:
-        cli.parse_args(["network", "--help"])
+    if getattr(options, f"{options.root_command}_command", None) is None:
+        cli.parse_args([options.root_command, "--help"])
         return 0
     try:
         adb = ADB(resolve_adb(options.adb), host=options.adb_host, port=options.adb_port)

--- a/tests/snapo_cli/test_snapo.py
+++ b/tests/snapo_cli/test_snapo.py
@@ -1,5 +1,6 @@
 import contextlib
 import gzip
+import http.server
 import importlib.machinery
 import importlib.util
 import io
@@ -8,6 +9,7 @@ import os
 import pathlib
 import select
 import socket
+import socketserver
 import tempfile
 import threading
 import unittest
@@ -138,6 +140,183 @@ class FakeADB:
         return ""
 
 
+class FakeTweakADB(FakeADB):
+    def __init__(self, sockets=None, devices=None, fail_forward=False):
+        super().__init__(fail_forward=fail_forward)
+        self.available_devices = devices or ["emulator-5554"]
+        self.available_sockets = sockets or {"emulator-5554": ["snapo_tweaks_42"]}
+
+    def devices(self):
+        return self.available_devices
+
+    def tweak_sockets(self, serial):
+        value = self.available_sockets.get(serial, [])
+        if isinstance(value, Exception):
+            raise value
+        return value
+
+
+def tweak_descriptors():
+    return [
+        {
+            "name": "Typography/Font size",
+            "type": "int",
+            "default": 16,
+            "value": 16,
+            "min": -8,
+            "max": 48,
+            "step": 2,
+        },
+        {
+            "name": "Motion/Damping ratio",
+            "type": "float",
+            "default": 0.5,
+            "value": 0.5,
+            "min": -1.0,
+            "max": 1.0,
+            "step": 0.1,
+        },
+        {"name": "Motion/Enabled", "type": "boolean", "default": True, "value": True},
+        {"name": "Palette/Accent color", "type": "color", "default": "#5468FF", "value": "#5468FF"},
+        {"name": "Preview/Text value", "type": "string", "default": "true", "value": "true"},
+    ]
+
+
+class TweakHTTPServer:
+    def __init__(self, descriptors=None, app=None, error=None, stream_events=None):
+        self.descriptors = json.loads(json.dumps(descriptors or tweak_descriptors()))
+        self.app = app or {"name": "Snap-O Tweaks Demo", "packageName": "com.example.tweaks"}
+        self.error = error
+        self.stream_events = stream_events
+        self.requests = []
+        owner = self
+
+        class Handler(http.server.BaseHTTPRequestHandler):
+            protocol_version = "HTTP/1.1"
+
+            def do_GET(self):
+                owner.requests.append(("GET", self.path, None))
+                if self.path == "/app":
+                    self.send_json(200, owner.app)
+                elif self.path == "/tweaks":
+                    self.send_json(200, {"tweaks": owner.descriptors})
+                elif self.path == "/tweaks/events":
+                    events = owner.stream_events or [
+                        ": keep-alive\n\n",
+                        "event: ignored\ndata: {\"unexpected\":true}\n\n",
+                        "event: tweaks\ndata: " + json.dumps({"tweaks": owner.descriptors}) + "\n\n",
+                    ]
+                    body = "".join(events).encode("utf-8")
+                    self.send_response(200)
+                    self.send_header("Content-Type", "text/event-stream")
+                    self.send_header("Content-Length", str(len(body)))
+                    self.send_header("Connection", "close")
+                    self.end_headers()
+                    self.wfile.write(body)
+                    self.wfile.flush()
+                else:
+                    self.send_json(404, {"error": f"Unknown endpoint: {self.path}"})
+
+            def do_PATCH(self):
+                length = int(self.headers.get("Content-Length", "0"))
+                payload = json.loads(self.rfile.read(length).decode("utf-8"))
+                owner.requests.append(("PATCH", self.path, payload))
+                if owner.error is not None:
+                    status, message = owner.error
+                    self.send_json(status, {"error": message})
+                    return
+
+                descriptors = {item["name"]: item for item in owner.descriptors}
+                unknown = next((name for name in payload["values"] if name not in descriptors), None)
+                if unknown is not None:
+                    self.send_json(404, {"error": f"Unknown tweak: {unknown}"})
+                    return
+
+                updates = []
+                for name, value in payload["values"].items():
+                    if descriptors[name]["type"] == "color":
+                        value = value.upper()
+                    descriptors[name]["value"] = value
+                    updates.append({"name": name, "value": value})
+                self.send_json(200, {"tweaks": updates})
+
+            def send_json(self, status, payload):
+                body = json.dumps(payload).encode("utf-8")
+                self.send_response(status)
+                self.send_header("Content-Type", "application/json")
+                self.send_header("Content-Length", str(len(body)))
+                self.send_header("Connection", "close")
+                self.end_headers()
+                self.wfile.write(body)
+
+            def log_message(self, format, *arguments):
+                return None
+
+        self.server = http.server.ThreadingHTTPServer(("127.0.0.1", 0), Handler)
+        self.port = self.server.server_address[1]
+        self.thread = threading.Thread(target=self.server.serve_forever, daemon=True)
+
+    def __enter__(self):
+        self.thread.start()
+        return self
+
+    def __exit__(self, error_type, error, traceback):
+        self.server.shutdown()
+        self.server.server_close()
+        self.thread.join(timeout=3)
+        if self.thread.is_alive():
+            raise AssertionError("tweak HTTP server did not stop")
+
+
+class TweakSmartSocketServer:
+    def __init__(self, payload):
+        self.payload = payload
+        self.received = []
+        owner = self
+
+        class Handler(socketserver.BaseRequestHandler):
+            def handle(self):
+                stream = self.request.makefile("rwb", buffering=0)
+                for _ in range(2):
+                    size = int(stream.read(4), 16)
+                    owner.received.append(stream.read(size).decode("utf-8"))
+                    stream.write(b"OKAY")
+
+                request_line = stream.readline().decode("utf-8").rstrip()
+                owner.received.append(request_line)
+                while stream.readline().strip():
+                    pass
+
+                body = json.dumps(owner.payload).encode("utf-8")
+                response = (
+                    b"HTTP/1.1 200 OK\r\n"
+                    b"Content-Type: application/json\r\n"
+                    + f"Content-Length: {len(body)}\r\n".encode("ascii")
+                    + b"Connection: close\r\n\r\n"
+                    + body
+                )
+                stream.write(response)
+
+        class Server(socketserver.ThreadingTCPServer):
+            allow_reuse_address = True
+            daemon_threads = True
+
+        self.server = Server(("127.0.0.1", 0), Handler)
+        self.port = self.server.server_address[1]
+        self.thread = threading.Thread(target=self.server.serve_forever, daemon=True)
+
+    def __enter__(self):
+        self.thread.start()
+        return self
+
+    def __exit__(self, error_type, error, traceback):
+        self.server.shutdown()
+        self.server.server_close()
+        self.thread.join(timeout=3)
+        if self.thread.is_alive():
+            raise AssertionError("tweak ADB smart-socket server did not stop")
+
+
 class PluginPackagingTests(unittest.TestCase):
     def test_plugin_bundles_the_network_inspector_skill(self):
         manifest = json.loads((REPOSITORY / ".codex-plugin" / "plugin.json").read_text(encoding="utf-8"))
@@ -221,6 +400,157 @@ usb-phone device product:oriole
         options = snapo.parser().parse_args(["network", "list"])
         servers = snapo.discover(PartiallyUnavailableADB(), options)
         self.assertEqual(servers, [snapo.Server("emulator-5554", "snapo_network_42")])
+
+
+class TweakDiscoveryTests(unittest.TestCase):
+    def test_server_pid_supports_both_network_and_tweak_socket_prefixes(self):
+        self.assertEqual(snapo.Server("emulator-5554", "snapo_network_42").pid, 42)
+        self.assertEqual(snapo.Server("emulator-5554", "snapo_tweaks_42").pid, 42)
+
+    def test_parses_tweak_sockets_without_mixing_network_inspectors(self):
+        output = """Num RefCount Protocol Flags Type St Inode Path
+1: 0 0 0 1 01 1 @snapo_network_42
+2: 0 0 0 1 01 2 @snapo_tweaks_93
+3: 0 0 0 1 01 3 @unrelated
+4: 0 0 0 1 01 4 @snapo_tweaks_7
+5: 0 0 0 1 01 5 @snapo_tweaks_93
+"""
+        self.assertEqual(snapo.parse_tweak_sockets(output), ["snapo_tweaks_7", "snapo_tweaks_93"])
+        self.assertEqual(snapo.parse_sockets(output), ["snapo_network_42"])
+
+    def test_adb_tweak_socket_discovery_reads_device_unix_sockets(self):
+        recorded = []
+
+        def run(command, **kwargs):
+            recorded.append(command)
+            output = "1: 0 0 0 1 01 1 @snapo_tweaks_42\n2: 0 0 0 1 01 2 @snapo_network_9\n"
+            return type("Result", (), {"returncode": 0, "stdout": output, "stderr": ""})()
+
+        adb = snapo.ADB("/configured/adb", run=run)
+        self.assertEqual(adb.tweak_sockets("emulator-5554"), ["snapo_tweaks_42"])
+        self.assertEqual(
+            recorded,
+            [["/configured/adb", "-s", "emulator-5554", "shell", "cat /proc/net/unix"]],
+        )
+
+    def test_discovers_tweaks_on_selected_devices_and_skips_unavailable_devices(self):
+        adb = FakeTweakADB(
+            devices=["disconnected-device", "emulator-5554", "usb-phone"],
+            sockets={
+                "disconnected-device": snapo.SnapOError("device disconnected"),
+                "emulator-5554": ["snapo_tweaks_42"],
+                "usb-phone": ["snapo_tweaks_8"],
+            },
+        )
+        options = snapo.parser().parse_args(["tweaks", "apps"])
+        self.assertEqual(
+            snapo.discover_tweaks(adb, options),
+            [snapo.Server("emulator-5554", "snapo_tweaks_42"), snapo.Server("usb-phone", "snapo_tweaks_8")],
+        )
+
+        selected = snapo.parser().parse_args(["tweaks", "apps", "-s", "usb-phone"])
+        self.assertEqual(snapo.discover_tweaks(adb, selected), [snapo.Server("usb-phone", "snapo_tweaks_8")])
+
+    def test_parser_registers_every_tweak_command_and_shared_selectors(self):
+        commands = {
+            "apps": ["apps"],
+            "list": ["list", "-n", "snapo_tweaks_42"],
+            "get": ["get", "Typography/Font size", "-n", "snapo_tweaks_42"],
+            "set": ["set", "Typography/Font size", "-2", "-n", "snapo_tweaks_42"],
+            "reset": ["reset", "Typography/Font size", "-n", "snapo_tweaks_42"],
+            "watch": ["watch", "--once", "-n", "snapo_tweaks_42"],
+        }
+        for name, arguments in commands.items():
+            with self.subTest(command=name):
+                options = snapo.parser().parse_args(
+                    ["tweaks", *arguments, "-s", "emulator-5554", "--adb", "/configured/adb", "--json"]
+                )
+                self.assertEqual(options.root_command, "tweaks")
+                self.assertEqual(options.tweaks_command, name)
+                self.assertEqual(options.serial, "emulator-5554")
+                self.assertEqual(options.adb, "/configured/adb")
+                self.assertTrue(options.json)
+
+    def test_tweak_commands_preserve_remote_adb_endpoint_validation(self):
+        commands = (
+            ["tweaks", "apps"],
+            ["tweaks", "list"],
+            ["tweaks", "get", "Motion/Enabled"],
+            ["tweaks", "set", "Motion/Enabled", "false"],
+            ["tweaks", "reset", "Motion/Enabled"],
+            ["tweaks", "watch", "--once"],
+        )
+        for command in commands:
+            with self.subTest(command=command[1]):
+                options = snapo.parser().parse_args(
+                    command + ["--adb-host", "adb.example.test", "--adb-port", "15037"]
+                )
+                self.assertEqual(options.adb_host, "adb.example.test")
+                self.assertEqual(options.adb_port, 15037)
+
+                errors = io.StringIO()
+                with contextlib.redirect_stderr(errors):
+                    with self.assertRaises(SystemExit):
+                        snapo.parser().parse_args(command + ["--adb-host", "adb.example.test"])
+                self.assertIn("--adb-host and --adb-port must be used together", errors.getvalue())
+
+    def test_main_shows_tweaks_group_help_without_starting_adb(self):
+        stdout = io.StringIO()
+        with mock.patch.object(snapo, "resolve_adb", side_effect=AssertionError("adb should not start")):
+            with contextlib.redirect_stdout(stdout):
+                with self.assertRaises(SystemExit) as result:
+                    snapo.main(["tweaks"])
+
+        self.assertEqual(result.exception.code, 0)
+        self.assertIn("apps", stdout.getvalue())
+        self.assertIn("watch", stdout.getvalue())
+
+
+class TweakValueTests(unittest.TestCase):
+    def descriptor(self, name):
+        return next(item for item in tweak_descriptors() if item["name"] == name)
+
+    def test_integer_values_preserve_negative_numbers_and_reject_fractional_values(self):
+        descriptor = self.descriptor("Typography/Font size")
+        self.assertEqual(snapo.parse_tweak_value(descriptor, "-2"), -2)
+        with self.assertRaises(snapo.SnapOError):
+            snapo.parse_tweak_value(descriptor, "2.5")
+        with self.assertRaises(snapo.SnapOError):
+            snapo.parse_tweak_value(descriptor, "true")
+
+    def test_float_values_preserve_negative_numbers_and_reject_nonfinite_numbers(self):
+        descriptor = self.descriptor("Motion/Damping ratio")
+        self.assertEqual(snapo.parse_tweak_value(descriptor, "-0.5"), -0.5)
+        self.assertEqual(snapo.parse_tweak_value(descriptor, "1"), 1.0)
+        for value in ("nan", "NaN", "inf", "-inf", "infinity"):
+            with self.subTest(value=value):
+                with self.assertRaises(snapo.SnapOError):
+                    snapo.parse_tweak_value(descriptor, value)
+
+    def test_float_json_values_reject_huge_integers_without_overflowing(self):
+        descriptor = self.descriptor("Motion/Damping ratio")
+        with self.assertRaises(snapo.SnapOError):
+            snapo.validate_tweak_json_value(descriptor, 10**400)
+
+    def test_boolean_values_are_typed_but_strings_remain_literal(self):
+        boolean = self.descriptor("Motion/Enabled")
+        self.assertIs(snapo.parse_tweak_value(boolean, "TRUE"), True)
+        self.assertIs(snapo.parse_tweak_value(boolean, "false"), False)
+        with self.assertRaises(snapo.SnapOError):
+            snapo.parse_tweak_value(boolean, "maybe")
+
+        string = self.descriptor("Preview/Text value")
+        self.assertEqual(snapo.parse_tweak_value(string, "true"), "true")
+        self.assertEqual(snapo.parse_tweak_value(string, "-0.5"), "-0.5")
+
+    def test_colors_accept_rgb_or_rgba_and_reject_invalid_hex(self):
+        descriptor = self.descriptor("Palette/Accent color")
+        self.assertEqual(snapo.parse_tweak_value(descriptor, "#3b82f6").upper(), "#3B82F6")
+        self.assertEqual(snapo.parse_tweak_value(descriptor, "#3B82F680").upper(), "#3B82F680")
+        for value in ("3B82F6", "#FFF", "#3B82FG", "#123456789"):
+            with self.subTest(value=value):
+                with self.assertRaises(snapo.SnapOError):
+                    snapo.parse_tweak_value(descriptor, value)
 
 
 class ADBTests(unittest.TestCase):
@@ -655,6 +985,305 @@ class ProtocolTests(unittest.TestCase):
 
         state.response_headers = {"Content-Length": "0" * 4999 + "1"}
         self.assertFalse(state.has_no_response_body())
+
+
+class TweakTransportTests(unittest.TestCase):
+    def test_local_http_transport_creates_and_removes_only_its_tweak_forward(self):
+        adb = FakeTweakADB()
+        server = snapo.Server("emulator-5554", "snapo_tweaks_42")
+        with TweakHTTPServer() as wire:
+            with mock.patch.object(snapo, "available_port", return_value=wire.port):
+                with snapo.TweakConnection(adb, server) as connection:
+                    response = connection.request("GET", "/tweaks")
+
+        self.assertEqual(response["tweaks"][0]["name"], "Typography/Font size")
+        self.assertEqual(
+            adb.calls,
+            [
+                ("emulator-5554", ("forward", f"tcp:{wire.port}", "localabstract:snapo_tweaks_42")),
+                ("emulator-5554", ("forward", "--remove", f"tcp:{wire.port}")),
+            ],
+        )
+
+    def test_explicit_adb_endpoint_sends_http_through_direct_smart_socket(self):
+        payload = {"tweaks": tweak_descriptors()}
+        with TweakSmartSocketServer(payload) as wire:
+            adb = snapo.ADB("/configured/adb", host="127.0.0.1", port=wire.port)
+            server = snapo.Server("emulator-5554", "snapo_tweaks_42")
+            with snapo.TweakConnection(adb, server) as connection:
+                response = connection.request("GET", "/tweaks")
+
+        self.assertEqual(response, payload)
+        self.assertEqual(
+            wire.received,
+            [
+                "host:transport:emulator-5554",
+                "localabstract:snapo_tweaks_42",
+                "GET /tweaks HTTP/1.1",
+            ],
+        )
+        self.assertNotIn("HelloSnapO", " ".join(wire.received))
+
+    def test_http_errors_include_status_and_server_message(self):
+        adb = FakeTweakADB()
+        server = snapo.Server("emulator-5554", "snapo_tweaks_42")
+        for status, detail in ((404, "Unknown tweak: Missing"), (422, "Value exceeds the maximum.")):
+            with self.subTest(status=status):
+                with TweakHTTPServer(error=(status, detail)) as wire:
+                    with mock.patch.object(snapo, "available_port", return_value=wire.port):
+                        with snapo.TweakConnection(adb, server) as connection:
+                            with self.assertRaisesRegex(snapo.SnapOError, f"HTTP {status}.*{detail}"):
+                                connection.request("PATCH", "/tweaks", {"values": {"Motion/Enabled": False}})
+
+                self.assertEqual(adb.calls[-1], ("emulator-5554", ("forward", "--remove", f"tcp:{wire.port}")))
+
+    def test_oversized_http_responses_are_rejected_and_forward_is_removed(self):
+        adb = FakeTweakADB()
+        server = snapo.Server("emulator-5554", "snapo_tweaks_42")
+        with TweakHTTPServer() as wire:
+            with mock.patch.object(snapo, "available_port", return_value=wire.port):
+                with mock.patch.object(snapo, "MAX_RECORD_BYTES", 16):
+                    with self.assertRaisesRegex(snapo.SnapOError, "oversized"):
+                        with snapo.TweakConnection(adb, server) as connection:
+                            connection.request("GET", "/tweaks")
+
+        self.assertEqual(adb.calls[-1], ("emulator-5554", ("forward", "--remove", f"tcp:{wire.port}")))
+
+
+class TweakCommandTests(unittest.TestCase):
+    def run_command(self, arguments, wire, adb=None):
+        adb = adb or FakeTweakADB()
+        stdout = io.StringIO()
+        stderr = io.StringIO()
+        with mock.patch.object(snapo, "resolve_adb", return_value="/configured/adb"):
+            with mock.patch.object(snapo, "ADB", return_value=adb):
+                with mock.patch.object(snapo, "available_port", return_value=wire.port):
+                    with contextlib.redirect_stdout(stdout):
+                        with contextlib.redirect_stderr(stderr):
+                            result = snapo.main(["tweaks", *arguments])
+        return result, stdout.getvalue(), stderr.getvalue(), adb
+
+    def test_apps_identifies_each_running_application_from_its_tweak_server(self):
+        with TweakHTTPServer() as wire:
+            result, output, errors, adb = self.run_command(["apps", "--json"], wire)
+
+        self.assertEqual(result, 0, errors)
+        app = json.loads(output)
+        self.assertEqual(app["deviceId"], "emulator-5554")
+        self.assertEqual(app["socketName"], "snapo_tweaks_42")
+        self.assertEqual(app["appName"], "Snap-O Tweaks Demo")
+        self.assertEqual(app["packageName"], "com.example.tweaks")
+        self.assertEqual(wire.requests, [("GET", "/app", None)])
+        self.assertEqual(adb.calls[-1], ("emulator-5554", ("forward", "--remove", f"tcp:{wire.port}")))
+
+    def test_list_emits_one_complete_json_snapshot(self):
+        with TweakHTTPServer() as wire:
+            result, output, errors, adb = self.run_command(["list", "--json"], wire)
+
+        self.assertEqual(result, 0, errors)
+        self.assertEqual(json.loads(output), {"tweaks": wire.descriptors})
+        self.assertEqual(wire.requests, [("GET", "/tweaks", None)])
+        self.assertEqual(adb.calls[-1], ("emulator-5554", ("forward", "--remove", f"tcp:{wire.port}")))
+
+    def test_list_renders_descriptive_human_readable_values(self):
+        with TweakHTTPServer() as wire:
+            result, output, errors, _ = self.run_command(["list"], wire)
+
+        self.assertEqual(result, 0, errors)
+        self.assertIn("Typography/Font size = 16 [int]", output)
+        self.assertIn("Motion/Enabled = true [boolean]", output)
+        self.assertIn('Preview/Text value = "true" [string]', output)
+
+    def test_get_accepts_tweak_names_with_slashes_and_spaces(self):
+        with TweakHTTPServer() as wire:
+            result, output, errors, _ = self.run_command(["get", "Typography/Font size", "--json"], wire)
+
+        self.assertEqual(result, 0, errors)
+        self.assertEqual(json.loads(output), wire.descriptors[0])
+        self.assertEqual(wire.requests, [("GET", "/tweaks", None)])
+
+    def test_get_reports_unknown_tweaks_without_mutating_the_application(self):
+        with TweakHTTPServer() as wire:
+            result, output, errors, adb = self.run_command(["get", "Motion/Missing", "--json"], wire)
+
+        self.assertEqual(result, 1)
+        self.assertEqual(output, "")
+        self.assertIn("Unknown tweak: Motion/Missing", errors)
+        self.assertEqual([request[0] for request in wire.requests], ["GET"])
+        self.assertEqual(adb.calls[-1], ("emulator-5554", ("forward", "--remove", f"tcp:{wire.port}")))
+
+    def test_set_parses_values_using_each_descriptor_type(self):
+        cases = (
+            ("Typography/Font size", "-2", -2),
+            ("Motion/Damping ratio", "-0.5", -0.5),
+            ("Motion/Enabled", "false", False),
+            ("Palette/Accent color", "#3b82f6", "#3B82F6"),
+            ("Preview/Text value", "true", "true"),
+        )
+        for name, raw, expected in cases:
+            with self.subTest(name=name):
+                with TweakHTTPServer() as wire:
+                    result, output, errors, adb = self.run_command(["set", name, raw, "--json"], wire)
+
+                self.assertEqual(result, 0, errors)
+                self.assertEqual(json.loads(output), {"tweaks": [{"name": name, "value": expected}]})
+                self.assertEqual(wire.requests[0], ("GET", "/tweaks", None))
+                self.assertEqual(len(wire.requests), 2)
+                self.assertEqual(wire.requests[1][0:2], ("PATCH", "/tweaks"))
+                sent = wire.requests[1][2]["values"][name]
+                if isinstance(expected, str) and name == "Palette/Accent color":
+                    self.assertEqual(sent.upper(), expected)
+                else:
+                    self.assertEqual(sent, expected)
+                self.assertEqual(adb.calls[-1], ("emulator-5554", ("forward", "--remove", f"tcp:{wire.port}")))
+
+    def test_set_rejects_invalid_values_without_sending_a_patch(self):
+        cases = (
+            ("Typography/Font size", "3.5"),
+            ("Motion/Damping ratio", "NaN"),
+            ("Motion/Damping ratio", "inf"),
+            ("Motion/Enabled", "probably"),
+            ("Palette/Accent color", "#nothex"),
+        )
+        for name, raw in cases:
+            with self.subTest(name=name, value=raw):
+                with TweakHTTPServer() as wire:
+                    result, output, errors, adb = self.run_command(["set", name, raw, "--json"], wire)
+
+                self.assertEqual(result, 1)
+                self.assertEqual(output, "")
+                self.assertTrue(errors.startswith("snapo:"), errors)
+                self.assertEqual(wire.requests, [("GET", "/tweaks", None)])
+                self.assertEqual(adb.calls[-1], ("emulator-5554", ("forward", "--remove", f"tcp:{wire.port}")))
+
+    def test_set_applies_a_typed_json_batch_in_one_atomic_patch(self):
+        values = {
+            "Typography/Font size": -2,
+            "Motion/Damping ratio": -0.5,
+            "Motion/Enabled": False,
+            "Preview/Text value": "true",
+        }
+        with TweakHTTPServer() as wire:
+            result, output, errors, _ = self.run_command(
+                ["set", "--values-json", json.dumps(values), "--json"],
+                wire,
+            )
+
+        self.assertEqual(result, 0, errors)
+        self.assertEqual(wire.requests, [("GET", "/tweaks", None), ("PATCH", "/tweaks", {"values": values})])
+        self.assertEqual(
+            json.loads(output),
+            {"tweaks": [{"name": name, "value": value} for name, value in values.items()]},
+        )
+
+    def test_invalid_json_batches_never_partially_update_tweaks(self):
+        batches = (
+            "{",
+            "[]",
+            "{}",
+            '{"Motion/Enabled":"false"}',
+            '{"Typography/Font size":true}',
+            '{"Motion/Damping ratio":NaN}',
+            '{"Motion/Damping ratio":' + "9" * 400 + "}",
+            '{"Motion/Enabled":false,"Motion/Missing":12}',
+        )
+        for batch in batches:
+            with self.subTest(batch=batch):
+                with TweakHTTPServer() as wire:
+                    result, output, errors, _ = self.run_command(
+                        ["set", "--values-json", batch, "--json"],
+                        wire,
+                    )
+
+                self.assertEqual(result, 1)
+                self.assertEqual(output, "")
+                self.assertTrue(errors.startswith("snapo:"), errors)
+                self.assertEqual(wire.requests, [("GET", "/tweaks", None)])
+
+    def test_reset_one_tweak_patches_its_declared_default(self):
+        descriptors = tweak_descriptors()
+        descriptors[0]["value"] = 24
+        with TweakHTTPServer(descriptors=descriptors) as wire:
+            result, output, errors, _ = self.run_command(
+                ["reset", "Typography/Font size", "--json"],
+                wire,
+            )
+
+        self.assertEqual(result, 0, errors)
+        self.assertEqual(wire.requests[1], ("PATCH", "/tweaks", {"values": {"Typography/Font size": 16}}))
+        self.assertEqual(json.loads(output), {"tweaks": [{"name": "Typography/Font size", "value": 16}]})
+
+    def test_reset_all_patches_every_default_in_one_atomic_request(self):
+        descriptors = tweak_descriptors()
+        descriptors[0]["value"] = 24
+        descriptors[2]["value"] = False
+        defaults = {descriptor["name"]: descriptor["default"] for descriptor in descriptors}
+        with TweakHTTPServer(descriptors=descriptors) as wire:
+            result, output, errors, _ = self.run_command(["reset", "--all", "--json"], wire)
+
+        self.assertEqual(result, 0, errors)
+        self.assertEqual(wire.requests, [("GET", "/tweaks", None), ("PATCH", "/tweaks", {"values": defaults})])
+        self.assertEqual(len(json.loads(output)["tweaks"]), len(descriptors))
+
+    def test_reset_requires_exactly_one_target(self):
+        for arguments in (["reset"], ["reset", "Motion/Enabled", "--all"]):
+            with self.subTest(arguments=arguments):
+                errors = io.StringIO()
+                with contextlib.redirect_stderr(errors):
+                    with self.assertRaises(SystemExit) as error:
+                        snapo.parser().parse_args(["tweaks", *arguments])
+                self.assertEqual(error.exception.code, 2)
+                self.assertIn("reset requires either NAME or --all", errors.getvalue())
+
+    def test_set_requires_either_one_value_or_an_atomic_batch(self):
+        invalid = (
+            ["set"],
+            ["set", "Motion/Enabled"],
+            ["set", "Motion/Enabled", "true", "--values-json", '{"Motion/Enabled":false}'],
+        )
+        for arguments in invalid:
+            with self.subTest(arguments=arguments):
+                errors = io.StringIO()
+                with contextlib.redirect_stderr(errors):
+                    with self.assertRaises(SystemExit) as error:
+                        snapo.parser().parse_args(["tweaks", *arguments])
+                self.assertEqual(error.exception.code, 2)
+                self.assertIn("set", errors.getvalue())
+
+    def test_server_validation_errors_reach_stderr_and_remove_the_forward(self):
+        for status, detail in ((404, "Unknown tweak: Motion/Enabled"), (422, "Value exceeds the maximum.")):
+            with self.subTest(status=status):
+                with TweakHTTPServer(error=(status, detail)) as wire:
+                    result, output, errors, adb = self.run_command(
+                        ["set", "Motion/Enabled", "false", "--json"],
+                        wire,
+                    )
+
+                self.assertEqual(result, 1)
+                self.assertEqual(output, "")
+                self.assertIn(f"HTTP {status}", errors)
+                self.assertIn(detail, errors)
+                self.assertEqual(adb.calls[-1], ("emulator-5554", ("forward", "--remove", f"tcp:{wire.port}")))
+
+    def test_watch_ignores_keepalives_and_other_events_then_emits_a_complete_snapshot(self):
+        with TweakHTTPServer() as wire:
+            result, output, errors, adb = self.run_command(["watch", "--once", "--json"], wire)
+
+        self.assertEqual(result, 0, errors)
+        self.assertEqual(json.loads(output), {"tweaks": wire.descriptors})
+        self.assertEqual(len(output.splitlines()), 1)
+        self.assertEqual(wire.requests, [("GET", "/tweaks/events", None)])
+        self.assertEqual(adb.calls[-1], ("emulator-5554", ("forward", "--remove", f"tcp:{wire.port}")))
+
+    def test_watch_rejects_malformed_snapshots_and_still_removes_its_forward(self):
+        events = ["event: tweaks\ndata: {\"tweaks\":\"not-a-list\"}\n\n"]
+        with TweakHTTPServer(stream_events=events) as wire:
+            result, output, errors, adb = self.run_command(["watch", "--once", "--json"], wire)
+
+        self.assertEqual(result, 1)
+        self.assertEqual(output, "")
+        self.assertIn("invalid tweak list", errors)
+        self.assertEqual(adb.calls[-1], ("emulator-5554", ("forward", "--remove", f"tcp:{wire.port}")))
 
 
 class OutputTests(unittest.TestCase):


### PR DESCRIPTION
## Summary

- Add `snapo tweaks apps`, `list`, `get`, `set`, `reset`, and `watch` commands to the existing dependency-free Python CLI.
- Discover tweak-enabled Android apps over ADB, preserve typed values, support atomic updates and SSE snapshots, clean up local forwards, and connect directly through explicit remote ADB servers.
- Rename the GitHub Actions workflow to `snapo-cli.yml` and expand cross-platform CLI coverage while leaving the README, existing network-inspector skill, and Codex plugin unchanged.

## Testing

- `python3 -B -m unittest discover -s tests/snapo_cli -p 'test_*.py'` — 73 tests passed.
- `xcodebuild -project Snap-O.xcodeproj -scheme Snap-O CODE_SIGNING_ALLOWED=NO CODE_SIGNING_REQUIRED=NO build` — succeeded.
- Verified discovery, reads, typed updates, atomic batches, resets, SSE watching, forward cleanup, and direct remote ADB against a physical Android device.