### PR TITLE
Add type-safe enum tweaks across Snap-O inspectors

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ Snap-O can replay network requests that happened before you opened Snap-O, so yo
 
 ## Tweaks (Alpha)
 
-Snap-O Tweaks lets you inspect and adjust Jetpack Compose UI values without rebuilding or restarting your app. Tweaks is an alpha feature; its APIs, behavior, and interface may change.
+Snap-O Tweaks lets you inspect and adjust Jetpack Compose UI values without rebuilding or restarting your app. It supports numbers, colors, booleans, strings, and type-safe enum pickers. Tweaks is an alpha feature; its APIs, behavior, and interface may change.
 
 Follow the [Tweaks developer guide](https://openai.github.io/snap-o/tweaks.html) for setup steps.
 
@@ -125,6 +125,7 @@ snapo network show -s <serial> -n <socket> -r <request-id> --json
 snapo tweaks apps --json
 snapo tweaks list -s <serial> -n <socket> --json
 snapo tweaks set 'Typography/Font size' 42 -s <serial> -n <socket>
+snapo tweaks set 'Motion/Marker shape' RoundedSquare -s <serial> -n <socket>
 snapo tweaks reset 'Typography/Font size' -s <serial> -n <socket>
 ```
 

--- a/contracts/tweaks/README.md
+++ b/contracts/tweaks/README.md
@@ -137,6 +137,13 @@ Return a flat list of currently registered tweaks:
       "type": "string",
       "default": "Make it feel right.",
       "value": "Make it feel right."
+    },
+    {
+      "name": "Marker shape",
+      "type": "enum",
+      "default": "Circle",
+      "value": "Circle",
+      "options": ["Circle", "RoundedSquare", "Square"]
     }
   ]
 }
@@ -149,15 +156,20 @@ until its last usage leaves composition. Its most recently edited value remains
 available if the same complete declaration later returns, but inactive tweaks do
 not appear in default responses or event snapshots.
 
-Usages with the same name must agree on the tweak type, default, and
-constraints. Conflicting declarations are a configuration error.
+Usages with the same name must agree on the tweak type, default, constraints,
+and ordered enum options. Conflicting declarations are a configuration error.
 
-Supported types are `int`, `float`, `boolean`, `color`, and `string`. Integer
-tweaks accept only whole numbers; float tweaks accept whole or fractional
-numbers. Numeric tweaks may include `min`, `max`, and `step`. Only include
-constraints actually supplied by the app. A `step` is relative to `min`, or to
-`default` if no `min` is supplied. Colors use `#RRGGBB`, or `#RRGGBBAA` when
-translucent.
+Supported types are `int`, `float`, `boolean`, `color`, `string`, and `enum`.
+Integer tweaks accept only whole numbers; float tweaks accept whole or
+fractional numbers. Numeric tweaks may include `min`, `max`, and `step`. Only
+include constraints actually supplied by the app. A `step` is relative to
+`min`, or to `default` if no `min` is supplied. Colors use `#RRGGBB`, or
+`#RRGGBBAA` when translucent.
+
+Enum tweaks include an ordered, nonempty `options` array containing the unique
+enum constant names. The descriptor's `default`, current `value`, picker text,
+and `PATCH` values all use those exact names. Preserve declaration order when
+rendering pickers; reject any value not present in `options`.
 
 Compose color defaults keep their exact in-process identity, including color
 space, component precision, and `Color.Unspecified`. The HTTP protocol still
@@ -247,7 +259,8 @@ curl -fsS -X PATCH http://127.0.0.1:43817/tweaks \
       "Animation duration": 550,
       "Spring damping": 0.8,
       "Use spring": false,
-      "Preview text": "A calmer direction."
+      "Preview text": "A calmer direction.",
+      "Marker shape": "RoundedSquare"
     }
   }'
 ```
@@ -261,7 +274,8 @@ curl -fsS -X PATCH http://127.0.0.1:43817/tweaks \
     { "name": "Animation duration", "value": 550 },
     { "name": "Spring damping", "value": 0.8 },
     { "name": "Use spring", "value": false },
-    { "name": "Preview text", "value": "A calmer direction." }
+    { "name": "Preview text", "value": "A calmer direction." },
+    { "name": "Marker shape", "value": "RoundedSquare" }
   ]
 }
 ```
@@ -269,7 +283,8 @@ curl -fsS -X PATCH http://127.0.0.1:43817/tweaks \
 Validate all values before changing any of them. Return `400` for malformed
 requests, `404` when an endpoint or requested tweak does not exist, `405`
 for an unsupported method, `413` for an oversized body, and `422` when a value
-has the wrong type or violates a constraint. Errors use a small JSON body:
+has the wrong type, violates a constraint, or is not one of the declared enum
+option values. Errors use a small JSON body:
 
 ```json
 {
@@ -285,6 +300,8 @@ any tweaks in that request. Reset a value by patching it with its default.
 ```kotlin
 import androidx.compose.runtime.getValue
 import com.openai.snapo.tweaks.tweak
+
+enum class MarkerShape { Circle, RoundedSquare, Square }
 
 @Composable
 fun TweakSpecimen() {
@@ -328,6 +345,7 @@ fun SpecimenAccessory() {
 @Composable
 fun MotionSpecimen() {
     val useSpring by tweak(true, "Use spring")
+    val markerShape by tweak(MarkerShape.Circle, "Marker shape")
 
     val animationSpec = if (useSpring) {
         val stiffness by tweak(280f, "Spring stiffness", 80f..800f, step = 20f)
@@ -340,7 +358,7 @@ fun MotionSpecimen() {
         tween<Float>(durationMillis = durationMillis)
     }
 
-    MotionContent(animationSpec)
+    MotionContent(animationSpec, markerShape)
 }
 ```
 
@@ -371,12 +389,14 @@ what appears in the default response without discarding edits; request
 screens that are no longer in composition.
 
 Provide overloaded `tweak(default, name)` functions for `Int`, `Float`,
-`Color`, `Boolean`, and `String` defaults; each returns its corresponding
+`Color`, `Boolean`, `String`, and enum defaults; each returns its corresponding
 `State<T>`. For strings, name the second argument to distinguish the label from
 the default, as in `tweak("Hello", name = "Greeting")`. Numeric tweaks accept
-an optional range and `step` of the same type. Convert delegated integer values
-into Compose units at the call site, such as `fontSize.sp`. The real and no-op
-artifacts expose the same package and public Compose API.
+an optional range and `step` of the same type. Enum tweaks infer their options
+from declaration order and use each constant's name everywhere. Convert
+delegated integer values into Compose units at the call site, such as
+`fontSize.sp`. The real and no-op artifacts expose the same package and public
+Compose API.
 
 ## Setup
 
@@ -475,7 +495,7 @@ overlay. It does not enable Network Inspector, which has its own
 `snapo.network.allow_release` application flag. The no-op release artifacts are
 still recommended: they return default values, contain no provider, and let R8
 remove unused calls and tweak-name strings. Verify the release APK contains
-neither tweak-name strings nor the live provider, registry, server, or socket.
+neither tweak-only strings nor the live provider, registry, server, or socket.
 
 Phase one requires no Ktor, OkHttp, extra JSON library, Snap-O Mac UI, network
 protocol change, actions, groups, scopes, units, separate tweak IDs, or

--- a/scripts/snapo
+++ b/scripts/snapo
@@ -1031,7 +1031,29 @@ def tweak_descriptors(document):
         for tweak in descriptors
     ):
         raise SnapOError("Snap-O tweaks server returned an invalid tweak list")
+    for descriptor in descriptors:
+        if descriptor["type"] == "enum":
+            validate_enum_tweak(descriptor)
     return descriptors
+
+
+def validate_enum_tweak(descriptor):
+    name = descriptor.get("name", "")
+    options = descriptor.get("options")
+
+    def invalid(reason):
+        raise SnapOError(f"Tweak '{name}' has invalid enum options: {reason}")
+
+    if not isinstance(options, list) or not options:
+        invalid("expected a non-empty option list")
+    if any(not isinstance(option, str) or not option.strip() for option in options):
+        invalid("option names must be nonblank strings")
+    if len(set(options)) != len(options):
+        invalid("option names must be unique")
+
+    for key in ("value", "default"):
+        if not isinstance(descriptor.get(key), str) or descriptor[key] not in options:
+            invalid(f"the {key} must match an option name")
 
 
 def find_tweak(descriptors, name):
@@ -1044,6 +1066,12 @@ def find_tweak(descriptors, name):
 def parse_tweak_value(descriptor, raw):
     kind = descriptor.get("type")
     if kind == "string":
+        return raw
+    if kind == "enum":
+        options = descriptor["options"]
+        if raw not in options:
+            choices = ", ".join(json.dumps(option, ensure_ascii=False) for option in options)
+            raise SnapOError(f"Tweak '{descriptor.get('name', '')}' requires one of: {choices}")
         return raw
     if kind == "boolean":
         value = raw.lower()
@@ -1081,8 +1109,11 @@ def emit_tweak_document(document, as_json):
     tweaks = document.get("tweaks") if isinstance(document.get("tweaks"), list) else [document]
     for tweak in tweaks:
         value = json.dumps(tweak.get("value"), ensure_ascii=False, allow_nan=False)
+        options = ""
+        if tweak.get("type") == "enum":
+            options = f"; options: {json.dumps(tweak['options'], ensure_ascii=False)}"
         kind = f" [{tweak['type']}]" if isinstance(tweak.get("type"), str) else ""
-        print(f"{tweak.get('name', 'unknown')} = {value}{kind}", flush=True)
+        print(f"{tweak.get('name', 'unknown')} = {value}{kind}{options}", flush=True)
 
 
 def run_tweak_apps(adb, options):

--- a/skills/snap-o-tweaks/SKILL.md
+++ b/skills/snap-o-tweaks/SKILL.md
@@ -90,13 +90,16 @@ ADB resolves from `PATH`, `ANDROID_SDK_ROOT`, or `ANDROID_HOME`. Use
 ## Change values only when requested
 
 Inspect the descriptor first: the CLI parses `int`, `float`, `boolean`,
-`color`, and `string` according to their declared types. Quote names containing
-spaces or `/`, string values containing spaces, and hex colors.
+`color`, `string`, and `enum` according to their declared types. Enum
+descriptors include an ordered list of enum names in `options`; use an exact
+option name when setting one. Quote names containing spaces or `/`, string
+values containing spaces, and hex colors.
 
 ```bash
 "$SNAPO_BIN" tweaks set 'Typography/Font size' 42 -s <serial> -n <socket>
 "$SNAPO_BIN" tweaks set 'Motion/Show' false -s <serial> -n <socket>
 "$SNAPO_BIN" tweaks set 'Colors/Accent' '#3B82F6' -s <serial> -n <socket>
+"$SNAPO_BIN" tweaks set 'Appearance/Theme' Dark -s <serial> -n <socket>
 ```
 
 Successful updates and resets produce no output.

--- a/skills/snap-o-tweaks/references/interaction-surfaces.md
+++ b/skills/snap-o-tweaks/references/interaction-surfaces.md
@@ -86,11 +86,14 @@ workflow needs every retained user adjustment, including inactive declarations.
 import androidx.compose.runtime.getValue
 import com.openai.snapo.tweaks.tweak
 
+enum class MotionStyle { Standard, Emphasized }
+
 @Composable
 fun AnimatedContent() {
     val duration by tweak(400, "Motion/Duration", 100..1500, step = 50)
     val enabled by tweak(true, "Motion/Enabled")
-    // Use duration and enabled when rendering the current screen.
+    val style by tweak(MotionStyle.Standard, "Motion/Style")
+    // Use duration, enabled, and style when rendering the current screen.
 }
 ```
 

--- a/skills/snap-o-tweaks/references/protocol.md
+++ b/skills/snap-o-tweaks/references/protocol.md
@@ -69,12 +69,28 @@ The tweak response has this shape:
       "type": "boolean",
       "default": true,
       "value": false
+    },
+    {
+      "name": "Appearance/Theme",
+      "type": "enum",
+      "default": "System",
+      "value": "Dark",
+      "options": ["System", "Light", "Dark"]
     }
   ]
 }
 ```
 
-The available types are `int`, `float`, `boolean`, `color`, and `string`. Preserve actual JSON types: booleans are not strings, integer values cannot be fractional, and floats accept whole or fractional finite numbers. Colors are strings in `#RRGGBB` or `#RRGGBBAA` format. Numeric descriptors may include `min`, `max`, and `step`; step alignment starts at `min`, or at `default` if there is no minimum.
+The available types are `int`, `float`, `boolean`, `color`, `string`, and
+`enum`. Preserve actual JSON types: booleans are not strings, integer values
+cannot be fractional, and floats accept whole or fractional finite numbers.
+Colors are strings in `#RRGGBB` or `#RRGGBBAA` format. Numeric descriptors may
+include `min`, `max`, and `step`; step alignment starts at `min`, or at
+`default` if there is no minimum.
+
+Enum descriptors include a nonempty, ordered `options` array containing unique,
+nonblank enum name strings. The `default` and current `value` are names from
+that list. Send an exact option name in `PATCH /tweaks`.
 
 Plain `GET /tweaks` includes only declarations active in Compose. Add
 `?include=adjusted` to include every tweak successfully adjusted by the user,
