### PR TITLE
Improve app inspector picker, ordering, and build signing

### DIFF
--- a/snapo-app-mac/Snap-O.xcodeproj/project.pbxproj
+++ b/snapo-app-mac/Snap-O.xcodeproj/project.pbxproj
@@ -193,6 +193,7 @@
 		};
 		A100000B2F5B123400C0FFEE /* Embed Snap-O CLI */ = {
 			isa = PBXShellScriptBuildPhase;
+			alwaysOutOfDate = 1;
 			buildActionMask = 2147483647;
 			files = (
 			);

--- a/snapo-app-mac/Snap-O/NetworkInspector/NetworkInspectorServerPicker.swift
+++ b/snapo-app-mac/Snap-O/NetworkInspector/NetworkInspectorServerPicker.swift
@@ -109,11 +109,17 @@ private struct AppInspectorPickerPopover: View {
         ScrollView {
           LazyVStack(alignment: .leading, spacing: 0) {
             ForEach(model.inspectorApps) { app in
-              AppInspectorPickerAppGroup(
-                app: app,
-                selection: model.selectedInspector,
-                selectInspector: selectInspector
-              )
+              ForEach(app.inspectors) { option in
+                AppInspectorPickerOptionRow(
+                  app: app,
+                  option: option,
+                  isSelected: model.selectedInspector?.appId == app.id
+                    && model.selectedInspector?.kind == option.kind
+                    && model.selectedInspector?.server == option.server
+                ) {
+                  selectInspector(app, option)
+                }
+              }
             }
           }
           .padding(6)
@@ -126,46 +132,8 @@ private struct AppInspectorPickerPopover: View {
   }
 }
 
-private struct AppInspectorPickerAppGroup: View {
-  let app: InspectableApp
-  let selection: SelectedAppInspector?
-  let selectInspector: (InspectableApp, AppInspectorOption) -> Void
-
-  var body: some View {
-    VStack(alignment: .leading, spacing: 0) {
-      HStack(spacing: 8) {
-        AppInspectorIcon(app: app, size: 16, statusSize: 0)
-
-        Text(app.name)
-          .font(.system(size: 11, weight: .medium))
-          .lineLimit(1)
-
-        Spacer(minLength: 8)
-
-        Text(app.deviceDisplayTitle)
-          .font(.system(size: 10))
-          .foregroundStyle(.secondary)
-          .lineLimit(1)
-      }
-      .frame(height: 30)
-      .padding(.horizontal, 8)
-      .help(app.packageName)
-
-      ForEach(app.inspectors) { option in
-        AppInspectorPickerOptionRow(
-          option: option,
-          isSelected: selection?.appId == app.id
-            && selection?.kind == option.kind
-            && selection?.server == option.server
-        ) {
-          selectInspector(app, option)
-        }
-      }
-    }
-  }
-}
-
 private struct AppInspectorPickerOptionRow: View {
+  let app: InspectableApp
   let option: AppInspectorOption
   let isSelected: Bool
   let select: () -> Void
@@ -175,23 +143,26 @@ private struct AppInspectorPickerOptionRow: View {
   var body: some View {
     Button(action: select) {
       HStack(spacing: 10) {
-        Image(systemName: option.kind.systemImage)
-          .font(.system(size: 13))
+        AppInspectorIcon(app: app, size: 32, statusSize: 0)
+
+        AppInspectorPickerText(
+          appName: app.name,
+          deviceName: app.deviceDisplayTitle
+        )
+
+        Spacer(minLength: 8)
+
+        Label(option.kind.title, systemImage: option.kind.systemImage)
+          .font(.system(size: 11))
           .foregroundStyle(.secondary)
-          .frame(width: 18)
-
-        Text(option.kind.title)
-          .font(.system(size: 12))
-
-        Spacer()
+          .fixedSize()
 
         Image(systemName: "checkmark")
           .font(.system(size: 11, weight: .semibold))
           .opacity(isSelected ? 1 : 0)
       }
-      .padding(.leading, 22)
-      .padding(.trailing, 8)
-      .frame(height: 38)
+      .padding(.horizontal, 8)
+      .frame(height: 52)
       .contentShape(Rectangle())
       .background {
         if isHovering || isSelected {
@@ -201,6 +172,7 @@ private struct AppInspectorPickerOptionRow: View {
       }
     }
     .buttonStyle(.plain)
+    .help(app.packageName)
     .onHover { isHovering = $0 }
   }
 }

--- a/snapo-app-mac/Snap-O/NetworkInspector/NetworkInspectorServerPicker.swift
+++ b/snapo-app-mac/Snap-O/NetworkInspector/NetworkInspectorServerPicker.swift
@@ -94,6 +94,12 @@ struct AppInspectorViewPicker: View {
 }
 
 private struct AppInspectorPickerPopover: View {
+  private enum Metrics {
+    static let minimumWidth: CGFloat = 320
+    static let maximumWidth: CGFloat = 480
+    static let nonTextWidth: CGFloat = 160
+  }
+
   @Bindable var model: NetworkInspectorHostModel
   let selectInspector: (InspectableApp, AppInspectorOption) -> Void
 
@@ -128,7 +134,28 @@ private struct AppInspectorPickerPopover: View {
         .fixedSize(horizontal: false, vertical: true)
       }
     }
-    .frame(width: 320)
+    .frame(width: preferredWidth)
+  }
+
+  private var preferredWidth: CGFloat {
+    let appFont = NSFont.systemFont(ofSize: 12, weight: .medium)
+    let deviceFont = NSFont.systemFont(ofSize: 12)
+    let inspectorFont = NSFont.systemFont(ofSize: 11)
+    let contentWidth = model.inspectorApps.flatMap { app in
+      let appWidth = max(
+        textWidth(app.name, font: appFont),
+        textWidth(app.deviceDisplayTitle, font: deviceFont)
+      )
+      return app.inspectors.map { option in
+        appWidth + textWidth(option.kind.title, font: inspectorFont) + Metrics.nonTextWidth
+      }
+    }.max() ?? Metrics.minimumWidth
+
+    return min(max(ceil(contentWidth), Metrics.minimumWidth), Metrics.maximumWidth)
+  }
+
+  private func textWidth(_ text: String, font: NSFont) -> CGFloat {
+    (text as NSString).size(withAttributes: [.font: font]).width
   }
 }
 

--- a/snapo-app-mac/Snap-O/NetworkInspector/NetworkInspectorService.swift
+++ b/snapo-app-mac/Snap-O/NetworkInspector/NetworkInspectorService.swift
@@ -35,6 +35,7 @@ actor NetworkInspectorService {
   private var activeStreamConnections: [String: UUID] = [:]
   private var streamStartFlights: [String: StreamStartFlight] = [:]
   private var tweakStreams: [String: Task<Void, Never>] = [:]
+  private var inspectorServerOrder: [InspectorServerReference] = []
   private var outputContinuations: [UUID: AsyncStream<NetworkInspectorOutput>.Continuation] = [:]
   private var refreshFlight: RefreshFlight?
   private var isStopped = false
@@ -116,12 +117,27 @@ actor NetworkInspectorService {
       )
     }
 
-    return apps.values.sorted {
-      if $0.deviceDisplayTitle != $1.deviceDisplayTitle {
-        return $0.deviceDisplayTitle < $1.deviceDisplayTitle
+    return orderedInspectorApps(Array(apps.values))
+  }
+
+  private func orderedInspectorApps(_ apps: [InspectableApp]) -> [InspectableApp] {
+    let previousOrder = Dictionary(
+      uniqueKeysWithValues: inspectorServerOrder.enumerated().map { ($0.element, $0.offset) }
+    )
+    let orderedApps = apps.sorted { first, second in
+      let firstOrder = first.inspectors.compactMap { previousOrder[$0.server] }.min() ?? -1
+      let secondOrder = second.inspectors.compactMap { previousOrder[$0.server] }.min() ?? -1
+
+      if firstOrder != secondOrder {
+        return firstOrder < secondOrder
       }
-      return $0.name.localizedStandardCompare($1.name) == .orderedAscending
+      if first.deviceId != second.deviceId {
+        return first.deviceId < second.deviceId
+      }
+      return first.packageName < second.packageName
     }
+    inspectorServerOrder = orderedApps.flatMap { $0.inspectors.map(\.server) }
+    return orderedApps
   }
 
   func listTweaks(for reference: InspectorServerReference) async throws -> TweakList {


### PR DESCRIPTION
## Summary
- Present each app and inspector as a single full-size picker row, with the app and device on the left and the inspector on the right.
- Size the picker to its contents between 320 and 480 points so package-style app names stay readable.
- Keep newly discovered apps first without moving existing apps as names, icons, and package metadata update.
- Run the embedded CLI build phase on every build so signed incremental builds cannot reuse an unsigned `snapo` script.
- Preserve support for apps with multiple inspectors and existing selection behavior.

## Why
The previous nested picker used separate rows for apps and inspectors, and sorting by mutable display names caused apps to shift as discovery metadata arrived. Signed Xcode builds could also fail after an unsigned command-line build because the cached CLI embedding phase did not re-sign the bundled executable.

## Validation
- `xcodebuild -project Snap-O.xcodeproj -scheme Snap-O CODE_SIGNING_ALLOWED=NO CODE_SIGNING_REQUIRED=NO build`
- `xcodebuild -project Snap-O.xcodeproj -scheme Snap-O build`
- `codesign --verify --deep --strict Snap-O.app`