### PR TITLE
Add app-owned actions to Snap-O Tweaks

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,23 @@ Snap-O can replay network requests that happened before you opened Snap-O, so yo
 
 ## Tweaks (Alpha)
 
-Snap-O Tweaks lets you inspect and adjust Jetpack Compose UI values without rebuilding or restarting your app. It supports numbers, colors, booleans, strings, and type-safe enum pickers. Tweaks is an alpha feature; its APIs, behavior, and interface may change.
+Snap-O Tweaks lets you inspect and adjust Jetpack Compose UI values or run explicitly registered app-owned actions without rebuilding or restarting your app. It supports numbers, colors, booleans, strings, and type-safe enum pickers. Tweaks is an alpha feature; its APIs, behavior, and interface may change.
+
+```kotlin
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import com.openai.snapo.tweaks.TweakAction
+import com.openai.snapo.tweaks.tweak
+
+@Composable
+fun MotionPreview() {
+    val duration by tweak(400, "Motion/Duration", 100..1500)
+    TweakAction("Motion/Restart animation") { restartAnimation() }
+}
+```
+
+`TweakAction` returns `Unit` and exposes its callback only while its owner is in
+composition; declaring the action does not run the callback.
 
 Follow the [Tweaks developer guide](https://openai.github.io/snap-o/tweaks.html) for setup steps.
 
@@ -127,6 +143,7 @@ snapo tweaks list -s <serial> -n <socket> --json
 snapo tweaks set 'Typography/Font size' 42 -s <serial> -n <socket>
 snapo tweaks set 'Motion/Marker shape' RoundedSquare -s <serial> -n <socket>
 snapo tweaks reset 'Typography/Font size' -s <serial> -n <socket>
+snapo tweaks action 'Motion/Toggle animation' -s <serial> -n <socket>
 ```
 
 ## Why a web UI for the App Inspector?
@@ -202,7 +219,7 @@ chmod +x ~/.local/bin/snapo
 
 This is the same CLI shipped as part of the macOS app at `Snap-O.app/Contents/MacOS/snapo`.
 
-The script supports `snapo network list`, `requests`, and `show`, as well as `snapo tweaks apps`, `list`, `get`, `set`, `reset`, and `watch`. It resolves `adb` from `PATH`, `ANDROID_SDK_ROOT`, or `ANDROID_HOME`; use `--adb <path>` or `SNAPO_ADB` to select a specific ADB executable or wrapper. By default, server selection is left to the configured ADB command, which normally connects to `127.0.0.1:5037`. Pass `--adb-host <host> --adb-port <port>` to use an explicit remote ADB server.
+The script supports `snapo network list`, `requests`, and `show`, as well as `snapo tweaks apps`, `list`, `get`, `set`, `action`, `reset`, and `watch`. It resolves `adb` from `PATH`, `ANDROID_SDK_ROOT`, or `ANDROID_HOME`; use `--adb <path>` or `SNAPO_ADB` to select a specific ADB executable or wrapper. By default, server selection is left to the configured ADB command, which normally connects to `127.0.0.1:5037`. Pass `--adb-host <host> --adb-port <port>` to use an explicit remote ADB server.
 
 Verify that ADB can see your Android device, then inspect its available Snap-O servers:
 

--- a/contracts/tweaks/README.md
+++ b/contracts/tweaks/README.md
@@ -2,10 +2,11 @@
 
 Status: phase one. The network inspector protocol is unchanged.
 
-Snap-O Tweaks exposes adjustable values from the currently composed Android UI
-through an app-local socket, enabled by default only in debug builds. Agents
-and desktop tools can use HTTP to inspect those values and change them while
-the app runs.
+Snap-O Tweaks exposes adjustable values and explicitly registered, parameterless
+actions from the currently composed Android UI through an app-local socket,
+enabled by default only in debug builds. Agents and desktop tools can use HTTP
+to inspect those values, change them, and invoke app-owned callbacks while the
+app runs.
 
 ## Transport
 
@@ -40,16 +41,22 @@ port, or `INTERNET` permission is needed.
 
 ### GET /app
 
-Return exactly the app's user-facing Android label and package name:
+Return the app's user-facing Android label, package name, and Tweaks protocol
+version:
 
 ```json
 {
   "name": "Snap-O Tweaks Demo",
-  "packageName": "com.openai.snapo.demo.tweaks"
+  "packageName": "com.openai.snapo.demo.tweaks",
+  "protocolVersion": 2
 }
 ```
 
-Resolve `name` from the actual Android app label.
+Resolve `name` from the actual Android app label. An absent `protocolVersion`
+identifies the original version 1, which exposes value tweaks only. Version 2
+adds action descriptors and `POST /tweaks/action`. The Tweaks protocol version
+is independent of the Network Inspector protocol version; hosts can use it to
+identify newer versions they do not support.
 
 ### GET /app/icon
 
@@ -144,6 +151,10 @@ Return a flat list of currently registered tweaks:
       "default": "Circle",
       "value": "Circle",
       "options": ["Circle", "RoundedSquare", "Square"]
+    },
+    {
+      "name": "Motion/Toggle animation",
+      "type": "action"
     }
   ]
 }
@@ -159,17 +170,36 @@ not appear in default responses or event snapshots.
 Usages with the same name must agree on the tweak type, default, constraints,
 and ordered enum options. Conflicting declarations are a configuration error.
 
-Supported types are `int`, `float`, `boolean`, `color`, `string`, and `enum`.
-Integer tweaks accept only whole numbers; float tweaks accept whole or
-fractional numbers. Numeric tweaks may include `min`, `max`, and `step`. Only
-include constraints actually supplied by the app. A `step` is relative to
-`min`, or to `default` if no `min` is supplied. Colors use `#RRGGBB`, or
-`#RRGGBBAA` when translucent.
+Supported value types are `int`, `float`, `boolean`, `color`, `string`, and
+`enum`. The `action` type describes an explicitly registered parameterless
+app-owned callback. Actions do not have `value`, `default`, options, or numeric
+constraints; clients must not attempt to patch or reset them. Integer tweaks
+accept only whole numbers; float tweaks accept whole or fractional numbers.
+Numeric tweaks may include `min`, `max`, and `step`. Only include constraints
+actually supplied by the app. A `step` is relative to `min`, or to `default` if
+no `min` is supplied. Colors use `#RRGGBB`, or `#RRGGBBAA` when translucent.
 
 Enum tweaks include an ordered, nonempty `options` array containing the unique
 enum constant names. The descriptor's `default`, current `value`, picker text,
 and `PATCH` values all use those exact names. Preserve declaration order when
 rendering pickers; reject any value not present in `options`.
+
+Action names must be explicit, stable, and unique among live registrations.
+Register a shared action once at the composable that owns its behavior rather
+than registering separate callbacks with the same name in multiple consumers.
+If multiple live owners register the same action name, the descriptor becomes:
+
+```json
+{
+  "name": "Motion/Toggle animation",
+  "type": "action",
+  "conflicted": true
+}
+```
+
+Conflicting actions remain discoverable but cannot be invoked until exactly one
+owner remains. Callbacks are never silently deduplicated, replaced, or renamed
+with generated suffixes.
 
 Compose color defaults keep their exact in-process identity, including color
 space, component precision, and `Color.Unspecified`. The HTTP protocol still
@@ -211,8 +241,10 @@ create history entries. Adjustment history exists only for the current app
 process and is discarded when that process exits.
 
 Historical inactive tweaks are read-only: `PATCH /tweaks` still accepts only
-currently active names and returns `404` for an inactive name. Plain
-`GET /tweaks` and `GET /tweaks/events` remain active-only. The only supported
+currently active names and returns `404` for an inactive name. Actions appear
+while active but never create adjusted-history entries because they have no
+editable or retained value. Plain `GET /tweaks` and
+`GET /tweaks/events` remain active-only. The only supported
 query is exactly `include=adjusted` on `GET /tweaks`; unsupported, repeated,
 or additional query parameters and queries on other endpoints or methods
 return `400`.
@@ -236,7 +268,8 @@ data: {"tweaks":[{"name":"Motion/Show","type":"boolean","default":true,"value":f
 
 The response uses `Content-Type: text/event-stream`. Its first event contains
 the complete current tweak list. Each later event also contains a complete,
-ordered list using exactly the `GET /tweaks` response shape. Clients replace
+ordered list of value and action descriptors using exactly the `GET /tweaks`
+response shape. Clients replace
 their previous snapshot; a missing tweak has left composition.
 
 Changes are published after the current Android main-thread turn. Tweaks added,
@@ -294,11 +327,47 @@ option values. Errors use a small JSON body:
 
 Apply changes on the Android main thread. If any value is invalid, do not update
 any tweaks in that request. Reset a value by patching it with its default.
+Actions are not valid patch targets; attempting to patch one returns `422`
+without changing any value in the same request.
+
+### POST /tweaks/action
+
+Invoke one explicitly registered parameterless app-owned action:
+
+```bash
+curl -fsS -X POST http://127.0.0.1:43817/tweaks/action \
+  -H 'Content-Type: application/json' \
+  -d '{"name":"Motion/Toggle animation"}'
+```
+
+```json
+{
+  "name": "Motion/Toggle animation"
+}
+```
+
+The JSON body must contain exactly one nonblank string field named `name`.
+The registered callback executes synchronously on the Android main thread.
+This endpoint accepts no arguments, arbitrary code, or dynamic invocation
+targets; only explicitly registered app-owned callbacks are available.
+
+Return `400` for malformed bodies, unsupported content types, additional
+fields, blank names, or unsupported query parameters; `404` for an unknown
+action or a name belonging to a value tweak; `405` for methods other than
+`POST`; and `409` when more than one live owner registered the same name.
+Duplicate registration errors explain that the action must be registered
+once at its owner. Main-thread unavailability, callback failures, and timeouts
+return `503`, `500`, and `504`, respectively. Errors use the same
+`{"error":"..."}` response shape as tweak updates.
 
 ## Compose API
 
 ```kotlin
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import com.openai.snapo.tweaks.TweakAction
 import com.openai.snapo.tweaks.tweak
 
 enum class MarkerShape { Circle, RoundedSquare, Square }
@@ -344,6 +413,8 @@ fun SpecimenAccessory() {
 
 @Composable
 fun MotionSpecimen() {
+    var isAnimating by remember { mutableStateOf(false) }
+    TweakAction("Motion/Toggle animation") { isAnimating = !isAnimating }
     val useSpring by tweak(true, "Use spring")
     val markerShape by tweak(MarkerShape.Circle, "Marker shape")
 
@@ -397,6 +468,16 @@ from declaration order and use each constant's name everywhere. Convert
 delegated integer values into Compose units at the call site, such as
 `fontSize.sp`. The real and no-op artifacts expose the same package and public
 Compose API.
+
+Declare a parameterless action with the `TweakAction(name) { ... }` composable.
+It returns `Unit` and does not execute its callback during composition or return
+a callable function. The action is available only while its owning composable
+is in composition, always uses its most recent callback, and is exposed with
+its explicit name rather than an inferred or generated identifier. Register
+each action exactly once at the composable that owns the state or operation;
+multiple owners using the same name produce a visible conflict and all
+invocation attempts fail closed. The release/no-op implementation accepts the
+same API without retaining or invoking the callback.
 
 ## Setup
 
@@ -456,10 +537,11 @@ fun DeveloperSettings() {
 
 The setting persists between app launches. When enabled, a movable button
 appears only while at least one tweak is in composition. Tap it to inspect or
-edit the active tweaks, and minimize the panel to return to the button. The
-panel stays synchronized with host-side changes, remembers its position, and
-disappears when the last tweak leaves composition. The no-op overlay keeps the
-same wrapper and settings APIs without showing a panel in release builds.
+edit the active tweaks, run registered actions, and minimize the panel to return
+to the button. Conflicted actions are visible but cannot be run. The panel stays
+synchronized with host-side changes, remembers its position, and disappears when
+the last tweak or action leaves composition. The no-op overlay keeps the same
+wrapper and settings APIs without showing a panel in release builds.
 
 Install the standalone debug sample on a connected Android device:
 
@@ -498,5 +580,4 @@ remove unused calls and tweak-name strings. Verify the release APK contains
 neither tweak-only strings nor the live provider, registry, server, or socket.
 
 Phase one requires no Ktor, OkHttp, extra JSON library, Snap-O Mac UI, network
-protocol change, actions, groups, scopes, units, separate tweak IDs, or
-revisions.
+protocol change, groups, scopes, units, separate tweak IDs, or revisions.

--- a/scripts/snapo
+++ b/scripts/snapo
@@ -762,17 +762,18 @@ def app_info(adb, server):
     return {}
 
 
-def emit_app(server, name, package, as_json, current_device, details=""):
+def emit_app(server, name, package, as_json, current_device, details="", protocol_version=None):
     if as_json:
-        print_json(
-            {
-                "server": server.identifier,
-                "deviceId": server.device_id,
-                "socketName": server.socket_name,
-                "packageName": package,
-                "appName": name,
-            }
-        )
+        app = {
+            "server": server.identifier,
+            "deviceId": server.device_id,
+            "socketName": server.socket_name,
+            "packageName": package,
+            "appName": name,
+        }
+        if protocol_version is not None:
+            app["protocolVersion"] = protocol_version
+        print_json(app)
     else:
         if current_device != server.device_id:
             print(f"{server.device_id}:")
@@ -1065,6 +1066,11 @@ def find_tweak(descriptors, name):
 
 def parse_tweak_value(descriptor, raw):
     kind = descriptor.get("type")
+    if kind == "action":
+        raise SnapOError(
+            f"Action '{descriptor.get('name', '')}' cannot be set; "
+            "use 'snapo tweaks action NAME' to invoke it"
+        )
     if kind == "string":
         return raw
     if kind == "enum":
@@ -1108,6 +1114,10 @@ def emit_tweak_document(document, as_json):
         return
     tweaks = document.get("tweaks") if isinstance(document.get("tweaks"), list) else [document]
     for tweak in tweaks:
+        if tweak.get("type") == "action":
+            status = ", conflicted" if tweak.get("conflicted") is True else ""
+            print(f"{tweak.get('name', 'unknown')} [action{status}]", flush=True)
+            continue
         value = json.dumps(tweak.get("value"), ensure_ascii=False, allow_nan=False)
         options = ""
         if tweak.get("type") == "enum":
@@ -1130,10 +1140,24 @@ def run_tweak_apps(adb, options):
             continue
         name = info.get("name")
         package = info.get("packageName")
-        if not isinstance(name, str) or not isinstance(package, str):
+        protocol_version = info.get("protocolVersion", 1)
+        if (
+            not isinstance(name, str)
+            or not isinstance(package, str)
+            or type(protocol_version) is not int
+            or protocol_version < 1
+        ):
             continue
         found = True
-        current_device = emit_app(server, name, package, options.json, current_device, f"  {name}  pkg:{package}")
+        current_device = emit_app(
+            server,
+            name,
+            package,
+            options.json,
+            current_device,
+            f"  {name}  pkg:{package}",
+            protocol_version=protocol_version,
+        )
     if not found:
         raise SnapOError("No reachable Snap-O tweaks apps found")
     return 0
@@ -1175,13 +1199,29 @@ def run_tweak_set(adb, options):
     return 0
 
 
+def run_tweak_action(adb, options):
+    server = choose_tweak_server(adb, options)
+    with TweakConnection(adb, server) as connection:
+        connection.request("POST", "/tweaks/action", {"name": options.name})
+    return 0
+
+
 def run_tweak_reset(adb, options):
     server = choose_tweak_server(adb, options)
     with TweakConnection(adb, server) as connection:
         descriptors = tweak_descriptors(connection.request("GET", "/tweaks"))
-        selected = descriptors if options.all else [find_tweak(descriptors, options.name)]
+        selected = (
+            [descriptor for descriptor in descriptors if descriptor["type"] != "action"]
+            if options.all
+            else [find_tweak(descriptors, options.name)]
+        )
         values = {}
         for descriptor in selected:
+            if descriptor["type"] == "action":
+                raise SnapOError(
+                    f"Action '{descriptor['name']}' cannot be reset; "
+                    "use 'snapo tweaks action NAME' to invoke it"
+                )
             if "default" not in descriptor:
                 raise SnapOError(f"Tweak '{descriptor['name']}' does not provide a default value")
             values[descriptor["name"]] = descriptor["default"]
@@ -1326,6 +1366,11 @@ def parser():
     set_tweak.add_argument("name", metavar="NAME")
     set_tweak.add_argument("value", metavar="VALUE")
     set_tweak.set_defaults(handler=run_tweak_set)
+
+    action = tweaks_commands.add_parser("action", help="invoke one app-owned action")
+    add_common_options(action, socket_option=True, json_option=False)
+    action.add_argument("name", metavar="NAME")
+    action.set_defaults(handler=run_tweak_action)
 
     reset = tweaks_commands.add_parser("reset", help="reset one tweak or all tweaks to their defaults")
     add_common_options(reset, socket_option=True, json_option=False)

--- a/skills/snap-o-tweaks/SKILL.md
+++ b/skills/snap-o-tweaks/SKILL.md
@@ -1,13 +1,14 @@
 ---
 name: snap-o-tweaks
-description: Inspect, stream, and explicitly adjust live Android UI tweak values through Snap-O. Use when a request mentions Snap-O Tweaks, tweak-enabled Android apps, runtime UI parameters, Compose tweak or overlay controls, tweak discovery, previously adjusted or currently inactive tweaks, applying all user-made tweak changes, typed values, defaults or resets, atomic tweak batches, the Tweaks REST/SSE API, or selecting between CLI, macOS inspector, in-app overlay, and custom tweak interfaces.
+description: Inspect, stream, and explicitly adjust live Android UI tweak values or invoke app-owned actions through Snap-O. Use when a request mentions Snap-O Tweaks, tweak-enabled Android apps, runtime UI parameters, Compose tweak or action controls, tweak discovery, previously adjusted or currently inactive tweaks, applying all user-made tweak changes, typed values, defaults or resets, atomic tweak batches, explicitly registered actions, the Tweaks REST/SSE API, or selecting between CLI, macOS inspector, in-app overlay, and custom tweak interfaces.
 ---
 
 # Snap-O Tweaks
 
-Inspect live values exposed by a debug-enabled Android app. Discovery, reads,
-and streams are read-only; change or reset values only when explicitly
-requested. Reset everything only when explicitly requested.
+Inspect live values and app-owned actions exposed by a debug-enabled Android
+app. Discovery, reads, and streams are read-only; change or reset values, or
+invoke an action, only when explicitly requested. Reset everything only when
+explicitly requested.
 
 ## Choose the interaction surface
 
@@ -66,14 +67,15 @@ ADB resolves from `PATH`, `ANDROID_SDK_ROOT`, or `ANDROID_HOME`. Use
    "$SNAPO_BIN" tweaks get 'Typography/Font size' --all -s <serial> -n <socket> --json
    ```
 
-   The expanded list combines current tweaks with retained, previously adjusted
-   tweaks. Compare each descriptor's `value` with its `default` when the user
-   asks to apply all changes they made. Separate screens can reuse tweak names
-   with different declarations; preserve every descriptor from `list --all`
-   instead of deduplicating by name. `get NAME --all` reports an error when
-   multiple declarations match; use `list --all --json` to inspect them.
-   Historical tweaks can be inspected while inactive, but can only be changed
-   or reset when their declaration is active.
+   The expanded list combines current tweaks and actions with retained,
+   previously adjusted tweaks. Compare each value descriptor's `value` with its
+   `default` when the user asks to apply all changes they made; action
+   descriptors have neither field. Separate screens can reuse tweak names with
+   different declarations; preserve every descriptor from `list --all` instead
+   of deduplicating by name. `get NAME --all` reports an error when multiple
+   declarations match; use `list --all --json` to inspect them. Historical
+   tweaks can be inspected while inactive, but can only be changed or reset
+   when their declaration is active. Actions are active-only.
 
 4. Observe live complete snapshots:
 
@@ -83,9 +85,9 @@ ADB resolves from `PATH`, `ANDROID_SDK_ROOT`, or `ANDROID_HOME`. Use
    ```
 
    `--once` exits after the first complete snapshot. `--json` emits
-   newline-delimited JSON; `list` and `watch` emit complete tweak snapshots.
-   Event streams contain only currently active tweaks; use `list --all` for
-   historical adjustments.
+   newline-delimited JSON; `list` and `watch` emit complete tweak and action
+   snapshots. Event streams contain only currently active declarations; use
+   `list --all` for historical value adjustments.
 
 ## Change values only when requested
 
@@ -111,6 +113,26 @@ reset-everything request:
 "$SNAPO_BIN" tweaks reset 'Typography/Font size' -s <serial> -n <socket>
 "$SNAPO_BIN" tweaks reset --all -s <serial> -n <socket>
 ```
+
+## Invoke actions only when requested
+
+Apps declare actions with the `TweakAction(name) { ... }` composable, imported
+from `com.openai.snapo.tweaks.TweakAction`. The declaration returns `Unit`,
+registers its callback only while the owner remains in composition, and does
+not execute the callback during composition. Actions have `"type":"action"`,
+no `value`, and no `default`. Invoke an action only when the user explicitly
+requests its app-defined behavior:
+
+```bash
+"$SNAPO_BIN" tweaks action 'Preview/Refresh visible content' -s <serial> -n <socket>
+```
+
+The action command sends the registered name exactly as provided and does not
+accept arguments or execute arbitrary code. A descriptor marked
+`"conflicted":true` has multiple live owners and cannot be invoked; report the
+server's conflict and ask the app owner to register the shared action once or
+choose explicit, stable, unique names. Do not deduplicate callbacks or invent
+numeric suffixes. Reset-all ignores actions.
 
 ## Availability and failures
 

--- a/skills/snap-o-tweaks/references/interaction-surfaces.md
+++ b/skills/snap-o-tweaks/references/interaction-surfaces.md
@@ -6,7 +6,9 @@ The same active Compose tweak registry can be inspected from several surfaces. C
 
 Use the dependency-free Snap-O CLI when a terminal, Codex agent, test script, or
 Linux/macOS workflow needs app discovery, typed value inspection or updates,
-atomic batches, resets, or live snapshots. Use `snapo tweaks list --all` or
+atomic batches, resets, app-owned action invocation, or live snapshots. Invoke
+an explicitly requested action with `snapo tweaks action NAME`; actions have no
+editable value, default, or arguments. Use `snapo tweaks list --all` or
 `snapo tweaks get NAME --all` to include previously adjusted tweaks no longer in
 composition; inactive historical tweaks are inspectable but not writable. Its
 tweaks workflow documents command selection and options. The CLI owns temporary
@@ -15,13 +17,22 @@ smart-socket transport.
 
 ## Snap-O macOS app: an existing desktop inspector
 
-Choose the Snap-O macOS app when someone wants an existing graphical inspector. Its app picker discovers connected devices and `snapo_tweaks_<pid>` servers, identifies each app through `/app`, and combines the Network and Tweaks inspector choices when one app supports both. The Tweaks inspector displays live values, streams changes, edits typed controls, and supports resetting changes.
+Choose the Snap-O macOS app when someone wants an existing graphical inspector.
+Its app picker discovers connected devices and `snapo_tweaks_<pid>` servers,
+identifies each app through `/app`, and combines the Network and Tweaks
+inspector choices when one app supports both. The Tweaks inspector displays live
+values and app-owned actions, streams changes, edits typed controls, invokes
+available action buttons, and supports resetting value changes. Conflicting
+actions are visible but cannot be invoked.
 
 The macOS app manages ADB forwarding and streaming itself. It is an existing interaction option, not a required proxy, dependency, or prerequisite for the standalone CLI and REST protocol.
 
 ## Optional in-app Compose overlay
 
-Choose the overlay when developers or designers should adjust values directly on the Android device without a separate desktop window. Add the published live artifacts to debug builds and matching no-op artifacts to release builds using the same Snap-O version:
+Choose the overlay when developers or designers should adjust values or invoke
+app-owned actions directly on the Android device without a separate desktop
+window. Add the published live artifacts to debug builds and matching no-op
+artifacts to release builds using the same Snap-O version:
 
 ```kotlin
 val snapoVersion = "<version>"
@@ -72,9 +83,12 @@ The CLI and Snap-O macOS app own socket discovery, forwarding, and cleanup. The 
 Build a custom surface when an existing CLI, desktop inspector, or in-app overlay
 does not match the desired controls or workflow. All external hosts should
 discover the tweak socket, establish an accessible ADB transport, read `/app`
-and `/tweaks`, send atomic `PATCH /tweaks` updates, and consume full active
-snapshots from `/tweaks/events`. Request `/tweaks?include=adjusted` when a
-workflow needs every retained user adjustment, including inactive declarations.
+and `/tweaks`, send atomic `PATCH /tweaks` value updates, invoke explicitly
+requested actions with `POST /tweaks/action`, and consume full active snapshots
+from `/tweaks/events`. Render actions without assuming `value` or `default`;
+disable invocation when `conflicted` is true. Request
+`/tweaks?include=adjusted` when a workflow needs every retained user value
+adjustment, including inactive declarations.
 
 - A browser interface can use `fetch` and `EventSource` through a same-origin proxy; see [protocol.md](protocol.md) for browser transport restrictions.
 - A Node host or terminal tool can use built-in `fetch` for requests and parse the response body as a standard SSE stream.
@@ -84,6 +98,7 @@ workflow needs every retained user adjustment, including inactive declarations.
 
 ```kotlin
 import androidx.compose.runtime.getValue
+import com.openai.snapo.tweaks.TweakAction
 import com.openai.snapo.tweaks.tweak
 
 enum class MotionStyle { Standard, Emphasized }
@@ -93,10 +108,22 @@ fun AnimatedContent() {
     val duration by tweak(400, "Motion/Duration", 100..1500, step = 50)
     val enabled by tweak(true, "Motion/Enabled")
     val style by tweak(MotionStyle.Standard, "Motion/Style")
+    TweakAction("Motion/Restart") { restartAnimation() }
     // Use duration, enabled, and style when rendering the current screen.
 }
 ```
 
-Those declarations are observable `State<T>` and update when any supported surface changes the shared registry. The registry-editing `SnapOTweaks` helpers are annotated `@RestrictTo(LIBRARY_GROUP)`; do not present them as a stable public app API for building arbitrary in-process inspectors. Use the supported overlay or an external REST client when an editable custom control surface is needed.
+Value declarations return observable `State<T>` and update when any supported
+surface changes the shared registry. `TweakAction` returns `Unit`, registers its
+parameterless callback only while its owner remains in composition, and does
+not execute the callback during composition. The registry-editing
+`SnapOTweaks` helpers are annotated
+`@RestrictTo(LIBRARY_GROUP)`; do not present them as a stable public app API for
+building arbitrary in-process inspectors. Use the supported overlay or an
+external REST client when an editable custom control surface is needed.
+
+Register each shared action once at its owning composable. Distinct callbacks
+must use explicit, stable, unique names; concurrent registrations of the same
+action name are surfaced as conflicts and cannot be invoked.
 
 For wire formats, transport cleanup, SSE semantics, validation, and security details, see [protocol.md](protocol.md).

--- a/skills/snap-o-tweaks/references/protocol.md
+++ b/skills/snap-o-tweaks/references/protocol.md
@@ -32,14 +32,21 @@ For remote ADB servers, an `adb forward` is local to the ADB server's host, not 
 
 | Request | Result |
 | --- | --- |
-| `GET /app` | JSON app metadata: `{"name":"Example","packageName":"com.example"}`. |
+| `GET /app` | JSON app metadata: `{"name":"Example","packageName":"com.example","protocolVersion":2}`. |
 | `GET /app/icon` | Optional application icon image; `404` if unavailable. Use its response `Content-Type` without assuming a particular format or size. |
-| `GET /tweaks` | Current active tweak descriptors and values. |
-| `GET /tweaks?include=adjusted` | Active descriptors plus all previously adjusted tweaks retained outside composition. |
+| `GET /tweaks` | Current active tweak and app-owned action descriptors. |
+| `GET /tweaks?include=adjusted` | Active descriptors plus all previously adjusted value tweaks retained outside composition. |
 | `PATCH /tweaks` | One atomic update containing one or more named values. |
-| `GET /tweaks/events` | Server-sent events containing complete current snapshots. |
+| `POST /tweaks/action` | Invoke one explicitly registered parameterless app-owned action by name. |
+| `GET /tweaks/events` | Server-sent events containing complete current tweak and action snapshots. |
 
 Ordinary responses close their connection and include a content length. The event response stays open and uses `Content-Type: text/event-stream`.
+
+`protocolVersion` is specific to Tweaks and independent of the Network Inspector
+protocol. Version 1 predates this field and supports only value tweaks; treat a
+missing version as 1. Version 2 adds app-owned action descriptors and
+`POST /tweaks/action`. A version newer than the host supports may require a
+compatibility warning.
 
 ### Read metadata and active values
 
@@ -76,40 +83,54 @@ The tweak response has this shape:
       "default": "System",
       "value": "Dark",
       "options": ["System", "Light", "Dark"]
+    },
+    {
+      "name": "Preview/Refresh visible content",
+      "type": "action"
     }
   ]
 }
 ```
 
-The available types are `int`, `float`, `boolean`, `color`, `string`, and
+The available value types are `int`, `float`, `boolean`, `color`, `string`, and
 `enum`. Preserve actual JSON types: booleans are not strings, integer values
 cannot be fractional, and floats accept whole or fractional finite numbers.
 Colors are strings in `#RRGGBB` or `#RRGGBBAA` format. Numeric descriptors may
 include `min`, `max`, and `step`; step alignment starts at `min`, or at
-`default` if there is no minimum.
+`default` if there is no minimum. Actions use `"type":"action"` and have no
+`value`, `default`, or `options`.
 
 Enum descriptors include a nonempty, ordered `options` array containing unique,
 nonblank enum name strings. The `default` and current `value` are names from
 that list. Send an exact option name in `PATCH /tweaks`.
 
-Plain `GET /tweaks` includes only declarations active in Compose. Add
+An action descriptor with `"conflicted":true` has multiple live registrations
+for the same name. It remains visible so clients can surface the conflict, but
+the server rejects invocation instead of choosing a callback, merging owners, or
+inventing unstable names. Register a shared action once at its owner, or use
+explicit, stable, unique names for distinct actions.
+
+Plain `GET /tweaks` includes only value and action declarations active in
+Compose. Add
 `?include=adjusted` to include every tweak successfully adjusted by the user,
 including retained descriptors whose declarations have since left composition.
 The expanded response uses the same descriptor shape and also includes current
-active tweaks. Separate screens can reuse a name with different complete
+active tweaks and actions; actions have no adjustment history. Separate screens
+can reuse a value tweak name with different complete
 declarations; preserve every returned descriptor instead of deduplicating by
 name. A tweak that was adjusted and later reset can still appear with its
 default value; compare `value` and `default` to identify outstanding user
 changes. Retention lasts for the current app process and is cleared with the
 registry; it is not persistent storage across app restarts.
 
-Names are shared identifiers: two active declarations of the same complete
-descriptor observe the same value. Names may contain spaces and `/`; send the
-entire name unchanged. Repeated names in expanded results represent distinct
-complete descriptors; active-only snapshots and updates still resolve at most
-one currently active descriptor per name. Historical descriptors are read-only
-while inactive: `PATCH /tweaks` still rejects their names until their
-declarations return.
+Names may contain spaces and `/`; send the entire name unchanged. Two active
+declarations of the same complete value descriptor observe the same value.
+Repeated value names in expanded results represent distinct complete
+descriptors; active-only snapshots and updates still resolve at most one
+currently active value descriptor per name. Historical descriptors are
+read-only while inactive: `PATCH /tweaks` still rejects their names until their
+declarations return. Separate active callbacks with the same action name are
+not interchangeable and are reported as conflicted.
 
 ### Update or reset values atomically
 
@@ -128,9 +149,33 @@ The response contains the changed names and their resulting values:
 Every value is validated before any update is applied. An invalid, unknown, or
 inactive entry prevents the entire batch from changing. Reset by fetching
 `GET /tweaks` and sending the target descriptor's `default` value back in a
-patch; reset all by patching every active name to its own default in one
-request. There is no separate get-by-name, reset, delete, action, or grouping
-endpoint.
+patch; reset all by patching every active value name to its own default in one
+request. Actions cannot be patched or reset and are excluded from reset-all.
+There is no separate get-by-name, reset, delete, or grouping endpoint.
+
+### Invoke an app-owned action
+
+```bash
+curl -fsS -X POST "$base/tweaks/action" \
+  -H 'Content-Type: application/json' \
+  -d '{"name":"Preview/Refresh visible content"}'
+```
+
+The name identifies an explicitly registered, parameterless app callback.
+Android apps expose these callbacks using the `TweakAction(name) { ... }`
+composable, imported from `com.openai.snapo.tweaks.TweakAction`. Declaring the
+action returns `Unit`, does not execute its callback, and registers it only
+while its owner remains in composition. A successful response is HTTP 200 with
+the invoked action's name:
+
+```json
+{"name":"Preview/Refresh visible content"}
+```
+
+Unknown names and value-only names return HTTP 404; conflicting live action
+registrations return HTTP 409. Malformed request bodies return HTTP 400, and
+unsupported methods return HTTP 405. The endpoint does not accept arguments,
+schemas, scripts, or arbitrary code.
 
 ### Watch complete snapshots
 
@@ -150,8 +195,9 @@ data: {"tweaks":[{"name":"Motion/Enabled","type":"boolean","default":true,"value
 ```
 
 The first event is the complete current active list. Every later `event: tweaks`
-is also a complete, ordered replacement snapshot, not a delta. Historical
-inactive tweaks are not included in event snapshots; request
+is also a complete, ordered replacement snapshot of active values and actions,
+not a delta. Historical inactive tweaks are not included in event snapshots;
+request
 `GET /tweaks?include=adjusted` separately when their retained values are needed.
 Remove items absent from the newest snapshot. Ignore lines starting with `:`;
 they are idle keepalives. Reconnect and replace state when the app process or
@@ -176,6 +222,6 @@ These relative URLs assume your host serves both the page and the proxy. The And
 
 ## Errors and security
 
-Errors use `{"error":"description"}`. Expect `400` for malformed input, `404` for missing endpoints or inactive tweak names, `405` for unsupported methods, `413` for oversized bodies, and `422` for invalid JSON value types, numeric bounds, numeric steps, color formats, or unknown enum option names.
+Errors use `{"error":"description"}`. Expect `400` for malformed input, `404` for missing endpoints or inactive tweak names, `405` for unsupported methods, `409` for conflicting action registrations, `413` for oversized bodies, and `422` for invalid JSON value types, numeric bounds, numeric steps, color formats, or unknown enum option names.
 
 The socket is app-local and normally enabled only when the Android app is debuggable. Release activation requires an explicit `snapo.tweaks.allow_release` manifest opt-in; release no-op artifacts are preferred. There is no HTTP bearer-token layer: access is controlled by the local socket and the connected ADB boundary. Do not expose a forwarded port or proxy publicly, and treat tweak names and values as potentially sensitive.

--- a/snapo-app-mac/Snap-O/NetworkInspector/NetworkInspectorBridgeModels.swift
+++ b/snapo-app-mac/Snap-O/NetworkInspector/NetworkInspectorBridgeModels.swift
@@ -14,6 +14,7 @@ struct InspectorServerReference: Codable, Hashable {
 struct AppInspectorOption: Codable, Identifiable {
   let kind: AppInspectorKind
   let server: InspectorServerReference
+  let protocolVersion: Int?
 
   var id: String {
     "\(kind.rawValue):\(server.deviceId):\(server.socketName)"
@@ -73,12 +74,13 @@ enum TweakValue: Codable {
 struct TweakDescriptor: Codable {
   let name: String
   let type: String
-  let `default`: TweakValue
-  let value: TweakValue
+  let `default`: TweakValue?
+  let value: TweakValue?
   let min: TweakValue?
   let max: TweakValue?
   let step: TweakValue?
   let options: [String]?
+  let conflicted: Bool?
 }
 
 struct TweakList: Codable {
@@ -112,6 +114,15 @@ struct TweakPatch: Codable {
 struct UpdateTweaksInput: Codable {
   let server: InspectorServerReference
   let values: [String: TweakValue]
+}
+
+struct InvokeTweakActionInput: Codable {
+  let server: InspectorServerReference
+  let name: String
+}
+
+struct TweakAction: Codable {
+  let name: String
 }
 
 struct NetworkInspectorServer: Codable {
@@ -219,6 +230,7 @@ extension NetworkInspectorOutput: Sendable {}
 enum NetworkInspectorError: LocalizedError {
   case invalidBridgeMessage
   case serverNotConnected(NetworkServerReference)
+  case tweakRequestFailed(statusCode: Int, message: String)
 
   var errorDescription: String? {
     switch self {
@@ -226,6 +238,8 @@ enum NetworkInspectorError: LocalizedError {
       "Invalid Network Inspector bridge message."
     case .serverNotConnected(let server):
       "Snap-O server is not connected: \(server.deviceId)/\(server.socketName)"
+    case .tweakRequestFailed(_, let message):
+      message
     }
   }
 }

--- a/snapo-app-mac/Snap-O/NetworkInspector/NetworkInspectorService.swift
+++ b/snapo-app-mac/Snap-O/NetworkInspector/NetworkInspectorService.swift
@@ -82,7 +82,8 @@ actor NetworkInspectorService {
         server: InspectorServerReference(
           deviceId: server.deviceId,
           socketName: server.socketName
-        )
+        ),
+        protocolVersion: server.protocolVersion
       )
       let appName = server.appName.flatMap { $0.isEmpty ? nil : $0 }
       apps[id] = InspectableApp(
@@ -103,7 +104,8 @@ actor NetworkInspectorService {
         server: InspectorServerReference(
           deviceId: app.deviceID,
           socketName: app.socketName
-        )
+        ),
+        protocolVersion: app.protocolVersion
       )
       let existing = apps[id]
       apps[id] = InspectableApp(
@@ -146,6 +148,10 @@ actor NetworkInspectorService {
 
   func updateTweaks(_ input: UpdateTweaksInput) async throws -> TweakUpdates {
     try await tweaksService.updateTweaks(input)
+  }
+
+  func invokeTweakAction(_ input: InvokeTweakActionInput) async throws {
+    try await tweaksService.invokeTweakAction(input)
   }
 
   func startTweakStream(_ reference: InspectorServerReference) async throws -> NetworkStreamStarted {

--- a/snapo-app-mac/Snap-O/NetworkInspector/NetworkInspectorWebBridge.swift
+++ b/snapo-app-mac/Snap-O/NetworkInspector/NetworkInspectorWebBridge.swift
@@ -81,6 +81,10 @@ final class NetworkInspectorWebBridge: NSObject, WKScriptMessageHandlerWithReply
     case "updateTweaks":
       let input = try Self.decode(UpdateTweaksInput.self, from: payload)
       return try await Self.jsonObject(service.updateTweaks(input))
+    case "invokeTweakAction":
+      let input = try Self.decode(InvokeTweakActionInput.self, from: payload)
+      try await service.invokeTweakAction(input)
+      return nil
     case "openNativeColorPanel":
       try openNativeColorPanel(Self.decode(NativeColorPanelInput.self, from: payload))
       return nil

--- a/snapo-app-mac/Snap-O/NetworkInspector/TweaksInspectorService.swift
+++ b/snapo-app-mac/Snap-O/NetworkInspector/TweaksInspectorService.swift
@@ -8,12 +8,18 @@ actor TweaksInspectorService {
     let socketName: String
     let name: String
     let packageName: String
+    let protocolVersion: Int
     let appIconBase64: String?
   }
 
   private struct AppInfo: Decodable {
     let name: String
     let packageName: String
+    let protocolVersion: Int?
+  }
+
+  private struct ErrorResponse: Decodable {
+    let error: String
   }
 
   private struct Connection {
@@ -87,8 +93,19 @@ actor TweaksInspectorService {
     request.httpBody = try JSONEncoder().encode(TweakPatch(values: input.values))
 
     let (data, response) = try await URLSession.shared.data(for: request)
-    try Self.validate(response)
+    try Self.validate(response, data: data)
     return try JSONDecoder().decode(TweakUpdates.self, from: data)
+  }
+
+  func invokeTweakAction(_ input: InvokeTweakActionInput) async throws {
+    let connection = try connection(for: input.server)
+    var request = URLRequest(url: connection.baseURL.appending(path: "tweaks/action"))
+    request.httpMethod = "POST"
+    request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+    request.httpBody = try JSONEncoder().encode(TweakAction(name: input.name))
+
+    let (data, response) = try await URLSession.shared.data(for: request)
+    try Self.validate(response, data: data)
   }
 
   func streamTweaks(
@@ -151,6 +168,7 @@ actor TweaksInspectorService {
         socketName: socketName,
         name: info.name,
         packageName: info.packageName,
+        protocolVersion: info.protocolVersion ?? 1,
         appIconBase64: iconData?.base64EncodedString()
       )
       let key = Self.connectionKey(deviceID: deviceID, socketName: socketName)
@@ -190,15 +208,21 @@ actor TweaksInspectorService {
     let (data, response) = try await URLSession.shared.data(
       from: baseURL.appending(path: path)
     )
-    try Self.validate(response)
+    try Self.validate(response, data: data)
     return try JSONDecoder().decode(type, from: data)
   }
 
-  private static func validate(_ response: URLResponse) throws {
-    guard let response = response as? HTTPURLResponse,
-          (200 ... 299).contains(response.statusCode)
-    else {
+  private static func validate(_ response: URLResponse, data: Data? = nil) throws {
+    guard let response = response as? HTTPURLResponse else {
       throw NetworkInspectorError.invalidBridgeMessage
+    }
+    guard (200 ... 299).contains(response.statusCode) else {
+      let message = data.flatMap { try? JSONDecoder().decode(ErrorResponse.self, from: $0).error }
+        ?? "Tweak request failed (\(response.statusCode))."
+      throw NetworkInspectorError.tweakRequestFailed(
+        statusCode: response.statusCode,
+        message: message
+      )
     }
   }
 

--- a/snapo-link-android/samples/demo-tweaks/src/main/java/com/openai/snapo/demo/tweaks/MainActivity.kt
+++ b/snapo-link-android/samples/demo-tweaks/src/main/java/com/openai/snapo/demo/tweaks/MainActivity.kt
@@ -52,6 +52,7 @@ import androidx.compose.ui.semantics.Role
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
+import com.openai.snapo.tweaks.TweakAction
 import com.openai.snapo.tweaks.overlay.SnapOTweakOverlay
 import com.openai.snapo.tweaks.overlay.SnapOTweakOverlaySettings
 import com.openai.snapo.tweaks.tweak
@@ -269,6 +270,7 @@ private fun TypographyDetails() {
 @Composable
 private fun MotionPreview() {
     var isStateB by rememberSaveable { mutableStateOf(false) }
+    TweakAction("Motion/Toggle animation") { isStateB = !isStateB }
     val useSpring by tweak(true, "Motion/Use spring")
 
     val animationSpec: FiniteAnimationSpec<Float> = if (useSpring) {

--- a/snapo-link-android/tweaks-noop/src/main/java/com/openai/snapo/tweaks/SnapOTweaks.kt
+++ b/snapo-link-android/tweaks-noop/src/main/java/com/openai/snapo/tweaks/SnapOTweaks.kt
@@ -23,6 +23,9 @@ object SnapOTweaks {
 
     /** Ignores tweak updates in a no-op build. */
     fun update(name: String, value: SnapOTweakValue) = Unit
+
+    /** Ignores action invocations in a no-op build. */
+    fun invokeAction(name: String) = Unit
 }
 
 /** The matching observable tweak shape from the live implementation. */
@@ -82,4 +85,9 @@ sealed interface SnapOTweakValue {
         val value: String,
         val options: List<String>,
     ) : SnapOTweakValue
+
+    /** Presentation-only marker matching the live action representation. */
+    @Immutable
+    @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
+    data class Action(val conflicted: Boolean = false) : SnapOTweakValue
 }

--- a/snapo-link-android/tweaks-noop/src/main/java/com/openai/snapo/tweaks/Tweaks.kt
+++ b/snapo-link-android/tweaks-noop/src/main/java/com/openai/snapo/tweaks/Tweaks.kt
@@ -52,3 +52,10 @@ fun <E : Enum<E>> tweak(
     default: E,
     name: String,
 ): State<E> = rememberUpdatedState(default)
+
+/** Returns Unit without exposing or invoking the supplied action in no-op builds. */
+@Composable
+fun TweakAction(
+    name: String,
+    onInvoke: () -> Unit,
+) = Unit

--- a/snapo-link-android/tweaks-overlay/src/main/java/com/openai/snapo/tweaks/overlay/TweakOverlayControls.kt
+++ b/snapo-link-android/tweaks-overlay/src/main/java/com/openai/snapo/tweaks/overlay/TweakOverlayControls.kt
@@ -29,6 +29,7 @@ import androidx.compose.material3.IconButton
 import androidx.compose.material3.Slider
 import androidx.compose.material3.SliderDefaults
 import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.derivedStateOf
@@ -105,6 +106,15 @@ internal fun TweakOverlayControl(
             }
             is SnapOTweakValue.ColorValue -> TweakOverlayLabelRow(tweak) {
                 TweakColorField(tweak, onSelectColor)
+            }
+            is SnapOTweakValue.Action -> TweakOverlayLabelRow(tweak) {
+                val action = tweak.value.value as SnapOTweakValue.Action
+                TextButton(
+                    onClick = { SnapOTweaks.invokeAction(tweak.name) },
+                    enabled = !action.conflicted,
+                ) {
+                    Text(if (action.conflicted) "Conflict" else "Run")
+                }
             }
         }
     }

--- a/snapo-link-android/tweaks-overlay/src/main/java/com/openai/snapo/tweaks/overlay/TweakOverlayRegistry.kt
+++ b/snapo-link-android/tweaks-overlay/src/main/java/com/openai/snapo/tweaks/overlay/TweakOverlayRegistry.kt
@@ -5,6 +5,7 @@ import androidx.compose.runtime.SideEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
 import com.openai.snapo.tweaks.SnapOTweakEntry
+import com.openai.snapo.tweaks.SnapOTweakValue
 import com.openai.snapo.tweaks.SnapOTweaks
 
 @Composable
@@ -67,4 +68,4 @@ internal class TweakOverlaySectionOrder {
 }
 
 internal val SnapOTweakEntry.isChanged: Boolean
-    get() = value.value != defaultValue
+    get() = value.value !is SnapOTweakValue.Action && value.value != defaultValue

--- a/snapo-link-android/tweaks/src/main/java/com/openai/snapo/tweaks/SnapOTweaks.kt
+++ b/snapo-link-android/tweaks/src/main/java/com/openai/snapo/tweaks/SnapOTweaks.kt
@@ -29,6 +29,13 @@ object SnapOTweaks {
 
         TweakRegistry.update(mapOf(name to value.toRegistryValue()))
     }
+
+    /** Invokes an explicitly registered application-owned action. */
+    fun invokeAction(name: String) {
+        if (!TweaksRuntimePolicy.isAllowed) return
+
+        TweakRegistry.invokeAction(name)
+    }
 }
 
 /** A stable active tweak whose current value can be observed independently. */
@@ -88,6 +95,11 @@ sealed interface SnapOTweakValue {
         val value: String,
         val options: List<String>,
     ) : SnapOTweakValue
+
+    /** Presentation-only marker for an action; actions do not have protocol values or defaults. */
+    @Immutable
+    @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
+    data class Action(val conflicted: Boolean = false) : SnapOTweakValue
 }
 
 private fun TweakSnapshot.toSnapOTweak(): SnapOTweak = SnapOTweak(
@@ -115,6 +127,7 @@ internal fun TweakDescriptor.toSnapOTweakValue(value: Any): SnapOTweakValue = wh
     TweakType.COLOR -> SnapOTweakValue.ColorValue((value as TweakColorValue).color)
     TweakType.STRING -> SnapOTweakValue.Text(value as String)
     TweakType.ENUM -> SnapOTweakValue.Selection(value as String, options)
+    TweakType.ACTION -> value as? SnapOTweakValue.Action ?: SnapOTweakValue.Action()
 }
 
 private fun SnapOTweakValue.toRegistryValue(): Any = when (this) {
@@ -124,4 +137,5 @@ private fun SnapOTweakValue.toRegistryValue(): Any = when (this) {
     is SnapOTweakValue.ColorValue -> value.toTweakColorValue()
     is SnapOTweakValue.Text -> value
     is SnapOTweakValue.Selection -> value
+    is SnapOTweakValue.Action -> throw IllegalArgumentException("Actions cannot be updated.")
 }

--- a/snapo-link-android/tweaks/src/main/java/com/openai/snapo/tweaks/Tweaks.kt
+++ b/snapo-link-android/tweaks/src/main/java/com/openai/snapo/tweaks/Tweaks.kt
@@ -1,6 +1,7 @@
 package com.openai.snapo.tweaks
 
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.RememberObserver
 import androidx.compose.runtime.State
 import androidx.compose.runtime.remember
@@ -125,6 +126,21 @@ internal fun <E : Enum<E>> enumTweakDescriptor(
         option.name
     },
 )
+
+/** Declares a parameterless action while in composition, returning Unit without invoking it. */
+@Composable
+fun TweakAction(
+    name: String,
+    onInvoke: () -> Unit,
+) {
+    if (!TweaksRuntimePolicy.isAllowed) return
+
+    val currentOnInvoke = rememberUpdatedState(onInvoke)
+    DisposableEffect(name) {
+        val registration = TweakRegistry.registerAction(name) { currentOnInvoke.value() }
+        onDispose { registration.close() }
+    }
+}
 
 @Composable
 private fun <T> rememberTweakState(

--- a/snapo-link-android/tweaks/src/main/java/com/openai/snapo/tweaks/internal/TweakHttpServer.kt
+++ b/snapo-link-android/tweaks/src/main/java/com/openai/snapo/tweaks/internal/TweakHttpServer.kt
@@ -8,6 +8,7 @@ import android.os.Process
 import android.util.JsonReader
 import android.util.JsonToken
 import android.util.JsonWriter
+import com.openai.snapo.tweaks.SnapOTweakValue
 import com.openai.snapo.tweaks.TweakColorValue
 import java.io.ByteArrayInputStream
 import java.io.ByteArrayOutputStream
@@ -26,6 +27,8 @@ import java.util.concurrent.Semaphore
 import java.util.concurrent.TimeUnit
 import java.util.concurrent.TimeoutException
 import kotlin.concurrent.thread
+
+internal const val TweaksProtocolVersion: Int = 2
 
 private const val MaxHeaderBytes = 16 * 1024
 private const val MaxBodyBytes = 64 * 1024
@@ -151,6 +154,7 @@ internal class TweakHttpServer(
         "/app" -> routeApp(request)
         "/app/icon" -> routeAppIcon(request)
         "/tweaks", "/tweaks?include=adjusted" -> routeTweaks(request)
+        "/tweaks/action" -> routeTweakAction(request)
         "/tweaks/events" -> throw HttpFailure(
             statusCode = 405,
             message = "Unsupported method: ${request.method}",
@@ -243,6 +247,21 @@ internal class TweakHttpServer(
             message = "Unsupported method: ${request.method}",
             allowedMethods = "GET, PATCH",
         )
+    }
+
+    private fun routeTweakAction(request: HttpRequest): HttpResponse {
+        if (request.method != "POST") {
+            throw HttpFailure(
+                statusCode = 405,
+                message = "Unsupported method: ${request.method}",
+                allowedMethods = "POST",
+            )
+        }
+
+        requireJsonRequest(request)
+        val name = readActionName(request.body)
+        invokeActionOnMainThread(name)
+        return actionResponse(name)
     }
 
     private fun readRequest(input: InputStream): HttpRequest {
@@ -346,14 +365,32 @@ internal class TweakHttpServer(
 
     private fun requireJsonRequest(request: HttpRequest) {
         if (request.body.isEmpty()) {
-            throw HttpFailure(400, "PATCH requires a JSON request body.")
+            throw HttpFailure(400, "${request.method} requires a JSON request body.")
         }
 
         val contentType = request.headers["content-type"]
         if (contentType != null &&
             !contentType.substringBefore(';').trim().equals("application/json", ignoreCase = true)
         ) {
-            throw HttpFailure(400, "PATCH requires application/json.")
+            throw HttpFailure(400, "${request.method} requires application/json.")
+        }
+    }
+
+    private fun readActionName(body: ByteArray): String {
+        JsonReader(InputStreamReader(ByteArrayInputStream(body), StandardCharsets.UTF_8)).use { reader ->
+            reader.beginObject()
+            if (!reader.hasNext() || reader.nextName() != "name" || reader.peek() != JsonToken.STRING) {
+                invalidRequest("POST must contain exactly one action name string.")
+            }
+            val name = reader.nextString()
+            if (name.isBlank() || reader.hasNext()) {
+                invalidRequest("POST must contain exactly one non-blank action name string.")
+            }
+            reader.endObject()
+            if (reader.peek() != JsonToken.END_DOCUMENT) {
+                invalidRequest("Unexpected content after the JSON request.")
+            }
+            return name
         }
     }
 
@@ -408,41 +445,41 @@ internal class TweakHttpServer(
         else -> throw HttpFailure(422, "Tweak values must be primitive JSON values.")
     }
 
-    private fun updateOnMainThread(values: Map<String, Any?>): List<TweakSnapshot> {
+    private fun updateOnMainThread(values: Map<String, Any?>): List<TweakSnapshot> =
+        runOnMainThread("update", "applied") { TweakRegistry.update(values) }
+
+    private fun invokeActionOnMainThread(name: String) =
+        runOnMainThread("action", "invoked") { TweakRegistry.invokeAction(name) }
+
+    private fun <T> runOnMainThread(
+        operationName: String,
+        failureVerb: String,
+        operation: () -> T,
+    ): T {
         if (Looper.myLooper() == Looper.getMainLooper()) {
-            return TweakRegistry.update(values)
+            return operation()
         }
 
-        val update = FutureTask { TweakRegistry.update(values) }
-        if (!mainHandler.post(update)) {
+        val task = FutureTask { operation() }
+        if (!mainHandler.post(task)) {
             throw HttpFailure(503, "The Android main thread is unavailable.")
         }
 
-        return awaitUpdate(update)
-    }
-
-    private fun awaitUpdate(update: FutureTask<List<TweakSnapshot>>): List<TweakSnapshot> =
-        try {
-            update.get(MainThreadTimeoutMillis, TimeUnit.MILLISECONDS)
+        val failure = try {
+            return task.get(MainThreadTimeoutMillis, TimeUnit.MILLISECONDS)
         } catch (error: ExecutionException) {
-            throw updateFailure(error)
-        } catch (_: TimeoutException) {
-            update.cancel(false)
-            throw HttpFailure(504, "The tweak update timed out.")
-        } catch (_: InterruptedException) {
-            update.cancel(false)
+            error.cause as? TweakUpdateException
+                ?: HttpFailure(500, "The tweak $operationName could not be $failureVerb.", error)
+        } catch (error: TimeoutException) {
+            task.cancel(false)
+            HttpFailure(504, "The tweak $operationName timed out.", error)
+        } catch (error: InterruptedException) {
+            task.cancel(false)
             Thread.currentThread().interrupt()
-            throw HttpFailure(503, "The tweak update was interrupted.")
+            HttpFailure(503, "The tweak $operationName was interrupted.", error)
         }
 
-    private fun updateFailure(error: ExecutionException): Exception {
-        val cause = error.cause
-
-        return if (cause is TweakUpdateException) {
-            cause
-        } else {
-            HttpFailure(500, "The tweak update could not be applied.", error)
-        }
+        throw failure
     }
 
     private fun appInfoResponse(appInfo: TweakAppInfo): HttpResponse {
@@ -451,6 +488,7 @@ internal class TweakHttpServer(
             writer.beginObject()
             writer.name("name").value(appInfo.name)
             writer.name("packageName").value(appInfo.packageName)
+            writer.name("protocolVersion").value(TweaksProtocolVersion)
             writer.endObject()
         }
 
@@ -477,6 +515,16 @@ internal class TweakHttpServer(
         return HttpResponse(200, output.toString().toByteArray(StandardCharsets.UTF_8))
     }
 
+    private fun actionResponse(name: String): HttpResponse {
+        val output = StringWriter()
+        JsonWriter(output).use { writer ->
+            writer.beginObject()
+            writer.name("name").value(name)
+            writer.endObject()
+        }
+        return HttpResponse(200, output.toString().toByteArray(StandardCharsets.UTF_8))
+    }
+
     private fun writeTweak(
         writer: JsonWriter,
         tweak: TweakSnapshot,
@@ -487,12 +535,19 @@ internal class TweakHttpServer(
 
         if (includeDescriptor) {
             writer.name("type").value(tweak.descriptor.type.wireName)
-            writer.name("default")
-            writeJsonValue(writer, tweak.descriptor.default)
+            if (tweak.descriptor.type != TweakType.ACTION) {
+                writer.name("default")
+                writeJsonValue(writer, tweak.descriptor.default)
+            }
+            if ((tweak.value as? SnapOTweakValue.Action)?.conflicted == true) {
+                writer.name("conflicted").value(true)
+            }
         }
 
-        writer.name("value")
-        writeJsonValue(writer, tweak.value)
+        if (tweak.descriptor.type != TweakType.ACTION) {
+            writer.name("value")
+            writeJsonValue(writer, tweak.value)
+        }
 
         if (includeDescriptor) {
             writeConstraints(writer, tweak.descriptor)
@@ -570,6 +625,7 @@ internal class TweakHttpServer(
         404 -> "Not Found"
         405 -> "Method Not Allowed"
         408 -> "Request Timeout"
+        409 -> "Conflict"
         413 -> "Payload Too Large"
         422 -> "Unprocessable Entity"
         500 -> "Internal Server Error"

--- a/snapo-link-android/tweaks/src/main/java/com/openai/snapo/tweaks/internal/TweakRegistry.kt
+++ b/snapo-link-android/tweaks/src/main/java/com/openai/snapo/tweaks/internal/TweakRegistry.kt
@@ -6,6 +6,7 @@ import androidx.compose.runtime.derivedStateOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.snapshots.Snapshot
 import com.openai.snapo.tweaks.SnapOTweakEntry
+import com.openai.snapo.tweaks.SnapOTweakValue
 import com.openai.snapo.tweaks.TweakColorValue
 import com.openai.snapo.tweaks.toSnapOTweakValue
 import com.openai.snapo.tweaks.toTweakColorValue
@@ -20,6 +21,7 @@ internal enum class TweakType(val wireName: String) {
     COLOR("color"),
     STRING("string"),
     ENUM("enum"),
+    ACTION("action"),
 }
 
 internal data class TweakDescriptor(
@@ -48,6 +50,15 @@ internal class UnknownTweakException(name: String) :
 internal class InvalidTweakValueException(name: String, reason: String) :
     TweakUpdateException(422, "Invalid value for $name: $reason")
 
+internal class UnknownTweakActionException(name: String) :
+    TweakUpdateException(404, "Unknown action: $name")
+
+internal class ConflictingTweakActionException(name: String) :
+    TweakUpdateException(
+        409,
+        "Conflicting registrations for action: $name. Register the action once at its owner.",
+    )
+
 internal object TweakRegistry {
     private val lock = Any()
     private val tweaks = LinkedHashMap<String, RegisteredTweak>()
@@ -67,6 +78,9 @@ internal object TweakRegistry {
     fun register(descriptor: TweakDescriptor): State<Any> {
         var changed = false
         val state = synchronized(lock) {
+            require(descriptor.type != TweakType.ACTION) {
+                "Actions must be registered with their composition owner: ${descriptor.name}"
+            }
             validateDescriptor(descriptor)
 
             val existing = tweaks[descriptor.name]
@@ -84,15 +98,7 @@ internal object TweakRegistry {
                     },
                     references = 1,
                 )
-                val wasObserved = observedTweakOrder.containsKey(descriptor.name)
-                if (!wasObserved) {
-                    observedTweakOrder[descriptor.name] = nextTweakOrder++
-                }
-                tweaks[descriptor.name] = tweak
-                if (wasObserved) {
-                    restoreObservedTweakOrder()
-                }
-                publishActiveEntries()
+                addRegisteredTweak(tweak)
                 changed = true
                 tweak.state
             }
@@ -116,6 +122,71 @@ internal object TweakRegistry {
         if (changed) notifyObservers()
     }
 
+    fun registerAction(
+        name: String,
+        onInvoke: () -> Unit,
+    ): Closeable {
+        val owner = Any()
+        synchronized(lock) {
+            val descriptor = TweakDescriptor(name = name, type = TweakType.ACTION, default = Unit)
+            validateDescriptor(descriptor)
+
+            val existing = tweaks[name]
+            if (existing == null) {
+                val action = RegisteredTweak(
+                    descriptor = descriptor,
+                    state = mutableStateOf<Any>(SnapOTweakValue.Action()),
+                    actionCallbacks = linkedMapOf(owner to onInvoke),
+                )
+                addRegisteredTweak(action)
+            } else {
+                require(existing.descriptor.type == TweakType.ACTION) {
+                    "An action cannot share the name of a value tweak: $name"
+                }
+                val callbacks = requireNotNull(existing.actionCallbacks)
+                callbacks[owner] = onInvoke
+                updateActionConflict(existing)
+            }
+        }
+        notifyObservers()
+        return Closeable { unregisterAction(name, owner) }
+    }
+
+    private fun unregisterAction(
+        name: String,
+        owner: Any,
+    ) {
+        val changed = synchronized(lock) {
+            val action = tweaks[name]
+                ?.takeIf { it.descriptor.type == TweakType.ACTION }
+                ?: return@synchronized false
+            val callbacks = requireNotNull(action.actionCallbacks)
+            if (callbacks.remove(owner) == null) return@synchronized false
+
+            if (callbacks.isEmpty()) {
+                tweaks.remove(name)
+                publishActiveEntries()
+            } else {
+                updateActionConflict(action)
+            }
+            true
+        }
+        if (changed) notifyObservers()
+    }
+
+    fun invokeAction(name: String) {
+        val callback = synchronized(lock) {
+            val action = tweaks[name]
+                ?.takeIf { it.descriptor.type == TweakType.ACTION }
+                ?: throw UnknownTweakActionException(name)
+            val callbacks = requireNotNull(action.actionCallbacks)
+            if (callbacks.size != 1) throw ConflictingTweakActionException(name)
+
+            callbacks.values.single()
+        }
+        callback()
+    }
+
     fun activeEntries(): State<List<SnapOTweakEntry>> = activeEntries
 
     fun snapshot(includeAdjusted: Boolean = false): List<TweakSnapshot> = synchronized(lock) {
@@ -127,9 +198,7 @@ internal object TweakRegistry {
             tweaks.values
         }
 
-        registeredTweaks.map { tweak ->
-            TweakSnapshot(tweak.descriptor, tweak.state.value)
-        }
+        registeredTweaks.map { tweak -> TweakSnapshot(tweak.descriptor, tweak.state.value) }
     }
 
     fun update(values: Map<String, Any?>): List<TweakSnapshot> {
@@ -199,6 +268,29 @@ internal object TweakRegistry {
         activeEntries.value = tweaks.values.map(RegisteredTweak::entry)
     }
 
+    private fun addRegisteredTweak(tweak: RegisteredTweak) {
+        val name = tweak.descriptor.name
+        val wasObserved = observedTweakOrder.containsKey(name)
+        if (!wasObserved) {
+            observedTweakOrder[name] = nextTweakOrder++
+        }
+        tweaks[name] = tweak
+        if (wasObserved) {
+            restoreObservedTweakOrder()
+        }
+        publishActiveEntries()
+    }
+
+    private fun updateActionConflict(action: RegisteredTweak) {
+        val conflicted = requireNotNull(action.actionCallbacks).size > 1
+        val current = action.state.value as SnapOTweakValue.Action
+        if (current.conflicted != conflicted) {
+            Snapshot.withMutableSnapshot {
+                action.state.value = SnapOTweakValue.Action(conflicted)
+            }
+        }
+    }
+
     private fun restoreObservedTweakOrder() {
         val orderedTweaks = tweaks.entries.sortedBy { entry ->
             observedTweakOrder.getValue(entry.key)
@@ -230,6 +322,9 @@ internal object TweakRegistry {
             }
 
             TweakType.ENUM -> validateEnumDescriptor(descriptor)
+            TweakType.ACTION -> require(descriptor.default === Unit) {
+                "Actions must not declare a default value: ${descriptor.name}"
+            }
         }
 
         if (descriptor.type != TweakType.ENUM) {
@@ -346,39 +441,42 @@ internal object TweakRegistry {
             }
 
             TweakType.STRING, TweakType.ENUM -> validateStringValue(descriptor, value)
-            TweakType.COLOR -> {
-                val defaultColor = descriptor.default as TweakColorValue
+            TweakType.COLOR -> validateColorValue(descriptor, value)
 
-                when (value) {
-                    is TweakColorValue -> {
-                        val color = try {
-                            value.color.toTweakColorValue()
-                        } catch (_: IllegalArgumentException) {
-                            invalidValue(descriptor, "Expected a supported color.")
-                        }
-                        if (color.color == defaultColor.color) {
-                            defaultColor
-                        } else {
-                            color
-                        }
-                    }
+            TweakType.ACTION -> invalidValue(
+                descriptor,
+                "Actions cannot be patched. Invoke the registered action instead.",
+            )
+        }
 
-                    is String -> {
-                        if (!colorPattern.matches(value)) {
-                            invalidValue(descriptor, "Expected #RRGGBB or #RRGGBBAA.")
-                        }
-                        val normalized = value.uppercase()
-                        if (normalized == defaultColor.wireValue) {
-                            defaultColor
-                        } else {
-                            normalized.toTweakColorValue()
-                        }
-                    }
+    private fun validateColorValue(descriptor: TweakDescriptor, value: Any?): TweakColorValue {
+        val defaultColor = descriptor.default as TweakColorValue
 
-                    else -> invalidValue(descriptor, "Expected a color string.")
+        return when (value) {
+            is TweakColorValue -> {
+                val color = try {
+                    value.color.toTweakColorValue()
+                } catch (_: IllegalArgumentException) {
+                    invalidValue(descriptor, "Expected a supported color.")
+                }
+                if (color.color == defaultColor.color) defaultColor else color
+            }
+
+            is String -> {
+                if (!colorPattern.matches(value)) {
+                    invalidValue(descriptor, "Expected #RRGGBB or #RRGGBBAA.")
+                }
+                val normalized = value.uppercase()
+                if (normalized == defaultColor.wireValue) {
+                    defaultColor
+                } else {
+                    normalized.toTweakColorValue()
                 }
             }
+
+            else -> invalidValue(descriptor, "Expected a color string.")
         }
+    }
 
     private fun validateStringValue(descriptor: TweakDescriptor, value: Any?): String {
         val isEnum = descriptor.type == TweakType.ENUM
@@ -461,7 +559,8 @@ internal object TweakRegistry {
     private data class RegisteredTweak(
         val descriptor: TweakDescriptor,
         val state: MutableState<Any>,
-        var references: Int,
+        var references: Int = 0,
+        val actionCallbacks: LinkedHashMap<Any, () -> Unit>? = null,
     ) {
         val entry = SnapOTweakEntry(
             name = descriptor.name,

--- a/snapo-link-android/tweaks/src/test/java/com/openai/snapo/tweaks/SnapOTweaksTest.kt
+++ b/snapo-link-android/tweaks/src/test/java/com/openai/snapo/tweaks/SnapOTweaksTest.kt
@@ -151,6 +151,18 @@ class SnapOTweaksTest {
     }
 
     @Test
+    fun `release invocations without an override do not run registered actions`() {
+        var invocations = 0
+        val registration = TweakRegistry.registerAction("Playback/Restart") { invocations += 1 }
+        TweaksRuntimePolicy.configure(isDebuggable = false, allowRelease = false)
+
+        SnapOTweaks.invokeAction("Playback/Restart")
+
+        assertEquals(0, invocations)
+        registration.close()
+    }
+
+    @Test
     fun `observable entries keep their identity while individual values update`() {
         val descriptor = TweakDescriptor(
             name = "Typography/Observable font size",

--- a/snapo-link-android/tweaks/src/test/java/com/openai/snapo/tweaks/internal/TweakActionChangePublisherTest.kt
+++ b/snapo-link-android/tweaks/src/test/java/com/openai/snapo/tweaks/internal/TweakActionChangePublisherTest.kt
@@ -1,0 +1,133 @@
+package com.openai.snapo.tweaks.internal
+
+import com.openai.snapo.tweaks.SnapOTweakValue
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class TweakActionChangePublisherTest {
+
+    @After
+    fun clearRegistry() {
+        TweakRegistry.clear()
+    }
+
+    @Test
+    fun `initial action events include every active value and action descriptor`() {
+        val value = TweakDescriptor("Motion/Duration", TweakType.INT, 400)
+        TweakRegistry.register(value)
+        val registration = TweakRegistry.registerAction("Playback/Restart") {}
+        val publisher = TweakChangePublisher { true }
+
+        publisher.subscribe().use { subscription ->
+            assertEquals(
+                listOf("Motion/Duration", "Playback/Restart"),
+                subscription.initial.map { it.descriptor.name },
+            )
+            assertEquals(TweakType.INT, subscription.initial[0].descriptor.type)
+            assertEquals(400, subscription.initial[0].value)
+            assertEquals(TweakType.ACTION, subscription.initial[1].descriptor.type)
+            assertEquals(SnapOTweakValue.Action(), subscription.initial[1].value)
+            assertNull(subscription.events.poll())
+        }
+
+        registration.close()
+        publisher.close()
+    }
+
+    @Test
+    fun `live conflict and recovery replace the complete streamed action snapshot`() {
+        val original = TweakRegistry.registerAction("Playback/Restart") {}
+        val scheduled = mutableListOf<Runnable>()
+        val publisher = TweakChangePublisher { runnable -> scheduled.add(runnable) }
+        val observer = TweakRegistry.observeChanges(publisher::notifyChanged)
+
+        publisher.subscribe().use { subscription ->
+            assertEquals(SnapOTweakValue.Action(), subscription.initial.single().value)
+
+            val duplicate = TweakRegistry.registerAction("Playback/Restart") {}
+
+            assertEquals(1, scheduled.size)
+            scheduled.removeAt(0).run()
+
+            val conflicted = subscription.events.poll()?.single()
+            assertEquals("Playback/Restart", conflicted?.descriptor?.name)
+            assertEquals(TweakType.ACTION, conflicted?.descriptor?.type)
+            assertEquals(SnapOTweakValue.Action(conflicted = true), conflicted?.value)
+            assertNull(subscription.events.poll())
+
+            duplicate.close()
+
+            assertEquals(1, scheduled.size)
+            scheduled.removeAt(0).run()
+
+            val recovered = subscription.events.poll()?.single()
+            assertEquals("Playback/Restart", recovered?.descriptor?.name)
+            assertEquals(SnapOTweakValue.Action(), recovered?.value)
+            assertNull(subscription.events.poll())
+        }
+
+        observer.close()
+        original.close()
+        publisher.close()
+    }
+
+    @Test
+    fun `action registration and disposal publish complete value-preserving snapshots`() {
+        val value = TweakDescriptor("Motion/Duration", TweakType.INT, 400)
+        TweakRegistry.register(value)
+        val scheduled = mutableListOf<Runnable>()
+        val publisher = TweakChangePublisher { runnable -> scheduled.add(runnable) }
+        val observer = TweakRegistry.observeChanges(publisher::notifyChanged)
+
+        publisher.subscribe().use { subscription ->
+            val registration = TweakRegistry.registerAction("Playback/Restart") {}
+            TweakRegistry.update(mapOf(value.name to 550))
+
+            assertEquals(1, scheduled.size)
+            scheduled.removeAt(0).run()
+
+            val added = requireNotNull(subscription.events.poll())
+            assertEquals(listOf(value.name, "Playback/Restart"), added.map { it.descriptor.name })
+            assertEquals(550, added[0].value)
+            assertEquals(TweakType.ACTION, added[1].descriptor.type)
+            assertNull(subscription.events.poll())
+
+            registration.close()
+
+            assertEquals(1, scheduled.size)
+            scheduled.removeAt(0).run()
+
+            val removed = requireNotNull(subscription.events.poll())
+            assertEquals(listOf(value.name), removed.map { it.descriptor.name })
+            assertEquals(550, removed.single().value)
+            assertNull(subscription.events.poll())
+        }
+
+        observer.close()
+        publisher.close()
+    }
+
+    @Test
+    fun `invoking an action without registry changes does not publish a new snapshot`() {
+        var invocations = 0
+        val registration = TweakRegistry.registerAction("Playback/Restart") { invocations += 1 }
+        val scheduled = mutableListOf<Runnable>()
+        val publisher = TweakChangePublisher { runnable -> scheduled.add(runnable) }
+        val observer = TweakRegistry.observeChanges(publisher::notifyChanged)
+
+        publisher.subscribe().use { subscription ->
+            TweakRegistry.invokeAction("Playback/Restart")
+
+            assertEquals(1, invocations)
+            assertTrue(scheduled.isEmpty())
+            assertNull(subscription.events.poll())
+        }
+
+        observer.close()
+        registration.close()
+        publisher.close()
+    }
+}

--- a/snapo-link-android/tweaks/src/test/java/com/openai/snapo/tweaks/internal/TweakActionRegistryTest.kt
+++ b/snapo-link-android/tweaks/src/test/java/com/openai/snapo/tweaks/internal/TweakActionRegistryTest.kt
@@ -1,0 +1,224 @@
+package com.openai.snapo.tweaks.internal
+
+import com.openai.snapo.tweaks.SnapOTweakValue
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertSame
+import org.junit.Assert.assertThrows
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class TweakActionRegistryTest {
+
+    @After
+    fun clearRegistry() {
+        TweakRegistry.clear()
+    }
+
+    @Test
+    fun `registered actions appear alongside value tweaks in composition order`() {
+        val first = TweakDescriptor("Typography/Size", TweakType.INT, 16)
+        val second = TweakDescriptor("Motion/Enabled", TweakType.BOOLEAN, true)
+
+        TweakRegistry.register(first)
+        TweakRegistry.registerAction("Playback/Restart") {}
+        TweakRegistry.register(second)
+
+        val snapshots = TweakRegistry.snapshot()
+
+        assertEquals(
+            listOf(first.name, "Playback/Restart", second.name),
+            snapshots.map { it.descriptor.name },
+        )
+        assertEquals(TweakType.ACTION, snapshots[1].descriptor.type)
+        assertEquals(SnapOTweakValue.Action(), snapshots[1].value)
+        assertEquals(
+            SnapOTweakValue.Action(),
+            TweakRegistry.activeEntries().value[1].value.value,
+        )
+    }
+
+    @Test
+    fun `invocation runs only its explicitly registered callback`() {
+        var invocations = 0
+        TweakRegistry.registerAction("Playback/Restart") { invocations += 1 }
+
+        assertEquals(0, invocations)
+
+        TweakRegistry.invokeAction("Playback/Restart")
+        TweakRegistry.invokeAction("Playback/Restart")
+
+        assertEquals(2, invocations)
+    }
+
+    @Test
+    fun `separate owners with the same callback still conflict`() {
+        var invocations = 0
+        val callback = { invocations += 1 }
+        TweakRegistry.registerAction("Playback/Restart", callback)
+        TweakRegistry.registerAction("Playback/Restart", callback)
+
+        val error = assertThrows(ConflictingTweakActionException::class.java) {
+            TweakRegistry.invokeAction("Playback/Restart")
+        }
+
+        assertEquals(409, error.statusCode)
+        assertTrue(error.message.orEmpty().contains("Playback/Restart"))
+        assertEquals(0, invocations)
+        assertEquals(
+            SnapOTweakValue.Action(conflicted = true),
+            TweakRegistry.snapshot().single().value,
+        )
+        assertEquals(
+            SnapOTweakValue.Action(conflicted = true),
+            TweakRegistry.activeEntries().value.single().value.value,
+        )
+    }
+
+    @Test
+    fun `conflicted actions recover only when their duplicate owner leaves`() {
+        var originalInvocations = 0
+        var duplicateInvocations = 0
+        TweakRegistry.registerAction("Playback/Restart") {
+            originalInvocations += 1
+        }
+        val duplicateRegistration = TweakRegistry.registerAction("Playback/Restart") {
+            duplicateInvocations += 1
+        }
+
+        duplicateRegistration.close()
+
+        assertEquals(SnapOTweakValue.Action(), TweakRegistry.snapshot().single().value)
+        assertEquals(
+            SnapOTweakValue.Action(),
+            TweakRegistry.activeEntries().value.single().value.value,
+        )
+
+        TweakRegistry.invokeAction("Playback/Restart")
+
+        assertEquals(1, originalInvocations)
+        assertEquals(0, duplicateInvocations)
+    }
+
+    @Test
+    fun `conflict changes notify snapshots without replacing observable entries`() {
+        val conflicts = mutableListOf<Boolean>()
+        val observer = TweakRegistry.observeChanges {
+            TweakRegistry.snapshot().singleOrNull()?.let { snapshot ->
+                conflicts += (snapshot.value as SnapOTweakValue.Action).conflicted
+            }
+        }
+        TweakRegistry.registerAction("Playback/Restart") {}
+        val entry = TweakRegistry.activeEntries().value.single()
+
+        val duplicateRegistration = TweakRegistry.registerAction("Playback/Restart") {}
+
+        assertSame(entry, TweakRegistry.activeEntries().value.single())
+
+        duplicateRegistration.close()
+
+        assertSame(entry, TweakRegistry.activeEntries().value.single())
+        assertEquals(listOf(false, true, false), conflicts)
+        observer.close()
+    }
+
+    @Test
+    fun `unknown and value-backed actions are unavailable for invocation`() {
+        TweakRegistry.register(TweakDescriptor("Typography/Size", TweakType.INT, 16))
+
+        val unknown = assertThrows(UnknownTweakActionException::class.java) {
+            TweakRegistry.invokeAction("Playback/Missing")
+        }
+        val value = assertThrows(UnknownTweakActionException::class.java) {
+            TweakRegistry.invokeAction("Typography/Size")
+        }
+
+        assertEquals(404, unknown.statusCode)
+        assertEquals(404, value.statusCode)
+    }
+
+    @Test
+    fun `action names cannot collide with value tweak names`() {
+        val descriptor = TweakDescriptor("Playback/Restart", TweakType.BOOLEAN, true)
+        TweakRegistry.register(descriptor)
+
+        assertThrows(IllegalArgumentException::class.java) {
+            TweakRegistry.registerAction(descriptor.name) {}
+        }
+
+        assertEquals(descriptor, TweakRegistry.snapshot().single().descriptor)
+    }
+
+    @Test
+    fun `value tweaks cannot collide with registered action names`() {
+        val name = "Playback/Restart"
+        TweakRegistry.registerAction(name) {}
+
+        assertThrows(IllegalArgumentException::class.java) {
+            TweakRegistry.register(TweakDescriptor(name, TweakType.BOOLEAN, true))
+        }
+
+        assertEquals(TweakType.ACTION, TweakRegistry.snapshot().single().descriptor.type)
+    }
+
+    @Test
+    fun `actions reject value patches without changing other tweaks`() {
+        val value = TweakDescriptor("Typography/Size", TweakType.INT, 16)
+        TweakRegistry.register(value)
+        TweakRegistry.registerAction("Playback/Restart") {}
+
+        val error = assertThrows(InvalidTweakValueException::class.java) {
+            TweakRegistry.update(
+                linkedMapOf(value.name to 20, "Playback/Restart" to "run"),
+            )
+        }
+
+        assertEquals(422, error.statusCode)
+        assertEquals(16, TweakRegistry.snapshot().first().value)
+    }
+
+    @Test
+    fun `actions never remain as adjusted history after their owner leaves`() {
+        val registration = TweakRegistry.registerAction("Playback/Restart") {}
+
+        registration.close()
+
+        assertTrue(TweakRegistry.snapshot(includeAdjusted = true).isEmpty())
+    }
+
+    @Test
+    fun `closing an old registration cannot remove a newer same-name action`() {
+        val previous = TweakRegistry.registerAction("Playback/Restart") {}
+        previous.close()
+        var invocations = 0
+        val replacement = TweakRegistry.registerAction("Playback/Restart") { invocations += 1 }
+
+        previous.close()
+        TweakRegistry.invokeAction("Playback/Restart")
+
+        assertEquals(1, invocations)
+        assertEquals(SnapOTweakValue.Action(), TweakRegistry.snapshot().single().value)
+        replacement.close()
+    }
+
+    @Test
+    fun `action registrations reject blank stable names`() {
+        assertThrows(IllegalArgumentException::class.java) {
+            TweakRegistry.registerAction("  ") {}
+        }
+
+        assertTrue(TweakRegistry.snapshot().isEmpty())
+    }
+
+    @Test
+    fun `clearing removes actions and their callbacks`() {
+        TweakRegistry.registerAction("Playback/Restart") {}
+
+        TweakRegistry.clear()
+
+        assertTrue(TweakRegistry.snapshot().isEmpty())
+        assertThrows(UnknownTweakActionException::class.java) {
+            TweakRegistry.invokeAction("Playback/Restart")
+        }
+    }
+}

--- a/snapo-network-inspector-web/src/features/tweaks-inspector/TweaksInspectorApp.test.ts
+++ b/snapo-network-inspector-web/src/features/tweaks-inspector/TweaksInspectorApp.test.ts
@@ -1,7 +1,12 @@
 import { createElement, type MouseEvent, type PointerEvent, type ReactElement } from "react";
 import { renderToStaticMarkup } from "react-dom/server";
 import { describe, expect, it, vi } from "vitest";
-import type { SelectedAppInspector, TweakDescriptor } from "../../network/bridge-types";
+import type {
+  SelectedAppInspector,
+  TweakActionDescriptor,
+  TweakDescriptor,
+  TweakValueDescriptor
+} from "../../network/bridge-types";
 import { createNetworkClient, type NetworkClient } from "../../network/client";
 import {
   canResetTweaks,
@@ -10,6 +15,7 @@ import {
   nativePanelTweakColor,
   parseTweakColor,
   reconcileStreamedTweaks,
+  TweakActionControl,
   TweakColorField,
   TweakEnumListbox,
   TweakField,
@@ -294,6 +300,142 @@ describe("native reset toolbar state", () => {
     expect(canResetTweaks([{ ...fontSize, value: 2 }])).toBe(true);
     expect(canResetTweaks([fontSize])).toBe(false);
   });
+
+  it("does not treat an action without a value or default as resettable", () => {
+    expect(canResetTweaks([action("Motion/Toggle animation")])).toBe(false);
+  });
+
+  it("keeps changed value tweaks resettable when actions are present", () => {
+    expect(canResetTweaks([action("Motion/Toggle animation"), { ...tweak("Motion/Duration"), value: 2 }])).toBe(true);
+  });
+});
+
+describe("registered tweak actions", () => {
+  const server = { deviceId: "pixel", socketName: "snapo_tweaks_10" };
+
+  it("renders an action label with an accessible Run button on the right", () => {
+    const markup = renderToStaticMarkup(
+      createElement(TweakActionControl, { action: action("Motion/Toggle animation"), onInvoke() {} })
+    );
+
+    expect(markup).toContain('class="tweaks-control-label">Toggle animation</span>');
+    expect(markup).toContain('class="tweaks-control-field"');
+    expect(markup).toContain('class="tweaks-action-button"');
+    expect(markup).toContain('aria-label="Run Motion/Toggle animation"');
+    expect(markup).toContain(">Run</button>");
+    expect(markup).not.toContain("tweaks-reset");
+    expect(markup).not.toContain("disabled");
+  });
+
+  it("passes the selected descriptor to the action invocation handler", () => {
+    const descriptor = action("Motion/Toggle animation");
+    const onInvoke = vi.fn();
+    const control = TweakActionControl({ action: descriptor, onInvoke });
+    const [, field] = control.props.children[0].props.children;
+    const button = field.props.children;
+
+    button.props.onClick();
+
+    expect(onInvoke).toHaveBeenCalledOnce();
+    expect(onInvoke).toHaveBeenCalledWith(descriptor);
+  });
+
+  it("disables conflicted registrations and explains why they cannot run", () => {
+    const markup = renderToStaticMarkup(
+      createElement(TweakActionControl, {
+        action: action("Motion/Toggle animation", true),
+        onInvoke() {}
+      })
+    );
+
+    expect(markup).toContain('disabled=""');
+    expect(markup).toContain('aria-label="Conflict Motion/Toggle animation"');
+    expect(markup).toContain(">Conflict</button>");
+    expect(markup).toContain('role="alert"');
+    expect(markup).toContain("Conflicting registrations. Use a unique action name.");
+  });
+
+  it("disables an action while its invocation is in flight", () => {
+    const markup = renderToStaticMarkup(
+      createElement(TweakActionControl, {
+        action: action("Motion/Toggle animation"),
+        invoking: true,
+        onInvoke() {}
+      })
+    );
+
+    expect(markup).toContain('disabled=""');
+  });
+
+  it("invokes actions through the native desktop bridge", async () => {
+    const postMessage = vi.fn().mockResolvedValue(undefined);
+    vi.stubGlobal("window", { webkit: { messageHandlers: { snapoNetwork: { postMessage } } } });
+
+    try {
+      await createNetworkClient().invokeTweakAction({ server, name: "Motion/Toggle animation" });
+
+      expect(postMessage).toHaveBeenCalledWith({
+        command: "invokeTweakAction",
+        payload: { server, name: "Motion/Toggle animation" }
+      });
+    } finally {
+      vi.unstubAllGlobals();
+    }
+  });
+
+  it("posts named action invocations through the browser inspector proxy", async () => {
+    const fetch = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({ name: "Motion/Toggle animation" })
+    });
+    vi.stubGlobal("window", {});
+    vi.stubGlobal("fetch", fetch);
+
+    try {
+      await createNetworkClient().invokeTweakAction({ server, name: "Motion/Toggle animation" });
+
+      expect(fetch).toHaveBeenCalledWith("/api/inspector/tweaks/action", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ server, name: "Motion/Toggle animation" })
+      });
+    } finally {
+      vi.unstubAllGlobals();
+    }
+  });
+
+  it("preserves upstream conflict errors instead of replacing them with an HTTP status", async () => {
+    vi.stubGlobal("window", {});
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue({
+        ok: false,
+        status: 409,
+        json: async () => ({ error: "Action Motion/Toggle animation has conflicting registrations." })
+      })
+    );
+
+    try {
+      await expect(
+        createNetworkClient().invokeTweakAction({ server, name: "Motion/Toggle animation" })
+      ).rejects.toThrow("Action Motion/Toggle animation has conflicting registrations.");
+    } finally {
+      vi.unstubAllGlobals();
+    }
+  });
+
+  it("preserves generic HTTP status errors for unrelated network requests", async () => {
+    const json = vi.fn().mockResolvedValue({ error: "Unrelated conflict" });
+    vi.stubGlobal("window", {});
+    vi.stubGlobal("fetch", vi.fn().mockResolvedValue({ ok: false, status: 409, json }));
+
+    try {
+      await expect(createNetworkClient().listServers()).rejects.toThrow("Request failed with 409");
+      expect(json).not.toHaveBeenCalled();
+    } finally {
+      vi.unstubAllGlobals();
+    }
+  });
 });
 
 describe("streamed tweak snapshots", () => {
@@ -332,6 +474,23 @@ describe("streamed tweak snapshots", () => {
     expect(reconcileStreamedTweaks(current, incoming, new Map([["Motion/Duration", 700]]), new Set())).toEqual([
       { ...incoming[0], value: 700 }
     ]);
+  });
+
+  it("adds and removes registered actions without assigning them a value", () => {
+    const current = [tweak("Motion/Duration")];
+    const incoming = [tweak("Motion/Duration"), action("Motion/Toggle animation")];
+
+    expect(reconcileStreamedTweaks(current, incoming, new Map(), new Set())).toEqual(incoming);
+    expect(reconcileStreamedTweaks(incoming, current, new Map(), new Set())).toEqual(current);
+  });
+
+  it("preserves action descriptors when a value update has the same name queued", () => {
+    const current = [action("Motion/Toggle animation")];
+    const incoming = [action("Motion/Toggle animation", true)];
+
+    expect(reconcileStreamedTweaks(current, incoming, new Map([["Motion/Toggle animation", 1]]), new Set())).toEqual(
+      incoming
+    );
   });
 });
 
@@ -389,9 +548,18 @@ describe("stable tweak section columns", () => {
 
     expect(columns.map((column) => column.map((section) => section.name))).toEqual([["Motion"], ["Colors"]]);
   });
+
+  it("keeps registered actions in the same named sections as value tweaks", () => {
+    const columns = groupTweaks([tweak("Motion/Duration"), action("Motion/Toggle animation")], "pixel:demo", new Map());
+
+    expect(columns[0][0].tweaks.map((descriptor) => descriptor.name)).toEqual([
+      "Motion/Duration",
+      "Motion/Toggle animation"
+    ]);
+  });
 });
 
-function tweak(name: string): TweakDescriptor {
+function tweak(name: string): TweakValueDescriptor {
   return {
     name,
     type: "int",
@@ -400,7 +568,7 @@ function tweak(name: string): TweakDescriptor {
   };
 }
 
-function colorTweak(): TweakDescriptor {
+function colorTweak(): TweakValueDescriptor {
   return {
     name: "Colors/Accent",
     type: "color",
@@ -409,7 +577,7 @@ function colorTweak(): TweakDescriptor {
   };
 }
 
-function enumTweak(): TweakDescriptor {
+function enumTweak(): TweakValueDescriptor {
   return {
     name: "Appearance/Theme",
     type: "enum",
@@ -422,7 +590,7 @@ function enumTweak(): TweakDescriptor {
 function enumListboxOption(
   index: number,
   handlers: {
-    onChange(tweak: TweakDescriptor, value: TweakDescriptor["value"]): void;
+    onChange(tweak: TweakValueDescriptor, value: TweakValueDescriptor["value"]): void;
     onClose(): void;
   }
 ): ReactElement<{
@@ -435,4 +603,12 @@ function enumListboxOption(
     ...handlers
   });
   return listbox.props.children[index];
+}
+
+function action(name: string, conflicted = false): TweakActionDescriptor {
+  return {
+    name,
+    type: "action",
+    ...(conflicted ? { conflicted: true } : {})
+  };
 }

--- a/snapo-network-inspector-web/src/features/tweaks-inspector/TweaksInspectorApp.tsx
+++ b/snapo-network-inspector-web/src/features/tweaks-inspector/TweaksInspectorApp.tsx
@@ -5,8 +5,10 @@ import type {
   InspectableApp,
   InspectorServerReference,
   SelectedAppInspector,
+  TweakActionDescriptor,
   TweakDescriptor,
-  TweakValue
+  TweakValue,
+  TweakValueDescriptor
 } from "../../network/bridge-types";
 import type { NativeColorPanelChange, NetworkClient } from "../../network/client";
 import { AppInspectorPicker } from "../app-inspector/components/AppInspectorPicker";
@@ -24,7 +26,7 @@ interface TweakOrdering {
 }
 
 interface ActiveColorPanelSession {
-  tweak: TweakDescriptor;
+  tweak: TweakValueDescriptor;
   sessionId: string;
 }
 
@@ -46,6 +48,7 @@ export function TweaksInspectorApp({
   const [loadedServer, setLoadedServer] = useState<InspectorServerReference | null>(null);
   const [error, setError] = useState<string | null>(null);
   const [saving, setSaving] = useState(false);
+  const [invokingActions, setInvokingActions] = useState(() => new Set<string>());
   const [orderByApp] = useState(() => new Map<string, TweakOrdering>());
   const activeColorPanel = useRef<ActiveColorPanelSession | null>(null);
   const server = selection.server;
@@ -60,7 +63,9 @@ export function TweaksInspectorApp({
           setTweaks((current) =>
             current.map((tweak) => {
               const update = updates.find((candidate) => candidate.name === tweak.name);
-              return update && !pending.has(tweak.name) ? { ...tweak, value: update.value } : tweak;
+              return tweak.type !== "action" && update && !pending.has(tweak.name)
+                ? { ...tweak, value: update.value }
+                : tweak;
             })
           );
         },
@@ -124,7 +129,7 @@ export function TweaksInspectorApp({
   }, [client, queue, server]);
 
   const openNativeColorPanel = useCallback(
-    (tweak: TweakDescriptor, present = true) => {
+    (tweak: TweakValueDescriptor, present = true) => {
       if (!hasNativeColorPanel || client.openNativeColorPanel === undefined) {
         activeColorPanel.current = null;
         return;
@@ -143,13 +148,15 @@ export function TweaksInspectorApp({
   );
 
   const updateTweak = useCallback(
-    (tweak: TweakDescriptor, value: TweakValue) => {
+    (tweak: TweakValueDescriptor, value: TweakValue) => {
       const active = activeColorPanel.current;
       if (active?.tweak.name === tweak.name && active.tweak.value !== value) {
         openNativeColorPanel({ ...tweak, value }, false);
       }
 
-      setTweaks((current) => current.map((item) => (item.name === tweak.name ? { ...item, value } : item)));
+      setTweaks((current) =>
+        current.map((item) => (item.name === tweak.name && item.type !== "action" ? { ...item, value } : item))
+      );
       queue.enqueue(tweak.name, value);
       void queue.flush();
     },
@@ -161,7 +168,7 @@ export function TweaksInspectorApp({
     if (active === null) return;
 
     const tweak = tweaks.find((candidate) => candidate.name === active.tweak.name && candidate.type === "color");
-    if (tweak === undefined) {
+    if (tweak === undefined || tweak.type === "action") {
       activeColorPanel.current = null;
       void client.closeNativeColorPanel?.(active.sessionId).catch((cause: unknown) => {
         if (activeColorPanel.current !== null) return;
@@ -199,11 +206,37 @@ export function TweaksInspectorApp({
     };
   }, [client, hasNativeColorPanel, updateTweak]);
 
+  const invokeAction = useCallback(
+    (action: TweakActionDescriptor) => {
+      if (action.conflicted) return;
+
+      setInvokingActions((current) => new Set(current).add(action.name));
+      setError(null);
+
+      void client
+        .invokeTweakAction({ server, name: action.name })
+        .catch((cause: unknown) => {
+          setError(cause instanceof Error ? cause.message : `Unable to invoke ${action.name}.`);
+        })
+        .finally(() => {
+          setInvokingActions((current) => {
+            const next = new Set(current);
+            next.delete(action.name);
+            return next;
+          });
+        });
+    },
+    [client, server]
+  );
+
   const resetAll = useCallback(() => {
     for (const tweak of tweaks) {
+      if (tweak.type === "action") continue;
       queue.enqueue(tweak.name, tweak.default);
     }
-    setTweaks((current) => current.map((tweak) => ({ ...tweak, value: tweak.default })));
+    setTweaks((current) =>
+      current.map((tweak) => (tweak.type === "action" ? tweak : { ...tweak, value: tweak.default }))
+    );
     void queue.flush();
   }, [queue, tweaks]);
 
@@ -263,6 +296,8 @@ export function TweaksInspectorApp({
                           key={tweak.name}
                           tweak={tweak}
                           onChange={updateTweak}
+                          onInvoke={invokeAction}
+                          invoking={invokingActions.has(tweak.name)}
                           onOpenColorPanel={hasNativeColorPanel ? openNativeColorPanel : undefined}
                         />
                       ))}
@@ -298,7 +333,7 @@ export function hasLoadedTweaksForServer(
 }
 
 export function canResetTweaks(tweaks: TweakDescriptor[]): boolean {
-  return tweaks.some((tweak) => tweak.value !== tweak.default);
+  return tweaks.some((tweak) => tweak.type !== "action" && tweak.value !== tweak.default);
 }
 
 export function reconcileStreamedTweaks(
@@ -311,7 +346,12 @@ export function reconcileStreamedTweaks(
 
   return incoming.map((tweak) => {
     const existing = currentByName.get(tweak.name);
-    if (existing && (pending.has(tweak.name) || inFlight.has(tweak.name))) {
+    if (
+      existing &&
+      existing.type !== "action" &&
+      tweak.type !== "action" &&
+      (pending.has(tweak.name) || inFlight.has(tweak.name))
+    ) {
       return { ...tweak, value: existing.value };
     }
     return tweak;
@@ -373,12 +413,20 @@ function tweakLabel(name: string): string {
 function TweakControl({
   tweak,
   onChange,
+  onInvoke,
+  invoking,
   onOpenColorPanel
 }: {
   tweak: TweakDescriptor;
-  onChange(tweak: TweakDescriptor, value: TweakValue): void;
-  onOpenColorPanel?(tweak: TweakDescriptor): void;
+  onChange(tweak: TweakValueDescriptor, value: TweakValue): void;
+  onInvoke(action: TweakActionDescriptor): void;
+  invoking: boolean;
+  onOpenColorPanel?(tweak: TweakValueDescriptor): void;
 }): JSX.Element {
+  if (tweak.type === "action") {
+    return <TweakActionControl action={tweak} invoking={invoking} onInvoke={onInvoke} />;
+  }
+
   const label = tweakLabel(tweak.name);
   const changed = tweak.value !== tweak.default;
 
@@ -428,14 +476,48 @@ function TweakControl({
   );
 }
 
+export function TweakActionControl({
+  action,
+  invoking = false,
+  onInvoke
+}: {
+  action: TweakActionDescriptor;
+  invoking?: boolean;
+  onInvoke(action: TweakActionDescriptor): void;
+}): JSX.Element {
+  return (
+    <div className="tweaks-control">
+      <div className="tweaks-control-line">
+        <span className="tweaks-control-label">{tweakLabel(action.name)}</span>
+        <span className="tweaks-control-field">
+          <button
+            className="tweaks-action-button"
+            type="button"
+            aria-label={`${action.conflicted ? "Conflict" : "Run"} ${action.name}`}
+            disabled={Boolean(action.conflicted) || invoking}
+            onClick={() => onInvoke(action)}
+          >
+            {action.conflicted ? "Conflict" : "Run"}
+          </button>
+        </span>
+      </div>
+      {action.conflicted ? (
+        <p className="tweaks-action-conflict" role="alert">
+          Conflicting registrations. Use a unique action name.
+        </p>
+      ) : null}
+    </div>
+  );
+}
+
 export function TweakField({
   tweak,
   onChange,
   onOpenColorPanel
 }: {
-  tweak: TweakDescriptor;
-  onChange(tweak: TweakDescriptor, value: TweakValue): void;
-  onOpenColorPanel?(tweak: TweakDescriptor): void;
+  tweak: TweakValueDescriptor;
+  onChange(tweak: TweakValueDescriptor, value: TweakValue): void;
+  onOpenColorPanel?(tweak: TweakValueDescriptor): void;
 }): JSX.Element | null {
   if (tweak.type === "boolean") {
     return (
@@ -484,8 +566,8 @@ function TweakEnumField({
   tweak,
   onChange
 }: {
-  tweak: TweakDescriptor;
-  onChange(tweak: TweakDescriptor, value: TweakValue): void;
+  tweak: TweakValueDescriptor;
+  onChange(tweak: TweakValueDescriptor, value: TweakValue): void;
 }): JSX.Element {
   const [listboxStyle, setListboxStyle] = useState<CSSProperties | null>(null);
   const rootRef = useRef<HTMLDivElement>(null);
@@ -592,8 +674,8 @@ export function TweakEnumListbox({
 }: {
   id: string;
   style?: CSSProperties;
-  tweak: TweakDescriptor;
-  onChange(tweak: TweakDescriptor, value: TweakValue): void;
+  tweak: TweakValueDescriptor;
+  onChange(tweak: TweakValueDescriptor, value: TweakValue): void;
   onClose(): void;
 }): JSX.Element {
   const select = (value: string) => {
@@ -633,9 +715,9 @@ export function TweakColorField({
   onChange,
   onOpenColorPanel
 }: {
-  tweak: TweakDescriptor;
-  onChange(tweak: TweakDescriptor, value: TweakValue): void;
-  onOpenColorPanel?(tweak: TweakDescriptor): void;
+  tweak: TweakValueDescriptor;
+  onChange(tweak: TweakValueDescriptor, value: TweakValue): void;
+  onOpenColorPanel?(tweak: TweakValueDescriptor): void;
 }): JSX.Element {
   const committed = String(tweak.value);
   const [draft, setDraft] = useState(() => ({ committed, value: committed }));

--- a/snapo-network-inspector-web/src/network/bridge-types.ts
+++ b/snapo-network-inspector-web/src/network/bridge-types.ts
@@ -26,6 +26,7 @@ export interface InspectorServerReference {
 export interface AppInspectorOption {
   kind: AppInspectorKind;
   server: InspectorServerReference;
+  protocolVersion?: number | null;
 }
 
 export interface InspectableApp {
@@ -46,7 +47,7 @@ export interface SelectedAppInspector {
 
 export type TweakValue = boolean | number | string;
 
-export interface TweakDescriptor {
+export interface TweakValueDescriptor {
   name: string;
   type: "int" | "float" | "boolean" | "color" | "string" | "enum";
   default: TweakValue;
@@ -56,6 +57,14 @@ export interface TweakDescriptor {
   step?: number;
   options?: string[];
 }
+
+export interface TweakActionDescriptor {
+  name: string;
+  type: "action";
+  conflicted?: boolean;
+}
+
+export type TweakDescriptor = TweakValueDescriptor | TweakActionDescriptor;
 
 export interface TweakList {
   tweaks: TweakDescriptor[];
@@ -83,6 +92,11 @@ export interface TweakUpdates {
 export interface UpdateTweaksInput {
   server: InspectorServerReference;
   values: Record<string, TweakValue>;
+}
+
+export interface InvokeTweakActionInput {
+  server: InspectorServerReference;
+  name: string;
 }
 
 export interface NativeInspectorState {

--- a/snapo-network-inspector-web/src/network/client.ts
+++ b/snapo-network-inspector-web/src/network/client.ts
@@ -2,6 +2,7 @@ import type {
   DebugInspectorPreset,
   InspectableApp,
   InspectorServerReference,
+  InvokeTweakActionInput,
   LoadBodiesInput,
   NativeInspectorState,
   NativeTweaksState,
@@ -32,6 +33,7 @@ export interface NetworkClient {
   listServers(): Promise<SnapOServer[]>;
   listTweaks(server: InspectorServerReference): Promise<TweakList>;
   updateTweaks(input: UpdateTweaksInput): Promise<TweakUpdates>;
+  invokeTweakAction(input: InvokeTweakActionInput): Promise<void>;
   startTweakStream(server: InspectorServerReference): Promise<StreamStarted>;
   stopTweakStream(streamId: string): Promise<void>;
   onTweaksChanged(callback: (event: TweakStreamEvent) => void): () => void;
@@ -100,6 +102,10 @@ class WebKitNetworkClient implements NetworkClient {
 
   updateTweaks(input: UpdateTweaksInput): Promise<TweakUpdates> {
     return this.invoke<TweakUpdates>("updateTweaks", input);
+  }
+
+  invokeTweakAction(input: InvokeTweakActionInput): Promise<void> {
+    return this.invoke<void>("invokeTweakAction", input);
   }
 
   startTweakStream(server: InspectorServerReference): Promise<StreamStarted> {
@@ -284,6 +290,32 @@ class HttpNetworkClient implements NetworkClient {
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify(input)
     });
+  }
+
+  async invokeTweakAction(input: InvokeTweakActionInput): Promise<void> {
+    const response = await fetch("/api/inspector/tweaks/action", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(input)
+    });
+    if (response.ok) return;
+
+    let message = `Request failed with ${response.status}`;
+    try {
+      const body: unknown = await response.json();
+      if (
+        body !== null &&
+        typeof body === "object" &&
+        "error" in body &&
+        typeof body.error === "string" &&
+        body.error.length > 0
+      ) {
+        message = body.error;
+      }
+    } catch {
+      // Preserve the HTTP status when the server did not return a JSON error.
+    }
+    throw new Error(message);
   }
 
   async startTweakStream(server: InspectorServerReference): Promise<StreamStarted> {

--- a/snapo-network-inspector-web/src/styles.css
+++ b/snapo-network-inspector-web/src/styles.css
@@ -1481,6 +1481,20 @@ pre {
   margin-left: auto;
 }
 
+.tweaks-action-button {
+  all: revert;
+  min-height: 27px;
+  padding-inline: 10px;
+  font: inherit;
+  font-size: 11px;
+}
+
+.tweaks-action-conflict {
+  margin: 0;
+  color: var(--error);
+  font-size: 11px;
+}
+
 .tweaks-number,
 .tweaks-hex,
 .tweaks-string,

--- a/tests/snapo_cli/test_snapo.py
+++ b/tests/snapo_cli/test_snapo.py
@@ -222,7 +222,11 @@ class TweakHTTPServer:
     def __init__(self, descriptors=None, app=None, error=None, stream_events=None, adjusted_descriptors=None):
         self.descriptors = json.loads(json.dumps(descriptors or tweak_descriptors()))
         self.adjusted_descriptors = self.descriptors if adjusted_descriptors is None else adjusted_descriptors
-        self.app = app or {"name": "Snap-O Tweaks Demo", "packageName": "com.example.tweaks"}
+        self.app = app or {
+            "name": "Snap-O Tweaks Demo",
+            "packageName": "com.example.tweaks",
+            "protocolVersion": 2,
+        }
         self.error = error
         self.stream_events = stream_events
         self.requests = []
@@ -278,6 +282,31 @@ class TweakHTTPServer:
                     descriptors[name]["value"] = value
                     updates.append({"name": name, "value": value})
                 self.send_json(200, {"tweaks": updates})
+
+            def do_POST(self):
+                length = int(self.headers.get("Content-Length", "0"))
+                payload = json.loads(self.rfile.read(length).decode("utf-8"))
+                owner.requests.append(("POST", self.path, payload))
+                if owner.error is not None:
+                    status, message = owner.error
+                    self.send_json(status, {"error": message})
+                    return
+                if self.path != "/tweaks/action":
+                    self.send_json(404, {"error": f"Unknown endpoint: {self.path}"})
+                    return
+
+                actions = [
+                    item
+                    for item in owner.descriptors
+                    if item["name"] == payload.get("name") and item["type"] == "action"
+                ]
+                if not actions:
+                    self.send_json(404, {"error": f"Unknown action: {payload.get('name')}"})
+                    return
+                if len(actions) != 1 or actions[0].get("conflicted") is True:
+                    self.send_json(409, {"error": f"Conflicting action registrations: {payload.get('name')}"})
+                    return
+                self.send_json(200, {"name": payload["name"]})
 
             def send_json(self, status, payload):
                 body = json.dumps(payload).encode("utf-8")
@@ -543,20 +572,21 @@ class TweakDiscoveryTests(unittest.TestCase):
             "list": ["list", "-n", "snapo_tweaks_42"],
             "get": ["get", "Typography/Font size", "-n", "snapo_tweaks_42"],
             "set": ["set", "Typography/Font size", "-2", "-n", "snapo_tweaks_42"],
+            "action": ["action", "Preview/Refresh", "-n", "snapo_tweaks_42"],
             "reset": ["reset", "Typography/Font size", "-n", "snapo_tweaks_42"],
             "watch": ["watch", "--once", "-n", "snapo_tweaks_42"],
         }
         for name, arguments in commands.items():
             with self.subTest(command=name):
                 command = ["tweaks", *arguments, "-s", "emulator-5554", "--adb", "/configured/adb"]
-                if name not in {"set", "reset"}:
+                if name not in {"set", "action", "reset"}:
                     command.append("--json")
                 options = snapo.parser().parse_args(command)
                 self.assertEqual(options.root_command, "tweaks")
                 self.assertEqual(options.tweaks_command, name)
                 self.assertEqual(options.serial, "emulator-5554")
                 self.assertEqual(options.adb, "/configured/adb")
-                if name not in {"set", "reset"}:
+                if name not in {"set", "action", "reset"}:
                     self.assertTrue(options.json)
 
     def test_tweak_commands_preserve_remote_adb_endpoint_validation(self):
@@ -565,6 +595,7 @@ class TweakDiscoveryTests(unittest.TestCase):
             ["tweaks", "list"],
             ["tweaks", "get", "Motion/Enabled"],
             ["tweaks", "set", "Motion/Enabled", "false"],
+            ["tweaks", "action", "Preview/Refresh"],
             ["tweaks", "reset", "Motion/Enabled"],
             ["tweaks", "watch", "--once"],
         )
@@ -591,6 +622,7 @@ class TweakDiscoveryTests(unittest.TestCase):
 
         self.assertEqual(result.exception.code, 0)
         self.assertIn("apps", stdout.getvalue())
+        self.assertIn("action", stdout.getvalue())
         self.assertIn("watch", stdout.getvalue())
 
 
@@ -1213,8 +1245,63 @@ class TweakCommandTests(unittest.TestCase):
         self.assertEqual(app["socketName"], "snapo_tweaks_42")
         self.assertEqual(app["appName"], "Snap-O Tweaks Demo")
         self.assertEqual(app["packageName"], "com.example.tweaks")
+        self.assertEqual(app["protocolVersion"], 2)
         self.assertEqual(wire.requests, [("GET", "/app", None)])
         self.assertEqual(adb.calls[-1], ("emulator-5554", ("forward", "--remove", f"tcp:{wire.port}")))
+
+    def test_apps_infers_protocol_version_one_for_legacy_tweak_servers(self):
+        app = {"name": "Snap-O Tweaks Demo", "packageName": "com.example.tweaks"}
+        with TweakHTTPServer(app=app) as wire:
+            result, output, errors, _ = self.run_command(["apps", "--json"], wire)
+
+        self.assertEqual(result, 0, errors)
+        self.assertEqual(json.loads(output)["protocolVersion"], 1)
+
+    def test_apps_preserves_future_tweak_protocol_versions(self):
+        app = {
+            "name": "Snap-O Tweaks Demo",
+            "packageName": "com.example.tweaks",
+            "protocolVersion": 7,
+        }
+        with TweakHTTPServer(app=app) as wire:
+            result, output, errors, _ = self.run_command(["apps", "--json"], wire)
+
+        self.assertEqual(result, 0, errors)
+        self.assertEqual(json.loads(output)["protocolVersion"], 7)
+
+    def test_apps_rejects_malformed_tweak_protocol_versions(self):
+        for version in (True, False, "2", 2.0, None, 0, -1):
+            with self.subTest(version=version):
+                app = {
+                    "name": "Snap-O Tweaks Demo",
+                    "packageName": "com.example.tweaks",
+                    "protocolVersion": version,
+                }
+                with TweakHTTPServer(app=app) as wire:
+                    result, output, errors, _ = self.run_command(["apps", "--json"], wire)
+
+                self.assertEqual(result, 1)
+                self.assertEqual(output, "")
+                self.assertIn("No reachable Snap-O tweaks apps found", errors)
+
+    def test_apps_preserves_existing_human_readable_output(self):
+        with TweakHTTPServer() as wire:
+            result, output, errors, _ = self.run_command(["apps"], wire)
+
+        self.assertEqual(result, 0, errors)
+        self.assertEqual(
+            output,
+            "emulator-5554:\n    snapo_tweaks_42  Snap-O Tweaks Demo  pkg:com.example.tweaks\n",
+        )
+
+    def test_network_discovery_does_not_include_tweak_protocol_version(self):
+        options = snapo.parser().parse_args(["network", "list", "--no-app-info", "--json"])
+        output = io.StringIO()
+        with contextlib.redirect_stdout(output):
+            result = snapo.run_list(FakeADB(), options)
+
+        self.assertEqual(result, 0)
+        self.assertNotIn("protocolVersion", json.loads(output.getvalue()))
 
     def test_list_emits_one_complete_json_snapshot(self):
         with TweakHTTPServer() as wire:
@@ -1260,12 +1347,48 @@ class TweakCommandTests(unittest.TestCase):
         self.assertIn('Preview/Text value = "true" [string]', output)
         self.assertIn('Appearance/Theme = "System" [enum]; options: ["System", "Light", "Dark"]', output)
 
+    def test_list_renders_actions_without_fabricating_values_and_surfaces_conflicts(self):
+        descriptors = [
+            *tweak_descriptors(),
+            {"name": "Preview/Refresh", "type": "action"},
+            {"name": "Preview/Reload", "type": "action", "conflicted": True},
+        ]
+        with TweakHTTPServer(descriptors=descriptors) as wire:
+            result, output, errors, _ = self.run_command(["list"], wire)
+
+        self.assertEqual(result, 0, errors)
+        self.assertIn("Preview/Refresh [action]", output)
+        self.assertIn("Preview/Reload [action, conflicted]", output)
+        self.assertNotIn("Preview/Refresh =", output)
+        self.assertNotIn("Preview/Reload =", output)
+
+    def test_list_preserves_complete_action_descriptors_in_json_snapshots(self):
+        descriptors = [
+            *tweak_descriptors(),
+            {"name": "Preview/Refresh", "type": "action"},
+            {"name": "Preview/Reload", "type": "action", "conflicted": True},
+        ]
+        with TweakHTTPServer(descriptors=descriptors) as wire:
+            result, output, errors, _ = self.run_command(["list", "--json"], wire)
+
+        self.assertEqual(result, 0, errors)
+        self.assertEqual(json.loads(output), {"tweaks": descriptors})
+
     def test_get_accepts_tweak_names_with_slashes_and_spaces(self):
         with TweakHTTPServer() as wire:
             result, output, errors, _ = self.run_command(["get", "Typography/Font size", "--json"], wire)
 
         self.assertEqual(result, 0, errors)
         self.assertEqual(json.loads(output), wire.descriptors[0])
+        self.assertEqual(wire.requests, [("GET", "/tweaks", None)])
+
+    def test_get_displays_an_action_descriptor_without_a_value(self):
+        action = {"name": "Preview/Refresh", "type": "action"}
+        with TweakHTTPServer(descriptors=[action]) as wire:
+            result, output, errors, _ = self.run_command(["get", action["name"]], wire)
+
+        self.assertEqual(result, 0, errors)
+        self.assertEqual(output, "Preview/Refresh [action]\n")
         self.assertEqual(wire.requests, [("GET", "/tweaks", None)])
 
     def test_get_all_finds_a_previously_adjusted_inactive_tweak(self):
@@ -1361,6 +1484,48 @@ class TweakCommandTests(unittest.TestCase):
                 self.assertEqual(wire.requests, [("GET", "/tweaks", None)])
                 self.assertEqual(adb.calls[-1], ("emulator-5554", ("forward", "--remove", f"tcp:{wire.port}")))
 
+    def test_set_rejects_actions_without_sending_a_patch(self):
+        action = {"name": "Preview/Refresh", "type": "action"}
+        with TweakHTTPServer(descriptors=[action]) as wire:
+            result, output, errors, adb = self.run_command(["set", action["name"], "true"], wire)
+
+        self.assertEqual(result, 1)
+        self.assertEqual(output, "")
+        self.assertIn(f"Action '{action['name']}' cannot be set", errors)
+        self.assertIn("snapo tweaks action NAME", errors)
+        self.assertEqual(wire.requests, [("GET", "/tweaks", None)])
+        self.assertEqual(adb.calls[-1], ("emulator-5554", ("forward", "--remove", f"tcp:{wire.port}")))
+
+    def test_action_invokes_the_exact_app_owned_name_without_fetching_a_snapshot(self):
+        action = {"name": "Preview/Refresh visible content", "type": "action"}
+        with TweakHTTPServer(descriptors=[action]) as wire:
+            result, output, errors, adb = self.run_command(["action", action["name"]], wire)
+
+        self.assertEqual(result, 0, errors)
+        self.assertEqual(output, "")
+        self.assertEqual(wire.requests, [("POST", "/tweaks/action", {"name": action["name"]})])
+        self.assertEqual(adb.calls[-1], ("emulator-5554", ("forward", "--remove", f"tcp:{wire.port}")))
+
+    def test_action_surfaces_unknown_non_action_and_conflicting_registrations(self):
+        conflicted = {"name": "Preview/Reload", "type": "action", "conflicted": True}
+        value = tweak_descriptors()[0]
+        cases = (
+            ("Preview/Missing", 404, "Unknown action: Preview/Missing"),
+            (value["name"], 404, f"Unknown action: {value['name']}"),
+            (conflicted["name"], 409, f"Conflicting action registrations: {conflicted['name']}"),
+        )
+        for name, status, detail in cases:
+            with self.subTest(name=name):
+                with TweakHTTPServer(descriptors=[value, conflicted]) as wire:
+                    result, output, errors, adb = self.run_command(["action", name], wire)
+
+                self.assertEqual(result, 1)
+                self.assertEqual(output, "")
+                self.assertIn(f"HTTP {status}", errors)
+                self.assertIn(detail, errors)
+                self.assertEqual(wire.requests, [("POST", "/tweaks/action", {"name": name})])
+                self.assertEqual(adb.calls[-1], ("emulator-5554", ("forward", "--remove", f"tcp:{wire.port}")))
+
     def test_reset_one_tweak_patches_its_declared_default(self):
         descriptors = tweak_descriptors()
         descriptors[0]["value"] = 24
@@ -1398,6 +1563,44 @@ class TweakCommandTests(unittest.TestCase):
         self.assertEqual(wire.requests, [("GET", "/tweaks", None), ("PATCH", "/tweaks", {"values": defaults})])
         self.assertEqual(output, "")
 
+    def test_reset_all_ignores_actions_without_defaults(self):
+        descriptors = [
+            *tweak_descriptors(),
+            {"name": "Preview/Refresh", "type": "action"},
+            {"name": "Preview/Reload", "type": "action", "conflicted": True},
+        ]
+        defaults = {
+            descriptor["name"]: descriptor["default"]
+            for descriptor in descriptors
+            if descriptor["type"] != "action"
+        }
+        with TweakHTTPServer(descriptors=descriptors) as wire:
+            result, output, errors, _ = self.run_command(["reset", "--all"], wire)
+
+        self.assertEqual(result, 0, errors)
+        self.assertEqual(wire.requests, [("GET", "/tweaks", None), ("PATCH", "/tweaks", {"values": defaults})])
+        self.assertEqual(output, "")
+
+    def test_reset_all_with_only_actions_sends_no_patch(self):
+        action = {"name": "Preview/Refresh", "type": "action"}
+        with TweakHTTPServer(descriptors=[action]) as wire:
+            result, output, errors, _ = self.run_command(["reset", "--all"], wire)
+
+        self.assertEqual(result, 0, errors)
+        self.assertEqual(wire.requests, [("GET", "/tweaks", None)])
+        self.assertEqual(output, "")
+
+    def test_reset_rejects_an_action_without_sending_a_patch(self):
+        action = {"name": "Preview/Refresh", "type": "action"}
+        with TweakHTTPServer(descriptors=[action]) as wire:
+            result, output, errors, _ = self.run_command(["reset", action["name"]], wire)
+
+        self.assertEqual(result, 1)
+        self.assertEqual(output, "")
+        self.assertIn(f"Action '{action['name']}' cannot be reset", errors)
+        self.assertIn("snapo tweaks action NAME", errors)
+        self.assertEqual(wire.requests, [("GET", "/tweaks", None)])
+
     def test_reset_requires_exactly_one_target(self):
         for arguments in (["reset"], ["reset", "Motion/Enabled", "--all"]):
             with self.subTest(arguments=arguments):
@@ -1422,9 +1625,23 @@ class TweakCommandTests(unittest.TestCase):
                 self.assertEqual(error.exception.code, 2)
                 self.assertIn("set", errors.getvalue())
 
+    def test_action_requires_exactly_one_name(self):
+        for arguments in (["action"], ["action", "Preview/Refresh", "unexpected"]):
+            with self.subTest(arguments=arguments):
+                errors = io.StringIO()
+                with contextlib.redirect_stderr(errors):
+                    with self.assertRaises(SystemExit) as error:
+                        snapo.parser().parse_args(["tweaks", *arguments])
+                self.assertEqual(error.exception.code, 2)
+                self.assertTrue(
+                    "required" in errors.getvalue() or "unrecognized arguments" in errors.getvalue(),
+                    errors.getvalue(),
+                )
+
     def test_mutations_do_not_accept_json_output(self):
         for command in (
             ["set", "Motion/Enabled", "false", "--json"],
+            ["action", "Preview/Refresh", "--json"],
             ["reset", "Motion/Enabled", "--json"],
         ):
             with self.subTest(command=command):
@@ -1460,6 +1677,15 @@ class TweakCommandTests(unittest.TestCase):
         self.assertEqual(len(output.splitlines()), 1)
         self.assertEqual(wire.requests, [("GET", "/tweaks/events", None)])
         self.assertEqual(adb.calls[-1], ("emulator-5554", ("forward", "--remove", f"tcp:{wire.port}")))
+
+    def test_watch_displays_action_descriptors_without_values(self):
+        action = {"name": "Preview/Refresh", "type": "action", "conflicted": True}
+        with TweakHTTPServer(descriptors=[action]) as wire:
+            result, output, errors, _ = self.run_command(["watch", "--once"], wire)
+
+        self.assertEqual(result, 0, errors)
+        self.assertEqual(output, "Preview/Refresh [action, conflicted]\n")
+        self.assertEqual(wire.requests, [("GET", "/tweaks/events", None)])
 
     def test_watch_rejects_malformed_snapshots_and_still_removes_its_forward(self):
         events = ["event: tweaks\ndata: {\"tweaks\":\"not-a-list\"}\n\n"]


### PR DESCRIPTION
## Summary

- Expose parameterless, composition-scoped app callbacks through `TweakAction(name) { ... }`, with matching release/no-op APIs.
- Include actions in active tweak snapshots and streams, invoke them through `POST /tweaks/action`, and support the desktop inspector, optional in-app overlay, and CLI.
- Fail closed on conflicting live registrations with HTTP 409 while preserving existing value patches, resets, and enum tweaks.
- Add independent Tweaks protocol discovery with `protocolVersion: 2` and compatibility with unversioned protocol-v1 apps.
- Update the Android demo, protocol documentation, accessibility behavior, and regression coverage.

## Validation

- 180 Android JVM tests; all five Detekt checks; debug/release demo and no-op artifact builds.
- 105 desktop web tests; lint, TypeScript checks, production web build, and macOS app build.
- 100 CLI tests, 42 demo-panel tests, and 19 Swift package tests.
- Verified protocol v2, enum tweaks, and action invocation descriptors on a connected Android device.