### PR TITLE
Endpoint for all previously adjusted tweaks

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,15 +6,9 @@
 
 # Snap-O: Android Inspection System
 
-Snap-O is a fast, tidy macOS app for Android inspection: capture screenshots and recordings, and inspect network traffic from Android devices and emulators.
+Snap-O is a fast, tidy macOS app for Android inspection. Originally built for streamlined screen capture, Snap-O now also supports network traffic inspection and live UI adjustments on Android devices and emulators.
 
 It runs on macOS 15 or later and requires `adb` from the Android Platform Tools.
-
-## Top-Level Features
-
-- **Network Inspector:** Mirror app traffic into the macOS client, inspect requests and responses, and explore payloads with collapsible JSON pretty printing. Start with the [Network Inspector guide](https://openai.github.io/snap-o/network-inspector.html).
-- **Snap-O Tweaks:** Inspect and adjust live Compose values, including previously adjusted tweaks that have since left composition.
-- **Screen Capture:** Grab screenshots and screen recordings quickly, preview recordings instantly, and drag captures directly into PRs, chat, and docs without save-first friction.
 
 ## Network Inspector
 
@@ -22,14 +16,21 @@ Curious about mirroring app traffic into the macOS client? Check the [Network In
 
 Snap-O can replay network requests that happened before you opened Snap-O, so you do not miss early events, and includes collapsible JSON pretty printing.
 
-## Snap-O Tweaks
+## Screen Capture
 
-Snap-O Tweaks exposes adjustable Compose values through an app-local Android
-socket. The default `GET /tweaks` response contains currently composed tweaks;
-`GET /tweaks?include=adjusted` also includes every previously adjusted tweak
-retained by the running app process. Historical inactive tweaks remain
-read-only until their declarations return. See the [Tweaks protocol
-guide](contracts/tweaks/README.md) for setup, descriptors, and updates.
+- Shows a screenshot the moment the window opens
+- Instantly preview screen recordings, and step through frame-by-frame.
+- Lets you drag and drop captures anywhere without saving them first
+- Multi-device support
+- Supports multiple windows of captures at once
+- Keeps your disk uncluttered by cleaning up after itself
+- Integrates with Android Studio External Tools
+
+## Tweaks (Alpha)
+
+Snap-O Tweaks lets you inspect and adjust Jetpack Compose UI values without rebuilding or restarting your app. Tweaks is an alpha feature; its APIs, behavior, and interface may change.
+
+Follow the [Tweaks developer guide](https://openai.github.io/snap-o/tweaks.html) for setup steps.
 
 ## Why build an Android inspection system?
 
@@ -43,16 +44,6 @@ You might like Snap-O if you've ever wished you could:
 
 I've built variations of this tool a few times over the last decade; this is the first one
 I'm open-sourcing.
-
-## Screen Capture Features
-
-- Shows a screenshot the moment the window opens
-- Instantly preview screen recordings, and step through frame-by-frame.
-- Lets you drag and drop captures anywhere without saving them first
-- Multi-device support
-- Supports multiple windows of captures at once
-- Keeps your disk uncluttered by cleaning up after itself
-- Integrates with Android Studio External Tools
 
 ## Usage
 
@@ -69,22 +60,37 @@ If the ADB server is not running, Snap-O asks you to pick your `adb` binary so i
 
 Note: Snap‑O uses the macOS Hardened Runtime. It will run the `adb` binary you select, so always choose a trusted `adb` from the official Android Platform Tools.
 
+### Previously adjusted Tweaks
+
+Include previously adjusted values even after their declarations leave composition:
+
+```bash
+snapo tweaks list --all -s <serial> -n <socket> --json
+snapo tweaks get 'Motion/Duration' --all -s <serial> -n <socket> --json
+```
+
+The equivalent API is `GET /tweaks?include=adjusted`. Inactive tweaks remain
+read-only. See the [Tweaks protocol guide](contracts/tweaks/README.md) for
+descriptors and updates.
+
 ### Drag and Drop
 
 After you capture a screenshot or screen recording, you can drag and drop it without saving first. Drop the capture straight into a GitHub pull request, a Slack message, or any app that accepts images and video.
 
 ### Keyboard Shortcuts
 
-| Action                   | Shortcut |
-|--------------------------|----------|
-| New screenshot           | `⌘R`     |
-| Start recording          | `⇧⌘R`    |
-| Start live preview       | `⇧⌘L`    |
-| Stop recording / preview | `⎋`      |
-| Save as                  | `⌘S`     |
-| Copy image to clipboard  | `⌘C`     |
-| Previous device          | `⌘[`     |
-| Next device              | `⌘]`     |
+| Action                    | Shortcut |
+|---------------------------|----------|
+| New screenshot            | `⌘R`     |
+| Start recording           | `⇧⌘R`    |
+| Start live preview        | `⇧⌘L`    |
+| Stop recording / preview  | `⎋`      |
+| Save as                   | `⌘S`     |
+| Copy image to clipboard   | `⌘C`     |
+| Previous device           | `⌘[`     |
+| Next device               | `⌘]`     |
+| Show / hide App Inspector | `⌥⌘I`    |
+| Show / hide Capture       | `⌥⌘C`    |
 
 ### Android Studio External Tools
 
@@ -102,7 +108,7 @@ Running these tools launches Snap-O (or brings it to the foreground) and immedia
 
 There is currently no support for choosing a specific device/emulator when starting Snap-O in this way.
 
-### Command Line Inspection
+### Command Line Inspector
 
 Snap-O bundles a small Python command-line client at:
 
@@ -118,13 +124,13 @@ snapo network requests -s <serial> -n <socket> --no-stream --json
 snapo network show -s <serial> -n <socket> -r <request-id> --json
 snapo tweaks apps --json
 snapo tweaks list -s <serial> -n <socket> --json
-snapo tweaks list --all -s <serial> -n <socket> --json
-snapo tweaks get 'Motion/Duration' --all -s <serial> -n <socket> --json
+snapo tweaks set 'Typography/Font size' 42 -s <serial> -n <socket> --json
+snapo tweaks reset 'Typography/Font size' -s <serial> -n <socket> --json
 ```
 
-## Why a web UI for the Network Inspector?
+## Why a web UI for the App Inspector?
 
-The Network Inspector uses a React UI hosted in the macOS app's system WebKit runtime. Native Swift code handles ADB and network transport through the host computer's existing ADB server, so the distribution does not include Chromium, Node.js, or another ADB executable. The same UI can also run in a browser through its HTTP transport.
+The Network and Tweaks inspectors share a React UI hosted in the macOS app's system WebKit runtime. Native Swift code handles ADB and transport through the host computer's existing ADB server, so the distribution does not include Chromium, Node.js, or another ADB executable. The same UI can also run in a browser through its HTTP transport.
 
 The screenshot tool remains in SwiftUI because it delivers a better macOS experience for video playback today. Snap-O uses AVKit because it gives a polished video player on macOS and keeps the download small. VLC-based playback felt clunky and the viewing experience suffered.
 
@@ -140,25 +146,24 @@ Snap-O is a small side project kept alive when time allows. If it works for you,
 
 ## Building from source
 
-The macOS app requires Xcode 16 or later.
+The macOS app requires Xcode 26 or later and Node.js 22.12 or later.
 
 1. Install the Android Platform Tools (via Android Studio or `brew install android-platform-tools`).
-2. Open `Snap-O.xcodeproj` in Xcode.
-3. Build and run.
+2. Install Node.js 22.12 or later and ensure `npm` is available to Xcode.
+3. Open `snapo-app-mac/Snap-O.xcodeproj` in Xcode.
+4. Build and run.
 
 ### Notarizing or shipping builds
 
 If you need to notarize the app yourself:
 
-1. Copy `Config/Signing.xcconfig.sample` → `Config/Signing.xcconfig`.
+1. Copy `snapo-app-mac/Config/Signing.xcconfig.sample` → `snapo-app-mac/Config/Signing.xcconfig`.
 2. Edit the new file with your Apple Developer Team ID and signing certificate name.
 3. Use Xcode's Product → Archive flow, then distribute or upload as usual. The file is ignored by Git, so your credentials remain private.
 
 ## Codex Plugin
 
-Snap-O includes a Codex plugin for macOS and Linux. It bundles the network
-inspector and Snap-O Tweaks skills with their shared Python CLI, and requires
-Python 3 and Android Platform Tools.
+Snap-O includes a Codex plugin for macOS and Linux. It bundles skills for network inspection and live Tweaks, along with their shared Python CLI, and requires Python 3 and Android Platform Tools.
 
 Add the Snap-O marketplace and install the plugin:
 
@@ -186,10 +191,7 @@ Start a new Codex session after installing or updating the plugin.
 
 ## Linux Support
 
-You can inspect network requests and live or previously adjusted tweaks from
-Snap-O on a Linux machine by using the dependency-free `snapo` Python CLI tool.
-Install Python 3 and Android Platform Tools, then download the script from the
-`main` branch and put it on `PATH`:
+You can inspect network requests and alpha Tweaks from Snap-O on a Linux machine by using the dependency-free `snapo` Python CLI tool. Install Python 3 and Android Platform Tools, then download the script from the `main` branch and put it on `PATH`:
 
 ```bash
 mkdir -p ~/.local/bin
@@ -199,23 +201,17 @@ chmod +x ~/.local/bin/snapo
 
 This is the same CLI shipped as part of the macOS app at `Snap-O.app/Contents/MacOS/snapo`.
 
-The script supports `snapo network list`, `requests`, and `show`, alongside
-`snapo tweaks apps`, `list`, `get`, `set`, `reset`, and `watch`. Pass `--all`
-to `tweaks list` or `tweaks get` to include previously adjusted inactive
-tweaks. It resolves `adb` from `PATH`, `ANDROID_SDK_ROOT`, or `ANDROID_HOME`;
-use `--adb <path>` or `SNAPO_ADB` to select a specific ADB executable or
-wrapper. By default, server selection is left to the configured ADB command,
-which normally connects to `127.0.0.1:5037`. Pass `--adb-host <host>` and
-`--adb-port <port>` to use an explicit remote ADB server.
+The script supports `snapo network list`, `requests`, and `show`, as well as `snapo tweaks apps`, `list`, `get`, `set`, `reset`, and `watch`. It resolves `adb` from `PATH`, `ANDROID_SDK_ROOT`, or `ANDROID_HOME`; use `--adb <path>` or `SNAPO_ADB` to select a specific ADB executable or wrapper. By default, server selection is left to the configured ADB command, which normally connects to `127.0.0.1:5037`. Pass `--adb-host <host> --adb-port <port>` to use an explicit remote ADB server.
 
 Verify that ADB can see your Android device, then inspect its available Snap-O servers:
 
 ```bash
 adb devices -l
 snapo network list --json
+snapo tweaks apps --json
 ```
 
-With the default ADB configuration, the CLI opens a localhost forward for the selected `snapo_network_<pid>` socket and removes it when the command exits. Wrappers selecting a remote ADB server must tunnel that forward back to localhost; otherwise, specify `--adb-host` and `--adb-port`. With an explicit ADB endpoint, the CLI connects through the ADB server directly and does not create a forward. Treat captured bodies and URL query values as sensitive.
+With the default ADB configuration, the CLI opens a localhost forward for the selected `snapo_network_<pid>` or `snapo_tweaks_<pid>` socket and removes it when the command exits. Wrappers selecting a remote ADB server must tunnel that forward back to localhost; otherwise, specify `--adb-host` and `--adb-port`. With an explicit ADB endpoint, the CLI connects through the ADB server directly and does not create a forward. Treat captured bodies, URL query values, and editable tweaks as sensitive.
 
 ## Community
 

--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ It runs on macOS 15 or later and requires `adb` from the Android Platform Tools.
 ## Top-Level Features
 
 - **Network Inspector:** Mirror app traffic into the macOS client, inspect requests and responses, and explore payloads with collapsible JSON pretty printing. Start with the [Network Inspector guide](https://openai.github.io/snap-o/network-inspector.html).
+- **Snap-O Tweaks:** Inspect and adjust live Compose values, including previously adjusted tweaks that have since left composition.
 - **Screen Capture:** Grab screenshots and screen recordings quickly, preview recordings instantly, and drag captures directly into PRs, chat, and docs without save-first friction.
 
 ## Network Inspector
@@ -20,6 +21,15 @@ It runs on macOS 15 or later and requires `adb` from the Android Platform Tools.
 Curious about mirroring app traffic into the macOS client? Check the [Network Inspector guide](https://openai.github.io/snap-o/network-inspector.html) for setup steps, dependency coordinates, and configuration tips.
 
 Snap-O can replay network requests that happened before you opened Snap-O, so you do not miss early events, and includes collapsible JSON pretty printing.
+
+## Snap-O Tweaks
+
+Snap-O Tweaks exposes adjustable Compose values through an app-local Android
+socket. The default `GET /tweaks` response contains currently composed tweaks;
+`GET /tweaks?include=adjusted` also includes every previously adjusted tweak
+retained by the running app process. Historical inactive tweaks remain
+read-only until their declarations return. See the [Tweaks protocol
+guide](contracts/tweaks/README.md) for setup, descriptors, and updates.
 
 ## Why build an Android inspection system?
 
@@ -92,7 +102,7 @@ Running these tools launches Snap-O (or brings it to the foreground) and immedia
 
 There is currently no support for choosing a specific device/emulator when starting Snap-O in this way.
 
-### Command Line Network Inspector
+### Command Line Inspection
 
 Snap-O bundles a small Python command-line client at:
 
@@ -106,6 +116,10 @@ It uses the host computer's configured `adb` command, requires Python 3, and doe
 snapo network list --json
 snapo network requests -s <serial> -n <socket> --no-stream --json
 snapo network show -s <serial> -n <socket> -r <request-id> --json
+snapo tweaks apps --json
+snapo tweaks list -s <serial> -n <socket> --json
+snapo tweaks list --all -s <serial> -n <socket> --json
+snapo tweaks get 'Motion/Duration' --all -s <serial> -n <socket> --json
 ```
 
 ## Why a web UI for the Network Inspector?
@@ -142,7 +156,9 @@ If you need to notarize the app yourself:
 
 ## Codex Plugin
 
-Snap-O includes a Codex plugin for macOS and Linux. It bundles the network-inspector skill and its Python CLI, and requires Python 3 and Android Platform Tools.
+Snap-O includes a Codex plugin for macOS and Linux. It bundles the network
+inspector and Snap-O Tweaks skills with their shared Python CLI, and requires
+Python 3 and Android Platform Tools.
 
 Add the Snap-O marketplace and install the plugin:
 
@@ -170,7 +186,10 @@ Start a new Codex session after installing or updating the plugin.
 
 ## Linux Support
 
-You can inspect network requests from Snap-O on a Linux machine by using the dependency-free `snapo` Python CLI tool. Install Python 3 and Android Platform Tools, then download the script from the `main` branch and put it on `PATH`:
+You can inspect network requests and live or previously adjusted tweaks from
+Snap-O on a Linux machine by using the dependency-free `snapo` Python CLI tool.
+Install Python 3 and Android Platform Tools, then download the script from the
+`main` branch and put it on `PATH`:
 
 ```bash
 mkdir -p ~/.local/bin
@@ -180,7 +199,14 @@ chmod +x ~/.local/bin/snapo
 
 This is the same CLI shipped as part of the macOS app at `Snap-O.app/Contents/MacOS/snapo`.
 
-The script supports `snapo network list`, `requests`, and `show`. It resolves `adb` from `PATH`, `ANDROID_SDK_ROOT`, or `ANDROID_HOME`; use `--adb <path>` or `SNAPO_ADB` to select a specific ADB executable or wrapper. By default, server selection is left to the configured ADB command, which normally connects to `127.0.0.1:5037`. Pass `--adb-host <host> --adb-port <port>` to use an explicit remote ADB server.
+The script supports `snapo network list`, `requests`, and `show`, alongside
+`snapo tweaks apps`, `list`, `get`, `set`, `reset`, and `watch`. Pass `--all`
+to `tweaks list` or `tweaks get` to include previously adjusted inactive
+tweaks. It resolves `adb` from `PATH`, `ANDROID_SDK_ROOT`, or `ANDROID_HOME`;
+use `--adb <path>` or `SNAPO_ADB` to select a specific ADB executable or
+wrapper. By default, server selection is left to the configured ADB command,
+which normally connects to `127.0.0.1:5037`. Pass `--adb-host <host>` and
+`--adb-port <port>` to use an explicit remote ADB server.
 
 Verify that ADB can see your Android device, then inspect its available Snap-O servers:
 

--- a/contracts/tweaks/README.md
+++ b/contracts/tweaks/README.md
@@ -147,7 +147,7 @@ composables may register the same name; the tweak appears only once, and an
 update changes the value observed by every usage. A tweak remains registered
 until its last usage leaves composition. Its most recently edited value remains
 available if the same complete declaration later returns, but inactive tweaks do
-not appear in responses or event snapshots.
+not appear in default responses or event snapshots.
 
 Usages with the same name must agree on the tweak type, default, and
 constraints. Conflicting declarations are a configuration error.
@@ -169,6 +169,41 @@ also express a distinct sRGB edit for a non-round-trippable default.
 Numeric JSON values may contain at most 128 characters and 64 significant
 digits, with a decimal scale between -64 and 64. Reject values outside those
 limits with `422` before changing any tweaks.
+
+### GET /tweaks?include=adjusted
+
+Opt in to a complete list of active tweaks and previously adjusted tweaks that
+have since left composition:
+
+```bash
+curl -fsS 'http://127.0.0.1:43817/tweaks?include=adjusted'
+```
+
+The response uses the same `{"tweaks":[...]}` shape and complete tweak
+descriptors as `GET /tweaks`. Include every currently active tweak, whether or
+not it has been adjusted, and every inactive tweak whose value was actually
+changed by a successful user adjustment. Preserve the tweak's original
+declaration, constraints, and latest value after its final usage leaves
+composition. Separate screens may reuse a name with different declarations;
+include each independently adjusted complete descriptor, even when names
+repeat. Repeated names occur only for distinct complete descriptors; active-only
+listings and updates still resolve at most one active descriptor per name.
+Order names by first observation, regardless of later activation or adjustment.
+For repeated names, list the active declaration first, followed by historical
+declarations in stable adjustment order.
+
+An adjusted tweak remains in this history even after its value is reset to its
+default. An inactive tweak that was never changed, a no-op update that leaves
+its value unchanged, and a rejected or atomically rolled-back update do not
+create history entries. Adjustment history exists only for the current app
+process and is discarded when that process exits.
+
+Historical inactive tweaks are read-only: `PATCH /tweaks` still accepts only
+currently active names and returns `404` for an inactive name. Plain
+`GET /tweaks` and `GET /tweaks/events` remain active-only. The only supported
+query is exactly `include=adjusted` on `GET /tweaks`; unsupported, repeated,
+or additional query parameters and queries on other endpoints or methods
+return `400`.
 
 ### GET /tweaks/events
 
@@ -331,7 +366,9 @@ Box(
 Each remembered usage registers with composition and removes the tweak from
 the active list only after its final usage leaves. Returning declarations
 restore their previously edited values. Screen navigation therefore determines
-what appears in the response without discarding edits.
+what appears in the default response without discarding edits; request
+`GET /tweaks?include=adjusted` to also recover previously adjusted values from
+screens that are no longer in composition.
 
 Provide overloaded `tweak(default, name)` functions for `Int`, `Float`,
 `Color`, `Boolean`, and `String` defaults; each returns its corresponding

--- a/scripts/snapo
+++ b/scripts/snapo
@@ -1196,7 +1196,7 @@ def run_tweak_apps(adb, options):
 def run_tweak_list(adb, options):
     server = choose_tweak_server(adb, options)
     with TweakConnection(adb, server) as connection:
-        document = connection.request("GET", "/tweaks")
+        document = connection.request("GET", tweak_listing_path(options))
     tweak_descriptors(document)
     emit_tweak_document(document, options.json)
     return 0
@@ -1205,9 +1205,18 @@ def run_tweak_list(adb, options):
 def run_tweak_get(adb, options):
     server = choose_tweak_server(adb, options)
     with TweakConnection(adb, server) as connection:
-        descriptors = tweak_descriptors(connection.request("GET", "/tweaks"))
+        descriptors = tweak_descriptors(connection.request("GET", tweak_listing_path(options)))
+    if options.all and sum(descriptor["name"] == options.name for descriptor in descriptors) > 1:
+        raise SnapOError(
+            f"Multiple tweaks named '{options.name}'; "
+            "use 'snapo tweaks list --all --json' to inspect their declarations"
+        )
     emit_tweak_document(find_tweak(descriptors, options.name), options.json)
     return 0
+
+
+def tweak_listing_path(options):
+    return "/tweaks?include=adjusted" if options.all else "/tweaks"
 
 
 def tweak_json_values(raw):
@@ -1380,11 +1389,13 @@ def parser():
 
     tweak_list = tweaks_commands.add_parser("list", help="list available tweaks and their values")
     add_common_options(tweak_list, socket_option=True)
+    tweak_list.add_argument("--all", action="store_true", help="include previously adjusted inactive tweaks")
     tweak_list.set_defaults(handler=run_tweak_list)
 
     get = tweaks_commands.add_parser("get", help="show one tweak and its current value")
     add_common_options(get, socket_option=True)
     get.add_argument("name", metavar="NAME")
+    get.add_argument("--all", action="store_true", help="include previously adjusted inactive tweaks")
     get.set_defaults(handler=run_tweak_get)
 
     set_tweak = tweaks_commands.add_parser("set", help="update one tweak or an atomic JSON batch")

--- a/skills/snap-o-tweaks/SKILL.md
+++ b/skills/snap-o-tweaks/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: snap-o-tweaks
-description: Inspect, stream, and explicitly adjust live Android UI tweak values through Snap-O. Use when a request mentions Snap-O Tweaks, tweak-enabled Android apps, runtime UI parameters, Compose tweak or overlay controls, tweak discovery, typed values, defaults or resets, atomic tweak batches, the Tweaks REST/SSE API, or selecting between CLI, macOS inspector, in-app overlay, and custom tweak interfaces.
+description: Inspect, stream, and explicitly adjust live Android UI tweak values through Snap-O. Use when a request mentions Snap-O Tweaks, tweak-enabled Android apps, runtime UI parameters, Compose tweak or overlay controls, tweak discovery, previously adjusted or currently inactive tweaks, applying all user-made tweak changes, typed values, defaults or resets, atomic tweak batches, the Tweaks REST/SSE API, or selecting between CLI, macOS inspector, in-app overlay, and custom tweak interfaces.
 ---
 
 # Snap-O Tweaks
@@ -58,7 +58,24 @@ ADB resolves from `PATH`, `ANDROID_SDK_ROOT`, or `ANDROID_HOME`. Use
    Select devices with `-s <serial>`, `-d` (USB), or `-e` (emulator). Use
    `-n <socket>` for every subcommand except `apps` when selection is ambiguous.
 
-3. Observe live complete snapshots:
+3. Include every tweak the user has adjusted, even when its declaration is not
+   currently in composition:
+
+   ```bash
+   "$SNAPO_BIN" tweaks list --all -s <serial> -n <socket> --json
+   "$SNAPO_BIN" tweaks get 'Typography/Font size' --all -s <serial> -n <socket> --json
+   ```
+
+   The expanded list combines current tweaks with retained, previously adjusted
+   tweaks. Compare each descriptor's `value` with its `default` when the user
+   asks to apply all changes they made. Separate screens can reuse tweak names
+   with different declarations; preserve every descriptor from `list --all`
+   instead of deduplicating by name. `get NAME --all` reports an error when
+   multiple declarations match; use `list --all --json` to inspect them.
+   Historical tweaks can be inspected while inactive, but can only be changed
+   or reset when their declaration is active.
+
+4. Observe live complete snapshots:
 
    ```bash
    "$SNAPO_BIN" tweaks watch -s <serial> -n <socket> --json
@@ -67,6 +84,8 @@ ADB resolves from `PATH`, `ANDROID_SDK_ROOT`, or `ANDROID_HOME`. Use
 
    `--once` exits after the first complete snapshot. `--json` emits
    newline-delimited JSON; `list` and `watch` emit complete tweak snapshots.
+   Event streams contain only currently active tweaks; use `list --all` for
+   historical adjustments.
 
 ## Change values only when requested
 
@@ -102,6 +121,8 @@ Tweaks use app-local `snapo_tweaks_<pid>` sockets and normally exist only in
 debug-enabled apps. If no socket appears, check device authorization and
 selection, whether the app is running, its live Tweaks dependency/integration,
 debug/runtime policy, and server startup. If a socket exists but `/tweaks` is
-empty, the current Compose UI has no active tweak declarations. Do not enable
-release servers or modify apps or dependencies without an explicit request.
-Preserve validation errors; the CLI cleans up its own temporary ADB forwards.
+empty, the current Compose UI has no active tweak declarations; `list --all`
+can still return retained adjustments. Adjustment history lasts only for the
+current Android app process. Do not enable release servers or modify apps or
+dependencies without an explicit request. Preserve validation errors; the CLI
+cleans up its own temporary ADB forwards.

--- a/skills/snap-o-tweaks/references/interaction-surfaces.md
+++ b/skills/snap-o-tweaks/references/interaction-surfaces.md
@@ -4,7 +4,14 @@ The same active Compose tweak registry can be inspected from several surfaces. C
 
 ## Command line: agents, automation, and repeatable checks
 
-Use the dependency-free Snap-O CLI when a terminal, Codex agent, test script, or Linux/macOS workflow needs app discovery, typed value inspection or updates, atomic batches, resets, or live snapshots. Its tweaks workflow documents command selection and options. The CLI owns temporary local forwarding and cleanup; explicit remote ADB endpoints use direct smart-socket transport.
+Use the dependency-free Snap-O CLI when a terminal, Codex agent, test script, or
+Linux/macOS workflow needs app discovery, typed value inspection or updates,
+atomic batches, resets, or live snapshots. Use `snapo tweaks list --all` or
+`snapo tweaks get NAME --all` to include previously adjusted tweaks no longer in
+composition; inactive historical tweaks are inspectable but not writable. Its
+tweaks workflow documents command selection and options. The CLI owns temporary
+local forwarding and cleanup; explicit remote ADB endpoints use direct
+smart-socket transport.
 
 ## Snap-O macOS app: an existing desktop inspector
 
@@ -62,7 +69,12 @@ The CLI and Snap-O macOS app own socket discovery, forwarding, and cleanup. The 
 
 ## Custom interfaces: browsers, Node, Swift, and Compose
 
-Build a custom surface when an existing CLI, desktop inspector, or in-app overlay does not match the desired controls or workflow. All external hosts should discover the tweak socket, establish an accessible ADB transport, read `/app` and `/tweaks`, send atomic `PATCH /tweaks` updates, and consume full snapshots from `/tweaks/events`.
+Build a custom surface when an existing CLI, desktop inspector, or in-app overlay
+does not match the desired controls or workflow. All external hosts should
+discover the tweak socket, establish an accessible ADB transport, read `/app`
+and `/tweaks`, send atomic `PATCH /tweaks` updates, and consume full active
+snapshots from `/tweaks/events`. Request `/tweaks?include=adjusted` when a
+workflow needs every retained user adjustment, including inactive declarations.
 
 - A browser interface can use `fetch` and `EventSource` through a same-origin proxy; see [protocol.md](protocol.md) for browser transport restrictions.
 - A Node host or terminal tool can use built-in `fetch` for requests and parse the response body as a standard SSE stream.

--- a/skills/snap-o-tweaks/references/protocol.md
+++ b/skills/snap-o-tweaks/references/protocol.md
@@ -35,6 +35,7 @@ For remote ADB servers, an `adb forward` is local to the ADB server's host, not 
 | `GET /app` | JSON app metadata: `{"name":"Example","packageName":"com.example"}`. |
 | `GET /app/icon` | Optional application icon image; `404` if unavailable. Use its response `Content-Type` without assuming a particular format or size. |
 | `GET /tweaks` | Current active tweak descriptors and values. |
+| `GET /tweaks?include=adjusted` | Active descriptors plus all previously adjusted tweaks retained outside composition. |
 | `PATCH /tweaks` | One atomic update containing one or more named values. |
 | `GET /tweaks/events` | Server-sent events containing complete current snapshots. |
 
@@ -45,6 +46,7 @@ Ordinary responses close their connection and include a content length. The even
 ```bash
 curl -fsS "$base/app"
 curl -fsS "$base/tweaks"
+curl -fsS "$base/tweaks?include=adjusted"
 curl -fsS "$base/app/icon" -o /tmp/snapo-tweak-app-icon
 ```
 
@@ -74,7 +76,24 @@ The tweak response has this shape:
 
 The available types are `int`, `float`, `boolean`, `color`, and `string`. Preserve actual JSON types: booleans are not strings, integer values cannot be fractional, and floats accept whole or fractional finite numbers. Colors are strings in `#RRGGBB` or `#RRGGBBAA` format. Numeric descriptors may include `min`, `max`, and `step`; step alignment starts at `min`, or at `default` if there is no minimum.
 
-A tweak exists only while its declaration is active in Compose. Names are shared identifiers: two active declarations of the same complete descriptor observe the same value. Names may contain spaces and `/`; send the entire name unchanged.
+Plain `GET /tweaks` includes only declarations active in Compose. Add
+`?include=adjusted` to include every tweak successfully adjusted by the user,
+including retained descriptors whose declarations have since left composition.
+The expanded response uses the same descriptor shape and also includes current
+active tweaks. Separate screens can reuse a name with different complete
+declarations; preserve every returned descriptor instead of deduplicating by
+name. A tweak that was adjusted and later reset can still appear with its
+default value; compare `value` and `default` to identify outstanding user
+changes. Retention lasts for the current app process and is cleared with the
+registry; it is not persistent storage across app restarts.
+
+Names are shared identifiers: two active declarations of the same complete
+descriptor observe the same value. Names may contain spaces and `/`; send the
+entire name unchanged. Repeated names in expanded results represent distinct
+complete descriptors; active-only snapshots and updates still resolve at most
+one currently active descriptor per name. Historical descriptors are read-only
+while inactive: `PATCH /tweaks` still rejects their names until their
+declarations return.
 
 ### Update or reset values atomically
 
@@ -90,7 +109,12 @@ The response contains the changed names and their resulting values:
 {"tweaks":[{"name":"Motion/Duration","value":550},{"name":"Motion/Enabled","value":false}]}
 ```
 
-Every value is validated before any update is applied. An invalid or unknown entry prevents the entire batch from changing. Reset by fetching `GET /tweaks` and sending the target descriptor's `default` value back in a patch; reset all by patching every active name to its own default in one request. There is no separate get-by-name, reset, delete, action, or grouping endpoint.
+Every value is validated before any update is applied. An invalid, unknown, or
+inactive entry prevents the entire batch from changing. Reset by fetching
+`GET /tweaks` and sending the target descriptor's `default` value back in a
+patch; reset all by patching every active name to its own default in one
+request. There is no separate get-by-name, reset, delete, action, or grouping
+endpoint.
 
 ### Watch complete snapshots
 
@@ -109,7 +133,13 @@ data: {"tweaks":[{"name":"Motion/Enabled","type":"boolean","default":true,"value
 
 ```
 
-The first event is the complete current list. Every later `event: tweaks` is also a complete, ordered replacement snapshot, not a delta. Remove items absent from the newest snapshot. Ignore lines starting with `:`; they are idle keepalives. Reconnect and replace state when the app process or socket changes.
+The first event is the complete current active list. Every later `event: tweaks`
+is also a complete, ordered replacement snapshot, not a delta. Historical
+inactive tweaks are not included in event snapshots; request
+`GET /tweaks?include=adjusted` separately when their retained values are needed.
+Remove items absent from the newest snapshot. Ignore lines starting with `:`;
+they are idle keepalives. Reconnect and replace state when the app process or
+socket changes.
 
 For a browser, serve a same-origin proxy that forwards these routes to the ADB-forwarded target:
 

--- a/snapo-link-android/samples/demo-tweaks/panel/README.md
+++ b/snapo-link-android/samples/demo-tweaks/panel/README.md
@@ -4,8 +4,8 @@ A model built this inspector as one way to find running apps and change live
 values. Each app must use Snap-O Tweaks.
 
 This is only a demo, not part of the feature or the expected way to use it.
-You do not need this inspector. Any tool can use `/app`, `/tweaks`, and
-`/tweaks/events` to build its own live UI.
+You do not need this inspector. Any tool can use `/app`, `/tweaks`,
+`/tweaks?include=adjusted`, and `/tweaks/events` to build its own live UI.
 
 ## What you need
 
@@ -136,6 +136,17 @@ You can set one value or all values back.
 Turn off **Show** in the **Motion** section to hide the motion preview in the
 sample app. Its animation tweaks leave the composition and vanish from the
 inspector. Turn it back on to see them appear again.
+
+The inspector continues to display only active tweaks. To inspect retained
+values the user previously adjusted, including tweaks that have since left
+composition, request the expanded view through the demo server:
+
+```bash
+curl -fsS 'http://127.0.0.1:4175/tweaks?include=adjusted'
+```
+
+Inactive historical tweaks can be inspected, but cannot be changed or reset
+until they return to composition.
 
 ## Test the panel
 

--- a/snapo-link-android/samples/demo-tweaks/panel/server.mjs
+++ b/snapo-link-android/samples/demo-tweaks/panel/server.mjs
@@ -476,7 +476,8 @@ async function proxyTweak(request, response, connection, pathname, target) {
     body = await readRequestBody(request);
   }
 
-  const performRequest = () => fetch(new URL(pathname, target ?? connection.target), {
+  const upstreamPath = pathname + new URL(request.url, "http://127.0.0.1").search;
+  const performRequest = () => fetch(new URL(upstreamPath, target ?? connection.target), {
     method: request.method,
     headers,
     body,
@@ -517,7 +518,7 @@ async function proxyTweakEvents(request, response, connection, target) {
 
   try {
     const performRequest = () => fetch(
-      new URL("/tweaks/events", target ?? connection.target),
+      new URL(request.url, target ?? connection.target),
       {
         method: request.method,
         headers: { Accept: "text/event-stream" },

--- a/snapo-link-android/samples/demo-tweaks/panel/server.test.mjs
+++ b/snapo-link-android/samples/demo-tweaks/panel/server.test.mjs
@@ -41,6 +41,12 @@ const initialTweaks = [
   },
 ];
 
+const inactiveAdjustedTweak = {
+  ...initialTweaks[0],
+  name: "Historical font size",
+  value: 48,
+};
+
 const icon = Buffer.from([
   0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a, 0x11, 0x22,
 ]);
@@ -78,6 +84,18 @@ before(async () => {
 
     if (request.url === "/tweaks" && request.method === "GET") {
       reply(response, 200, { tweaks: initialTweaks });
+      return;
+    }
+
+    if (request.url === "/tweaks?include=adjusted" && request.method === "GET") {
+      reply(response, 200, {
+        tweaks: [...initialTweaks, inactiveAdjustedTweak],
+      });
+      return;
+    }
+
+    if (request.url.startsWith("/tweaks/events?") && request.method === "GET") {
+      reply(response, 400, { error: "Unsupported query parameters." });
       return;
     }
 
@@ -444,6 +462,22 @@ test("proxies the original flat tweak descriptors", async () => {
 
   assert.equal(response.status, 200);
   assert.deepEqual(await response.json(), { tweaks: initialTweaks });
+});
+
+test("preserves the query when proxying previously adjusted tweaks", async () => {
+  const response = await fetch(new URL("/tweaks?include=adjusted", panel.url));
+
+  assert.equal(response.status, 200);
+  assert.deepEqual(await response.json(), {
+    tweaks: [...initialTweaks, inactiveAdjustedTweak],
+  });
+});
+
+test("preserves Android validation errors for queried event streams", async () => {
+  const response = await fetch(new URL("/tweaks/events?include=adjusted", panel.url));
+
+  assert.equal(response.status, 400);
+  assert.deepEqual(await response.json(), { error: "Unsupported query parameters." });
 });
 
 test("streams complete tweak snapshots while allowing concurrent patches", async () => {

--- a/snapo-link-android/tweaks/src/main/java/com/openai/snapo/tweaks/internal/TweakHttpServer.kt
+++ b/snapo-link-android/tweaks/src/main/java/com/openai/snapo/tweaks/internal/TweakHttpServer.kt
@@ -150,7 +150,7 @@ internal class TweakHttpServer(
     private fun route(request: HttpRequest): HttpResponse = when (request.path) {
         "/app" -> routeApp(request)
         "/app/icon" -> routeAppIcon(request)
-        "/tweaks" -> routeTweaks(request)
+        "/tweaks", "/tweaks?include=adjusted" -> routeTweaks(request)
         "/tweaks/events" -> throw HttpFailure(
             statusCode = 405,
             message = "Unsupported method: ${request.method}",
@@ -228,7 +228,10 @@ internal class TweakHttpServer(
     }
 
     private fun routeTweaks(request: HttpRequest): HttpResponse = when (request.method) {
-        "GET" -> tweaksResponse(TweakRegistry.snapshot(), includeDescriptors = true)
+        "GET" -> tweaksResponse(
+            TweakRegistry.snapshot(includeAdjusted = request.path != "/tweaks"),
+            includeDescriptors = true,
+        )
         "PATCH" -> {
             requireJsonRequest(request)
             val changes = readPatchValues(request.body)
@@ -252,10 +255,14 @@ internal class TweakHttpServer(
         val headers = readHeaders(input, firstLine.length)
         val contentLength = readContentLength(headers)
         val body = readBody(input, contentLength)
+        val target = parts[1]
+        if ('?' in target && (target != "/tweaks?include=adjusted" || parts[0] != "GET")) {
+            invalidRequest("Unsupported query parameters.")
+        }
 
         return HttpRequest(
             method = parts[0],
-            path = parts[1],
+            path = target,
             headers = headers,
             body = body,
         )

--- a/snapo-link-android/tweaks/src/main/java/com/openai/snapo/tweaks/internal/TweakRegistry.kt
+++ b/snapo-link-android/tweaks/src/main/java/com/openai/snapo/tweaks/internal/TweakRegistry.kt
@@ -50,6 +50,7 @@ internal object TweakRegistry {
     private val lock = Any()
     private val tweaks = LinkedHashMap<String, RegisteredTweak>()
     private val observedTweakOrder = HashMap<String, Long>()
+    private val adjustedTweaks = LinkedHashMap<TweakDescriptor, RegisteredTweak>()
     private val tweakStates = HashMap<TweakDescriptor, MutableState<Any>>()
     private val activeEntries = mutableStateOf<List<SnapOTweakEntry>>(emptyList())
     private val observers = LinkedHashMap<Long, () -> Unit>()
@@ -115,8 +116,16 @@ internal object TweakRegistry {
 
     fun activeEntries(): State<List<SnapOTweakEntry>> = activeEntries
 
-    fun snapshot(): List<TweakSnapshot> = synchronized(lock) {
-        tweaks.values.map { tweak ->
+    fun snapshot(includeAdjusted: Boolean = false): List<TweakSnapshot> = synchronized(lock) {
+        val registeredTweaks = if (includeAdjusted) {
+            (tweaks.values + adjustedTweaks.values)
+                .distinctBy(RegisteredTweak::descriptor)
+                .sortedBy { tweak -> observedTweakOrder.getValue(tweak.descriptor.name) }
+        } else {
+            tweaks.values
+        }
+
+        registeredTweaks.map { tweak ->
             TweakSnapshot(tweak.descriptor, tweak.state.value)
         }
     }
@@ -130,13 +139,18 @@ internal object TweakRegistry {
                 tweak to validateValue(tweak.descriptor, value)
             }
 
+            val changedTweaks = ArrayList<RegisteredTweak>()
             Snapshot.withMutableSnapshot {
                 changes.forEach { (tweak, value) ->
                     if (tweak.state.value != value) {
                         tweak.state.value = value
+                        changedTweaks.add(tweak)
                         changed = true
                     }
                 }
+            }
+            changedTweaks.forEach { tweak ->
+                adjustedTweaks[tweak.descriptor] = tweak
             }
 
             changes.map { (tweak, _) ->
@@ -159,6 +173,7 @@ internal object TweakRegistry {
     fun clear() {
         val changed = synchronized(lock) {
             observedTweakOrder.clear()
+            adjustedTweaks.clear()
             tweakStates.clear()
             nextTweakOrder = 0L
 

--- a/snapo-link-android/tweaks/src/test/java/com/openai/snapo/tweaks/SnapOTweaksTest.kt
+++ b/snapo-link-android/tweaks/src/test/java/com/openai/snapo/tweaks/SnapOTweaksTest.kt
@@ -85,6 +85,22 @@ class SnapOTweaksTest {
     }
 
     @Test
+    fun `overlay updates remain available as adjusted history after leaving composition`() {
+        val descriptor = TweakDescriptor(
+            name = "Typography/Historical font size",
+            type = TweakType.INT,
+            default = 16,
+        )
+        TweakRegistry.register(descriptor)
+
+        SnapOTweaks.update(descriptor.name, SnapOTweakValue.Integer(20))
+        TweakRegistry.unregister(descriptor.name)
+
+        assertTrue(SnapOTweaks.activeTweaks().isEmpty())
+        assertEquals(20, TweakRegistry.snapshot(includeAdjusted = true).single().value)
+    }
+
+    @Test
     fun `release updates without an override ignore unavailable tweaks`() {
         TweaksRuntimePolicy.configure(isDebuggable = false, allowRelease = false)
 

--- a/snapo-link-android/tweaks/src/test/java/com/openai/snapo/tweaks/internal/TweakRegistryLifecycleTest.kt
+++ b/snapo-link-android/tweaks/src/test/java/com/openai/snapo/tweaks/internal/TweakRegistryLifecycleTest.kt
@@ -179,6 +179,169 @@ class TweakRegistryLifecycleTest {
     }
 
     @Test
+    fun `expanded snapshots include adjusted inactive tweaks and exclude untouched inactive tweaks`() {
+        val untouched = TweakDescriptor("Lifecycle untouched historical tweak", TweakType.INT, 8)
+        val adjusted = TweakDescriptor("Lifecycle adjusted historical tweak", TweakType.INT, 16)
+        val active = TweakDescriptor("Lifecycle active historical tweak", TweakType.INT, 24)
+
+        TweakRegistry.register(untouched)
+        TweakRegistry.unregister(untouched.name)
+        TweakRegistry.register(adjusted)
+        TweakRegistry.update(mapOf(adjusted.name to 20))
+        TweakRegistry.unregister(adjusted.name)
+        TweakRegistry.register(active)
+
+        assertEquals(listOf(active.name), TweakRegistry.snapshot().map { it.descriptor.name })
+        assertEquals(
+            listOf(adjusted.name, active.name),
+            TweakRegistry.snapshot(includeAdjusted = true).map { it.descriptor.name },
+        )
+        assertEquals(20, TweakRegistry.snapshot(includeAdjusted = true).first().value)
+    }
+
+    @Test
+    fun `unchanged updates do not add inactive tweaks to adjusted history`() {
+        val descriptor = TweakDescriptor("Lifecycle unchanged historical tweak", TweakType.INT, 16)
+
+        TweakRegistry.register(descriptor)
+        TweakRegistry.update(mapOf(descriptor.name to descriptor.default))
+        TweakRegistry.unregister(descriptor.name)
+
+        assertTrue(TweakRegistry.snapshot(includeAdjusted = true).isEmpty())
+    }
+
+    @Test
+    fun `resetting adjusted tweaks retains their historical descriptors and default values`() {
+        val descriptor = TweakDescriptor("Lifecycle reset historical tweak", TweakType.INT, 16)
+
+        TweakRegistry.register(descriptor)
+        TweakRegistry.update(mapOf(descriptor.name to 24))
+        TweakRegistry.update(mapOf(descriptor.name to descriptor.default))
+        TweakRegistry.unregister(descriptor.name)
+
+        assertEquals(
+            TweakSnapshot(descriptor, descriptor.default),
+            TweakRegistry.snapshot(includeAdjusted = true).single(),
+        )
+    }
+
+    @Test
+    fun `rejected updates do not create adjusted tweak history`() {
+        val descriptor = TweakDescriptor("Lifecycle rejected historical tweak", TweakType.INT, 16)
+
+        TweakRegistry.register(descriptor)
+        assertThrows(UnknownTweakException::class.java) {
+            TweakRegistry.update(
+                linkedMapOf(
+                    descriptor.name to 24,
+                    "Lifecycle missing historical tweak" to 32,
+                ),
+            )
+        }
+        TweakRegistry.unregister(descriptor.name)
+
+        assertTrue(TweakRegistry.snapshot(includeAdjusted = true).isEmpty())
+    }
+
+    @Test
+    fun `expanded snapshots preserve observed order across active and historical tweaks`() {
+        val first = TweakDescriptor("Lifecycle first expanded tweak", TweakType.INT, 1)
+        val second = TweakDescriptor("Lifecycle second expanded tweak", TweakType.INT, 2)
+        val third = TweakDescriptor("Lifecycle third expanded tweak", TweakType.INT, 3)
+
+        TweakRegistry.register(first)
+        TweakRegistry.register(second)
+        TweakRegistry.register(third)
+        TweakRegistry.update(mapOf(first.name to 11, third.name to 33))
+        TweakRegistry.unregister(first.name)
+        TweakRegistry.unregister(third.name)
+
+        assertEquals(
+            listOf(first.name, second.name, third.name),
+            TweakRegistry.snapshot(includeAdjusted = true).map { it.descriptor.name },
+        )
+    }
+
+    @Test
+    fun `expanded snapshots retain independently adjusted declarations with the same name`() {
+        val original = TweakDescriptor(
+            name = "Lifecycle distinct historical declarations",
+            type = TweakType.INT,
+            default = 16,
+            min = 0,
+            max = 48,
+        )
+        val replacement = original.copy(default = 24, max = 64)
+
+        TweakRegistry.register(original)
+        TweakRegistry.update(mapOf(original.name to 20))
+        TweakRegistry.unregister(original.name)
+        TweakRegistry.register(replacement)
+        TweakRegistry.update(mapOf(replacement.name to 32))
+        TweakRegistry.unregister(replacement.name)
+
+        assertEquals(
+            listOf(TweakSnapshot(original, 20), TweakSnapshot(replacement, 32)),
+            TweakRegistry.snapshot(includeAdjusted = true),
+        )
+    }
+
+    @Test
+    fun `expanded snapshots prioritize active declarations over same-name adjusted history`() {
+        val original = TweakDescriptor("Lifecycle replaced historical tweak", TweakType.INT, 16)
+        val replacement = original.copy(default = 24)
+
+        TweakRegistry.register(original)
+        TweakRegistry.update(mapOf(original.name to 20))
+        TweakRegistry.unregister(original.name)
+        TweakRegistry.register(replacement)
+
+        assertEquals(
+            listOf(
+                TweakSnapshot(replacement, replacement.default),
+                TweakSnapshot(original, 20),
+            ),
+            TweakRegistry.snapshot(includeAdjusted = true),
+        )
+
+        TweakRegistry.update(mapOf(replacement.name to 32))
+        assertEquals(
+            listOf(TweakSnapshot(replacement, 32), TweakSnapshot(original, 20)),
+            TweakRegistry.snapshot(includeAdjusted = true),
+        )
+
+        TweakRegistry.unregister(replacement.name)
+
+        assertEquals(
+            listOf(TweakSnapshot(original, 20), TweakSnapshot(replacement, 32)),
+            TweakRegistry.snapshot(includeAdjusted = true),
+        )
+    }
+
+    @Test
+    fun `resetting same-name adjusted declarations preserves their separate history`() {
+        val original = TweakDescriptor("Lifecycle reset shared-name history", TweakType.INT, 16)
+        val replacement = original.copy(default = 24)
+
+        TweakRegistry.register(original)
+        TweakRegistry.update(mapOf(original.name to 20))
+        TweakRegistry.update(mapOf(original.name to original.default))
+        TweakRegistry.unregister(original.name)
+        TweakRegistry.register(replacement)
+        TweakRegistry.update(mapOf(replacement.name to 32))
+        TweakRegistry.update(mapOf(replacement.name to replacement.default))
+        TweakRegistry.unregister(replacement.name)
+
+        assertEquals(
+            listOf(
+                TweakSnapshot(original, original.default),
+                TweakSnapshot(replacement, replacement.default),
+            ),
+            TweakRegistry.snapshot(includeAdjusted = true),
+        )
+    }
+
+    @Test
     fun `same-name descriptors retain their edited values independently`() {
         val original = TweakDescriptor(
             name = "Lifecycle descriptor-specific values",
@@ -266,15 +429,23 @@ class TweakRegistryLifecycleTest {
             type = TweakType.INT,
             default = 16,
         )
+        val sameNameReplacement = descriptor.copy(default = 24)
         TweakRegistry.register(descriptor)
-        TweakRegistry.update(mapOf(descriptor.name to 24))
+        TweakRegistry.update(mapOf(descriptor.name to 20))
         TweakRegistry.unregister(descriptor.name)
+        TweakRegistry.register(sameNameReplacement)
+        TweakRegistry.update(mapOf(sameNameReplacement.name to 32))
+        TweakRegistry.unregister(sameNameReplacement.name)
+
+        assertEquals(2, TweakRegistry.snapshot(includeAdjusted = true).size)
 
         TweakRegistry.clear()
 
         val replacement = TweakRegistry.stateFor(descriptor)
 
+        assertTrue(TweakRegistry.snapshot(includeAdjusted = true).isEmpty())
         assertEquals(16, replacement.value)
+        assertEquals(24, TweakRegistry.stateFor(sameNameReplacement).value)
         assertSame(replacement, TweakRegistry.register(descriptor))
     }
 

--- a/tests/snapo_cli/test_snapo.py
+++ b/tests/snapo_cli/test_snapo.py
@@ -183,8 +183,9 @@ def tweak_descriptors():
 
 
 class TweakHTTPServer:
-    def __init__(self, descriptors=None, app=None, error=None, stream_events=None):
+    def __init__(self, descriptors=None, app=None, error=None, stream_events=None, adjusted_descriptors=None):
         self.descriptors = json.loads(json.dumps(descriptors or tweak_descriptors()))
+        self.adjusted_descriptors = self.descriptors if adjusted_descriptors is None else adjusted_descriptors
         self.app = app or {"name": "Snap-O Tweaks Demo", "packageName": "com.example.tweaks"}
         self.error = error
         self.stream_events = stream_events
@@ -200,6 +201,8 @@ class TweakHTTPServer:
                     self.send_json(200, owner.app)
                 elif self.path == "/tweaks":
                     self.send_json(200, {"tweaks": owner.descriptors})
+                elif self.path == "/tweaks?include=adjusted":
+                    self.send_json(200, {"tweaks": owner.adjusted_descriptors})
                 elif self.path == "/tweaks/events":
                     events = owner.stream_events or [
                         ": keep-alive\n\n",
@@ -381,6 +384,10 @@ class PluginPackagingTests(unittest.TestCase):
         self.assertIn("forward tcp:0", protocol)
         self.assertIn("forward --remove", protocol)
         self.assertIn("[protocol.md](protocol.md)", interaction_guide)
+        self.assertIn("tweaks list --all", skill_content)
+        self.assertIn("tweaks get 'Typography/Font size' --all", skill_content)
+        self.assertIn("GET /tweaks?include=adjusted", protocol)
+        self.assertIn("snapo tweaks list --all", interaction_guide)
 
         for artifact in ("tweaks", "tweaks-noop", "tweaks-overlay", "tweaks-overlay-noop"):
             with self.subTest(artifact=artifact):
@@ -1156,6 +1163,31 @@ class TweakCommandTests(unittest.TestCase):
         self.assertEqual(wire.requests, [("GET", "/tweaks", None)])
         self.assertEqual(adb.calls[-1], ("emulator-5554", ("forward", "--remove", f"tcp:{wire.port}")))
 
+    def test_list_all_includes_previously_adjusted_inactive_tweaks(self):
+        active = tweak_descriptors()[0]
+        inactive = {**tweak_descriptors()[1], "name": "Motion/Historical duration", "value": 0.7}
+
+        with TweakHTTPServer(descriptors=[active], adjusted_descriptors=[active, inactive]) as wire:
+            result, output, errors, adb = self.run_command(["list", "--all", "--json"], wire)
+
+        self.assertEqual(result, 0, errors)
+        self.assertEqual(json.loads(output), {"tweaks": [active, inactive]})
+        self.assertEqual(wire.requests, [("GET", "/tweaks?include=adjusted", None)])
+        self.assertEqual(adb.calls[-1], ("emulator-5554", ("forward", "--remove", f"tcp:{wire.port}")))
+
+    def test_list_all_preserves_independently_adjusted_tweaks_with_the_same_name(self):
+        active = tweak_descriptors()[1]
+        first = {**tweak_descriptors()[0], "value": 20}
+        second = {**first, "default": 24, "value": 32, "max": 64}
+        expanded = [active, first, second]
+
+        with TweakHTTPServer(descriptors=[active], adjusted_descriptors=expanded) as wire:
+            result, output, errors, _ = self.run_command(["list", "--all", "--json"], wire)
+
+        self.assertEqual(result, 0, errors)
+        self.assertEqual(json.loads(output), {"tweaks": expanded})
+        self.assertEqual(wire.requests, [("GET", "/tweaks?include=adjusted", None)])
+
     def test_list_renders_descriptive_human_readable_values(self):
         with TweakHTTPServer() as wire:
             result, output, errors, _ = self.run_command(["list"], wire)
@@ -1172,6 +1204,36 @@ class TweakCommandTests(unittest.TestCase):
         self.assertEqual(result, 0, errors)
         self.assertEqual(json.loads(output), wire.descriptors[0])
         self.assertEqual(wire.requests, [("GET", "/tweaks", None)])
+
+    def test_get_all_finds_a_previously_adjusted_inactive_tweak(self):
+        active = tweak_descriptors()[0]
+        inactive = {**tweak_descriptors()[1], "name": "Motion/Historical duration", "value": 0.7}
+
+        with TweakHTTPServer(descriptors=[active], adjusted_descriptors=[active, inactive]) as wire:
+            result, output, errors, adb = self.run_command(
+                ["get", inactive["name"], "--all", "--json"],
+                wire,
+            )
+
+        self.assertEqual(result, 0, errors)
+        self.assertEqual(json.loads(output), inactive)
+        self.assertEqual(wire.requests, [("GET", "/tweaks?include=adjusted", None)])
+        self.assertEqual(adb.calls[-1], ("emulator-5554", ("forward", "--remove", f"tcp:{wire.port}")))
+
+    def test_get_all_rejects_independently_adjusted_tweaks_with_the_same_name(self):
+        active = tweak_descriptors()[1]
+        first = {**tweak_descriptors()[0], "value": 20}
+        second = {**first, "default": 24, "value": 32, "max": 64}
+
+        with TweakHTTPServer(descriptors=[active], adjusted_descriptors=[active, first, second]) as wire:
+            result, output, errors, adb = self.run_command(["get", first["name"], "--all", "--json"], wire)
+
+        self.assertEqual(result, 1)
+        self.assertEqual(output, "")
+        self.assertIn(f"Multiple tweaks named '{first['name']}'", errors)
+        self.assertIn("snapo tweaks list --all --json", errors)
+        self.assertEqual(wire.requests, [("GET", "/tweaks?include=adjusted", None)])
+        self.assertEqual(adb.calls[-1], ("emulator-5554", ("forward", "--remove", f"tcp:{wire.port}")))
 
     def test_get_reports_unknown_tweaks_without_mutating_the_application(self):
         with TweakHTTPServer() as wire:


### PR DESCRIPTION
## Summary

- Add `GET /tweaks?include=adjusted` to return active tweaks together with user-adjusted declarations that have left composition.
- Preserve distinct tweaks by their complete descriptor, including their name, type, default, and numeric constraints, so reused names do not overwrite independent adjustments.
- Extend the shared CLI with `snapo tweaks list --all` and `snapo tweaks get NAME --all`, including explicit errors for ambiguous repeated names.
- Keep ordinary listings, event streams, and writes active-only; validate unsupported query/method combinations and preserve browser-proxy query parameters.
- Update the protocol contract, repository documentation, sample inspector, and Snap-O Tweaks Codex skill.

## Validation

- `./gradlew :tweaks:testDebugUnitTest :tweaks:detekt :samples:demo-tweaks:assembleDebug` — 103 Android tests, static analysis, and demo APK build.
- `python3 -m unittest discover -s tests/snapo_cli -p 'test_*.py' -q` — 79 CLI/plugin tests.
- `npm test` in `snapo-link-android/samples/demo-tweaks/panel` — 42 browser/proxy tests.
- `xcodebuild -project Snap-O.xcodeproj -scheme Snap-O CODE_SIGNING_ALLOWED=NO CODE_SIGNING_REQUIRED=NO -quiet build` — macOS application build.
- `git diff --cached --check`