### PR TITLE
Fix Snap-O tweak values and wire server teardown

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,8 +124,8 @@ snapo network requests -s <serial> -n <socket> --no-stream --json
 snapo network show -s <serial> -n <socket> -r <request-id> --json
 snapo tweaks apps --json
 snapo tweaks list -s <serial> -n <socket> --json
-snapo tweaks set 'Typography/Font size' 42 -s <serial> -n <socket> --json
-snapo tweaks reset 'Typography/Font size' -s <serial> -n <socket> --json
+snapo tweaks set 'Typography/Font size' 42 -s <serial> -n <socket>
+snapo tweaks reset 'Typography/Font size' -s <serial> -n <socket>
 ```
 
 ## Why a web UI for the App Inspector?

--- a/scripts/snapo
+++ b/scripts/snapo
@@ -1336,6 +1336,8 @@ def valid_port(value):
 class SnapOArgumentParser(argparse.ArgumentParser):
     def parse_args(self, args=None, namespace=None):
         arguments = list(sys.argv[1:] if args is None else args)
+        if arguments[:2] == ["tweaks", "set"] and len(arguments) > 3 and arguments[3].startswith("-"):
+            arguments.extend(["--", arguments.pop(3)])
         for index in range(len(arguments) - 2, -1, -1):
             if arguments[index] != "--filter":
                 continue

--- a/scripts/snapo
+++ b/scripts/snapo
@@ -225,36 +225,24 @@ def choose_server(servers, requested, feature="network"):
     return matches[0]
 
 
-def available_port():
-    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as candidate:
-        candidate.bind(("127.0.0.1", 0))
-        return candidate.getsockname()[1]
-
-
 class Forward:
-    def __init__(self, adb, server, attempts=4):
+    def __init__(self, adb, server):
         self.adb = adb
         self.server = server
-        self.attempts = attempts
         self.port = None
 
     def __enter__(self):
-        last_error = None
-        for _ in range(self.attempts):
-            port = available_port()
-            try:
-                self.adb.command(
-                    "forward",
-                    f"tcp:{port}",
-                    f"localabstract:{self.server.socket_name}",
-                    serial=self.server.device_id,
-                )
-            except SnapOError as error:
-                last_error = error
-                continue
-            self.port = port
-            return self
-        raise last_error or SnapOError("Unable to create an adb forward")
+        output = self.adb.command(
+            "forward",
+            "tcp:0",
+            f"localabstract:{self.server.socket_name}",
+            serial=self.server.device_id,
+        )
+        try:
+            self.port = int(output.strip())
+        except (TypeError, ValueError) as error:
+            raise SnapOError("ADB did not report the allocated forwarding port") from error
+        return self
 
     def __exit__(self, error_type, error, traceback):
         if self.port is None:
@@ -273,16 +261,12 @@ class Forward:
 
 
 class LocalAbstractSocket:
-    def __init__(self, port=None, adb=None, server=None, timeout=5, feature="network"):
+    def __init__(self, port=None, adb=None, server=None, timeout=5):
         endpoint = ("127.0.0.1", port) if adb is None else adb.endpoint
         try:
             self.socket = socket.create_connection(endpoint, timeout=timeout)
         except OSError as error:
-            target = "ADB server" if adb is not None else "forwarded Snap-O socket"
-            if adb is None and feature == "tweaks":
-                target = "forwarded Snap-O tweaks socket"
-            raise SnapOError(f"Failed to connect to {target}: {error}") from error
-        self.feature = feature
+            raise SnapOError(f"Failed to connect to Snap-O socket: {error}") from error
         try:
             if adb is not None:
                 self.adb_request(f"host:transport:{server.device_id}")
@@ -308,7 +292,7 @@ class LocalAbstractSocket:
             except ValueError as error:
                 raise SnapOError("ADB returned an invalid failure response") from error
             message = self.read_exact(length).decode("utf-8", errors="replace")
-            raise SnapOError(f"ADB rejected the {self.feature} connection: {message}")
+            raise SnapOError(f"ADB rejected the connection: {message}")
         raise SnapOError("ADB returned an invalid status response")
 
     def read_exact(self, count):
@@ -324,9 +308,35 @@ class LocalAbstractSocket:
         return bytes(data)
 
 
+class ServerConnection:
+    def __init__(self, adb, server):
+        self.adb = adb
+        self.server = server
+        self.forward = None
+
+    def __enter__(self):
+        if not self.adb.has_explicit_endpoint:
+            self.forward = Forward(self.adb, self.server)
+            self.forward.__enter__()
+        return self
+
+    def __exit__(self, error_type, error, traceback):
+        if self.forward is not None:
+            return self.forward.__exit__(error_type, error, traceback)
+        return False
+
+    def open_socket(self, timeout=5):
+        return LocalAbstractSocket(
+            port=self.forward.port if self.forward is not None else None,
+            adb=None if self.forward is not None else self.adb,
+            server=self.server,
+            timeout=timeout,
+        )
+
+
 class Session:
-    def __init__(self, port=None, adb=None, server=None, connect_timeout=5):
-        self.socket = LocalAbstractSocket(port, adb, server, connect_timeout).socket
+    def __init__(self, transport):
+        self.socket = transport.socket
         self.buffer = bytearray()
         self.next_id = 1
         try:
@@ -463,48 +473,43 @@ def valid_response(response):
 
 class ConnectedSession:
     def __init__(self, adb, server):
-        self.forward = Forward(adb, server)
+        self.connection = ServerConnection(adb, server)
         self.session = None
 
     def __enter__(self):
-        if getattr(self.forward.adb, "has_explicit_endpoint", False):
-            self.session = Session(adb=self.forward.adb, server=self.forward.server)
-            return self.session
-        forward = self.forward.__enter__()
+        self.connection.__enter__()
         try:
-            self.session = Session(forward.port)
+            self.session = Session(self.connection.open_socket())
         except BaseException:
-            self.forward.__exit__(*sys.exc_info())
+            self.connection.__exit__(*sys.exc_info())
             raise
         return self.session
 
     def __exit__(self, error_type, error, traceback):
-        if self.session:
-            self.session.close()
-        if getattr(self.forward.adb, "has_explicit_endpoint", False):
-            return False
-        return self.forward.__exit__(error_type, error, traceback)
+        try:
+            if self.session:
+                self.session.close()
+        finally:
+            self.connection.__exit__(error_type, error, traceback)
+        return False
 
 
 class TweakConnection:
     def __init__(self, adb, server, timeout=10):
-        self.adb = adb
-        self.server = server
+        self.connection = ServerConnection(adb, server)
         self.timeout = timeout
-        self.forward = None
         self.socket = None
         self.response = None
 
     def __enter__(self):
-        if not getattr(self.adb, "has_explicit_endpoint", False):
-            self.forward = Forward(self.adb, self.server)
-            self.forward.__enter__()
+        self.connection.__enter__()
         return self
 
     def __exit__(self, error_type, error, traceback):
-        self.close()
-        if self.forward is not None:
-            return self.forward.__exit__(error_type, error, traceback)
+        try:
+            self.close()
+        finally:
+            self.connection.__exit__(error_type, error, traceback)
         return False
 
     def close(self):
@@ -516,14 +521,7 @@ class TweakConnection:
             self.socket = None
 
     def _open_socket(self):
-        explicit_endpoint = getattr(self.adb, "has_explicit_endpoint", False)
-        self.socket = LocalAbstractSocket(
-            port=None if explicit_endpoint else self.forward.port,
-            adb=self.adb if explicit_endpoint else None,
-            server=self.server,
-            timeout=self.timeout,
-            feature="tweaks",
-        ).socket
+        self.socket = self.connection.open_socket(self.timeout).socket
 
     def request(self, method, path, payload=None, stream=False):
         self.close()
@@ -764,6 +762,24 @@ def app_info(adb, server):
     return {}
 
 
+def emit_app(server, name, package, as_json, current_device, details=""):
+    if as_json:
+        print_json(
+            {
+                "server": server.identifier,
+                "deviceId": server.device_id,
+                "socketName": server.socket_name,
+                "packageName": package,
+                "appName": name,
+            }
+        )
+    else:
+        if current_device != server.device_id:
+            print(f"{server.device_id}:")
+        print(f"    {server.socket_name}{details}")
+    return server.device_id
+
+
 def run_list(adb, options):
     servers = discover(adb, options)
     if not servers:
@@ -773,22 +789,8 @@ def run_list(adb, options):
         info = app_info(adb, server) if options.include_app_info else {}
         package = info.get("packageName") or (adb.package_hint(server) if options.include_app_info else None)
         app_name = info.get("processName")
-        if options.json:
-            print_json(
-                {
-                    "server": server.identifier,
-                    "deviceId": server.device_id,
-                    "socketName": server.socket_name,
-                    "packageName": package,
-                    "appName": app_name,
-                }
-            )
-        else:
-            if current_device != server.device_id:
-                current_device = server.device_id
-                print(f"{current_device}:")
-            suffix = f"  pkg:{package or 'unknown'}" if options.include_app_info else ""
-            print(f"    {server.socket_name}{suffix}")
+        details = f"  pkg:{package or 'unknown'}" if options.include_app_info else ""
+        current_device = emit_app(server, app_name, package, options.json, current_device, details)
     return 0
 
 
@@ -1072,32 +1074,6 @@ def parse_tweak_value(descriptor, raw):
     raise SnapOError(f"Tweak '{descriptor.get('name', '')}' has unsupported type '{kind}'")
 
 
-def validate_tweak_json_value(descriptor, value):
-    kind = descriptor["type"]
-    valid = {
-        "int": lambda item: isinstance(item, int) and not isinstance(item, bool),
-        "float": lambda item: (
-            isinstance(item, (int, float))
-            and not isinstance(item, bool)
-            and math.isfinite(item)
-        ),
-        "boolean": lambda item: isinstance(item, bool),
-        "color": lambda item: (
-            isinstance(item, str)
-            and re.fullmatch(r"#[0-9a-fA-F]{6}(?:[0-9a-fA-F]{2})?", item) is not None
-        ),
-        "string": lambda item: isinstance(item, str),
-    }.get(kind)
-    if valid is None:
-        raise SnapOError(f"Tweak '{descriptor['name']}' has unsupported type '{kind}'")
-    try:
-        is_valid = valid(value)
-    except (OverflowError, TypeError, ValueError):
-        is_valid = False
-    if not is_valid:
-        raise SnapOError(f"Tweak '{descriptor['name']}' requires a {kind} value")
-
-
 def emit_tweak_document(document, as_json):
     if as_json:
         print_json(document)
@@ -1126,21 +1102,7 @@ def run_tweak_apps(adb, options):
         if not isinstance(name, str) or not isinstance(package, str):
             continue
         found = True
-        if options.json:
-            print_json(
-                {
-                    "server": server.identifier,
-                    "deviceId": server.device_id,
-                    "socketName": server.socket_name,
-                    "packageName": package,
-                    "appName": name,
-                }
-            )
-        else:
-            if current_device != server.device_id:
-                current_device = server.device_id
-                print(f"{current_device}:")
-            print(f"    {server.socket_name}  {name}  pkg:{package}")
+        current_device = emit_app(server, name, package, options.json, current_device, f"  {name}  pkg:{package}")
     if not found:
         raise SnapOError("No reachable Snap-O tweaks apps found")
     return 0
@@ -1172,29 +1134,13 @@ def tweak_listing_path(options):
     return "/tweaks?include=adjusted" if options.all else "/tweaks"
 
 
-def tweak_json_values(raw):
-    try:
-        values = json.loads(raw, parse_constant=lambda value: (_ for _ in ()).throw(ValueError(value)))
-    except (TypeError, ValueError) as error:
-        raise SnapOError(f"--values-json must contain a valid JSON object: {error}") from error
-    if not isinstance(values, dict) or not values:
-        raise SnapOError("--values-json must contain a nonempty JSON object")
-    return values
-
-
 def run_tweak_set(adb, options):
     server = choose_tweak_server(adb, options)
     with TweakConnection(adb, server) as connection:
         descriptors = tweak_descriptors(connection.request("GET", "/tweaks"))
-        if options.values_json is not None:
-            values = tweak_json_values(options.values_json)
-            for name, value in values.items():
-                validate_tweak_json_value(find_tweak(descriptors, name), value)
-        else:
-            descriptor = find_tweak(descriptors, options.name)
-            values = {options.name: parse_tweak_value(descriptor, options.value)}
-        document = connection.request("PATCH", "/tweaks", {"values": values})
-    emit_tweak_document(document, options.json)
+        descriptor = find_tweak(descriptors, options.name)
+        values = {options.name: parse_tweak_value(descriptor, options.value)}
+        connection.request("PATCH", "/tweaks", {"values": values})
     return 0
 
 
@@ -1208,12 +1154,8 @@ def run_tweak_reset(adb, options):
             if "default" not in descriptor:
                 raise SnapOError(f"Tweak '{descriptor['name']}' does not provide a default value")
             values[descriptor["name"]] = descriptor["default"]
-        document = (
+        if values:
             connection.request("PATCH", "/tweaks", {"values": values})
-            if values
-            else {"tweaks": []}
-        )
-    emit_tweak_document(document, options.json)
     return 0
 
 
@@ -1263,7 +1205,7 @@ def run_tweak_watch(adb, options):
                 return 0
 
 
-def add_common_options(parser, socket_option=False):
+def add_common_options(parser, socket_option=False, json_option=True):
     selection = parser.add_mutually_exclusive_group()
     selection.add_argument("-s", "--serial")
     selection.add_argument("-d", dest="usb", action="store_true")
@@ -1273,7 +1215,8 @@ def add_common_options(parser, socket_option=False):
     parser.add_argument("--adb", help="path to the configured adb executable or shim")
     parser.add_argument("--adb-host", help="explicit ADB server host (requires --adb-port)")
     parser.add_argument("--adb-port", type=valid_port, help="explicit ADB server port (requires --adb-host)")
-    parser.add_argument("--json", action="store_true", help="emit newline-delimited JSON")
+    if json_option:
+        parser.add_argument("--json", action="store_true", help="emit newline-delimited JSON")
 
 
 def valid_port(value):
@@ -1302,13 +1245,7 @@ class SnapOArgumentParser(argparse.ArgumentParser):
             self.error("--adb-host and --adb-port must be used together")
         if getattr(options, "root_command", None) == "tweaks":
             command = getattr(options, "tweaks_command", None)
-            if command == "set":
-                if options.values_json is not None:
-                    if options.name is not None or options.value is not None:
-                        self.error("set accepts either NAME VALUE or --values-json, not both")
-                elif options.name is None or options.value is None:
-                    self.error("set requires NAME VALUE or --values-json")
-            elif command == "reset" and (options.name is None) == (not options.all):
+            if command == "reset" and (options.name is None) == (not options.all):
                 self.error("reset requires either NAME or --all")
         return options
 
@@ -1353,15 +1290,14 @@ def parser():
     get.add_argument("--all", action="store_true", help="include previously adjusted inactive tweaks")
     get.set_defaults(handler=run_tweak_get)
 
-    set_tweak = tweaks_commands.add_parser("set", help="update one tweak or an atomic JSON batch")
-    add_common_options(set_tweak, socket_option=True)
-    set_tweak.add_argument("name", metavar="NAME", nargs="?")
-    set_tweak.add_argument("value", metavar="VALUE", nargs="?")
-    set_tweak.add_argument("--values-json", help="JSON object containing an atomic batch of tweak values")
+    set_tweak = tweaks_commands.add_parser("set", help="update one tweak")
+    add_common_options(set_tweak, socket_option=True, json_option=False)
+    set_tweak.add_argument("name", metavar="NAME")
+    set_tweak.add_argument("value", metavar="VALUE")
     set_tweak.set_defaults(handler=run_tweak_set)
 
     reset = tweaks_commands.add_parser("reset", help="reset one tweak or all tweaks to their defaults")
-    add_common_options(reset, socket_option=True)
+    add_common_options(reset, socket_option=True, json_option=False)
     reset.add_argument("name", metavar="NAME", nargs="?")
     reset.add_argument("--all", action="store_true", help="reset every currently registered tweak")
     reset.set_defaults(handler=run_tweak_reset)

--- a/scripts/snapo
+++ b/scripts/snapo
@@ -117,13 +117,9 @@ class ADB:
     def devices(self):
         return parse_devices(self.command("devices", "-l"))
 
-    def sockets(self, serial):
+    def sockets(self, serial, prefix=SOCKET_PREFIX):
         output = self.command("shell", "cat /proc/net/unix", serial=serial)
-        return parse_sockets(output)
-
-    def tweak_sockets(self, serial):
-        output = self.command("shell", "cat /proc/net/unix", serial=serial)
-        return parse_tweak_sockets(output)
+        return parse_sockets(output, prefix)
 
     def package_hint(self, server):
         if server.pid is None:
@@ -157,16 +153,10 @@ def parse_sockets(output, prefix=SOCKET_PREFIX):
             continue
         name = fields[-1]
         if name.startswith("@" + prefix):
-            sockets.add(name[1:])
+            socket_name = name[1:]
+            if prefix != TWEAK_SOCKET_PREFIX or socket_name[len(prefix) :].isdigit():
+                sockets.add(socket_name)
     return sorted(sockets)
-
-
-def parse_tweak_sockets(output):
-    return [
-        name
-        for name in parse_sockets(output, TWEAK_SOCKET_PREFIX)
-        if name[len(TWEAK_SOCKET_PREFIX) :].isdigit()
-    ]
 
 
 def select_devices(devices, serial=None, usb=False, emulator=False):
@@ -191,7 +181,7 @@ def select_devices(devices, serial=None, usb=False, emulator=False):
     return devices
 
 
-def discover(adb, options):
+def discover(adb, options, prefix=SOCKET_PREFIX):
     devices = select_devices(
         adb.devices(),
         serial=options.serial,
@@ -203,25 +193,7 @@ def discover(adb, options):
     servers = []
     for device in devices:
         try:
-            servers.extend(Server(device, name) for name in adb.sockets(device))
-        except SnapOError:
-            continue
-    return sorted(servers, key=lambda server: (server.device_id, server.socket_name))
-
-
-def discover_tweaks(adb, options):
-    devices = select_devices(
-        adb.devices(),
-        serial=options.serial,
-        usb=options.usb,
-        emulator=options.emulator,
-    )
-    if not devices:
-        raise SnapOError("No connected devices found")
-    servers = []
-    for device in devices:
-        try:
-            servers.extend(Server(device, name) for name in adb.tweak_sockets(device))
+            servers.extend(Server(device, name) for name in adb.sockets(device, prefix))
         except SnapOError:
             continue
     return sorted(servers, key=lambda server: (server.device_id, server.socket_name))
@@ -1045,7 +1017,7 @@ def run_show(adb, options):
 
 
 def choose_tweak_server(adb, options):
-    return choose_server(discover_tweaks(adb, options), options.socket, feature="tweaks")
+    return choose_server(discover(adb, options, TWEAK_SOCKET_PREFIX), options.socket, feature="tweaks")
 
 
 def tweak_descriptors(document):
@@ -1138,7 +1110,7 @@ def emit_tweak_document(document, as_json):
 
 
 def run_tweak_apps(adb, options):
-    servers = discover_tweaks(adb, options)
+    servers = discover(adb, options, TWEAK_SOCKET_PREFIX)
     if not servers:
         raise SnapOError("No Snap-O tweaks servers found")
     found = False

--- a/scripts/snapo
+++ b/scripts/snapo
@@ -300,21 +300,21 @@ class Forward:
         return False
 
 
-class Session:
-    def __init__(self, port=None, adb=None, server=None, connect_timeout=5):
+class LocalAbstractSocket:
+    def __init__(self, port=None, adb=None, server=None, timeout=5, feature="network"):
         endpoint = ("127.0.0.1", port) if adb is None else adb.endpoint
         try:
-            self.socket = socket.create_connection(endpoint, timeout=connect_timeout)
+            self.socket = socket.create_connection(endpoint, timeout=timeout)
         except OSError as error:
-            target = "forwarded Snap-O socket" if adb is None else "ADB server"
+            target = "ADB server" if adb is not None else "forwarded Snap-O socket"
+            if adb is None and feature == "tweaks":
+                target = "forwarded Snap-O tweaks socket"
             raise SnapOError(f"Failed to connect to {target}: {error}") from error
-        self.buffer = bytearray()
-        self.next_id = 1
+        self.feature = feature
         try:
             if adb is not None:
                 self.adb_request(f"host:transport:{server.device_id}")
                 self.adb_request(f"localabstract:{server.socket_name}")
-            self.send_bytes(b"HelloSnapO\n")
         except BaseException:
             self.socket.close()
             raise
@@ -323,7 +323,10 @@ class Session:
         payload = request.encode("utf-8")
         if len(payload) > 0xFFFF:
             raise SnapOError("ADB request is too large")
-        self.send_bytes(f"{len(payload):04X}".encode("ascii") + payload)
+        try:
+            self.socket.sendall(f"{len(payload):04X}".encode("ascii") + payload)
+        except OSError as error:
+            raise SnapOError(f"Failed to write to ADB server: {error}") from error
         status = self.read_exact(4)
         if status == b"OKAY":
             return
@@ -333,7 +336,7 @@ class Session:
             except ValueError as error:
                 raise SnapOError("ADB returned an invalid failure response") from error
             message = self.read_exact(length).decode("utf-8", errors="replace")
-            raise SnapOError(f"ADB rejected the network connection: {message}")
+            raise SnapOError(f"ADB rejected the {self.feature} connection: {message}")
         raise SnapOError("ADB returned an invalid status response")
 
     def read_exact(self, count):
@@ -347,6 +350,18 @@ class Session:
                 raise SnapOError("ADB server closed the connection unexpectedly")
             data.extend(chunk)
         return bytes(data)
+
+
+class Session:
+    def __init__(self, port=None, adb=None, server=None, connect_timeout=5):
+        self.socket = LocalAbstractSocket(port, adb, server, connect_timeout).socket
+        self.buffer = bytearray()
+        self.next_id = 1
+        try:
+            self.send_bytes(b"HelloSnapO\n")
+        except BaseException:
+            self.socket.close()
+            raise
 
     def close(self):
         self.socket.close()
@@ -528,49 +543,15 @@ class TweakConnection:
             self.socket.close()
             self.socket = None
 
-    def _read_exact(self, count):
-        received = bytearray()
-        while len(received) < count:
-            try:
-                chunk = self.socket.recv(count - len(received))
-            except OSError as error:
-                raise SnapOError(f"Failed to read from ADB server: {error}") from error
-            if not chunk:
-                raise SnapOError("ADB server closed the connection unexpectedly")
-            received.extend(chunk)
-        return bytes(received)
-
-    def _adb_request(self, request):
-        payload = request.encode("utf-8")
-        if len(payload) > 0xFFFF:
-            raise SnapOError("ADB request is too large")
-        try:
-            self.socket.sendall(f"{len(payload):04X}".encode("ascii") + payload)
-        except OSError as error:
-            raise SnapOError(f"Failed to write to ADB server: {error}") from error
-        status = self._read_exact(4)
-        if status == b"OKAY":
-            return
-        if status == b"FAIL":
-            try:
-                length = int(self._read_exact(4), 16)
-            except ValueError as error:
-                raise SnapOError("ADB returned an invalid failure response") from error
-            message = self._read_exact(length).decode("utf-8", errors="replace")
-            raise SnapOError(f"ADB rejected the tweaks connection: {message}")
-        raise SnapOError("ADB returned an invalid status response")
-
     def _open_socket(self):
         explicit_endpoint = getattr(self.adb, "has_explicit_endpoint", False)
-        endpoint = self.adb.endpoint if explicit_endpoint else ("127.0.0.1", self.forward.port)
-        try:
-            self.socket = socket.create_connection(endpoint, timeout=self.timeout)
-        except OSError as error:
-            target = "ADB server" if explicit_endpoint else "forwarded Snap-O tweaks socket"
-            raise SnapOError(f"Failed to connect to {target}: {error}") from error
-        if explicit_endpoint:
-            self._adb_request(f"host:transport:{self.server.device_id}")
-            self._adb_request(f"localabstract:{self.server.socket_name}")
+        self.socket = LocalAbstractSocket(
+            port=None if explicit_endpoint else self.forward.port,
+            adb=self.adb if explicit_endpoint else None,
+            server=self.server,
+            timeout=self.timeout,
+            feature="tweaks",
+        ).socket
 
     def request(self, method, path, payload=None, stream=False):
         self.close()

--- a/skills/snap-o-tweaks/SKILL.md
+++ b/skills/snap-o-tweaks/SKILL.md
@@ -94,25 +94,19 @@ Inspect the descriptor first: the CLI parses `int`, `float`, `boolean`,
 spaces or `/`, string values containing spaces, and hex colors.
 
 ```bash