@@ -100,13 +116,13 @@ declarations return.
 ```bash
 curl -fsS -X PATCH "$base/tweaks" \
   -H 'Content-Type: application/json' \
-  -d '{"values":{"Motion/Duration":550,"Motion/Enabled":false}}'
+  -d '{"values":{"Motion/Duration":550,"Motion/Enabled":false,"Appearance/Theme":"Dark"}}'
 ```
 
 The response contains the changed names and their resulting values:
 
 ```json
-{"tweaks":[{"name":"Motion/Duration","value":550},{"name":"Motion/Enabled","value":false}]}
+{"tweaks":[{"name":"Motion/Duration","value":550},{"name":"Motion/Enabled","value":false},{"name":"Appearance/Theme","value":"Dark"}]}
 ```
 
 Every value is validated before any update is applied. An invalid, unknown, or
@@ -160,6 +176,6 @@ These relative URLs assume your host serves both the page and the proxy. The And
 
 ## Errors and security
 
-Errors use `{"error":"description"}`. Expect `400` for malformed input, `404` for missing endpoints or inactive tweak names, `405` for unsupported methods, `413` for oversized bodies, and `422` for invalid JSON value types, numeric bounds, numeric steps, or color formats.
+Errors use `{"error":"description"}`. Expect `400` for malformed input, `404` for missing endpoints or inactive tweak names, `405` for unsupported methods, `413` for oversized bodies, and `422` for invalid JSON value types, numeric bounds, numeric steps, color formats, or unknown enum option names.
 
 The socket is app-local and normally enabled only when the Android app is debuggable. Release activation requires an explicit `snapo.tweaks.allow_release` manifest opt-in; release no-op artifacts are preferred. There is no HTTP bearer-token layer: access is controlled by the local socket and the connected ADB boundary. Do not expose a forwarded port or proxy publicly, and treat tweak names and values as potentially sensitive.

