### PR TITLE
Add Tweaks alpha links to website

### DIFF
--- a/index.html
+++ b/index.html
@@ -353,6 +353,19 @@
               pull requests, chats, or docs.
             </p>
           </section>
+
+          <section class="product-section">
+            <h2 class="product-title">Tweaks (Alpha)</h2>
+            <div>
+              <p class="product-copy">
+                Adjust Compose UI values live with App Inspector, an optional
+                on-device panel, the REST API, or an agent.
+              </p>
+              <a class="section-link" href="tweaks.html">
+                Set up Tweaks (Alpha)
+              </a>
+            </div>
+          </section>
         </div>
       </div>
     </main>

--- a/tweaks.html
+++ b/tweaks.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
-    <title>Tweaks Guide · Snap-O</title>
+    <title>Tweaks Guide (Alpha) · Snap-O</title>
     <meta
       name="description"
       content="Expose Jetpack Compose values to Snap-O and adjust them live with App Inspector, an on-device panel, the REST API, or an agent."
@@ -592,7 +592,7 @@
         <div class="wrap">
           <div class="hero-copy">
             <a class="back-link" href="index.html">Snap-O</a>
-            <h1>Tweaks Guide</h1>
+            <h1>Tweaks Guide (Alpha)</h1>
             <p class="lead">
               Expose values directly from your Compose UI and see changes
               immediately. Interact with them through Snap-O’s Mac App


### PR DESCRIPTION
## Summary

- add Tweaks as the final feature on the Snap-O homepage
- label the homepage title and setup link as Alpha
- label the Tweaks guide heading and browser title as Alpha

## Why

Tweaks is available for discovery from the main website, while clearly communicating that the feature is still in alpha.

## Validation

- verified the homepage entry is last in the feature list
- verified the setup link resolves to `tweaks.html`
- verified the guide browser title and visible heading include `(Alpha)`
- ran `git diff --check`