-"$SNAPO_BIN" tweaks set 'Typography/Font size' 42 -s <serial> -n <socket> --json
-"$SNAPO_BIN" tweaks set 'Motion/Show' false -s <serial> -n <socket> --json
-"$SNAPO_BIN" tweaks set 'Colors/Accent' '#3B82F6' -s <serial> -n <socket> --json
+"$SNAPO_BIN" tweaks set 'Typography/Font size' 42 -s <serial> -n <socket>
+"$SNAPO_BIN" tweaks set 'Motion/Show' false -s <serial> -n <socket>
+"$SNAPO_BIN" tweaks set 'Colors/Accent' '#3B82F6' -s <serial> -n <socket>
 ```
 
-Submit related updates together as one atomic JSON batch:
-
-```bash
-"$SNAPO_BIN" tweaks set \
-  --values-json '{"Typography/Font size":42,"Motion/Show":false}' \
-  -s <serial> -n <socket> --json
-```
+Successful updates and resets produce no output.
 
 Reset only the explicitly requested value, or use `--all` only for an explicit
 reset-everything request:
 
 ```bash
-"$SNAPO_BIN" tweaks reset 'Typography/Font size' -s <serial> -n <socket> --json
-"$SNAPO_BIN" tweaks reset --all -s <serial> -n <socket> --json
+"$SNAPO_BIN" tweaks reset 'Typography/Font size' -s <serial> -n <socket>
+"$SNAPO_BIN" tweaks reset --all -s <serial> -n <socket>
 ```
 
 ## Availability and failures

--- a/tests/snapo_cli/test_snapo.py
+++ b/tests/snapo_cli/test_snapo.py
@@ -76,6 +76,7 @@ class WireServer:
         self.port = self.listener.getsockname()[1]
         self.received = []
         self.failure = None
+        self.stopping = threading.Event()
         self.thread = threading.Thread(target=self.run, daemon=True)
 
     def __enter__(self):
@@ -83,8 +84,14 @@ class WireServer:
         return self
 
     def __exit__(self, error_type, error, traceback):
+        if self.thread.is_alive():
+            self.stopping.set()
+            with socket.create_connection(("127.0.0.1", self.port), timeout=1):
+                pass
         self.thread.join(timeout=3)
         self.listener.close()
+        if error_type is not None:
+            return
         if self.failure:
             raise self.failure
         if self.thread.is_alive():
@@ -94,6 +101,8 @@ class WireServer:
         try:
             connection, _ = self.listener.accept()
             with connection:
+                if self.stopping.is_set():
+                    return
                 connection.settimeout(2)
                 stream = connection.makefile("rwb", buffering=0)
                 if self.adb_handshake:
@@ -138,6 +147,19 @@ class FakeADB:
             self.fail_forward = False
             raise snapo.SnapOError("port in use")
         return ""
+
+
+class WireServerTests(unittest.TestCase):
+    def test_idle_listener_stops_without_a_client_connection(self):
+        with WireServer(lambda stream, received: self.fail("handler should not run")) as server:
+            pass
+
+        self.assertFalse(server.thread.is_alive())
+
+    def test_idle_listener_preserves_an_exception_from_the_context(self):
+        with self.assertRaisesRegex(RuntimeError, "original test failure"):
+            with WireServer(lambda stream, received: self.fail("handler should not run")):
+                raise RuntimeError("original test failure")
 
 
 class FakeTweakADB(FakeADB):
@@ -1252,9 +1274,14 @@ class TweakCommandTests(unittest.TestCase):
             ("Motion/Enabled", "false", False),
             ("Palette/Accent color", "#3b82f6", "#3B82F6"),
             ("Preview/Text value", "true", "true"),
+            ("Preview/Text value", "-hello", "-hello"),
+            ("Preview/Text value", "-foo", "-foo"),
+            ("Preview/Text value", "--literal", "--literal"),
+            ("Preview/Text value", "-h", "-h"),
+            ("Preview/Text value", "--help", "--help"),
         )
         for name, raw, expected in cases:
-            with self.subTest(name=name):
+            with self.subTest(name=name, value=raw):
                 with TweakHTTPServer() as wire:
                     result, output, errors, adb = self.run_command(["set", name, raw, "--json"], wire)
 

--- a/tests/snapo_cli/test_snapo.py
+++ b/tests/snapo_cli/test_snapo.py
@@ -398,23 +398,6 @@ class PluginPackagingTests(unittest.TestCase):
                 self.assertTrue(reference.read_text(encoding="utf-8").strip())
                 self.assertIn(f"references/{name}", skill_content)
 
-        interaction_guide = (skill_root / "references" / "interaction-surfaces.md").read_text(
-            encoding="utf-8"
-        )
-        protocol = (skill_root / "references" / "protocol.md").read_text(encoding="utf-8")
-        self.assertIn("/proc/net/unix", protocol)
-        self.assertIn("forward tcp:0", protocol)
-        self.assertIn("forward --remove", protocol)
-        self.assertIn("[protocol.md](protocol.md)", interaction_guide)
-        self.assertIn("tweaks list --all", skill_content)
-        self.assertIn("tweaks get 'Typography/Font size' --all", skill_content)
-        self.assertIn("GET /tweaks?include=adjusted", protocol)
-        self.assertIn("snapo tweaks list --all", interaction_guide)
-
-        for artifact in ("tweaks", "tweaks-noop", "tweaks-overlay", "tweaks-overlay-noop"):
-            with self.subTest(artifact=artifact):
-                self.assertIn(f"com.openai.snapo:{artifact}:$snapoVersion", interaction_guide)
-
     def test_marketplace_exposes_the_repository_plugin(self):
         marketplace = json.loads(
             (REPOSITORY / ".agents" / "plugins" / "marketplace.json").read_text(encoding="utf-8")

--- a/tests/snapo_cli/test_snapo.py
+++ b/tests/snapo_cli/test_snapo.py
@@ -135,7 +135,7 @@ class FakeADB:
     def devices(self):
         return ["emulator-5554"]
 
-    def sockets(self, serial):
+    def sockets(self, serial, prefix=snapo.SOCKET_PREFIX):
         return ["snapo_network_42"]
 
     def package_hint(self, server):
@@ -171,7 +171,9 @@ class FakeTweakADB(FakeADB):
     def devices(self):
         return self.available_devices
 
-    def tweak_sockets(self, serial):
+    def sockets(self, serial, prefix=snapo.SOCKET_PREFIX):
+        if prefix != snapo.TWEAK_SOCKET_PREFIX:
+            return super().sockets(serial, prefix)
         value = self.available_sockets.get(serial, [])
         if isinstance(value, Exception):
             raise value
@@ -475,7 +477,7 @@ usb-phone device product:oriole
             def devices(self):
                 return ["disconnected-device", "emulator-5554"]
 
-            def sockets(self, serial):
+            def sockets(self, serial, prefix=snapo.SOCKET_PREFIX):
                 if serial == "disconnected-device":
                     raise snapo.SnapOError("device disconnected")
                 return ["snapo_network_42"]
@@ -497,8 +499,12 @@ class TweakDiscoveryTests(unittest.TestCase):
 3: 0 0 0 1 01 3 @unrelated
 4: 0 0 0 1 01 4 @snapo_tweaks_7
 5: 0 0 0 1 01 5 @snapo_tweaks_93
+6: 0 0 0 1 01 6 @snapo_tweaks_invalid
 """
-        self.assertEqual(snapo.parse_tweak_sockets(output), ["snapo_tweaks_7", "snapo_tweaks_93"])
+        self.assertEqual(
+            snapo.parse_sockets(output, snapo.TWEAK_SOCKET_PREFIX),
+            ["snapo_tweaks_7", "snapo_tweaks_93"],
+        )
         self.assertEqual(snapo.parse_sockets(output), ["snapo_network_42"])
 
     def test_adb_tweak_socket_discovery_reads_device_unix_sockets(self):
@@ -510,7 +516,7 @@ class TweakDiscoveryTests(unittest.TestCase):
             return type("Result", (), {"returncode": 0, "stdout": output, "stderr": ""})()
 
         adb = snapo.ADB("/configured/adb", run=run)
-        self.assertEqual(adb.tweak_sockets("emulator-5554"), ["snapo_tweaks_42"])
+        self.assertEqual(adb.sockets("emulator-5554", snapo.TWEAK_SOCKET_PREFIX), ["snapo_tweaks_42"])
         self.assertEqual(
             recorded,
             [["/configured/adb", "-s", "emulator-5554", "shell", "cat /proc/net/unix"]],
@@ -527,12 +533,15 @@ class TweakDiscoveryTests(unittest.TestCase):
         )
         options = snapo.parser().parse_args(["tweaks", "apps"])
         self.assertEqual(
-            snapo.discover_tweaks(adb, options),
+            snapo.discover(adb, options, snapo.TWEAK_SOCKET_PREFIX),
             [snapo.Server("emulator-5554", "snapo_tweaks_42"), snapo.Server("usb-phone", "snapo_tweaks_8")],
         )
 
         selected = snapo.parser().parse_args(["tweaks", "apps", "-s", "usb-phone"])
-        self.assertEqual(snapo.discover_tweaks(adb, selected), [snapo.Server("usb-phone", "snapo_tweaks_8")])
+        self.assertEqual(
+            snapo.discover(adb, selected, snapo.TWEAK_SOCKET_PREFIX),
+            [snapo.Server("usb-phone", "snapo_tweaks_8")],
+        )
 
     def test_parser_registers_every_tweak_command_and_shared_selectors(self):
         commands = {

--- a/tests/snapo_cli/test_snapo.py
+++ b/tests/snapo_cli/test_snapo.py
@@ -127,9 +127,15 @@ def write_message(stream, value):
     stream.write(json.dumps(value, separators=(",", ":")).encode("utf-8") + b"\n")
 
 
+def open_session(port):
+    return snapo.Session(snapo.LocalAbstractSocket(port=port))
+
+
 class FakeADB:
-    def __init__(self, fail_forward=False):
-        self.fail_forward = fail_forward
+    has_explicit_endpoint = False
+
+    def __init__(self, forward_port=27185):
+        self.forward_port = forward_port
         self.calls = []
 
     def devices(self):
@@ -143,9 +149,8 @@ class FakeADB:
 
     def command(self, *arguments, serial=None):
         self.calls.append((serial, arguments))
-        if arguments and arguments[0] == "forward" and "--remove" not in arguments and self.fail_forward:
-            self.fail_forward = False
-            raise snapo.SnapOError("port in use")
+        if arguments[:2] == ("forward", "tcp:0"):
+            return str(self.forward_port)
         return ""
 
 
@@ -163,8 +168,8 @@ class WireServerTests(unittest.TestCase):
 
 
 class FakeTweakADB(FakeADB):
-    def __init__(self, sockets=None, devices=None, fail_forward=False):
-        super().__init__(fail_forward=fail_forward)
+    def __init__(self, sockets=None, devices=None, forward_port=27185):
+        super().__init__(forward_port=forward_port)
         self.available_devices = devices or ["emulator-5554"]
         self.available_sockets = sockets or {"emulator-5554": ["snapo_tweaks_42"]}
 
@@ -414,24 +419,6 @@ class PluginPackagingTests(unittest.TestCase):
         self.assertEqual(plugin["policy"]["installation"], "AVAILABLE")
         self.assertEqual(plugin["policy"]["authentication"], "ON_INSTALL")
 
-    def test_documented_marketplace_install_avoids_sparse_paths_and_migrates_existing_users(self):
-        readme = (REPOSITORY / "README.md").read_text(encoding="utf-8")
-        add_command = "codex plugin marketplace add openai/snap-o --ref main"
-        install_command = "codex plugin add snap-o@snap-o"
-        add_commands = [line.strip() for line in readme.splitlines() if line.strip().startswith(add_command)]
-
-        self.assertGreaterEqual(len(add_commands), 2)
-        self.assertTrue(all(command == add_command for command in add_commands))
-        self.assertNotIn("--sparse", readme)
-
-        migration_start = readme.index("codex plugin marketplace remove snap-o")
-        migration_add = readme.index(add_command, migration_start)
-        migration_install = readme.index(install_command, migration_add)
-        self.assertLess(migration_start, migration_add)
-        self.assertLess(migration_add, migration_install)
-        self.assertIn("codex plugin marketplace upgrade snap-o", readme[migration_install:])
-
-
 class DiscoveryTests(unittest.TestCase):
     def test_parses_devices_and_deduplicates_sockets(self):
         devices = snapo.parse_devices(
@@ -554,14 +541,16 @@ class TweakDiscoveryTests(unittest.TestCase):
         }
         for name, arguments in commands.items():
             with self.subTest(command=name):
-                options = snapo.parser().parse_args(
-                    ["tweaks", *arguments, "-s", "emulator-5554", "--adb", "/configured/adb", "--json"]
-                )
+                command = ["tweaks", *arguments, "-s", "emulator-5554", "--adb", "/configured/adb"]
+                if name not in {"set", "reset"}:
+                    command.append("--json")
+                options = snapo.parser().parse_args(command)
                 self.assertEqual(options.root_command, "tweaks")
                 self.assertEqual(options.tweaks_command, name)
                 self.assertEqual(options.serial, "emulator-5554")
                 self.assertEqual(options.adb, "/configured/adb")
-                self.assertTrue(options.json)
+                if name not in {"set", "reset"}:
+                    self.assertTrue(options.json)
 
     def test_tweak_commands_preserve_remote_adb_endpoint_validation(self):
         commands = (
@@ -618,11 +607,6 @@ class TweakValueTests(unittest.TestCase):
             with self.subTest(value=value):
                 with self.assertRaises(snapo.SnapOError):
                     snapo.parse_tweak_value(descriptor, value)
-
-    def test_float_json_values_reject_huge_integers_without_overflowing(self):
-        descriptor = self.descriptor("Motion/Damping ratio")
-        with self.assertRaises(snapo.SnapOError):
-            snapo.validate_tweak_json_value(descriptor, 10**400)
 
     def test_boolean_values_are_typed_but_strings_remain_literal(self):
         boolean = self.descriptor("Motion/Enabled")
@@ -746,17 +730,15 @@ class ADBTests(unittest.TestCase):
         with self.assertRaisesRegex(snapo.SnapOError, "timed out"):
             adb.devices()
 
-    def test_forward_retries_and_removes_only_its_forward(self):
-        adb = FakeADB(fail_forward=True)
+    def test_forward_uses_adb_allocated_port_and_removes_only_its_forward(self):
+        adb = FakeADB(forward_port=27186)
         server = snapo.Server("emulator-5554", "snapo_network_42")
-        with mock.patch.object(snapo, "available_port", side_effect=[27185, 27186]):
-            with snapo.Forward(adb, server) as forward:
-                self.assertEqual(forward.port, 27186)
+        with snapo.Forward(adb, server) as forward:
+            self.assertEqual(forward.port, 27186)
         self.assertEqual(
             adb.calls,
             [
-                ("emulator-5554", ("forward", "tcp:27185", "localabstract:snapo_network_42")),
-                ("emulator-5554", ("forward", "tcp:27186", "localabstract:snapo_network_42")),
+                ("emulator-5554", ("forward", "tcp:0", "localabstract:snapo_network_42")),
                 ("emulator-5554", ("forward", "--remove", "tcp:27186")),
             ],
         )
@@ -764,10 +746,39 @@ class ADBTests(unittest.TestCase):
     def test_forward_is_removed_when_session_work_fails(self):
         adb = FakeADB()
         server = snapo.Server("emulator-5554", "snapo_network_42")
-        with mock.patch.object(snapo, "available_port", return_value=27185):
-            with self.assertRaisesRegex(RuntimeError, "expected"):
-                with snapo.Forward(adb, server):
-                    raise RuntimeError("expected")
+        with self.assertRaisesRegex(RuntimeError, "expected"):
+            with snapo.Forward(adb, server):
+                raise RuntimeError("expected")
+        self.assertEqual(adb.calls[-1], ("emulator-5554", ("forward", "--remove", "tcp:27185")))
+
+    def test_forward_rejects_an_invalid_allocated_port(self):
+        adb = FakeADB(forward_port="invalid")
+        server = snapo.Server("emulator-5554", "snapo_network_42")
+        with self.assertRaisesRegex(snapo.SnapOError, "allocated forwarding port"):
+            with snapo.Forward(adb, server):
+                self.fail("forward unexpectedly opened")
+
+    def test_network_forward_is_removed_when_session_close_fails(self):
+        adb = FakeADB()
+        server = snapo.Server("emulator-5554", "snapo_network_42")
+        transport = mock.Mock(socket=mock.Mock())
+        with mock.patch.object(snapo.ServerConnection, "open_socket", return_value=transport):
+            with mock.patch.object(snapo.Session, "close", side_effect=RuntimeError("close failed")):
+                with self.assertRaisesRegex(RuntimeError, "close failed"):
+                    with snapo.ConnectedSession(adb, server):
+                        pass
+
+        self.assertEqual(adb.calls[-1], ("emulator-5554", ("forward", "--remove", "tcp:27185")))
+
+    def test_tweak_forward_is_removed_when_connection_close_fails(self):
+        adb = FakeADB()
+        server = snapo.Server("emulator-5554", "snapo_tweaks_42")
+        connection = snapo.TweakConnection(adb, server)
+        with mock.patch.object(connection, "close", side_effect=RuntimeError("close failed")):
+            with self.assertRaisesRegex(RuntimeError, "close failed"):
+                with connection:
+                    pass
+
         self.assertEqual(adb.calls[-1], ("emulator-5554", ("forward", "--remove", "tcp:27185")))
 
 
@@ -787,7 +798,7 @@ class ProtocolTests(unittest.TestCase):
             write_message(stream, {"method": "SnapO.replayComplete", "params": {"watermark": 3}})
 
         with WireServer(handler) as server:
-            session = snapo.Session(server.port)
+            session = open_session(server.port)
             try:
                 session.start_stream()
                 self.assertEqual(session.read(1)["method"], "SnapO.appInfo")
@@ -823,7 +834,7 @@ class ProtocolTests(unittest.TestCase):
             write_message(stream, {"method": "SnapO.replayComplete", "params": {"watermark": 0}})
 
         with WireServer(handler) as wire:
-            session = snapo.Session(wire.port)
+            session = open_session(wire.port)
             try:
                 self.assertEqual(session.read(1)["method"], "SnapO.replayComplete")
             finally:
@@ -857,7 +868,7 @@ class ProtocolTests(unittest.TestCase):
             write_message(stream, {"method": "SnapO.replayComplete", "params": {"watermark": 0}})
 
         with WireServer(handler) as wire:
-            session = snapo.Session(wire.port)
+            session = open_session(wire.port)
             try:
                 self.assertEqual(session.read(1)["method"], "SnapO.replayComplete")
             finally:
@@ -868,7 +879,7 @@ class ProtocolTests(unittest.TestCase):
             stream.write(b'{"oversized":true}\n')
 
         with WireServer(handler) as wire:
-            session = snapo.Session(wire.port)
+            session = open_session(wire.port)
             try:
                 with mock.patch.object(snapo, "MAX_RECORD_BYTES", 8):
                     with self.assertRaisesRegex(snapo.SnapOError, "oversized"):
@@ -886,7 +897,7 @@ class ProtocolTests(unittest.TestCase):
             write_message(stream, {"id": command["id"], "result": {"body": "expected"}})
 
         with WireServer(handler) as server:
-            session = snapo.Session(server.port)
+            session = open_session(server.port)
             try:
                 reply = session.command(
                     "Network.getResponseBody",
@@ -906,7 +917,7 @@ class ProtocolTests(unittest.TestCase):
             threading.Event().wait(0.12)
 
         with WireServer(handler) as server:
-            session = snapo.Session(server.port)
+            session = open_session(server.port)
             try:
                 with self.assertRaisesRegex(snapo.SnapOError, "Timed out waiting"):
                     session.command("Network.getResponseBody", {"requestId": "request-1"}, timeout=0.03)
@@ -929,7 +940,7 @@ class ProtocolTests(unittest.TestCase):
             )
 
         with WireServer(handler) as wire:
-            session = snapo.Session(wire.port)
+            session = open_session(wire.port)
             try:
                 details = snapo.request_details(
                     session,
@@ -961,7 +972,7 @@ class ProtocolTests(unittest.TestCase):
             write_message(stream, {"method": "Network.loadingFinished", "params": {"requestId": "request-1"}})
 
         with WireServer(handler) as wire:
-            session = snapo.Session(wire.port)
+            session = open_session(wire.port)
             try:
                 details = snapo.request_details(
                     session,
@@ -990,7 +1001,7 @@ class ProtocolTests(unittest.TestCase):
             )
 
         with WireServer(handler) as wire:
-            session = snapo.Session(wire.port)
+            session = open_session(wire.port)
             try:
                 details = snapo.request_details(
                     session,
@@ -1084,15 +1095,15 @@ class TweakTransportTests(unittest.TestCase):
         adb = FakeTweakADB()
         server = snapo.Server("emulator-5554", "snapo_tweaks_42")
         with TweakHTTPServer() as wire:
-            with mock.patch.object(snapo, "available_port", return_value=wire.port):
-                with snapo.TweakConnection(adb, server) as connection:
-                    response = connection.request("GET", "/tweaks")
+            adb.forward_port = wire.port
+            with snapo.TweakConnection(adb, server) as connection:
+                response = connection.request("GET", "/tweaks")
 
         self.assertEqual(response["tweaks"][0]["name"], "Typography/Font size")
         self.assertEqual(
             adb.calls,
             [
-                ("emulator-5554", ("forward", f"tcp:{wire.port}", "localabstract:snapo_tweaks_42")),
+                ("emulator-5554", ("forward", "tcp:0", "localabstract:snapo_tweaks_42")),
                 ("emulator-5554", ("forward", "--remove", f"tcp:{wire.port}")),
             ],
         )
@@ -1122,10 +1133,10 @@ class TweakTransportTests(unittest.TestCase):
         for status, detail in ((404, "Unknown tweak: Missing"), (422, "Value exceeds the maximum.")):
             with self.subTest(status=status):
                 with TweakHTTPServer(error=(status, detail)) as wire:
-                    with mock.patch.object(snapo, "available_port", return_value=wire.port):
-                        with snapo.TweakConnection(adb, server) as connection:
-                            with self.assertRaisesRegex(snapo.SnapOError, f"HTTP {status}.*{detail}"):
-                                connection.request("PATCH", "/tweaks", {"values": {"Motion/Enabled": False}})
+                    adb.forward_port = wire.port
+                    with snapo.TweakConnection(adb, server) as connection:
+                        with self.assertRaisesRegex(snapo.SnapOError, f"HTTP {status}.*{detail}"):
+                            connection.request("PATCH", "/tweaks", {"values": {"Motion/Enabled": False}})
 
                 self.assertEqual(adb.calls[-1], ("emulator-5554", ("forward", "--remove", f"tcp:{wire.port}")))
 
@@ -1133,11 +1144,11 @@ class TweakTransportTests(unittest.TestCase):
         adb = FakeTweakADB()
         server = snapo.Server("emulator-5554", "snapo_tweaks_42")
         with TweakHTTPServer() as wire:
-            with mock.patch.object(snapo, "available_port", return_value=wire.port):
-                with mock.patch.object(snapo, "MAX_RECORD_BYTES", 16):
-                    with self.assertRaisesRegex(snapo.SnapOError, "oversized"):
-                        with snapo.TweakConnection(adb, server) as connection:
-                            connection.request("GET", "/tweaks")
+            adb.forward_port = wire.port
+            with mock.patch.object(snapo, "MAX_RECORD_BYTES", 16):
+                with self.assertRaisesRegex(snapo.SnapOError, "oversized"):
+                    with snapo.TweakConnection(adb, server) as connection:
+                        connection.request("GET", "/tweaks")
 
         self.assertEqual(adb.calls[-1], ("emulator-5554", ("forward", "--remove", f"tcp:{wire.port}")))
 
@@ -1145,14 +1156,14 @@ class TweakTransportTests(unittest.TestCase):
 class TweakCommandTests(unittest.TestCase):
     def run_command(self, arguments, wire, adb=None):
         adb = adb or FakeTweakADB()
+        adb.forward_port = wire.port
         stdout = io.StringIO()
         stderr = io.StringIO()
         with mock.patch.object(snapo, "resolve_adb", return_value="/configured/adb"):
             with mock.patch.object(snapo, "ADB", return_value=adb):
-                with mock.patch.object(snapo, "available_port", return_value=wire.port):
-                    with contextlib.redirect_stdout(stdout):
-                        with contextlib.redirect_stderr(stderr):
-                            result = snapo.main(["tweaks", *arguments])
+                with contextlib.redirect_stdout(stdout):
+                    with contextlib.redirect_stderr(stderr):
+                        result = snapo.main(["tweaks", *arguments])
         return result, stdout.getvalue(), stderr.getvalue(), adb
 
     def test_apps_identifies_each_running_application_from_its_tweak_server(self):
@@ -1275,10 +1286,10 @@ class TweakCommandTests(unittest.TestCase):
         for name, raw, expected in cases:
             with self.subTest(name=name, value=raw):
                 with TweakHTTPServer() as wire:
-                    result, output, errors, adb = self.run_command(["set", name, raw, "--json"], wire)
+                    result, output, errors, adb = self.run_command(["set", name, raw], wire)
 
                 self.assertEqual(result, 0, errors)
-                self.assertEqual(json.loads(output), {"tweaks": [{"name": name, "value": expected}]})
+                self.assertEqual(output, "")
                 self.assertEqual(wire.requests[0], ("GET", "/tweaks", None))
                 self.assertEqual(len(wire.requests), 2)
                 self.assertEqual(wire.requests[1][0:2], ("PATCH", "/tweaks"))
@@ -1300,7 +1311,7 @@ class TweakCommandTests(unittest.TestCase):
         for name, raw in cases:
             with self.subTest(name=name, value=raw):
                 with TweakHTTPServer() as wire:
-                    result, output, errors, adb = self.run_command(["set", name, raw, "--json"], wire)
+                    result, output, errors, adb = self.run_command(["set", name, raw], wire)
 
                 self.assertEqual(result, 1)
                 self.assertEqual(output, "")
@@ -1308,62 +1319,18 @@ class TweakCommandTests(unittest.TestCase):
                 self.assertEqual(wire.requests, [("GET", "/tweaks", None)])
                 self.assertEqual(adb.calls[-1], ("emulator-5554", ("forward", "--remove", f"tcp:{wire.port}")))
 
-    def test_set_applies_a_typed_json_batch_in_one_atomic_patch(self):
-        values = {
-            "Typography/Font size": -2,
-            "Motion/Damping ratio": -0.5,
-            "Motion/Enabled": False,
-            "Preview/Text value": "true",
-        }
-        with TweakHTTPServer() as wire:
-            result, output, errors, _ = self.run_command(
-                ["set", "--values-json", json.dumps(values), "--json"],
-                wire,
-            )
-
-        self.assertEqual(result, 0, errors)
-        self.assertEqual(wire.requests, [("GET", "/tweaks", None), ("PATCH", "/tweaks", {"values": values})])
-        self.assertEqual(
-            json.loads(output),
-            {"tweaks": [{"name": name, "value": value} for name, value in values.items()]},
-        )
-
-    def test_invalid_json_batches_never_partially_update_tweaks(self):
-        batches = (
-            "{",
-            "[]",
-            "{}",
-            '{"Motion/Enabled":"false"}',
-            '{"Typography/Font size":true}',
-            '{"Motion/Damping ratio":NaN}',
-            '{"Motion/Damping ratio":' + "9" * 400 + "}",
-            '{"Motion/Enabled":false,"Motion/Missing":12}',
-        )
-        for batch in batches:
-            with self.subTest(batch=batch):
-                with TweakHTTPServer() as wire:
-                    result, output, errors, _ = self.run_command(
-                        ["set", "--values-json", batch, "--json"],
-                        wire,
-                    )
-
-                self.assertEqual(result, 1)
-                self.assertEqual(output, "")
-                self.assertTrue(errors.startswith("snapo:"), errors)
-                self.assertEqual(wire.requests, [("GET", "/tweaks", None)])
-
     def test_reset_one_tweak_patches_its_declared_default(self):
         descriptors = tweak_descriptors()
         descriptors[0]["value"] = 24
         with TweakHTTPServer(descriptors=descriptors) as wire:
             result, output, errors, _ = self.run_command(
-                ["reset", "Typography/Font size", "--json"],
+                ["reset", "Typography/Font size"],
                 wire,
             )
 
         self.assertEqual(result, 0, errors)
         self.assertEqual(wire.requests[1], ("PATCH", "/tweaks", {"values": {"Typography/Font size": 16}}))
-        self.assertEqual(json.loads(output), {"tweaks": [{"name": "Typography/Font size", "value": 16}]})
+        self.assertEqual(output, "")
 
     def test_reset_all_patches_every_default_in_one_atomic_request(self):
         descriptors = tweak_descriptors()
@@ -1371,11 +1338,11 @@ class TweakCommandTests(unittest.TestCase):
         descriptors[2]["value"] = False
         defaults = {descriptor["name"]: descriptor["default"] for descriptor in descriptors}
         with TweakHTTPServer(descriptors=descriptors) as wire:
-            result, output, errors, _ = self.run_command(["reset", "--all", "--json"], wire)
+            result, output, errors, _ = self.run_command(["reset", "--all"], wire)
 
         self.assertEqual(result, 0, errors)
         self.assertEqual(wire.requests, [("GET", "/tweaks", None), ("PATCH", "/tweaks", {"values": defaults})])
-        self.assertEqual(len(json.loads(output)["tweaks"]), len(descriptors))
+        self.assertEqual(output, "")
 
     def test_reset_requires_exactly_one_target(self):
         for arguments in (["reset"], ["reset", "Motion/Enabled", "--all"]):
@@ -1387,11 +1354,10 @@ class TweakCommandTests(unittest.TestCase):
                 self.assertEqual(error.exception.code, 2)
                 self.assertIn("reset requires either NAME or --all", errors.getvalue())
 
-    def test_set_requires_either_one_value_or_an_atomic_batch(self):
+    def test_set_requires_a_name_and_value(self):
         invalid = (
             ["set"],
             ["set", "Motion/Enabled"],
-            ["set", "Motion/Enabled", "true", "--values-json", '{"Motion/Enabled":false}'],
         )
         for arguments in invalid:
             with self.subTest(arguments=arguments):
@@ -1402,12 +1368,26 @@ class TweakCommandTests(unittest.TestCase):
                 self.assertEqual(error.exception.code, 2)
                 self.assertIn("set", errors.getvalue())
 
+    def test_mutations_do_not_accept_json_output(self):
+        for command in (
+            ["set", "Motion/Enabled", "false", "--json"],
+            ["reset", "Motion/Enabled", "--json"],
+        ):
+            with self.subTest(command=command):
+                errors = io.StringIO()
+                with contextlib.redirect_stderr(errors):
+                    with self.assertRaises(SystemExit) as error:
+                        snapo.parser().parse_args(["tweaks", *command])
+
+                self.assertEqual(error.exception.code, 2)
+                self.assertIn("unrecognized arguments: --json", errors.getvalue())
+
     def test_server_validation_errors_reach_stderr_and_remove_the_forward(self):
         for status, detail in ((404, "Unknown tweak: Motion/Enabled"), (422, "Value exceeds the maximum.")):
             with self.subTest(status=status):
                 with TweakHTTPServer(error=(status, detail)) as wire:
                     result, output, errors, adb = self.run_command(
-                        ["set", "Motion/Enabled", "false", "--json"],
+                        ["set", "Motion/Enabled", "false"],
                         wire,
                     )
 
@@ -1554,22 +1534,22 @@ class OutputTests(unittest.TestCase):
         adb = FakeADB()
         stdout = io.StringIO()
         with WireServer(handler) as wire:
+            adb.forward_port = wire.port
             with mock.patch.object(snapo, "resolve_adb", return_value="/configured/adb"):
                 with mock.patch.object(snapo, "ADB", return_value=adb):
-                    with mock.patch.object(snapo, "available_port", return_value=wire.port):
-                        with contextlib.redirect_stdout(stdout):
-                            code = snapo.main(
-                                [
-                                    "network",
-                                    "requests",
-                                    "-s",
-                                    "emulator-5554",
-                                    "-n",
-                                    "snapo_network_42",
-                                    "--no-stream",
-                                    "--json",
-                                ]
-                            )
+                    with contextlib.redirect_stdout(stdout):
+                        code = snapo.main(
+                            [
+                                "network",
+                                "requests",
+                                "-s",
+                                "emulator-5554",
+                                "-n",
+                                "snapo_network_42",
+                                "--no-stream",
+                                "--json",
+                            ]
+                        )
         output = stdout.getvalue()
         self.assertEqual(code, 0)
         self.assertNotIn(REQUEST_SECRET, output)
@@ -1599,21 +1579,21 @@ class OutputTests(unittest.TestCase):
         adb = FakeADB()
         output = ClosedPipe()
         with WireServer(handler) as wire:
+            adb.forward_port = wire.port
             with mock.patch.object(snapo, "resolve_adb", return_value="/configured/adb"):
                 with mock.patch.object(snapo, "ADB", return_value=adb):
-                    with mock.patch.object(snapo, "available_port", return_value=wire.port):
-                        with contextlib.redirect_stdout(output):
-                            code = snapo.main(
-                                [
-                                    "network",
-                                    "requests",
-                                    "-s",
-                                    "emulator-5554",
-                                    "-n",
-                                    "snapo_network_42",
-                                    "--json",
-                                ]
-                            )
+                    with contextlib.redirect_stdout(output):
+                        code = snapo.main(
+                            [
+                                "network",
+                                "requests",
+                                "-s",
+                                "emulator-5554",
+                                "-n",
+                                "snapo_network_42",
+                                "--json",
+                            ]
+                        )
         self.assertEqual(code, 0)
         self.assertTrue(output.closed)
         self.assertEqual(adb.calls[-1], ("emulator-5554", ("forward", "--remove", f"tcp:{wire.port}")))


### PR DESCRIPTION
## Summary

- Treat dash-prefixed strings in `snapo tweaks set NAME VALUE` as literal tweak values, including strings that resemble help flags.
- Wake idle CLI wire-server listeners before joining their worker threads and preserve exceptions raised by the original test body.
- Extend the existing HTTP-backed tweak command coverage and add focused idle-listener teardown regressions.

## Why

Python argument parsing interpreted values such as `-hello` as help and rejected values such as `-foo`, so string tweaks could not reliably receive leading-dash values. Separately, an unused test wire server blocked in `accept()` and could mask the real test failure during teardown.

## Validation

- `python3 -m unittest discover -s tests/snapo_cli -p 'test_*.py'` — 81 tests passed.
- `python3 -m py_compile scripts/snapo tests/snapo_cli/test_snapo.py`
- The equivalent Android upstream CLI suite also passed: 78 tests.