--- a/snapo-app-mac/Snap-O/NetworkInspector/NetworkInspectorBridgeModels.swift
+++ b/snapo-app-mac/Snap-O/NetworkInspector/NetworkInspectorBridgeModels.swift
@@ -78,6 +78,7 @@ struct TweakDescriptor: Codable {
   let min: TweakValue?
   let max: TweakValue?
   let step: TweakValue?
+  let options: [String]?
 }
 
 struct TweakList: Codable {

--- a/snapo-link-android/samples/demo-tweaks/panel/README.md
+++ b/snapo-link-android/samples/demo-tweaks/panel/README.md
@@ -84,6 +84,7 @@ To put a tweak in a section, use a `/` in its name:
 val fontSize by tweak(36, "Typography/Font size", 16..72)
 val isMotionEnabled by tweak(true, "Motion/Enabled")
 val animationDuration by tweak(400, "Motion/Duration", 100..1500)
+val markerShape by tweak(MotionMarkerShape.Circle, "Motion/Marker shape")
 ```
 
 The part before `/` is the section. The part after `/` is the label. A tweak
@@ -129,9 +130,10 @@ npm start -- --port 4176
 
 ## Change a live value
 
-Move a slider or choose a color. The app changes at once. The inspector waits
-for each request before it sends the next value or switches to another app.
-You can set one value or all values back.
+Move a slider, choose a color, or select a marker shape by its enum name. The
+app changes at once. The inspector waits for each request before it sends the
+next value or switches to another app. You can set one value or all values
+back.
 
 Turn off **Show** in the **Motion** section to hide the motion preview in the
 sample app. Its animation tweaks leave the composition and vanish from the

--- a/snapo-link-android/samples/demo-tweaks/panel/app.js
+++ b/snapo-link-android/samples/demo-tweaks/panel/app.js
@@ -58,6 +58,13 @@ const mockTweaks = [
   { name: "Motion/Spring stiffness", type: "float", default: 280, value: 280, min: 80, max: 800, step: 20 },
   { name: "Motion/Spring damping", type: "float", default: 0.7, value: 0.7, min: 0.1, max: 1, step: 0.05 },
   { name: "Motion/Use spring", type: "boolean", default: true, value: true },
+  {
+    name: "Motion/Marker shape",
+    type: "enum",
+    default: "Circle",
+    value: "Circle",
+    options: ["Circle", "RoundedSquare", "Square"],
+  },
 ];
 
 let mockSelectedAppId = mockApps[0].id;

--- a/snapo-link-android/samples/demo-tweaks/panel/app.js
+++ b/snapo-link-android/samples/demo-tweaks/panel/app.js
@@ -419,6 +419,7 @@ function updateTweakRow(tweak) {
   if (fields.hex) fields.hex.value = tweak.value;
   if (fields.text) fields.text.value = tweak.value;
   if (fields.checkbox) fields.checkbox.checked = tweak.value;
+  if (fields.selection) fields.selection.value = tweak.value;
 }
 
 function updateValue(tweak, value, delay = 75) {
@@ -652,6 +653,30 @@ function makeStringTweak(tweak) {
   });
 }
 
+function makeEnumTweak(tweak) {
+  const row = node("div", "tweak-row");
+  const { line, actions, reset } = makeTweakLine(tweak);
+  const input = node("select", "enum-input");
+
+  input.setAttribute("aria-label", tweak.name);
+  input.replaceChildren(...tweak.options.map((value) => {
+    const option = node("option", undefined, value);
+    option.value = value;
+    return option;
+  }));
+  input.value = tweak.value;
+  input.addEventListener("change", () => {
+    updateValue(tweak, input.value, 0);
+  });
+
+  actions.append(input);
+  row.append(line);
+  return registerTweakRow(tweak, row, {
+    reset,
+    selection: input,
+  });
+}
+
 function makeTweak(tweak) {
   switch (tweak.type) {
     case "int":
@@ -663,6 +688,8 @@ function makeTweak(tweak) {
       return makeBooleanTweak(tweak);
     case "string":
       return makeStringTweak(tweak);
+    case "enum":
+      return makeEnumTweak(tweak);
     default:
       return null;
   }
@@ -783,9 +810,19 @@ function sameTweakShape(current, incoming) {
       tweak.default === next.default &&
       tweak.min === next.min &&
       tweak.max === next.max &&
-      tweak.step === next.step
+      tweak.step === next.step &&
+      sameTweakOptions(tweak.options, next.options)
     );
   });
+}
+
+function sameTweakOptions(current, incoming) {
+  if (current === undefined || incoming === undefined) {
+    return current === incoming;
+  }
+
+  return current.length === incoming.length &&
+    current.every((option, index) => option === incoming[index]);
 }
 
 function applyTweakSnapshot(incoming) {
@@ -801,7 +838,11 @@ function applyTweakSnapshot(incoming) {
     }
 
     const fields = state.rows.get(next.name);
-    if (current && Object.values(fields ?? {}).includes(document.activeElement)) {
+    if (
+      current &&
+      fields?.selection !== document.activeElement &&
+      Object.values(fields ?? {}).includes(document.activeElement)
+    ) {
       return { ...next, value: current.value };
     }
 

--- a/snapo-link-android/samples/demo-tweaks/panel/app.test.mjs
+++ b/snapo-link-android/samples/demo-tweaks/panel/app.test.mjs
@@ -278,7 +278,14 @@ function jsonResponse(payload, status = 200) {
 
 test("browser panel renders, streams, validates, and resets live tweaks", async () => {
   const document = makeDocument();
-  const tweaks = structuredClone(descriptors);
+  const markerShape = {
+    name: "Motion/Marker shape",
+    type: "enum",
+    default: "Circle",
+    value: "Circle",
+    options: ["Circle", "RoundedSquare"],
+  };
+  const tweaks = [...structuredClone(descriptors), markerShape];
   const patches = [];
   const originalDocument = globalThis.document;
   const originalFetch = globalThis.fetch;
@@ -357,7 +364,7 @@ test("browser panel renders, streams, validates, and resets live tweaks", async 
       document.querySelector("#connection-status").getAttribute("aria-label"),
       "Connected",
     );
-    assert.equal(document.querySelector("#tweak-sections").childElementCount, 1);
+    assert.equal(document.querySelector("#tweak-sections").childElementCount, 2);
     assert.equal(findTweakList(document).childElementCount, 10);
     assert.equal(document.properties.has("--accent"), false);
     assert.equal(document.querySelector("#reset-button").disabled, true);
@@ -427,6 +434,15 @@ test("browser panel renders, streams, validates, and resets live tweaks", async 
     spring.checked = false;
     await spring.emit("change");
 
+    const marker = findInput(findTweakList(document, "Motion"), markerShape.name);
+    assert.equal(marker.tagName, "SELECT");
+    assert.deepEqual(
+      marker.children.map((option) => [option.value, option.textContent]),
+      markerShape.options.map((option) => [option, option]),
+    );
+    marker.value = "RoundedSquare";
+    await marker.emit("change");
+
     const preview = findInput(appearance, "Preview text");
     preview.value = "A calmer direction.";
     await preview.emit("input");
@@ -444,6 +460,7 @@ test("browser panel renders, streams, validates, and resets live tweaks", async 
       "Spring stiffness": 400,
       "Spring damping": 0.8,
       "Use spring": false,
+      "Motion/Marker shape": "RoundedSquare",
       "Preview text": "A calmer direction.",
     });
     assert.equal(document.properties.has("--accent"), false);
@@ -456,6 +473,14 @@ test("browser panel renders, streams, validates, and resets live tweaks", async 
     assert.deepEqual(patches.at(-1), { "Accent color": "#5468FF" });
     assert.equal(resetAccent.hidden, true);
     assert.equal(document.properties.has("--accent"), false);
+
+    const resetMarker = findInput(findTweakList(document, "Motion"), "Reset Motion/Marker shape");
+    assert.equal(resetMarker.hidden, false);
+    await resetMarker.emit("click");
+    await delay(0);
+    assert.deepEqual(patches.at(-1), { "Motion/Marker shape": "Circle" });
+    assert.equal(marker.value, "Circle");
+    assert.equal(resetMarker.hidden, true);
 
     const patchesBeforeInvalid = patches.length;
     fontWeight.value = "701";
@@ -470,7 +495,7 @@ test("browser panel renders, streams, validates, and resets live tweaks", async 
     assert.equal(patches.length, patchesBeforeReset + 1);
     assert.deepEqual(
       patches.at(-1),
-      Object.fromEntries(descriptors.map((tweak) => [tweak.name, tweak.default])),
+      Object.fromEntries(tweaks.map((tweak) => [tweak.name, tweak.default])),
     );
     assert.equal(document.querySelector("#reset-button").disabled, true);
     assert.equal(document.properties.has("--accent"), false);
@@ -1189,6 +1214,13 @@ test("motion tweaks appear and disappear as the visibility tweak changes composi
 
 test("streams batched composition changes without polling tweak values", async () => {
   const document = makeDocument();
+  const markerShape = {
+    name: "Motion/Marker shape",
+    type: "enum",
+    default: "Circle",
+    value: "Circle",
+    options: ["Circle", "RoundedSquare"],
+  };
   const originalDocument = globalThis.document;
   const originalFetch = globalThis.fetch;
   const originalEventSource = globalThis.EventSource;
@@ -1275,6 +1307,26 @@ test("streams batched composition changes without polling tweak values", async (
       findInput(findTweakList(document, "Motion"), "Motion/Duration").value,
       "550",
     );
+
+    sources[0].emitTweaks([typography, motion, markerShape]);
+    let marker = findInput(findTweakList(document, "Motion"), markerShape.name);
+    document.activeElement = marker;
+    sources[0].emitTweaks([typography, motion, {
+      ...markerShape,
+      value: "RoundedSquare",
+    }]);
+    assert.equal(marker.value, "RoundedSquare");
+
+    const expandedOptions = ["Circle", "RoundedSquare", "Square"];
+    sources[0].emitTweaks([typography, motion, {
+      ...markerShape,
+      value: "Square",
+      options: expandedOptions,
+    }]);
+    marker = findInput(findTweakList(document, "Motion"), markerShape.name);
+    assert.equal(marker.value, "Square");
+    assert.deepEqual(marker.children.map((option) => option.value), expandedOptions);
+    document.activeElement = undefined;
 
     sources[0].emitTweaks([typography]);
 

--- a/snapo-link-android/samples/demo-tweaks/panel/styles.css
+++ b/snapo-link-android/samples/demo-tweaks/panel/styles.css
@@ -62,7 +62,8 @@ body {
 }
 
 button,
-input {
+input,
+select {
   font: inherit;
 }
 
@@ -623,7 +624,8 @@ button {
 }
 
 .number-input,
-.hex-input {
+.hex-input,
+.enum-input {
   min-width: 0;
   border: 1px solid transparent;
   border-radius: 4px;
@@ -637,7 +639,8 @@ button {
 
 .number-input:hover,
 .hex-input:hover,
-.string-input:hover {
+.string-input:hover,
+.enum-input:hover {
   background: var(--input-hover);
 }
 
@@ -649,6 +652,10 @@ button {
 .hex-input {
   width: 88px;
   text-transform: uppercase;
+}
+
+.enum-input {
+  max-width: 168px;
 }
 
 .number-input[aria-invalid="true"],
@@ -702,7 +709,8 @@ button {
 }
 
 button:focus-visible,
-input:focus-visible {
+input:focus-visible,
+select:focus-visible {
   outline: 2px solid var(--control-accent);
   outline-offset: 2px;
 }

--- a/snapo-link-android/samples/demo-tweaks/src/main/java/com/openai/snapo/demo/tweaks/MainActivity.kt
+++ b/snapo-link-android/samples/demo-tweaks/src/main/java/com/openai/snapo/demo/tweaks/MainActivity.kt
@@ -25,6 +25,7 @@ import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.windowInsetsPadding
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.Button
 import androidx.compose.material3.HorizontalDivider
@@ -44,6 +45,8 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.drawBehind
 import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.RectangleShape
+import androidx.compose.ui.graphics.Shape
 import androidx.compose.ui.layout.layout
 import androidx.compose.ui.semantics.Role
 import androidx.compose.ui.text.font.FontWeight
@@ -57,6 +60,12 @@ import kotlin.math.roundToInt
 private val DefaultTextColor = Color(0xFF18212F)
 private val DefaultBackgroundColor = Color(0xFFF7F8FA)
 private val DefaultAccentColor = Color(0xFF5468FF)
+
+private enum class MotionMarkerShape(val shape: Shape) {
+    Circle(CircleShape),
+    RoundedSquare(RoundedCornerShape(28)),
+    Square(RectangleShape),
+}
 
 class MainActivity : ComponentActivity() {
 
@@ -315,6 +324,7 @@ private fun MotionTrack(
     val mutedColor = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.55f)
     val trackColor = accentColor.copy(alpha = 0.22f)
     val trackThickness by tweak(2f, "Motion/Track thickness", 1f..8f, step = 0.5f)
+    val markerShape by tweak(MotionMarkerShape.Circle, "Motion/Marker shape")
 
     Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
         Row(
@@ -345,7 +355,7 @@ private fun MotionTrack(
                 modifier = Modifier
                     .motionMarkerOffset(progress)
                     .size(markerSize)
-                    .background(accentColor, CircleShape),
+                    .background(accentColor, markerShape.shape),
             )
         }
     }

--- a/snapo-link-android/tweaks-noop/src/main/java/com/openai/snapo/tweaks/SnapOTweaks.kt
+++ b/snapo-link-android/tweaks-noop/src/main/java/com/openai/snapo/tweaks/SnapOTweaks.kt
@@ -75,4 +75,11 @@ sealed interface SnapOTweakValue {
     @Immutable
     @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
     data class Text(val value: String) : SnapOTweakValue
+
+    @Immutable
+    @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
+    data class Selection(
+        val value: String,
+        val options: List<String>,
+    ) : SnapOTweakValue
 }

--- a/snapo-link-android/tweaks-noop/src/main/java/com/openai/snapo/tweaks/Tweaks.kt
+++ b/snapo-link-android/tweaks-noop/src/main/java/com/openai/snapo/tweaks/Tweaks.kt
@@ -45,3 +45,10 @@ fun tweak(
     default: String,
     name: String,
 ): State<String> = rememberUpdatedState(default)
+
+/** Returns observable release-build state for the current enum default. */
+@Composable
+fun <E : Enum<E>> tweak(
+    default: E,
+    name: String,
+): State<E> = rememberUpdatedState(default)

--- a/snapo-link-android/tweaks-overlay/src/main/java/com/openai/snapo/tweaks/overlay/TweakOverlayControls.kt
+++ b/snapo-link-android/tweaks-overlay/src/main/java/com/openai/snapo/tweaks/overlay/TweakOverlayControls.kt
@@ -1,6 +1,7 @@
 package com.openai.snapo.tweaks.overlay
 
 import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
 import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
@@ -13,12 +14,15 @@ import androidx.compose.foundation.layout.offset
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.requiredHeight
 import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.sizeIn
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.text.BasicTextField
 import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.material3.Checkbox
 import androidx.compose.material3.CheckboxDefaults
+import androidx.compose.material3.DropdownMenu
+import androidx.compose.material3.DropdownMenuItem
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
@@ -38,6 +42,9 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.focus.onFocusChanged
 import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.semantics.Role
+import androidx.compose.ui.semantics.contentDescription
+import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.text.style.TextAlign
@@ -92,6 +99,9 @@ internal fun TweakOverlayControl(
             }
             is SnapOTweakValue.Toggle -> TweakOverlayLabelRow(tweak) {
                 TweakToggleField(tweak)
+            }
+            is SnapOTweakValue.Selection -> TweakOverlayLabelRow(tweak) {
+                TweakSelectionField(tweak)
             }
             is SnapOTweakValue.ColorValue -> TweakOverlayLabelRow(tweak) {
                 TweakColorField(tweak, onSelectColor)
@@ -270,6 +280,66 @@ private fun TweakToggleField(tweak: SnapOTweakEntry) {
             uncheckedColor = TweakOverlayColors.secondary,
         ),
     )
+}
+
+@Composable
+private fun TweakSelectionField(tweak: SnapOTweakEntry) {
+    val selection = tweak.value.value as SnapOTweakValue.Selection
+    var expanded by remember { mutableStateOf(false) }
+
+    Box {
+        Row(
+            modifier = Modifier
+                .sizeIn(minWidth = 48.dp, minHeight = 48.dp)
+                .clickable(
+                    role = Role.Button,
+                    onClick = { expanded = true },
+                )
+                .semantics {
+                    contentDescription = "Choose option for ${tweak.name}. Current value: ${selection.value}"
+                }
+                .padding(start = 8.dp),
+            verticalAlignment = Alignment.CenterVertically,
+            horizontalArrangement = Arrangement.spacedBy(6.dp),
+        ) {
+            TweakFieldText(selection.value)
+            Text(text = "▾", color = TweakOverlayColors.secondary, fontSize = 11.sp)
+        }
+
+        DropdownMenu(
+            expanded = expanded,
+            onDismissRequest = { expanded = false },
+            modifier = Modifier.background(TweakOverlayColors.surface),
+        ) {
+            selection.options.forEach { option ->
+                DropdownMenuItem(
+                    text = {
+                        Text(
+                            text = option,
+                            color = TweakOverlayColors.foreground,
+                            fontSize = 13.sp,
+                        )
+                    },
+                    onClick = {
+                        expanded = false
+                        SnapOTweaks.update(tweak.name, selection.copy(value = option))
+                    },
+                    trailingIcon = if (option == selection.value) {
+                        {
+                            Icon(
+                                painter = painterResource(R.drawable.snapo_tweaks_check),
+                                contentDescription = null,
+                                modifier = Modifier.size(16.dp),
+                                tint = TweakOverlayColors.foreground,
+                            )
+                        }
+                    } else {
+                        null
+                    },
+                )
+            }
+        }
+    }
 }
 
 @Composable

--- a/snapo-link-android/tweaks/src/main/java/com/openai/snapo/tweaks/SnapOTweaks.kt
+++ b/snapo-link-android/tweaks/src/main/java/com/openai/snapo/tweaks/SnapOTweaks.kt
@@ -81,6 +81,13 @@ sealed interface SnapOTweakValue {
     @Immutable
     @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
     data class Text(val value: String) : SnapOTweakValue
+
+    @Immutable
+    @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
+    data class Selection(
+        val value: String,
+        val options: List<String>,
+    ) : SnapOTweakValue
 }
 
 private fun TweakSnapshot.toSnapOTweak(): SnapOTweak = SnapOTweak(
@@ -107,6 +114,7 @@ internal fun TweakDescriptor.toSnapOTweakValue(value: Any): SnapOTweakValue = wh
     TweakType.BOOLEAN -> SnapOTweakValue.Toggle(value as Boolean)
     TweakType.COLOR -> SnapOTweakValue.ColorValue((value as TweakColorValue).color)
     TweakType.STRING -> SnapOTweakValue.Text(value as String)
+    TweakType.ENUM -> SnapOTweakValue.Selection(value as String, options)
 }
 
 private fun SnapOTweakValue.toRegistryValue(): Any = when (this) {
@@ -115,4 +123,5 @@ private fun SnapOTweakValue.toRegistryValue(): Any = when (this) {
     is SnapOTweakValue.Toggle -> value
     is SnapOTweakValue.ColorValue -> value.toTweakColorValue()
     is SnapOTweakValue.Text -> value
+    is SnapOTweakValue.Selection -> value
 }

--- a/snapo-link-android/tweaks/src/main/java/com/openai/snapo/tweaks/Tweaks.kt
+++ b/snapo-link-android/tweaks/src/main/java/com/openai/snapo/tweaks/Tweaks.kt
@@ -94,6 +94,38 @@ fun tweak(
     default = default,
 ) { value -> value as String }
 
+/** Exposes every enum constant, in declaration order, as a selection using [Enum.name]. */
+@Composable
+fun <E : Enum<E>> tweak(
+    default: E,
+    name: String,
+): State<E> {
+    if (!TweaksRuntimePolicy.isAllowed) return rememberUpdatedState(default)
+
+    val enumClass = default.declaringJavaClass
+    val descriptor = remember(default, name) { enumTweakDescriptor(default, name) }
+    val decode = remember(enumClass) {
+        val decoder: (Any) -> E = { value ->
+            java.lang.Enum.valueOf(enumClass, value as String)
+        }
+        decoder
+    }
+
+    return rememberTweakState(descriptor, default, decode)
+}
+
+internal fun <E : Enum<E>> enumTweakDescriptor(
+    default: E,
+    name: String,
+): TweakDescriptor = TweakDescriptor(
+    name = name,
+    type = TweakType.ENUM,
+    default = default.name,
+    options = requireNotNull(default.declaringJavaClass.enumConstants).map { option ->
+        option.name
+    },
+)
+
 @Composable
 private fun <T> rememberTweakState(
     descriptor: TweakDescriptor,

--- a/snapo-link-android/tweaks/src/main/java/com/openai/snapo/tweaks/internal/TweakHttpServer.kt
+++ b/snapo-link-android/tweaks/src/main/java/com/openai/snapo/tweaks/internal/TweakHttpServer.kt
@@ -496,6 +496,7 @@ internal class TweakHttpServer(
 
         if (includeDescriptor) {
             writeConstraints(writer, tweak.descriptor)
+            writeOptions(writer, tweak.descriptor)
         }
 
         writer.endObject()
@@ -505,6 +506,16 @@ internal class TweakHttpServer(
         descriptor.min?.let { minimum -> writer.name("min").value(minimum) }
         descriptor.max?.let { maximum -> writer.name("max").value(maximum) }
         descriptor.step?.let { increment -> writer.name("step").value(increment) }
+    }
+
+    private fun writeOptions(writer: JsonWriter, descriptor: TweakDescriptor) {
+        if (descriptor.type != TweakType.ENUM) return
+
+        writer.name("options").beginArray()
+        descriptor.options.forEach { option ->
+            writer.value(option)
+        }
+        writer.endArray()
     }
 
     private fun writeJsonValue(writer: JsonWriter, value: Any) {

--- a/snapo-link-android/tweaks/src/main/java/com/openai/snapo/tweaks/internal/TweakRegistry.kt
+++ b/snapo-link-android/tweaks/src/main/java/com/openai/snapo/tweaks/internal/TweakRegistry.kt
@@ -19,6 +19,7 @@ internal enum class TweakType(val wireName: String) {
     BOOLEAN("boolean"),
     COLOR("color"),
     STRING("string"),
+    ENUM("enum"),
 }
 
 internal data class TweakDescriptor(
@@ -28,6 +29,7 @@ internal data class TweakDescriptor(
     val min: Number? = null,
     val max: Number? = null,
     val step: Number? = null,
+    val options: List<String> = emptyList(),
 )
 
 internal data class TweakSnapshot(
@@ -226,6 +228,14 @@ internal object TweakRegistry {
             TweakType.STRING -> require(descriptor.default is String) {
                 "String tweaks must have a string default: ${descriptor.name}"
             }
+
+            TweakType.ENUM -> validateEnumDescriptor(descriptor)
+        }
+
+        if (descriptor.type != TweakType.ENUM) {
+            require(descriptor.options.isEmpty()) {
+                "Only enum tweaks can define selectable options: ${descriptor.name}"
+            }
         }
 
         if (descriptor.type != TweakType.INT && descriptor.type != TweakType.FLOAT) {
@@ -234,6 +244,24 @@ internal object TweakRegistry {
             ) {
                 "Only numeric tweaks can define numeric constraints: ${descriptor.name}"
             }
+        }
+    }
+
+    private fun validateEnumDescriptor(descriptor: TweakDescriptor) {
+        require(descriptor.default is String) {
+            "Enum tweaks must have an enum-name default: ${descriptor.name}"
+        }
+        require(descriptor.options.isNotEmpty()) {
+            "Enum tweaks must define at least one option: ${descriptor.name}"
+        }
+        require(descriptor.options.all { option -> option.isNotBlank() }) {
+            "Enum option values must not be blank: ${descriptor.name}"
+        }
+        require(descriptor.options.distinct().size == descriptor.options.size) {
+            "Enum option values must be unique: ${descriptor.name}"
+        }
+        require(descriptor.default in descriptor.options) {
+            "Enum tweak defaults must match a declared option: ${descriptor.name}"
         }
     }
 
@@ -317,10 +345,7 @@ internal object TweakRegistry {
                 value as? Boolean ?: invalidValue(descriptor, "Expected a boolean.")
             }
 
-            TweakType.STRING -> {
-                value as? String ?: invalidValue(descriptor, "Expected a string.")
-            }
-
+            TweakType.STRING, TweakType.ENUM -> validateStringValue(descriptor, value)
             TweakType.COLOR -> {
                 val defaultColor = descriptor.default as TweakColorValue
 
@@ -354,6 +379,20 @@ internal object TweakRegistry {
                 }
             }
         }
+
+    private fun validateStringValue(descriptor: TweakDescriptor, value: Any?): String {
+        val isEnum = descriptor.type == TweakType.ENUM
+        val selection = value as? String
+            ?: invalidValue(
+                descriptor,
+                if (isEnum) "Expected an enum name." else "Expected a string.",
+            )
+        if (isEnum && selection !in descriptor.options) {
+            invalidValue(descriptor, "Expected one of the declared enum options.")
+        }
+
+        return selection
+    }
 
     private fun validateNumericValue(descriptor: TweakDescriptor, value: Any?): Number {
         val number = value as? Number

--- a/snapo-link-android/tweaks/src/test/java/com/openai/snapo/tweaks/SnapOTweaksTest.kt
+++ b/snapo-link-android/tweaks/src/test/java/com/openai/snapo/tweaks/SnapOTweaksTest.kt
@@ -85,6 +85,32 @@ class SnapOTweaksTest {
     }
 
     @Test
+    fun `enum overlay values expose and update enum constant names`() {
+        val options = listOf("System", "Light", "Dark")
+        val descriptor = TweakDescriptor(
+            name = "Appearance/Theme",
+            type = TweakType.ENUM,
+            default = "System",
+            options = options,
+        )
+        val state = TweakRegistry.register(descriptor)
+        val entry = SnapOTweaks.activeTweakEntries().value.single()
+
+        assertEquals(SnapOTweakValue.Selection("System", options), entry.value.value)
+        assertEquals(SnapOTweakValue.Selection("System", options), entry.defaultValue)
+
+        SnapOTweaks.update(descriptor.name, SnapOTweakValue.Selection("Dark", options))
+
+        assertEquals("Dark", state.value)
+        assertEquals(SnapOTweakValue.Selection("Dark", options), entry.value.value)
+
+        SnapOTweaks.update(descriptor.name, entry.defaultValue)
+
+        assertEquals("System", state.value)
+        assertEquals(SnapOTweakValue.Selection("System", options), entry.value.value)
+    }
+
+    @Test
     fun `overlay updates remain available as adjusted history after leaving composition`() {
         val descriptor = TweakDescriptor(
             name = "Typography/Historical font size",

--- a/snapo-link-android/tweaks/src/test/java/com/openai/snapo/tweaks/TweakRegistrationTest.kt
+++ b/snapo-link-android/tweaks/src/test/java/com/openai/snapo/tweaks/TweakRegistrationTest.kt
@@ -183,6 +183,50 @@ class TweakRegistrationTest {
     }
 
     @Test
+    fun `enum tweak descriptors default to enum names in declaration order`() {
+        val descriptor = enumTweakDescriptor(
+            default = PreviewMode.Dark,
+            name = "Appearance/Preview mode",
+        )
+
+        assertEquals(TweakType.ENUM, descriptor.type)
+        assertEquals("Dark", descriptor.default)
+        assertEquals(listOf("System", "Light", "Dark"), descriptor.options)
+    }
+
+    @Test
+    fun `enum registrations decode updated constant names into their original type`() {
+        val descriptor = enumTweakDescriptor(
+            default = PreviewMode.Light,
+            name = "Appearance/Preview mode",
+        )
+        val registration = TweakRegistration(descriptor) { storedValue ->
+            PreviewMode.valueOf(storedValue as String)
+        }
+
+        assertEquals("Light", descriptor.default)
+        assertEquals(listOf("System", "Light", "Dark"), descriptor.options)
+        assertEquals(PreviewMode.Light, registration.value)
+
+        registration.onRemembered()
+        TweakRegistry.update(mapOf(descriptor.name to "Dark"))
+
+        assertEquals(PreviewMode.Dark, registration.value)
+        registration.onForgotten()
+    }
+
+    @Test
+    fun `enum tweaks discover every option when the default has a constant specific body`() {
+        val descriptor = enumTweakDescriptor(
+            default = SpecializedPreviewMode.Automatic,
+            name = "Appearance/Specialized preview mode",
+        )
+
+        assertEquals("Automatic", descriptor.default)
+        assertEquals(listOf("Automatic", "Manual"), descriptor.options)
+    }
+
+    @Test
     fun `registrations do not decode their values until observed`() {
         var decodes = 0
         val state = TweakRegistration(descriptor()) { value ->
@@ -421,4 +465,17 @@ class TweakRegistrationTest {
         type = TweakType.INT,
         default = 16,
     )
+
+    private enum class PreviewMode {
+        System,
+        Light,
+        Dark,
+    }
+
+    private enum class SpecializedPreviewMode {
+        Automatic {
+            override fun toString(): String = "Automatic"
+        },
+        Manual,
+    }
 }

--- a/snapo-link-android/tweaks/src/test/java/com/openai/snapo/tweaks/internal/TweakEnumRegistryLifecycleTest.kt
+++ b/snapo-link-android/tweaks/src/test/java/com/openai/snapo/tweaks/internal/TweakEnumRegistryLifecycleTest.kt
@@ -1,0 +1,90 @@
+package com.openai.snapo.tweaks.internal
+
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotSame
+import org.junit.Assert.assertSame
+import org.junit.Assert.assertThrows
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class TweakEnumRegistryLifecycleTest {
+
+    @After
+    fun clearRegistry() {
+        TweakRegistry.clear()
+    }
+
+    @Test
+    fun `conflicting enum defaults do not replace the existing declaration or selection`() {
+        val descriptor = enumDescriptor("Lifecycle conflicting enum defaults")
+        val original = TweakRegistry.register(descriptor)
+        TweakRegistry.update(mapOf(descriptor.name to "Dark"))
+        val conflicting = descriptor.copy(default = "Dark")
+
+        assertThrows(IllegalArgumentException::class.java) {
+            TweakRegistry.register(conflicting)
+        }
+
+        assertEquals("Dark", original.value)
+        assertEquals(descriptor, TweakRegistry.snapshot().single().descriptor)
+
+        TweakRegistry.unregister(descriptor.name)
+
+        assertTrue(TweakRegistry.snapshot().isEmpty())
+    }
+
+    @Test
+    fun `conflicting enum option order or values do not acquire another registration`() {
+        val descriptor = enumDescriptor("Lifecycle conflicting enum options")
+        TweakRegistry.register(descriptor)
+
+        listOf(
+            descriptor.copy(options = descriptor.options.reversed()),
+            descriptor.copy(options = listOf("System", "Light")),
+        ).forEach { conflicting ->
+            assertThrows(IllegalArgumentException::class.java) {
+                TweakRegistry.register(conflicting)
+            }
+        }
+
+        TweakRegistry.unregister(descriptor.name)
+
+        assertTrue(TweakRegistry.snapshot().isEmpty())
+    }
+
+    @Test
+    fun `enum selections survive removal and reject stale options from replacement declarations`() {
+        val original = enumDescriptor("Lifecycle returning enum selection")
+        val state = TweakRegistry.register(original)
+        TweakRegistry.update(mapOf(original.name to "Dark"))
+        TweakRegistry.unregister(original.name)
+
+        val restored = TweakRegistry.register(original.copy())
+
+        assertSame(state, restored)
+        assertEquals("Dark", restored.value)
+
+        TweakRegistry.unregister(original.name)
+
+        val replacement = original.copy(options = listOf("System", "Light"))
+        val replacementState = TweakRegistry.register(replacement)
+
+        assertNotSame(state, replacementState)
+        assertEquals("System", replacementState.value)
+
+        val error = assertThrows(TweakUpdateException::class.java) {
+            TweakRegistry.update(mapOf(replacement.name to "Dark"))
+        }
+
+        assertEquals(422, error.statusCode)
+        assertEquals("System", replacementState.value)
+    }
+
+    private fun enumDescriptor(name: String) = TweakDescriptor(
+        name = name,
+        type = TweakType.ENUM,
+        default = "System",
+        options = listOf("System", "Dark"),
+    )
+}

--- a/snapo-link-android/tweaks/src/test/java/com/openai/snapo/tweaks/internal/TweakEnumValidationTest.kt
+++ b/snapo-link-android/tweaks/src/test/java/com/openai/snapo/tweaks/internal/TweakEnumValidationTest.kt
@@ -1,0 +1,118 @@
+package com.openai.snapo.tweaks.internal
+
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertThrows
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class TweakEnumValidationTest {
+
+    @After
+    fun clearRegistry() {
+        TweakRegistry.clear()
+    }
+
+    @Test
+    fun `enum tweaks accept only their exact constant names`() {
+        val descriptor = enumDescriptor()
+        val state = TweakRegistry.register(descriptor)
+
+        TweakRegistry.update(mapOf(descriptor.name to "Dark"))
+
+        assertEquals("Dark", state.value)
+        assertInvalidUpdate(descriptor.name, "DARK")
+        assertInvalidUpdate(descriptor.name, "Stale")
+        assertInvalidUpdate(descriptor.name, true)
+        assertInvalidUpdate(descriptor.name, null)
+        assertEquals("Dark", state.value)
+    }
+
+    @Test
+    fun `enum tweaks preserve declaration order and wire identity`() {
+        val descriptor = enumDescriptor()
+
+        TweakRegistry.register(descriptor)
+
+        val snapshot = TweakRegistry.snapshot().single()
+        assertEquals("enum", snapshot.descriptor.type.wireName)
+        assertEquals("System", snapshot.value)
+        assertEquals(listOf("System", "Light", "Dark"), snapshot.descriptor.options)
+    }
+
+    @Test
+    fun `invalid enum descriptors are rejected before registration`() {
+        val descriptor = enumDescriptor()
+
+        listOf(
+            descriptor.copy(default = false),
+            descriptor.copy(default = "Missing"),
+            descriptor.copy(options = emptyList()),
+            descriptor.copy(options = listOf("")),
+            descriptor.copy(options = listOf("   ")),
+            descriptor.copy(options = listOf("System", "System")),
+            descriptor.copy(min = 0),
+            descriptor.copy(max = 1),
+            descriptor.copy(step = 1),
+        ).forEach { invalid ->
+            assertThrows(IllegalArgumentException::class.java) {
+                TweakRegistry.register(invalid)
+            }
+        }
+
+        assertTrue(TweakRegistry.snapshot().isEmpty())
+    }
+
+    @Test
+    fun `primitive tweaks cannot declare enum options`() {
+        listOf(
+            TweakDescriptor("Validation optioned string", TweakType.STRING, "System"),
+            TweakDescriptor("Validation optioned boolean", TweakType.BOOLEAN, false),
+            TweakDescriptor("Validation optioned integer", TweakType.INT, 1),
+        ).forEach { descriptor ->
+            assertThrows(IllegalArgumentException::class.java) {
+                TweakRegistry.register(
+                    descriptor.copy(options = listOf("System")),
+                )
+            }
+        }
+
+        assertTrue(TweakRegistry.snapshot().isEmpty())
+    }
+
+    @Test
+    fun `invalid enum selections do not partially apply multi tweak updates`() {
+        val selection = enumDescriptor()
+        val count = TweakDescriptor("Validation atomic enum count", TweakType.INT, 2)
+        val selectionState = TweakRegistry.register(selection)
+        val countState = TweakRegistry.register(count)
+
+        val error = assertThrows(TweakUpdateException::class.java) {
+            TweakRegistry.update(
+                linkedMapOf(
+                    count.name to 4,
+                    selection.name to "Stale",
+                ),
+            )
+        }
+
+        assertEquals(422, error.statusCode)
+        assertEquals("System", selectionState.value)
+        assertEquals(2, countState.value)
+    }
+
+    private fun assertInvalidUpdate(name: String, value: Any?) {
+        val error = assertThrows(TweakUpdateException::class.java) {
+            TweakRegistry.update(mapOf(name to value))
+        }
+
+        assertEquals(422, error.statusCode)
+    }
+
+    private fun enumDescriptor() = TweakDescriptor(
+        name = "Validation appearance mode",
+        type = TweakType.ENUM,
+        default = "System",
+        options = listOf("System", "Light", "Dark"),
+    )
+}

--- a/snapo-network-inspector-web/src/features/tweaks-inspector/TweaksInspectorApp.test.ts
+++ b/snapo-network-inspector-web/src/features/tweaks-inspector/TweaksInspectorApp.test.ts
@@ -1,4 +1,4 @@
-import { createElement } from "react";
+import { createElement, type MouseEvent, type PointerEvent, type ReactElement } from "react";
 import { renderToStaticMarkup } from "react-dom/server";
 import { describe, expect, it, vi } from "vitest";
 import type { SelectedAppInspector, TweakDescriptor } from "../../network/bridge-types";
@@ -11,6 +11,8 @@ import {
   parseTweakColor,
   reconcileStreamedTweaks,
   TweakColorField,
+  TweakEnumListbox,
+  TweakField,
   TweaksEmptyState,
   TweaksInspectorApp,
   tweakColorWithPreservedAlpha
@@ -166,6 +168,113 @@ describe("editable tweak colors", () => {
   });
 });
 
+describe("enumerated tweak values", () => {
+  it("shows the current enum name in an accessible listbox trigger", () => {
+    const markup = renderToStaticMarkup(
+      createElement(TweakField, {
+        tweak: enumTweak(),
+        onChange() {}
+      })
+    );
+
+    expect(markup).toContain('aria-label="Appearance/Theme: System"');
+    expect(markup).toContain('aria-haspopup="listbox"');
+    expect(markup).toContain('aria-expanded="false"');
+    expect(markup).toContain("<span>System</span>");
+  });
+
+  it("shows exact enum names and identifies the selected listbox option", () => {
+    const markup = renderToStaticMarkup(
+      createElement(TweakEnumListbox, {
+        id: "appearance-theme-options",
+        tweak: enumTweak(),
+        onChange() {},
+        onClose() {}
+      })
+    );
+
+    expect(markup).toContain('role="listbox"');
+    expect(markup).toContain('role="option" aria-selected="true" data-option-index="0"');
+    expect(markup).toContain('role="option" aria-selected="false" data-option-index="1"');
+    expect(markup).toContain(">System</button>");
+    expect(markup).toContain(">Dark</button>");
+  });
+
+  it("sends a primary-pointer selection before dismissing the listbox", () => {
+    const events: string[] = [];
+    const preventDefault = vi.fn();
+    const option = enumListboxOption(1, {
+      onChange: (_tweak, value) => events.push(`change:${value}`),
+      onClose: () => events.push("close")
+    });
+
+    option.props.onPointerDown({ button: 0, preventDefault } as unknown as PointerEvent<HTMLButtonElement>);
+    option.props.onClick({ detail: 1 } as MouseEvent<HTMLButtonElement>);
+
+    expect(preventDefault).toHaveBeenCalledOnce();
+    expect(events).toEqual(["change:Dark", "close"]);
+  });
+
+  it("ignores non-primary pointer selection", () => {
+    const onChange = vi.fn();
+    const onClose = vi.fn();
+    const preventDefault = vi.fn();
+    const option = enumListboxOption(1, { onChange, onClose });
+
+    option.props.onPointerDown({ button: 2, preventDefault } as unknown as PointerEvent<HTMLButtonElement>);
+
+    expect(preventDefault).not.toHaveBeenCalled();
+    expect(onChange).not.toHaveBeenCalled();
+    expect(onClose).not.toHaveBeenCalled();
+  });
+
+  it("commits changed keyboard or assistive-technology selections once", () => {
+    const onChange = vi.fn();
+    const onClose = vi.fn();
+    const current = enumListboxOption(0, { onChange, onClose });
+    const changed = enumListboxOption(1, { onChange, onClose });
+
+    current.props.onClick({ detail: 0 } as MouseEvent<HTMLButtonElement>);
+    expect(onChange).not.toHaveBeenCalled();
+
+    changed.props.onClick({ detail: 0 } as MouseEvent<HTMLButtonElement>);
+
+    expect(onChange).toHaveBeenCalledExactlyOnceWith(enumTweak(), "Dark");
+    expect(onClose).toHaveBeenCalledTimes(2);
+  });
+
+  it("updates the displayed selection when its enum name changes", () => {
+    const markup = renderToStaticMarkup(
+      createElement(TweakField, {
+        tweak: { ...enumTweak(), value: "Dark" },
+        onChange() {}
+      })
+    );
+
+    expect(markup).toContain("<span>Dark</span>");
+    expect(markup).not.toContain("<span>System</span>");
+  });
+
+  it("recognizes changed and reset enum values", () => {
+    expect(canResetTweaks([enumTweak()])).toBe(false);
+    expect(canResetTweaks([{ ...enumTweak(), value: "Dark" }])).toBe(true);
+  });
+
+  it("preserves updated enum options while a local selection is pending", () => {
+    const current = [{ ...enumTweak(), value: "Dark" }];
+    const incoming = [
+      {
+        ...enumTweak(),
+        options: ["System", "Light", "Dark"]
+      }
+    ];
+
+    expect(reconcileStreamedTweaks(current, incoming, new Map([["Appearance/Theme", "Dark"]]), new Set())).toEqual([
+      { ...incoming[0], value: "Dark" }
+    ]);
+  });
+});
+
 describe("native reset toolbar state", () => {
   it("disables reset when no tweaks exist", () => {
     expect(canResetTweaks([])).toBe(false);
@@ -298,4 +407,32 @@ function colorTweak(): TweakDescriptor {
     default: "#5468FF80",
     value: "#5468FF80"
   };
+}
+
+function enumTweak(): TweakDescriptor {
+  return {
+    name: "Appearance/Theme",
+    type: "enum",
+    default: "System",
+    value: "System",
+    options: ["System", "Dark"]
+  };
+}
+
+function enumListboxOption(
+  index: number,
+  handlers: {
+    onChange(tweak: TweakDescriptor, value: TweakDescriptor["value"]): void;
+    onClose(): void;
+  }
+): ReactElement<{
+  onPointerDown(event: PointerEvent<HTMLButtonElement>): void;
+  onClick(event: MouseEvent<HTMLButtonElement>): void;
+}> {
+  const listbox = TweakEnumListbox({
+    id: "appearance-theme-options",
+    tweak: enumTweak(),
+    ...handlers
+  });
+  return listbox.props.children[index];
 }

--- a/snapo-network-inspector-web/src/features/tweaks-inspector/TweaksInspectorApp.tsx
+++ b/snapo-network-inspector-web/src/features/tweaks-inspector/TweaksInspectorApp.tsx
@@ -1,5 +1,5 @@
-import { RotateCcw } from "lucide-react";
-import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { ChevronDown, RotateCcw } from "lucide-react";
+import { useCallback, useEffect, useId, useMemo, useRef, useState, type CSSProperties } from "react";
 import type {
   AppInspectorOption,
   InspectableApp,
@@ -428,7 +428,7 @@ function TweakControl({
   );
 }
 
-function TweakField({
+export function TweakField({
   tweak,
   onChange,
   onOpenColorPanel
@@ -453,6 +453,10 @@ function TweakField({
     return <TweakColorField tweak={tweak} onChange={onChange} onOpenColorPanel={onOpenColorPanel} />;
   }
 
+  if (tweak.type === "enum") {
+    return <TweakEnumField tweak={tweak} onChange={onChange} />;
+  }
+
   if (tweak.type === "int" || tweak.type === "float") {
     return (
       <input
@@ -474,6 +478,154 @@ function TweakField({
   }
 
   return null;
+}
+
+function TweakEnumField({
+  tweak,
+  onChange
+}: {
+  tweak: TweakDescriptor;
+  onChange(tweak: TweakDescriptor, value: TweakValue): void;
+}): JSX.Element {
+  const [listboxStyle, setListboxStyle] = useState<CSSProperties | null>(null);
+  const rootRef = useRef<HTMLDivElement>(null);
+  const triggerRef = useRef<HTMLButtonElement>(null);
+  const listboxId = useId();
+  const options = tweak.options ?? [];
+  const expanded = listboxStyle !== null;
+  const close = useCallback(() => {
+    setListboxStyle(null);
+    triggerRef.current?.focus();
+  }, []);
+
+  useEffect(() => {
+    if (!expanded) return;
+
+    const dismissOutside = (event: Event) => {
+      if (event.target instanceof Node && rootRef.current?.contains(event.target)) return;
+      setListboxStyle(null);
+    };
+    const closeOnEscape = (event: KeyboardEvent) => {
+      if (event.key !== "Escape") return;
+      event.preventDefault();
+      close();
+    };
+
+    const controller = new AbortController();
+    const { signal } = controller;
+    window.addEventListener("pointerdown", dismissOutside, { signal });
+    window.addEventListener("keydown", closeOnEscape, { signal });
+    window.addEventListener("scroll", dismissOutside, { capture: true, signal });
+    window.addEventListener("resize", dismissOutside, { signal });
+    return () => controller.abort();
+  }, [close, expanded]);
+
+  const open = () => {
+    const bounds = triggerRef.current?.getBoundingClientRect();
+    if (!bounds) return;
+
+    const availableBelow = window.innerHeight - bounds.bottom;
+    const openAbove = availableBelow < Math.min(options.length * 30 + 8, 240) && bounds.top > availableBelow;
+    setListboxStyle({
+      ...(openAbove ? { bottom: window.innerHeight - bounds.top + 4 } : { top: bounds.bottom + 4 }),
+      right: Math.max(8, window.innerWidth - bounds.right),
+      minWidth: bounds.width,
+      maxHeight: Math.max(80, (openAbove ? bounds.top : availableBelow) - 12)
+    });
+  };
+
+  const navigate = (event: React.KeyboardEvent<HTMLDivElement>) => {
+    if (!["ArrowDown", "ArrowUp", "Home", "End"].includes(event.key) || options.length === 0) return;
+
+    event.preventDefault();
+    const selected = options.indexOf(String(tweak.value));
+    const focused = Number((event.target as HTMLElement).dataset.optionIndex ?? selected);
+    const current = focused < 0 ? 0 : focused;
+    const index =
+      event.key === "Home"
+        ? 0
+        : event.key === "End"
+          ? options.length - 1
+          : Math.max(0, Math.min(options.length - 1, current + (expanded ? (event.key === "ArrowDown" ? 1 : -1) : 0)));
+
+    if (!expanded) open();
+    requestAnimationFrame(() => {
+      rootRef.current?.querySelector<HTMLButtonElement>(`[data-option-index="${index}"]`)?.focus();
+    });
+  };
+
+  return (
+    <div
+      className="tweaks-select-wrap"
+      ref={rootRef}
+      onKeyDown={navigate}
+      onBlur={(event) => {
+        if (!event.currentTarget.contains(event.relatedTarget)) setListboxStyle(null);
+      }}
+    >
+      <button
+        className="tweaks-select"
+        type="button"
+        aria-label={`${tweak.name}: ${String(tweak.value)}`}
+        aria-haspopup="listbox"
+        aria-expanded={expanded}
+        aria-controls={expanded ? listboxId : undefined}
+        ref={triggerRef}
+        onClick={() => (expanded ? setListboxStyle(null) : open())}
+      >
+        <span>{String(tweak.value)}</span>
+        <ChevronDown size={12} aria-hidden="true" />
+      </button>
+      {expanded ? (
+        <TweakEnumListbox id={listboxId} style={listboxStyle} tweak={tweak} onChange={onChange} onClose={close} />
+      ) : null}
+    </div>
+  );
+}
+
+export function TweakEnumListbox({
+  id,
+  style,
+  tweak,
+  onChange,
+  onClose
+}: {
+  id: string;
+  style?: CSSProperties;
+  tweak: TweakDescriptor;
+  onChange(tweak: TweakDescriptor, value: TweakValue): void;
+  onClose(): void;
+}): JSX.Element {
+  const select = (value: string) => {
+    if (value !== String(tweak.value)) onChange(tweak, value);
+    onClose();
+  };
+
+  return (
+    <div className="tweaks-select-listbox" id={id} role="listbox" aria-label={tweak.name} style={style}>
+      {(tweak.options ?? []).map((option, index) => (
+        <button
+          className="tweaks-select-option"
+          key={option}
+          type="button"
+          role="option"
+          aria-selected={option === String(tweak.value)}
+          data-option-index={index}
+          tabIndex={option === String(tweak.value) ? 0 : -1}
+          onPointerDown={(event) => {
+            if (event.button !== 0) return;
+            event.preventDefault();
+            select(option);
+          }}
+          onClick={(event) => {
+            if (event.detail === 0) select(option);
+          }}
+        >
+          {option}
+        </button>
+      ))}
+    </div>
+  );
 }
 
 export function TweakColorField({

--- a/snapo-network-inspector-web/src/network/bridge-types.ts
+++ b/snapo-network-inspector-web/src/network/bridge-types.ts
@@ -48,12 +48,13 @@ export type TweakValue = boolean | number | string;
 
 export interface TweakDescriptor {
   name: string;
-  type: "int" | "float" | "boolean" | "color" | "string";
+  type: "int" | "float" | "boolean" | "color" | "string" | "enum";
   default: TweakValue;
   value: TweakValue;
   min?: number;
   max?: number;
   step?: number;
+  options?: string[];
 }
 
 export interface TweakList {

--- a/snapo-network-inspector-web/src/styles.css
+++ b/snapo-network-inspector-web/src/styles.css
@@ -1461,12 +1461,16 @@ pre {
   gap: 9px;
 }
 
-.tweaks-control-label {
-  min-width: 0;
+.tweaks-control-label,
+.tweaks-select span {
   overflow: hidden;
-  font-size: 12px;
   text-overflow: ellipsis;
   white-space: nowrap;
+}
+
+.tweaks-control-label {
+  min-width: 0;
+  font-size: 12px;
 }
 
 .tweaks-control-field {
@@ -1479,7 +1483,8 @@ pre {
 
 .tweaks-number,
 .tweaks-hex,
-.tweaks-string {
+.tweaks-string,
+.tweaks-select {
   min-width: 0;
   border: 1px solid transparent;
   border-radius: 4px;
@@ -1503,6 +1508,47 @@ pre {
 .tweaks-string {
   width: 100%;
   min-height: 32px;
+}
+
+.tweaks-select-wrap {
+  min-width: 0;
+}
+
+.tweaks-select {
+  display: flex;
+  max-width: 176px;
+  align-items: center;
+  gap: 7px;
+  text-align: left;
+}
+
+.tweaks-select-listbox {
+  position: fixed;
+  z-index: 30;
+  max-width: min(240px, calc(100vw - 16px));
+  overflow-y: auto;
+  border: 1px solid var(--outline);
+  border-radius: 4px;
+  background: var(--surface-bright);
+  padding: 4px;
+}
+
+.tweaks-select-option {
+  display: block;
+  width: 100%;
+  min-height: 28px;
+  border: 0;
+  border-radius: 3px;
+  background: transparent;
+  padding: 5px 8px;
+  color: var(--on-surface);
+  font-size: 11px;
+  text-align: left;
+  white-space: nowrap;
+}
+
+.tweaks-select-option:is(:hover, :focus-visible, [aria-selected="true"]) {
+  background: var(--surface-container-high);
 }
 
 .tweaks-range {

--- a/tests/snapo_cli/test_snapo.py
+++ b/tests/snapo_cli/test_snapo.py
@@ -208,6 +208,13 @@ def tweak_descriptors():
         {"name": "Motion/Enabled", "type": "boolean", "default": True, "value": True},
         {"name": "Palette/Accent color", "type": "color", "default": "#5468FF", "value": "#5468FF"},
         {"name": "Preview/Text value", "type": "string", "default": "true", "value": "true"},
+        {
+            "name": "Appearance/Theme",
+            "type": "enum",
+            "default": "System",
+            "value": "System",
+            "options": ["System", "Light", "Dark"],
+        },
     ]
 
 
@@ -627,6 +634,36 @@ class TweakValueTests(unittest.TestCase):
             with self.subTest(value=value):
                 with self.assertRaises(snapo.SnapOError):
                     snapo.parse_tweak_value(descriptor, value)
+
+    def test_enums_accept_only_exact_declared_option_names(self):
+        descriptor = self.descriptor("Appearance/Theme")
+
+        self.assertEqual(snapo.parse_tweak_value(descriptor, "Dark"), "Dark")
+        self.assertEqual(snapo.parse_tweak_value(descriptor, "System"), "System")
+
+        for invalid in ("dark", "DARK", "Dark mode", "Unknown"):
+            with self.subTest(value=invalid):
+                with self.assertRaisesRegex(snapo.SnapOError, '"System", "Light", "Dark"'):
+                    snapo.parse_tweak_value(descriptor, invalid)
+
+    def test_enums_reject_malformed_option_descriptors(self):
+        original = self.descriptor("Appearance/Theme")
+        cases = (
+            ({"options": None}, "non-empty option list"),
+            ({"options": []}, "non-empty option list"),
+            ({"options": [" "]}, "nonblank strings"),
+            ({"options": [{"value": "System"}]}, "nonblank strings"),
+            ({"options": ["System", "System"]}, "must be unique"),
+            ({"value": "unknown"}, "the value must match"),
+            ({"default": "unknown"}, "the default must match"),
+        )
+
+        for changes, detail in cases:
+            with self.subTest(detail=detail):
+                descriptor = json.loads(json.dumps(original))
+                descriptor.update(changes)
+                with self.assertRaisesRegex(snapo.SnapOError, detail):
+                    snapo.tweak_descriptors({"tweaks": [descriptor]})
 
 
 class ADBTests(unittest.TestCase):
@@ -1221,6 +1258,7 @@ class TweakCommandTests(unittest.TestCase):
         self.assertIn("Typography/Font size = 16 [int]", output)
         self.assertIn("Motion/Enabled = true [boolean]", output)
         self.assertIn('Preview/Text value = "true" [string]', output)
+        self.assertIn('Appearance/Theme = "System" [enum]; options: ["System", "Light", "Dark"]', output)
 
     def test_get_accepts_tweak_names_with_slashes_and_spaces(self):
         with TweakHTTPServer() as wire:
@@ -1277,6 +1315,7 @@ class TweakCommandTests(unittest.TestCase):
             ("Motion/Enabled", "false", False),
             ("Palette/Accent color", "#3b82f6", "#3B82F6"),
             ("Preview/Text value", "true", "true"),
+            ("Appearance/Theme", "Dark", "Dark"),
             ("Preview/Text value", "-hello", "-hello"),
             ("Preview/Text value", "-foo", "-foo"),
             ("Preview/Text value", "--literal", "--literal"),
@@ -1307,6 +1346,9 @@ class TweakCommandTests(unittest.TestCase):
             ("Motion/Damping ratio", "inf"),
             ("Motion/Enabled", "probably"),
             ("Palette/Accent color", "#nothex"),
+            ("Appearance/Theme", "dark"),
+            ("Appearance/Theme", "DARK"),
+            ("Appearance/Theme", "Dark mode"),
         )
         for name, raw in cases:
             with self.subTest(name=name, value=raw):
@@ -1330,6 +1372,18 @@ class TweakCommandTests(unittest.TestCase):
 
         self.assertEqual(result, 0, errors)
         self.assertEqual(wire.requests[1], ("PATCH", "/tweaks", {"values": {"Typography/Font size": 16}}))
+        self.assertEqual(output, "")
+
+    def test_reset_enum_patches_its_declared_default_name(self):
+        descriptors = tweak_descriptors()
+        descriptor = next(item for item in descriptors if item["name"] == "Appearance/Theme")
+        descriptor["value"] = "Dark"
+
+        with TweakHTTPServer(descriptors=descriptors) as wire:
+            result, output, errors, _ = self.run_command(["reset", "Appearance/Theme"], wire)
+
+        self.assertEqual(result, 0, errors)
+        self.assertEqual(wire.requests[1], ("PATCH", "/tweaks", {"values": {"Appearance/Theme": "System"}}))
         self.assertEqual(output, "")
 
     def test_reset_all_patches_every_default_in_one_atomic_request(self):


### PR DESCRIPTION
## Summary

- Add `tweak(default: E, name: String): State<E>` for Kotlin enum values, including matching release no-op behavior.
- Represent choices as ordered, exact-case enum names and validate them consistently across the registry, HTTP protocol, and CLI.
- Add enum controls to the macOS/web inspector, Android overlay, browser sample, and demo; apply inspector selections immediately before dismissing the menu.
- Document the enum wire contract and add coverage for validation, lifecycle, pickers, CLI commands, and release behavior.

```kotlin
enum class MarkerShape { Circle, RoundedSquare, Square }
val shape by tweak(MarkerShape.Circle, "Motion/Marker shape")
```

## Verification

- Android: 115 core and 47 overlay tests; four Detekt checks; sample debug/release and no-op release builds; packaged release stripping verified.
- Web inspector: 92 tests; production build, TypeScript checks, lint, and formatting.
- CLI: 84 tests.
- Browser sample: 42 tests.
- macOS: unsigned application build succeeded.