### PR TITLE
Add an empty state to the Tweaks inspector

### DIFF
--- a/snapo-network-inspector-web/src/features/tweaks-inspector/TweaksInspectorApp.test.ts
+++ b/snapo-network-inspector-web/src/features/tweaks-inspector/TweaksInspectorApp.test.ts
@@ -1,8 +1,8 @@
 import { createElement } from "react";
 import { renderToStaticMarkup } from "react-dom/server";
 import { describe, expect, it, vi } from "vitest";
-import type { TweakDescriptor } from "../../network/bridge-types";
-import { createNetworkClient } from "../../network/client";
+import type { SelectedAppInspector, TweakDescriptor } from "../../network/bridge-types";
+import { createNetworkClient, type NetworkClient } from "../../network/client";
 import {
   canResetTweaks,
   groupTweaks,
@@ -10,8 +10,31 @@ import {
   parseTweakColor,
   reconcileStreamedTweaks,
   TweakColorField,
+  TweaksInspectorApp,
   tweakColorWithPreservedAlpha
 } from "./TweaksInspectorApp";
+
+describe("empty tweaks inspector", () => {
+  it("uses the network inspector empty-state layout and offers the developer guide", () => {
+    const client = { usesNativeServerPicker: true, openExternal: async () => {} } as unknown as NetworkClient;
+    const selection: SelectedAppInspector = {
+      appId: "pixel:com.openai.chatgpt",
+      kind: "tweaks",
+      server: { deviceId: "pixel", socketName: "snapo_tweaks_10" }
+    };
+
+    const markup = renderToStaticMarkup(
+      createElement(TweaksInspectorApp, { client, apps: [], selection, onSelect() {} })
+    );
+
+    expect(markup).toContain('class="empty-detail"');
+    expect(markup).toContain("No tweaks on screen");
+    expect(markup).toContain("Add a tweak to your app’s Compose UI to see it here.");
+    expect(markup).toContain('class="text-button"');
+    expect(markup).toContain("Read the developer guide");
+    expect(markup).not.toContain('class="tweaks-columns"');
+  });
+});
 
 describe("editable tweak colors", () => {
   it("normalizes complete RGB colors", () => {

--- a/snapo-network-inspector-web/src/features/tweaks-inspector/TweaksInspectorApp.test.ts
+++ b/snapo-network-inspector-web/src/features/tweaks-inspector/TweaksInspectorApp.test.ts
@@ -6,26 +6,35 @@ import { createNetworkClient, type NetworkClient } from "../../network/client";
 import {
   canResetTweaks,
   groupTweaks,
+  hasLoadedTweaksForServer,
   nativePanelTweakColor,
   parseTweakColor,
   reconcileStreamedTweaks,
   TweakColorField,
+  TweaksEmptyState,
   TweaksInspectorApp,
   tweakColorWithPreservedAlpha
 } from "./TweaksInspectorApp";
 
 describe("empty tweaks inspector", () => {
-  it("uses the network inspector empty-state layout and offers the developer guide", () => {
-    const client = { usesNativeServerPicker: true, openExternal: async () => {} } as unknown as NetworkClient;
-    const selection: SelectedAppInspector = {
-      appId: "pixel:com.openai.chatgpt",
-      kind: "tweaks",
-      server: { deviceId: "pixel", socketName: "snapo_tweaks_10" }
-    };
+  const client = { usesNativeServerPicker: true, openExternal: async () => {} } as unknown as NetworkClient;
+  const selection: SelectedAppInspector = {
+    appId: "pixel:com.openai.chatgpt",
+    kind: "tweaks",
+    server: { deviceId: "pixel", socketName: "snapo_tweaks_10" }
+  };
 
+  it("waits for the initial tweak request before showing an empty state", () => {
     const markup = renderToStaticMarkup(
       createElement(TweaksInspectorApp, { client, apps: [], selection, onSelect() {} })
     );
+
+    expect(markup).not.toContain('class="empty-detail"');
+    expect(markup).not.toContain("No tweaks on screen");
+  });
+
+  it("uses the network inspector empty-state layout and offers the developer guide", () => {
+    const markup = renderToStaticMarkup(createElement(TweaksEmptyState, { onOpenDocs() {} }));
 
     expect(markup).toContain('class="empty-detail"');
     expect(markup).toContain("No tweaks on screen");
@@ -33,6 +42,21 @@ describe("empty tweaks inspector", () => {
     expect(markup).toContain('class="text-button"');
     expect(markup).toContain("Read the developer guide");
     expect(markup).not.toContain('class="tweaks-columns"');
+  });
+
+  it("does not treat an incomplete request as loaded", () => {
+    expect(hasLoadedTweaksForServer(null, selection.server)).toBe(false);
+  });
+
+  it("recognizes when the selected server has finished loading", () => {
+    expect(hasLoadedTweaksForServer({ ...selection.server }, selection.server)).toBe(true);
+  });
+
+  it("waits again when switching to another app or device", () => {
+    expect(hasLoadedTweaksForServer(selection.server, { ...selection.server, deviceId: "emulator" })).toBe(false);
+    expect(hasLoadedTweaksForServer(selection.server, { ...selection.server, socketName: "snapo_tweaks_20" })).toBe(
+      false
+    );
   });
 });
 

--- a/snapo-network-inspector-web/src/features/tweaks-inspector/TweaksInspectorApp.tsx
+++ b/snapo-network-inspector-web/src/features/tweaks-inspector/TweaksInspectorApp.tsx
@@ -3,6 +3,7 @@ import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import type {
   AppInspectorOption,
   InspectableApp,
+  InspectorServerReference,
   SelectedAppInspector,
   TweakDescriptor,
   TweakValue
@@ -42,6 +43,7 @@ export function TweaksInspectorApp({
   onSelect(app: InspectableApp, option: AppInspectorOption): void;
 }): JSX.Element {
   const [tweaks, setTweaks] = useState<TweakDescriptor[]>([]);
+  const [loadedServer, setLoadedServer] = useState<InspectorServerReference | null>(null);
   const [error, setError] = useState<string | null>(null);
   const [saving, setSaving] = useState(false);
   const [orderByApp] = useState(() => new Map<string, TweakOrdering>());
@@ -91,6 +93,7 @@ export function TweaksInspectorApp({
       .then((response) => {
         if (disposed) return;
         setTweaks((current) => reconcileStreamedTweaks(current, response.tweaks, queue.pending, queue.inFlight));
+        setLoadedServer(server);
         setError(null);
       })
       .catch((cause: unknown) => {
@@ -239,14 +242,8 @@ export function TweaksInspectorApp({
         </header>
       ) : null}
 
-      {!error && tweaks.length === 0 ? (
-        <section className="empty-detail">
-          <h1>No tweaks on screen</h1>
-          <p>Add a tweak to your app’s Compose UI to see it here.</p>
-          <button className="text-button" type="button" onClick={() => void client.openExternal(docsUrl)}>
-            Read the developer guide
-          </button>
-        </section>
+      {hasLoadedTweaksForServer(loadedServer, server) && !error && tweaks.length === 0 ? (
+        <TweaksEmptyState onOpenDocs={() => void client.openExternal(docsUrl)} />
       ) : (
         <div className="tweaks-inspector-content">
           {error ? (
@@ -279,6 +276,25 @@ export function TweaksInspectorApp({
       )}
     </main>
   );
+}
+
+export function TweaksEmptyState({ onOpenDocs }: { onOpenDocs(): void }): JSX.Element {
+  return (
+    <section className="empty-detail">
+      <h1>No tweaks on screen</h1>
+      <p>Add a tweak to your app’s Compose UI to see it here.</p>
+      <button className="text-button" type="button" onClick={onOpenDocs}>
+        Read the developer guide
+      </button>
+    </section>
+  );
+}
+
+export function hasLoadedTweaksForServer(
+  loadedServer: InspectorServerReference | null,
+  server: InspectorServerReference
+): boolean {
+  return loadedServer?.deviceId === server.deviceId && loadedServer.socketName === server.socketName;
 }
 
 export function canResetTweaks(tweaks: TweakDescriptor[]): boolean {

--- a/snapo-network-inspector-web/src/features/tweaks-inspector/TweaksInspectorApp.tsx
+++ b/snapo-network-inspector-web/src/features/tweaks-inspector/TweaksInspectorApp.tsx
@@ -28,6 +28,7 @@ interface ActiveColorPanelSession {
 }
 
 let nextColorPanelSession = 0;
+const docsUrl = "https://openai.github.io/snap-o/tweaks.html#expose-values";
 
 export function TweaksInspectorApp({
   client,
@@ -238,34 +239,44 @@ export function TweaksInspectorApp({
         </header>
       ) : null}
 
-      <div className="tweaks-inspector-content">
-        {error ? (
-          <p className="tweaks-error" role="alert">
-            {error}
-          </p>
-        ) : null}
-        <div className="tweaks-columns">
-          {sections.map((column, index) => (
-            <div className="tweaks-column" key={index}>
-              {column.map((section) => (
-                <section className="tweaks-section" key={section.name}>
-                  {section.name ? <h2>{section.name}</h2> : null}
-                  <div className="tweaks-section-list">
-                    {section.tweaks.map((tweak) => (
-                      <TweakControl
-                        key={tweak.name}
-                        tweak={tweak}
-                        onChange={updateTweak}
-                        onOpenColorPanel={hasNativeColorPanel ? openNativeColorPanel : undefined}
-                      />
-                    ))}
-                  </div>
-                </section>
-              ))}
-            </div>
-          ))}
+      {!error && tweaks.length === 0 ? (
+        <section className="empty-detail">
+          <h1>No tweaks on screen</h1>
+          <p>Add a tweak to your app’s Compose UI to see it here.</p>
+          <button className="text-button" type="button" onClick={() => void client.openExternal(docsUrl)}>
+            Read the developer guide
+          </button>
+        </section>
+      ) : (
+        <div className="tweaks-inspector-content">
+          {error ? (
+            <p className="tweaks-error" role="alert">
+              {error}
+            </p>
+          ) : null}
+          <div className="tweaks-columns">
+            {sections.map((column, index) => (
+              <div className="tweaks-column" key={index}>
+                {column.map((section) => (
+                  <section className="tweaks-section" key={section.name}>
+                    {section.name ? <h2>{section.name}</h2> : null}
+                    <div className="tweaks-section-list">
+                      {section.tweaks.map((tweak) => (
+                        <TweakControl
+                          key={tweak.name}
+                          tweak={tweak}
+                          onChange={updateTweak}
+                          onOpenColorPanel={hasNativeColorPanel ? openNativeColorPanel : undefined}
+                        />
+                      ))}
+                    </div>
+                  </section>
+                ))}
+              </div>
+            ))}
+          </div>
         </div>
-      </div>
+      )}
     </main>
   );
 }

--- a/snapo-network-inspector-web/src/styles.css
+++ b/snapo-network-inspector-web/src/styles.css
@@ -1410,6 +1410,10 @@ pre {
   padding: 20px clamp(18px, 4vw, 36px) 48px;
 }
 
+.tweaks-inspector > .empty-detail {
+  grid-row: 2;
+}
+
 .tweaks-error {
   margin: 0 0 14px;
   color: var(--error);


### PR DESCRIPTION

<img width="400" alt="CleanShot 2026-07-30 at 14 54 52@2x" src="https://github.com/user-attachments/assets/4704bd43-73d7-4911-9b69-241c4707b121" />


## Summary
- Show a centered empty state when the selected app has no tweaks on screen.
- Reuse the Network inspector’s existing empty-state layout and open the Tweaks developer guide directly at its Compose examples.
- Preserve native macOS centering and cover the new state with a rendering test.

## Validation
- `npm test` (80 tests passing)
- `npm run lint`
- `npm run format:check`
- `npm run typecheck`
- `xcodebuild -project Snap-O.xcodeproj -scheme Snap-O -derivedDataPath /Users/rz/.cache/snap-o-bb9b-derived-data CODE_SIGNING_ALLOWED=NO CODE_SIGNING_REQUIRED=NO build -quiet`