### PR TITLE
Unwrap Markdown prose for line-based readers

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -1,7 +1,6 @@
 # Snap-O Architecture
 
-Snap-O is a macOS host for Android capture and network inspection. The main app intentionally uses one
-shared device-client module and keeps feature presentation in the app target.
+Snap-O is a macOS host for Android capture and network inspection. The main app intentionally uses one shared device-client module and keeps feature presentation in the app target.
 
 ## Dependency direction
 
@@ -14,12 +13,9 @@ Android integrations ──> :network ──wire protocol──> SnapODeviceClie
 React inspector <──typed host bridge──> Snap-O app
 ```
 
-`SnapODeviceClient` is Foundation/Darwin-only. It owns ADB transport, device and network-server discovery,
-network wire types, and ordered network sessions. It must not import AppKit, SwiftUI, WebKit, AVKit, or CLI
-formatting concerns.
+`SnapODeviceClient` is Foundation/Darwin-only. It owns ADB transport, device and network-server discovery, network wire types, and ordered network sessions. It must not import AppKit, SwiftUI, WebKit, AVKit, or CLI formatting concerns.
 
-The Android implementation remains idiomatic Kotlin. The React inspector remains idiomatic TypeScript.
-These runtimes share contract fixtures and observable behavior, not generated implementation code.
+The Android implementation remains idiomatic Kotlin. The React inspector remains idiomatic TypeScript. These runtimes share contract fixtures and observable behavior, not generated implementation code.
 
 ## macOS runtime
 
@@ -30,56 +26,31 @@ These runtimes share contract fixtures and observable behavior, not generated im
 - capture resource coordination
 - temporary media storage
 
-SwiftUI creates one `@MainActor @Observable` feature model per window. Window models own presentation state;
-app-scoped actors own device resources. Views render state and send intents, but do not own recordings,
-live-preview processes, or network connections. Each window creates its Network Inspector service when the
-pane is first shown and closes it with the window; transport and protocol behavior still come from the shared
-device-client module.
+SwiftUI creates one `@MainActor @Observable` feature model per window. Window models own presentation state; app-scoped actors own device resources. Views render state and send intents, but do not own recordings, live-preview processes, or network connections. Each window creates its Network Inspector service when the pane is first shown and closes it with the window; transport and protocol behavior still come from the shared device-client module.
 
 ## Capture ownership
 
-`AppRuntime` composes three capability-focused actors: `ScreenshotService`, `RecordingService`, and
-`LivePreviewService`. Each service owns its feature's ADB workflow, cancellation, and cleanup. The
-per-window `CaptureWindowController` coordinates presentation modes; there is no catch-all capture service.
+`AppRuntime` composes three capability-focused actors: `ScreenshotService`, `RecordingService`, and `LivePreviewService`. Each service owns its feature's ADB workflow, cancellation, and cleanup. The per-window `CaptureWindowController` coordinates presentation modes; there is no catch-all capture service.
 
-Recording and live-preview operations use explicit, idempotent handles. A handle owns every session it
-starts and releases each session during finish, cancellation, partial failure, device removal, or window
-closure. The small `CaptureCoordinator` owns only app-wide resource policy: it leases devices atomically,
-prevents recording and live preview from using the same device across windows, and gates shutdown.
-Screenshots remain independent because they do not hold a long-lived device resource.
+Recording and live-preview operations use explicit, idempotent handles. A handle owns every session it starts and releases each session during finish, cancellation, partial failure, device removal, or window closure. The small `CaptureCoordinator` owns only app-wide resource policy: it leases devices atomically, prevents recording and live preview from using the same device across windows, and gates shutdown. Screenshots remain independent because they do not hold a long-lived device resource.
 
-Capture options are values passed into an operation. Capture services do not read UI globals or infer their
-device set from mutable presentation state. A visible live-preview surface observes its stream lifecycle;
-an unexpected stop releases the old operation and retries with bounded backoff while the surface remains
-active.
+Capture options are values passed into an operation. Capture services do not read UI globals or infer their device set from mutable presentation state. A visible live-preview surface observes its stream lifecycle; an unexpected stop releases the old operation and retries with bounded backoff while the surface remains active.
 
 ## Network inspection
 
-The Android library assigns a process-monotonic sequence to every network event. A replay snapshot includes
-an atomic watermark, and queued live events at or below that watermark are skipped. A full delivery queue
-closes the session so the host reconnects and obtains a complete snapshot instead of silently losing data.
+The Android library assigns a process-monotonic sequence to every network event. A replay snapshot includes an atomic watermark, and queued live events at or below that watermark are skipped. A full delivery queue closes the session so the host reconnects and obtains a complete snapshot instead of silently losing data.
 
-The host uses protocol timestamps for request duration and event time. Arrival time is only a fallback for
-legacy messages. Stores are bounded, ingestion is idempotent by server and sequence, and body loading uses
-limited concurrency. Process-start identity scopes sequences, records, and body requests so Android PID
-reuse cannot merge data from different app processes.
+The host uses protocol timestamps for request duration and event time. Arrival time is only a fallback for legacy messages. Stores are bounded, ingestion is idempotent by server and sequence, and body loading uses limited concurrency. Process-start identity scopes sequences, records, and body requests so Android PID reuse cannot merge data from different app processes.
 
-Delivery is bounded at every host hop, including the Swift-to-WebKit bridge. If a consumer falls behind or
-WebKit delivery fails, the host closes that delivery path and reloads from a fresh Android replay instead of
-silently dropping events. Request bodies load on demand into a bounded cache; the selected request remains
-pinned while export commands hydrate any missing bodies explicitly.
+Delivery is bounded at every host hop, including the Swift-to-WebKit bridge. If a consumer falls behind or WebKit delivery fails, the host closes that delivery path and reloads from a fresh Android replay instead of silently dropping events. Request bodies load on demand into a bounded cache; the selected request remains pinned while export commands hydrate any missing bodies explicitly.
 
-Swift owns ADB and network transport. React owns inspector UI state. Native controls send intents to React;
-React sends an immutable state projection back for native toolbar rendering.
+Swift owns ADB and network transport. React owns inspector UI state. Native controls send intents to React; React sends an immutable state projection back for native toolbar rendering.
 
 ## Testing seams
 
-- Swift Testing covers discovery, wire compatibility, ordered sessions, cancellation, timeouts, and
-  backpressure.
+- Swift Testing covers discovery, wire compatibility, ordered sessions, cancellation, timeouts, and backpressure.
 - Kotlin tests cover sequencing, replay overlap, compatibility, backpressure, and hard-limit eviction.
-- TypeScript tests cover reducer idempotence, protocol timing, retention, restart identity, stream recovery,
-  body scheduling, and export budgets.
-- A shared JSONL replay fixture protects the Swift and TypeScript sides of the Android wire contract; Kotlin
-  compatibility tests verify the producer schema.
+- TypeScript tests cover reducer idempotence, protocol timing, retention, restart identity, stream recovery, body scheduling, and export budgets.
+- A shared JSONL replay fixture protects the Swift and TypeScript sides of the Android wire contract; Kotlin compatibility tests verify the producer schema.
 
 UI tests are reserved for a small number of end-to-end capture and inspector flows.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -23,8 +23,7 @@ Thank you for considering contributing to Snap-O! We welcome improvements, bug f
 
 ### macOS Swift Tooling
 
-The macOS app pins SwiftFormat and SwiftLint in `snapo-app-mac/mise.toml`.
-Install the repo-owned tool versions once, then use the shared `mise` tasks so local checks match CI:
+The macOS app pins SwiftFormat and SwiftLint in `snapo-app-mac/mise.toml`. Install the repo-owned tool versions once, then use the shared `mise` tasks so local checks match CI:
 
 ```bash
 cd snapo-app-mac
@@ -34,8 +33,7 @@ mise run format
 mise run lint
 ```
 
-To update the pinned tools intentionally, bump the versions in `snapo-app-mac/mise.toml`
-and rerun `mise install` plus `mise run lint`.
+To update the pinned tools intentionally, bump the versions in `snapo-app-mac/mise.toml` and rerun `mise install` plus `mise run lint`.
 
 ## Pull Requests
 

--- a/README.md
+++ b/README.md
@@ -43,23 +43,20 @@ fun MotionPreview() {
 }
 ```
 
-`TweakAction` returns `Unit` and exposes its callback only while its owner is in
-composition; declaring the action does not run the callback.
+`TweakAction` returns `Unit` and exposes its callback only while its owner is in composition; declaring the action does not run the callback.
 
 Follow the [Tweaks developer guide](https://openai.github.io/snap-o/tweaks.html) for setup steps.
 
 ## Why build an Android inspection system?
 
-Capturing visuals and validating traffic for teammates or pull requests adds many small paper cuts.
-You might like Snap-O if you've ever wished you could:
+Capturing visuals and validating traffic for teammates or pull requests adds many small paper cuts. You might like Snap-O if you've ever wished you could:
 
 - Share screenshots and recordings without littering your disk with throwaway files
 - Preview a recording instantly without saving it first
 - Scrub frame by frame to confirm an animation behaves as expected
 - Use something that feels faster than the default capture tools
 
-I've built variations of this tool a few times over the last decade; this is the first one
-I'm open-sourcing.
+I've built variations of this tool a few times over the last decade; this is the first one I'm open-sourcing.
 
 ## Usage
 
@@ -85,9 +82,7 @@ snapo tweaks list --all -s <serial> -n <socket> --json
 snapo tweaks get 'Motion/Duration' --all -s <serial> -n <socket> --json
 ```
 
-The equivalent API is `GET /tweaks?include=adjusted`. Inactive tweaks remain
-read-only. See the [Tweaks protocol guide](contracts/tweaks/README.md) for
-descriptors and updates.
+The equivalent API is `GET /tweaks?include=adjusted`. Inactive tweaks remain read-only. See the [Tweaks protocol guide](contracts/tweaks/README.md) for descriptors and updates.
 
 ### Drag and Drop
 
@@ -233,10 +228,7 @@ With the default ADB configuration, the CLI opens a localhost forward for the se
 
 ## Community
 
-Bug reports and small patches are welcome, but there is no formal roadmap. If
-you do decide to contribute, please take a quick look at
-[CONTRIBUTING.md](CONTRIBUTING.md) and the
-[CODE_OF_CONDUCT.md](CODE_OF_CONDUCT.md).
+Bug reports and small patches are welcome, but there is no formal roadmap. If you do decide to contribute, please take a quick look at [CONTRIBUTING.md](CONTRIBUTING.md) and the [CODE_OF_CONDUCT.md](CODE_OF_CONDUCT.md).
 
 ## License
 

--- a/contracts/tweaks/README.md
+++ b/contracts/tweaks/README.md
@@ -2,11 +2,7 @@
 
 Status: phase one. The network inspector protocol is unchanged.
 
-Snap-O Tweaks exposes adjustable values and explicitly registered, parameterless
-actions from the currently composed Android UI through an app-local socket,
-enabled by default only in debug builds. Agents and desktop tools can use HTTP
-to inspect those values, change them, and invoke app-owned callbacks while the
-app runs.
+Snap-O Tweaks exposes adjustable values and explicitly registered, parameterless actions from the currently composed Android UI through an app-local socket, enabled by default only in debug builds. Agents and desktop tools can use HTTP to inspect those values, change them, and invoke app-owned callbacks while the app runs.
 
 ## Transport
 
@@ -29,20 +25,13 @@ ADB prints the assigned localhost port:
 curl -fsS http://127.0.0.1:43817/tweaks
 ```
 
-Implement HTTP with Android `LocalServerSocket`, standard streams, and Android
-`JsonReader`/`JsonWriter`. Use JSON for app and tweak responses, PNG for
-`/app/icon`, and server-sent events for `/tweaks/events`. Ordinary responses
-include `Content-Length` and close their connection. Event streams keep their
-connection open. Bound request sizes and concurrent connections, and apply a
-read timeout while receiving each request. No server dependency, Android TCP
-port, or `INTERNET` permission is needed.
+Implement HTTP with Android `LocalServerSocket`, standard streams, and Android `JsonReader`/`JsonWriter`. Use JSON for app and tweak responses, PNG for `/app/icon`, and server-sent events for `/tweaks/events`. Ordinary responses include `Content-Length` and close their connection. Event streams keep their connection open. Bound request sizes and concurrent connections, and apply a read timeout while receiving each request. No server dependency, Android TCP port, or `INTERNET` permission is needed.
 
 ## REST API
 
 ### GET /app
 
-Return the app's user-facing Android label, package name, and Tweaks protocol
-version:
+Return the app's user-facing Android label, package name, and Tweaks protocol version:
 
 ```json
 {
@@ -52,16 +41,11 @@ version:
 }
 ```
 
-Resolve `name` from the actual Android app label. An absent `protocolVersion`
-identifies the original version 1, which exposes value tweaks only. Version 2
-adds action descriptors and `POST /tweaks/action`. The Tweaks protocol version
-is independent of the Network Inspector protocol version; hosts can use it to
-identify newer versions they do not support.
+Resolve `name` from the actual Android app label. An absent `protocolVersion` identifies the original version 1, which exposes value tweaks only. Version 2 adds action descriptors and `POST /tweaks/action`. The Tweaks protocol version is independent of the Network Inspector protocol version; hosts can use it to identify newer versions they do not support.
 
 ### GET /app/icon
 
-Lazily return the app icon as a 96 × 96 PNG with `Content-Type: image/png`.
-Return `404` when the icon is unavailable.
+Lazily return the app icon as a 96 × 96 PNG with `Content-Type: image/png`. Return `404` when the icon is unavailable.
 
 ### GET /tweaks
 
@@ -160,34 +144,15 @@ Return a flat list of currently registered tweaks:
 }
 ```
 
-A tweak name represents one shared value, not one composable. Multiple active
-composables may register the same name; the tweak appears only once, and an
-update changes the value observed by every usage. A tweak remains registered
-until its last usage leaves composition. Its most recently edited value remains
-available if the same complete declaration later returns, but inactive tweaks do
-not appear in default responses or event snapshots.
+A tweak name represents one shared value, not one composable. Multiple active composables may register the same name; the tweak appears only once, and an update changes the value observed by every usage. A tweak remains registered until its last usage leaves composition. Its most recently edited value remains available if the same complete declaration later returns, but inactive tweaks do not appear in default responses or event snapshots.
 
-Usages with the same name must agree on the tweak type, default, constraints,
-and ordered enum options. Conflicting declarations are a configuration error.
+Usages with the same name must agree on the tweak type, default, constraints, and ordered enum options. Conflicting declarations are a configuration error.
 
-Supported value types are `int`, `float`, `boolean`, `color`, `string`, and
-`enum`. The `action` type describes an explicitly registered parameterless
-app-owned callback. Actions do not have `value`, `default`, options, or numeric
-constraints; clients must not attempt to patch or reset them. Integer tweaks
-accept only whole numbers; float tweaks accept whole or fractional numbers.
-Numeric tweaks may include `min`, `max`, and `step`. Only include constraints
-actually supplied by the app. A `step` is relative to `min`, or to `default` if
-no `min` is supplied. Colors use `#RRGGBB`, or `#RRGGBBAA` when translucent.
+Supported value types are `int`, `float`, `boolean`, `color`, `string`, and `enum`. The `action` type describes an explicitly registered parameterless app-owned callback. Actions do not have `value`, `default`, options, or numeric constraints; clients must not attempt to patch or reset them. Integer tweaks accept only whole numbers; float tweaks accept whole or fractional numbers. Numeric tweaks may include `min`, `max`, and `step`. Only include constraints actually supplied by the app. A `step` is relative to `min`, or to `default` if no `min` is supplied. Colors use `#RRGGBB`, or `#RRGGBBAA` when translucent.
 
-Enum tweaks include an ordered, nonempty `options` array containing the unique
-enum constant names. The descriptor's `default`, current `value`, picker text,
-and `PATCH` values all use those exact names. Preserve declaration order when
-rendering pickers; reject any value not present in `options`.
+Enum tweaks include an ordered, nonempty `options` array containing the unique enum constant names. The descriptor's `default`, current `value`, picker text, and `PATCH` values all use those exact names. Preserve declaration order when rendering pickers; reject any value not present in `options`.
 
-Action names must be explicit, stable, and unique among live registrations.
-Register a shared action once at the composable that owns its behavior rather
-than registering separate callbacks with the same name in multiple consumers.
-If multiple live owners register the same action name, the descriptor becomes:
+Action names must be explicit, stable, and unique among live registrations. Register a shared action once at the composable that owns its behavior rather than registering separate callbacks with the same name in multiple consumers. If multiple live owners register the same action name, the descriptor becomes:
 
 ```json
 {
@@ -197,57 +162,25 @@ If multiple live owners register the same action name, the descriptor becomes:
 }
 ```
 
-Conflicting actions remain discoverable but cannot be invoked until exactly one
-owner remains. Callbacks are never silently deduplicated, replaced, or renamed
-with generated suffixes.
+Conflicting actions remain discoverable but cannot be invoked until exactly one owner remains. Callbacks are never silently deduplicated, replaced, or renamed with generated suffixes.
 
-Compose color defaults keep their exact in-process identity, including color
-space, component precision, and `Color.Unspecified`. The HTTP protocol still
-presents colors as sRGB hex; non-sRGB defaults are projected, and
-`Color.Unspecified` appears as `#00000000`. Patching a color with that presented
-default remains the legacy reset operation, so the same projected hex cannot
-also express a distinct sRGB edit for a non-round-trippable default.
+Compose color defaults keep their exact in-process identity, including color space, component precision, and `Color.Unspecified`. The HTTP protocol still presents colors as sRGB hex; non-sRGB defaults are projected, and `Color.Unspecified` appears as `#00000000`. Patching a color with that presented default remains the legacy reset operation, so the same projected hex cannot also express a distinct sRGB edit for a non-round-trippable default.
 
-Numeric JSON values may contain at most 128 characters and 64 significant
-digits, with a decimal scale between -64 and 64. Reject values outside those
-limits with `422` before changing any tweaks.
+Numeric JSON values may contain at most 128 characters and 64 significant digits, with a decimal scale between -64 and 64. Reject values outside those limits with `422` before changing any tweaks.
 
 ### GET /tweaks?include=adjusted
 
-Opt in to a complete list of active tweaks and previously adjusted tweaks that
-have since left composition:
+Opt in to a complete list of active tweaks and previously adjusted tweaks that have since left composition:
 
 ```bash
 curl -fsS 'http://127.0.0.1:43817/tweaks?include=adjusted'
 ```
 
-The response uses the same `{"tweaks":[...]}` shape and complete tweak
-descriptors as `GET /tweaks`. Include every currently active tweak, whether or
-not it has been adjusted, and every inactive tweak whose value was actually
-changed by a successful user adjustment. Preserve the tweak's original
-declaration, constraints, and latest value after its final usage leaves
-composition. Separate screens may reuse a name with different declarations;
-include each independently adjusted complete descriptor, even when names
-repeat. Repeated names occur only for distinct complete descriptors; active-only
-listings and updates still resolve at most one active descriptor per name.
-Order names by first observation, regardless of later activation or adjustment.
-For repeated names, list the active declaration first, followed by historical
-declarations in stable adjustment order.
+The response uses the same `{"tweaks":[...]}` shape and complete tweak descriptors as `GET /tweaks`. Include every currently active tweak, whether or not it has been adjusted, and every inactive tweak whose value was actually changed by a successful user adjustment. Preserve the tweak's original declaration, constraints, and latest value after its final usage leaves composition. Separate screens may reuse a name with different declarations; include each independently adjusted complete descriptor, even when names repeat. Repeated names occur only for distinct complete descriptors; active-only listings and updates still resolve at most one active descriptor per name. Order names by first observation, regardless of later activation or adjustment. For repeated names, list the active declaration first, followed by historical declarations in stable adjustment order.
 
-An adjusted tweak remains in this history even after its value is reset to its
-default. An inactive tweak that was never changed, a no-op update that leaves
-its value unchanged, and a rejected or atomically rolled-back update do not
-create history entries. Adjustment history exists only for the current app
-process and is discarded when that process exits.
+An adjusted tweak remains in this history even after its value is reset to its default. An inactive tweak that was never changed, a no-op update that leaves its value unchanged, and a rejected or atomically rolled-back update do not create history entries. Adjustment history exists only for the current app process and is discarded when that process exits.
 
-Historical inactive tweaks are read-only: `PATCH /tweaks` still accepts only
-currently active names and returns `404` for an inactive name. Actions appear
-while active but never create adjusted-history entries because they have no
-editable or retained value. Plain `GET /tweaks` and
-`GET /tweaks/events` remain active-only. The only supported
-query is exactly `include=adjusted` on `GET /tweaks`; unsupported, repeated,
-or additional query parameters and queries on other endpoints or methods
-return `400`.
+Historical inactive tweaks are read-only: `PATCH /tweaks` still accepts only currently active names and returns `404` for an inactive name. Actions appear while active but never create adjusted-history entries because they have no editable or retained value. Plain `GET /tweaks` and `GET /tweaks/events` remain active-only. The only supported query is exactly `include=adjusted` on `GET /tweaks`; unsupported, repeated, or additional query parameters and queries on other endpoints or methods return `400`.
 
 ### GET /tweaks/events
 
@@ -266,18 +199,9 @@ data: {"tweaks":[{"name":"Motion/Show","type":"boolean","default":true,"value":f
 
 ```
 
-The response uses `Content-Type: text/event-stream`. Its first event contains
-the complete current tweak list. Each later event also contains a complete,
-ordered list of value and action descriptors using exactly the `GET /tweaks`
-response shape. Clients replace
-their previous snapshot; a missing tweak has left composition.
+The response uses `Content-Type: text/event-stream`. Its first event contains the complete current tweak list. Each later event also contains a complete, ordered list of value and action descriptors using exactly the `GET /tweaks` response shape. Clients replace their previous snapshot; a missing tweak has left composition.
 
-Changes are published after the current Android main-thread turn. Tweaks added,
-removed, or changed during the same Compose update appear together in one
-event. Value changes are streamed whether they originated from an HTTP request
-or a Compose snapshot. Idle connections receive occasional SSE comments as
-keep-alives. A slow client receives the latest complete snapshot rather than
-an unbounded queue of intermediate states.
+Changes are published after the current Android main-thread turn. Tweaks added, removed, or changed during the same Compose update appear together in one event. Value changes are streamed whether they originated from an HTTP request or a Compose snapshot. Idle connections receive occasional SSE comments as keep-alives. A slow client receives the latest complete snapshot rather than an unbounded queue of intermediate states.
 
 ### PATCH /tweaks
 
@@ -313,11 +237,7 @@ curl -fsS -X PATCH http://127.0.0.1:43817/tweaks \
 }
 ```
 
-Validate all values before changing any of them. Return `400` for malformed
-requests, `404` when an endpoint or requested tweak does not exist, `405`
-for an unsupported method, `413` for an oversized body, and `422` when a value
-has the wrong type, violates a constraint, or is not one of the declared enum
-option values. Errors use a small JSON body:
+Validate all values before changing any of them. Return `400` for malformed requests, `404` when an endpoint or requested tweak does not exist, `405` for an unsupported method, `413` for an oversized body, and `422` when a value has the wrong type, violates a constraint, or is not one of the declared enum option values. Errors use a small JSON body:
 
 ```json
 {
@@ -325,10 +245,7 @@ option values. Errors use a small JSON body:
 }
 ```
 
-Apply changes on the Android main thread. If any value is invalid, do not update
-any tweaks in that request. Reset a value by patching it with its default.
-Actions are not valid patch targets; attempting to patch one returns `422`
-without changing any value in the same request.
+Apply changes on the Android main thread. If any value is invalid, do not update any tweaks in that request. Reset a value by patching it with its default. Actions are not valid patch targets; attempting to patch one returns `422` without changing any value in the same request.
 
 ### POST /tweaks/action
 
@@ -346,19 +263,9 @@ curl -fsS -X POST http://127.0.0.1:43817/tweaks/action \
 }
 ```
 
-The JSON body must contain exactly one nonblank string field named `name`.
-The registered callback executes synchronously on the Android main thread.
-This endpoint accepts no arguments, arbitrary code, or dynamic invocation
-targets; only explicitly registered app-owned callbacks are available.
+The JSON body must contain exactly one nonblank string field named `name`. The registered callback executes synchronously on the Android main thread. This endpoint accepts no arguments, arbitrary code, or dynamic invocation targets; only explicitly registered app-owned callbacks are available.
 
-Return `400` for malformed bodies, unsupported content types, additional
-fields, blank names, or unsupported query parameters; `404` for an unknown
-action or a name belonging to a value tweak; `405` for methods other than
-`POST`; and `409` when more than one live owner registered the same name.
-Duplicate registration errors explain that the action must be registered
-once at its owner. Main-thread unavailability, callback failures, and timeouts
-return `503`, `500`, and `504`, respectively. Errors use the same
-`{"error":"..."}` response shape as tweak updates.
+Return `400` for malformed bodies, unsupported content types, additional fields, blank names, or unsupported query parameters; `404` for an unknown action or a name belonging to a value tweak; `405` for methods other than `POST`; and `409` when more than one live owner registered the same name. Duplicate registration errors explain that the action must be registered once at its owner. Main-thread unavailability, callback failures, and timeouts return `503`, `500`, and `504`, respectively. Errors use the same `{"error":"..."}` response shape as tweak updates.
 
 ## Compose API
 
@@ -433,14 +340,7 @@ fun MotionSpecimen() {
 }
 ```
 
-Each tweak function returns `State<T>`. Read it with `.value`, or delegate it
-with `by`; `androidx.compose.runtime.getValue` supplies the delegate operator.
-Theme colors are intentionally read at the theme boundary; font, text, and
-animation changes recompose their respective leaf composables rather than the
-entire screen. Both typography composables read the same Font size state, so
-one host update changes both. When a value only affects layout or drawing,
-read the delegated value inside the corresponding callback instead of
-composition:
+Each tweak function returns `State<T>`. Read it with `.value`, or delegate it with `by`; `androidx.compose.runtime.getValue` supplies the delegate operator. Theme colors are intentionally read at the theme boundary; font, text, and animation changes recompose their respective leaf composables rather than the entire screen. Both typography composables read the same Font size state, so one host update changes both. When a value only affects layout or drawing, read the delegated value inside the corresponding callback instead of composition:
 
 ```kotlin
 val horizontalOffset by tweak(0, "Horizontal offset", 0..200)
@@ -452,32 +352,11 @@ Box(
 )
 ```
 
-Each remembered usage registers with composition and removes the tweak from
-the active list only after its final usage leaves. Returning declarations
-restore their previously edited values. Screen navigation therefore determines
-what appears in the default response without discarding edits; request
-`GET /tweaks?include=adjusted` to also recover previously adjusted values from
-screens that are no longer in composition.
+Each remembered usage registers with composition and removes the tweak from the active list only after its final usage leaves. Returning declarations restore their previously edited values. Screen navigation therefore determines what appears in the default response without discarding edits; request `GET /tweaks?include=adjusted` to also recover previously adjusted values from screens that are no longer in composition.
 
-Provide overloaded `tweak(default, name)` functions for `Int`, `Float`,
-`Color`, `Boolean`, `String`, and enum defaults; each returns its corresponding
-`State<T>`. For strings, name the second argument to distinguish the label from
-the default, as in `tweak("Hello", name = "Greeting")`. Numeric tweaks accept
-an optional range and `step` of the same type. Enum tweaks infer their options
-from declaration order and use each constant's name everywhere. Convert
-delegated integer values into Compose units at the call site, such as
-`fontSize.sp`. The real and no-op artifacts expose the same package and public
-Compose API.
+Provide overloaded `tweak(default, name)` functions for `Int`, `Float`, `Color`, `Boolean`, `String`, and enum defaults; each returns its corresponding `State<T>`. For strings, name the second argument to distinguish the label from the default, as in `tweak("Hello", name = "Greeting")`. Numeric tweaks accept an optional range and `step` of the same type. Enum tweaks infer their options from declaration order and use each constant's name everywhere. Convert delegated integer values into Compose units at the call site, such as `fontSize.sp`. The real and no-op artifacts expose the same package and public Compose API.
 
-Declare a parameterless action with the `TweakAction(name) { ... }` composable.
-It returns `Unit` and does not execute its callback during composition or return
-a callable function. The action is available only while its owning composable
-is in composition, always uses its most recent callback, and is exposed with
-its explicit name rather than an inferred or generated identifier. Register
-each action exactly once at the composable that owns the state or operation;
-multiple owners using the same name produce a visible conflict and all
-invocation attempts fail closed. The release/no-op implementation accepts the
-same API without retaining or invoking the callback.
+Declare a parameterless action with the `TweakAction(name) { ... }` composable. It returns `Unit` and does not execute its callback during composition or return a callable function. The action is available only while its owning composable is in composition, always uses its most recent callback, and is exposed with its explicit name rather than an inferred or generated identifier. Register each action exactly once at the composable that owns the state or operation; multiple owners using the same name produce a visible conflict and all invocation attempts fail closed. The release/no-op implementation accepts the same API without retaining or invoking the callback.
 
 ## Setup
 
@@ -516,8 +395,7 @@ fun App() {
 }
 ```
 
-The overlay is disabled by default. Expose its app-wide setting from a
-developer-settings screen:
+The overlay is disabled by default. Expose its app-wide setting from a developer-settings screen:
 
 ```kotlin
 import androidx.compose.material3.Switch
@@ -535,13 +413,7 @@ fun DeveloperSettings() {
 }
 ```
 
-The setting persists between app launches. When enabled, a movable button
-appears only while at least one tweak is in composition. Tap it to inspect or
-edit the active tweaks, run registered actions, and minimize the panel to return
-to the button. Conflicted actions are visible but cannot be run. The panel stays
-synchronized with host-side changes, remembers its position, and disappears when
-the last tweak or action leaves composition. The no-op overlay keeps the same
-wrapper and settings APIs without showing a panel in release builds.
+The setting persists between app launches. When enabled, a movable button appears only while at least one tweak is in composition. Tap it to inspect or edit the active tweaks, run registered actions, and minimize the panel to return to the button. Conflicted actions are visible but cannot be run. The panel stays synchronized with host-side changes, remembers its position, and disappears when the last tweak or action leaves composition. The no-op overlay keeps the same wrapper and settings APIs without showing a panel in release builds.
 
 Install the standalone debug sample on a connected Android device:
 
@@ -555,16 +427,9 @@ From the repository root, start the sample's optional host-side tweak panel:
 node snapo-link-android/samples/demo-tweaks/panel/server.mjs
 ```
 
-Open `http://127.0.0.1:4175`. The dependency-free panel discovers connected
-devices and live tweak sockets, creates its own ADB forward, displays the app
-icon and tweaks, and reconnects when the app process changes. It is a model-built
-demo, not a required setup step or the expected way to use Snap-O Tweaks. Any
-agent or host can use the same endpoints to create its own UI. See the sample
-panel's README for device and package selection.
+Open `http://127.0.0.1:4175`. The dependency-free panel discovers connected devices and live tweak sockets, creates its own ADB forward, displays the app icon and tweaks, and reconnects when the app process changes. It is a model-built demo, not a required setup step or the expected way to use Snap-O Tweaks. Any agent or host can use the same endpoints to create its own UI. See the sample panel's README for device and package selection.
 
-A non-exported `ContentProvider` in the live artifact starts the runtime by
-default only when `ApplicationInfo.FLAG_DEBUGGABLE` is set. To intentionally
-enable live Snap-O Tweaks in a non-debuggable app, set its application flag:
+A non-exported `ContentProvider` in the live artifact starts the runtime by default only when `ApplicationInfo.FLAG_DEBUGGABLE` is set. To intentionally enable live Snap-O Tweaks in a non-debuggable app, set its application flag:
 
 ```xml
 <application>
@@ -572,12 +437,6 @@ enable live Snap-O Tweaks in a non-debuggable app, set its application flag:
 </application>
 ```
 
-This flag allows the Tweaks server and, if installed and enabled, the in-app
-overlay. It does not enable Network Inspector, which has its own
-`snapo.network.allow_release` application flag. The no-op release artifacts are
-still recommended: they return default values, contain no provider, and let R8
-remove unused calls and tweak-name strings. Verify the release APK contains
-neither tweak-only strings nor the live provider, registry, server, or socket.
+This flag allows the Tweaks server and, if installed and enabled, the in-app overlay. It does not enable Network Inspector, which has its own `snapo.network.allow_release` application flag. The no-op release artifacts are still recommended: they return default values, contain no provider, and let R8 remove unused calls and tweak-name strings. Verify the release APK contains neither tweak-only strings nor the live provider, registry, server, or socket.
 
-Phase one requires no Ktor, OkHttp, extra JSON library, Snap-O Mac UI, network
-protocol change, groups, scopes, units, separate tweak IDs, or revisions.
+Phase one requires no Ktor, OkHttp, extra JSON library, Snap-O Mac UI, network protocol change, groups, scopes, units, separate tweak IDs, or revisions.

--- a/skills/snap-o-network-inspector/SKILL.md
+++ b/skills/snap-o-network-inspector/SKILL.md
@@ -15,10 +15,7 @@ Use the shared Python CLI bundled at the Snap-O plugin root:
 SNAPO_BIN=/path/to/snap-o/scripts/snapo
 ```
 
-Resolve `../../scripts/snapo` relative to the directory containing this
-`SKILL.md`; do not assume the current working directory. The script requires
-Python 3 and Android Platform Tools; no Python packages, compiler toolchain,
-or macOS application are required.
+Resolve `../../scripts/snapo` relative to the directory containing this `SKILL.md`; do not assume the current working directory. The script requires Python 3 and Android Platform Tools; no Python packages, compiler toolchain, or macOS application are required.
 
 The script resolves `adb` from `PATH`, `ANDROID_SDK_ROOT`, or `ANDROID_HOME`. Use `--adb <path>` or `SNAPO_ADB` to select a specific ADB executable or wrapper. Wrappers selecting a remote ADB server must tunnel Snap-O forwards back to localhost; otherwise, pass both `--adb-host` and `--adb-port`.
 

--- a/skills/snap-o-tweaks/SKILL.md
+++ b/skills/snap-o-tweaks/SKILL.md
@@ -5,25 +5,17 @@ description: Inspect, stream, and explicitly adjust live Android UI tweak values
 
 # Snap-O Tweaks
 
-Inspect live values and app-owned actions exposed by a debug-enabled Android
-app. Discovery, reads, and streams are read-only; change or reset values, or
-invoke an action, only when explicitly requested. Reset everything only when
-explicitly requested.
+Inspect live values and app-owned actions exposed by a debug-enabled Android app. Discovery, reads, and streams are read-only; change or reset values, or invoke an action, only when explicitly requested. Reset everything only when explicitly requested.
 
 ## Choose the interaction surface
 
-- **Agents, shells, automation, or CI:** Default to the shared `snapo` CLI;
-  it requires only Python 3 and Android Platform Tools on macOS or Linux.
-- **Direct integration:** Use REST and server-sent events. See
-  [references/protocol.md](references/protocol.md) for ADB forwarding,
-  endpoints, typed values, atomic updates, and streaming.
+- **Agents, shells, automation, or CI:** Default to the shared `snapo` CLI; it requires only Python 3 and Android Platform Tools on macOS or Linux.
+- **Direct integration:** Use REST and server-sent events. See [references/protocol.md](references/protocol.md) for ADB forwarding, endpoints, typed values, atomic updates, and streaming.
 - **Desktop inspection:** Use Snap-O's macOS Tweaks inspector.
 - **In-app controls:** Integrate `SnapOTweakOverlay`.
-- **Custom interfaces:** Build a browser, native, or Compose UI; browsers
-  require a same-origin proxy.
+- **Custom interfaces:** Build a browser, native, or Compose UI; browsers require a same-origin proxy.
 
-Read [references/interaction-surfaces.md](references/interaction-surfaces.md)
-for desktop, overlay, release/no-op, and custom-interface integration.
+Read [references/interaction-surfaces.md](references/interaction-surfaces.md) for desktop, overlay, release/no-op, and custom-interface integration.
 
 ## Resolve the shared CLI
 
@@ -33,13 +25,9 @@ Use the executable shared by the installed Snap-O plugin:
 ../../scripts/snapo
 ```
 
-Resolve this plugin-root path relative to this `SKILL.md`, not the current
-working directory. Call the resolved path `$SNAPO_BIN`; if it is absent, the
-Snap-O plugin installation is incomplete.
+Resolve this plugin-root path relative to this `SKILL.md`, not the current working directory. Call the resolved path `$SNAPO_BIN`; if it is absent, the Snap-O plugin installation is incomplete.
 
-ADB resolves from `PATH`, `ANDROID_SDK_ROOT`, or `ANDROID_HOME`. Use
-`--adb <path>` or `SNAPO_ADB` to override it; pass `--adb-host <host>` and
-`--adb-port <port>` together for a remote ADB server.
+ADB resolves from `PATH`, `ANDROID_SDK_ROOT`, or `ANDROID_HOME`. Use `--adb <path>` or `SNAPO_ADB` to override it; pass `--adb-host <host>` and `--adb-port <port>` together for a remote ADB server.
 
 ## Discover and inspect
 
@@ -56,26 +44,16 @@ ADB resolves from `PATH`, `ANDROID_SDK_ROOT`, or `ANDROID_HOME`. Use
    "$SNAPO_BIN" tweaks get 'Typography/Font size' -s <serial> -n <socket> --json
    ```
 
-   Select devices with `-s <serial>`, `-d` (USB), or `-e` (emulator). Use
-   `-n <socket>` for every subcommand except `apps` when selection is ambiguous.
+   Select devices with `-s <serial>`, `-d` (USB), or `-e` (emulator). Use `-n <socket>` for every subcommand except `apps` when selection is ambiguous.
 
-3. Include every tweak the user has adjusted, even when its declaration is not
-   currently in composition:
+3. Include every tweak the user has adjusted, even when its declaration is not currently in composition:
 
    ```bash
    "$SNAPO_BIN" tweaks list --all -s <serial> -n <socket> --json
    "$SNAPO_BIN" tweaks get 'Typography/Font size' --all -s <serial> -n <socket> --json
    ```
 
-   The expanded list combines current tweaks and actions with retained,
-   previously adjusted tweaks. Compare each value descriptor's `value` with its
-   `default` when the user asks to apply all changes they made; action
-   descriptors have neither field. Separate screens can reuse tweak names with
-   different declarations; preserve every descriptor from `list --all` instead
-   of deduplicating by name. `get NAME --all` reports an error when multiple
-   declarations match; use `list --all --json` to inspect them. Historical
-   tweaks can be inspected while inactive, but can only be changed or reset
-   when their declaration is active. Actions are active-only.
+   The expanded list combines current tweaks and actions with retained, previously adjusted tweaks. Compare each value descriptor's `value` with its `default` when the user asks to apply all changes they made; action descriptors have neither field. Separate screens can reuse tweak names with different declarations; preserve every descriptor from `list --all` instead of deduplicating by name. `get NAME --all` reports an error when multiple declarations match; use `list --all --json` to inspect them. Historical tweaks can be inspected while inactive, but can only be changed or reset when their declaration is active. Actions are active-only.
 
 4. Observe live complete snapshots:
 
@@ -84,18 +62,11 @@ ADB resolves from `PATH`, `ANDROID_SDK_ROOT`, or `ANDROID_HOME`. Use
    "$SNAPO_BIN" tweaks watch -s <serial> -n <socket> --once --json
    ```
 
-   `--once` exits after the first complete snapshot. `--json` emits
-   newline-delimited JSON; `list` and `watch` emit complete tweak and action
-   snapshots. Event streams contain only currently active declarations; use
-   `list --all` for historical value adjustments.
+   `--once` exits after the first complete snapshot. `--json` emits newline-delimited JSON; `list` and `watch` emit complete tweak and action snapshots. Event streams contain only currently active declarations; use `list --all` for historical value adjustments.
 
 ## Change values only when requested
 
-Inspect the descriptor first: the CLI parses `int`, `float`, `boolean`,
-`color`, `string`, and `enum` according to their declared types. Enum
-descriptors include an ordered list of enum names in `options`; use an exact
-option name when setting one. Quote names containing spaces or `/`, string
-values containing spaces, and hex colors.
+Inspect the descriptor first: the CLI parses `int`, `float`, `boolean`, `color`, `string`, and `enum` according to their declared types. Enum descriptors include an ordered list of enum names in `options`; use an exact option name when setting one. Quote names containing spaces or `/`, string values containing spaces, and hex colors.
 
 ```bash
 "$SNAPO_BIN" tweaks set 'Typography/Font size' 42 -s <serial> -n <socket>
@@ -106,8 +77,7 @@ values containing spaces, and hex colors.
 
 Successful updates and resets produce no output.
 
-Reset only the explicitly requested value, or use `--all` only for an explicit
-reset-everything request:
+Reset only the explicitly requested value, or use `--all` only for an explicit reset-everything request:
 
 ```bash
 "$SNAPO_BIN" tweaks reset 'Typography/Font size' -s <serial> -n <socket>
@@ -116,32 +86,14 @@ reset-everything request:
 
 ## Invoke actions only when requested
 
-Apps declare actions with the `TweakAction(name) { ... }` composable, imported
-from `com.openai.snapo.tweaks.TweakAction`. The declaration returns `Unit`,
-registers its callback only while the owner remains in composition, and does
-not execute the callback during composition. Actions have `"type":"action"`,
-no `value`, and no `default`. Invoke an action only when the user explicitly
-requests its app-defined behavior:
+Apps declare actions with the `TweakAction(name) { ... }` composable, imported from `com.openai.snapo.tweaks.TweakAction`. The declaration returns `Unit`, registers its callback only while the owner remains in composition, and does not execute the callback during composition. Actions have `"type":"action"`, no `value`, and no `default`. Invoke an action only when the user explicitly requests its app-defined behavior:
 
 ```bash
 "$SNAPO_BIN" tweaks action 'Preview/Refresh visible content' -s <serial> -n <socket>
 ```
 
-The action command sends the registered name exactly as provided and does not
-accept arguments or execute arbitrary code. A descriptor marked
-`"conflicted":true` has multiple live owners and cannot be invoked; report the
-server's conflict and ask the app owner to register the shared action once or
-choose explicit, stable, unique names. Do not deduplicate callbacks or invent
-numeric suffixes. Reset-all ignores actions.
+The action command sends the registered name exactly as provided and does not accept arguments or execute arbitrary code. A descriptor marked `"conflicted":true` has multiple live owners and cannot be invoked; report the server's conflict and ask the app owner to register the shared action once or choose explicit, stable, unique names. Do not deduplicate callbacks or invent numeric suffixes. Reset-all ignores actions.
 
 ## Availability and failures
 
-Tweaks use app-local `snapo_tweaks_<pid>` sockets and normally exist only in
-debug-enabled apps. If no socket appears, check device authorization and
-selection, whether the app is running, its live Tweaks dependency/integration,
-debug/runtime policy, and server startup. If a socket exists but `/tweaks` is
-empty, the current Compose UI has no active tweak declarations; `list --all`
-can still return retained adjustments. Adjustment history lasts only for the
-current Android app process. Do not enable release servers or modify apps or
-dependencies without an explicit request. Preserve validation errors; the CLI
-cleans up its own temporary ADB forwards.
+Tweaks use app-local `snapo_tweaks_<pid>` sockets and normally exist only in debug-enabled apps. If no socket appears, check device authorization and selection, whether the app is running, its live Tweaks dependency/integration, debug/runtime policy, and server startup. If a socket exists but `/tweaks` is empty, the current Compose UI has no active tweak declarations; `list --all` can still return retained adjustments. Adjustment history lasts only for the current Android app process. Do not enable release servers or modify apps or dependencies without an explicit request. Preserve validation errors; the CLI cleans up its own temporary ADB forwards.

--- a/skills/snap-o-tweaks/references/interaction-surfaces.md
+++ b/skills/snap-o-tweaks/references/interaction-surfaces.md
@@ -4,35 +4,17 @@ The same active Compose tweak registry can be inspected from several surfaces. C
 
 ## Command line: agents, automation, and repeatable checks
 
-Use the dependency-free Snap-O CLI when a terminal, Codex agent, test script, or
-Linux/macOS workflow needs app discovery, typed value inspection or updates,
-atomic batches, resets, app-owned action invocation, or live snapshots. Invoke
-an explicitly requested action with `snapo tweaks action NAME`; actions have no
-editable value, default, or arguments. Use `snapo tweaks list --all` or
-`snapo tweaks get NAME --all` to include previously adjusted tweaks no longer in
-composition; inactive historical tweaks are inspectable but not writable. Its
-tweaks workflow documents command selection and options. The CLI owns temporary
-local forwarding and cleanup; explicit remote ADB endpoints use direct
-smart-socket transport.
+Use the dependency-free Snap-O CLI when a terminal, Codex agent, test script, or Linux/macOS workflow needs app discovery, typed value inspection or updates, atomic batches, resets, app-owned action invocation, or live snapshots. Invoke an explicitly requested action with `snapo tweaks action NAME`; actions have no editable value, default, or arguments. Use `snapo tweaks list --all` or `snapo tweaks get NAME --all` to include previously adjusted tweaks no longer in composition; inactive historical tweaks are inspectable but not writable. Its tweaks workflow documents command selection and options. The CLI owns temporary local forwarding and cleanup; explicit remote ADB endpoints use direct smart-socket transport.
 
 ## Snap-O macOS app: an existing desktop inspector
 
-Choose the Snap-O macOS app when someone wants an existing graphical inspector.
-Its app picker discovers connected devices and `snapo_tweaks_<pid>` servers,
-identifies each app through `/app`, and combines the Network and Tweaks
-inspector choices when one app supports both. The Tweaks inspector displays live
-values and app-owned actions, streams changes, edits typed controls, invokes
-available action buttons, and supports resetting value changes. Conflicting
-actions are visible but cannot be invoked.
+Choose the Snap-O macOS app when someone wants an existing graphical inspector. Its app picker discovers connected devices and `snapo_tweaks_<pid>` servers, identifies each app through `/app`, and combines the Network and Tweaks inspector choices when one app supports both. The Tweaks inspector displays live values and app-owned actions, streams changes, edits typed controls, invokes available action buttons, and supports resetting value changes. Conflicting actions are visible but cannot be invoked.
 
 The macOS app manages ADB forwarding and streaming itself. It is an existing interaction option, not a required proxy, dependency, or prerequisite for the standalone CLI and REST protocol.
 
 ## Optional in-app Compose overlay
 
-Choose the overlay when developers or designers should adjust values or invoke
-app-owned actions directly on the Android device without a separate desktop
-window. Add the published live artifacts to debug builds and matching no-op
-artifacts to release builds using the same Snap-O version:
+Choose the overlay when developers or designers should adjust values or invoke app-owned actions directly on the Android device without a separate desktop window. Add the published live artifacts to debug builds and matching no-op artifacts to release builds using the same Snap-O version:
 
 ```kotlin
 val snapoVersion = "<version>"
@@ -80,15 +62,7 @@ The CLI and Snap-O macOS app own socket discovery, forwarding, and cleanup. The 
 
 ## Custom interfaces: browsers, Node, Swift, and Compose
 
-Build a custom surface when an existing CLI, desktop inspector, or in-app overlay
-does not match the desired controls or workflow. All external hosts should
-discover the tweak socket, establish an accessible ADB transport, read `/app`
-and `/tweaks`, send atomic `PATCH /tweaks` value updates, invoke explicitly
-requested actions with `POST /tweaks/action`, and consume full active snapshots
-from `/tweaks/events`. Render actions without assuming `value` or `default`;
-disable invocation when `conflicted` is true. Request
-`/tweaks?include=adjusted` when a workflow needs every retained user value
-adjustment, including inactive declarations.
+Build a custom surface when an existing CLI, desktop inspector, or in-app overlay does not match the desired controls or workflow. All external hosts should discover the tweak socket, establish an accessible ADB transport, read `/app` and `/tweaks`, send atomic `PATCH /tweaks` value updates, invoke explicitly requested actions with `POST /tweaks/action`, and consume full active snapshots from `/tweaks/events`. Render actions without assuming `value` or `default`; disable invocation when `conflicted` is true. Request `/tweaks?include=adjusted` when a workflow needs every retained user value adjustment, including inactive declarations.
 
 - A browser interface can use `fetch` and `EventSource` through a same-origin proxy; see [protocol.md](protocol.md) for browser transport restrictions.
 - A Node host or terminal tool can use built-in `fetch` for requests and parse the response body as a standard SSE stream.
@@ -113,17 +87,8 @@ fun AnimatedContent() {
 }
 ```
 
-Value declarations return observable `State<T>` and update when any supported
-surface changes the shared registry. `TweakAction` returns `Unit`, registers its
-parameterless callback only while its owner remains in composition, and does
-not execute the callback during composition. The registry-editing
-`SnapOTweaks` helpers are annotated
-`@RestrictTo(LIBRARY_GROUP)`; do not present them as a stable public app API for
-building arbitrary in-process inspectors. Use the supported overlay or an
-external REST client when an editable custom control surface is needed.
+Value declarations return observable `State<T>` and update when any supported surface changes the shared registry. `TweakAction` returns `Unit`, registers its parameterless callback only while its owner remains in composition, and does not execute the callback during composition. The registry-editing `SnapOTweaks` helpers are annotated `@RestrictTo(LIBRARY_GROUP)`; do not present them as a stable public app API for building arbitrary in-process inspectors. Use the supported overlay or an external REST client when an editable custom control surface is needed.
 
-Register each shared action once at its owning composable. Distinct callbacks
-must use explicit, stable, unique names; concurrent registrations of the same
-action name are surfaced as conflicts and cannot be invoked.
+Register each shared action once at its owning composable. Distinct callbacks must use explicit, stable, unique names; concurrent registrations of the same action name are surfaced as conflicts and cannot be invoked.
 
 For wire formats, transport cleanup, SSE semantics, validation, and security details, see [protocol.md](protocol.md).

--- a/skills/snap-o-tweaks/references/protocol.md
+++ b/skills/snap-o-tweaks/references/protocol.md
@@ -42,11 +42,7 @@ For remote ADB servers, an `adb forward` is local to the ADB server's host, not 
 
 Ordinary responses close their connection and include a content length. The event response stays open and uses `Content-Type: text/event-stream`.
 
-`protocolVersion` is specific to Tweaks and independent of the Network Inspector
-protocol. Version 1 predates this field and supports only value tweaks; treat a
-missing version as 1. Version 2 adds app-owned action descriptors and
-`POST /tweaks/action`. A version newer than the host supports may require a
-compatibility warning.
+`protocolVersion` is specific to Tweaks and independent of the Network Inspector protocol. Version 1 predates this field and supports only value tweaks; treat a missing version as 1. Version 2 adds app-owned action descriptors and `POST /tweaks/action`. A version newer than the host supports may require a compatibility warning.
 
 ### Read metadata and active values
 
@@ -92,45 +88,15 @@ The tweak response has this shape:
 }
 ```
 
-The available value types are `int`, `float`, `boolean`, `color`, `string`, and
-`enum`. Preserve actual JSON types: booleans are not strings, integer values
-cannot be fractional, and floats accept whole or fractional finite numbers.
-Colors are strings in `#RRGGBB` or `#RRGGBBAA` format. Numeric descriptors may
-include `min`, `max`, and `step`; step alignment starts at `min`, or at
-`default` if there is no minimum. Actions use `"type":"action"` and have no
-`value`, `default`, or `options`.
+The available value types are `int`, `float`, `boolean`, `color`, `string`, and `enum`. Preserve actual JSON types: booleans are not strings, integer values cannot be fractional, and floats accept whole or fractional finite numbers. Colors are strings in `#RRGGBB` or `#RRGGBBAA` format. Numeric descriptors may include `min`, `max`, and `step`; step alignment starts at `min`, or at `default` if there is no minimum. Actions use `"type":"action"` and have no `value`, `default`, or `options`.
 
-Enum descriptors include a nonempty, ordered `options` array containing unique,
-nonblank enum name strings. The `default` and current `value` are names from
-that list. Send an exact option name in `PATCH /tweaks`.
+Enum descriptors include a nonempty, ordered `options` array containing unique, nonblank enum name strings. The `default` and current `value` are names from that list. Send an exact option name in `PATCH /tweaks`.
 
-An action descriptor with `"conflicted":true` has multiple live registrations
-for the same name. It remains visible so clients can surface the conflict, but
-the server rejects invocation instead of choosing a callback, merging owners, or
-inventing unstable names. Register a shared action once at its owner, or use
-explicit, stable, unique names for distinct actions.
+An action descriptor with `"conflicted":true` has multiple live registrations for the same name. It remains visible so clients can surface the conflict, but the server rejects invocation instead of choosing a callback, merging owners, or inventing unstable names. Register a shared action once at its owner, or use explicit, stable, unique names for distinct actions.
 
-Plain `GET /tweaks` includes only value and action declarations active in
-Compose. Add
-`?include=adjusted` to include every tweak successfully adjusted by the user,
-including retained descriptors whose declarations have since left composition.
-The expanded response uses the same descriptor shape and also includes current
-active tweaks and actions; actions have no adjustment history. Separate screens
-can reuse a value tweak name with different complete
-declarations; preserve every returned descriptor instead of deduplicating by
-name. A tweak that was adjusted and later reset can still appear with its
-default value; compare `value` and `default` to identify outstanding user
-changes. Retention lasts for the current app process and is cleared with the
-registry; it is not persistent storage across app restarts.
+Plain `GET /tweaks` includes only value and action declarations active in Compose. Add `?include=adjusted` to include every tweak successfully adjusted by the user, including retained descriptors whose declarations have since left composition. The expanded response uses the same descriptor shape and also includes current active tweaks and actions; actions have no adjustment history. Separate screens can reuse a value tweak name with different complete declarations; preserve every returned descriptor instead of deduplicating by name. A tweak that was adjusted and later reset can still appear with its default value; compare `value` and `default` to identify outstanding user changes. Retention lasts for the current app process and is cleared with the registry; it is not persistent storage across app restarts.
 
-Names may contain spaces and `/`; send the entire name unchanged. Two active
-declarations of the same complete value descriptor observe the same value.
-Repeated value names in expanded results represent distinct complete
-descriptors; active-only snapshots and updates still resolve at most one
-currently active value descriptor per name. Historical descriptors are
-read-only while inactive: `PATCH /tweaks` still rejects their names until their
-declarations return. Separate active callbacks with the same action name are
-not interchangeable and are reported as conflicted.
+Names may contain spaces and `/`; send the entire name unchanged. Two active declarations of the same complete value descriptor observe the same value. Repeated value names in expanded results represent distinct complete descriptors; active-only snapshots and updates still resolve at most one currently active value descriptor per name. Historical descriptors are read-only while inactive: `PATCH /tweaks` still rejects their names until their declarations return. Separate active callbacks with the same action name are not interchangeable and are reported as conflicted.
 
 ### Update or reset values atomically
 
@@ -146,12 +112,7 @@ The response contains the changed names and their resulting values:
 {"tweaks":[{"name":"Motion/Duration","value":550},{"name":"Motion/Enabled","value":false},{"name":"Appearance/Theme","value":"Dark"}]}
 ```
 
-Every value is validated before any update is applied. An invalid, unknown, or
-inactive entry prevents the entire batch from changing. Reset by fetching
-`GET /tweaks` and sending the target descriptor's `default` value back in a
-patch; reset all by patching every active value name to its own default in one
-request. Actions cannot be patched or reset and are excluded from reset-all.
-There is no separate get-by-name, reset, delete, or grouping endpoint.
+Every value is validated before any update is applied. An invalid, unknown, or inactive entry prevents the entire batch from changing. Reset by fetching `GET /tweaks` and sending the target descriptor's `default` value back in a patch; reset all by patching every active value name to its own default in one request. Actions cannot be patched or reset and are excluded from reset-all. There is no separate get-by-name, reset, delete, or grouping endpoint.
 
 ### Invoke an app-owned action
 
@@ -161,21 +122,13 @@ curl -fsS -X POST "$base/tweaks/action" \
   -d '{"name":"Preview/Refresh visible content"}'
 ```
 
-The name identifies an explicitly registered, parameterless app callback.
-Android apps expose these callbacks using the `TweakAction(name) { ... }`
-composable, imported from `com.openai.snapo.tweaks.TweakAction`. Declaring the
-action returns `Unit`, does not execute its callback, and registers it only
-while its owner remains in composition. A successful response is HTTP 200 with
-the invoked action's name:
+The name identifies an explicitly registered, parameterless app callback. Android apps expose these callbacks using the `TweakAction(name) { ... }` composable, imported from `com.openai.snapo.tweaks.TweakAction`. Declaring the action returns `Unit`, does not execute its callback, and registers it only while its owner remains in composition. A successful response is HTTP 200 with the invoked action's name:
 
 ```json
 {"name":"Preview/Refresh visible content"}
 ```
 
-Unknown names and value-only names return HTTP 404; conflicting live action
-registrations return HTTP 409. Malformed request bodies return HTTP 400, and
-unsupported methods return HTTP 405. The endpoint does not accept arguments,
-schemas, scripts, or arbitrary code.
+Unknown names and value-only names return HTTP 404; conflicting live action registrations return HTTP 409. Malformed request bodies return HTTP 400, and unsupported methods return HTTP 405. The endpoint does not accept arguments, schemas, scripts, or arbitrary code.
 
 ### Watch complete snapshots
 
@@ -194,14 +147,7 @@ data: {"tweaks":[{"name":"Motion/Enabled","type":"boolean","default":true,"value
 
 ```
 
-The first event is the complete current active list. Every later `event: tweaks`
-is also a complete, ordered replacement snapshot of active values and actions,
-not a delta. Historical inactive tweaks are not included in event snapshots;
-request
-`GET /tweaks?include=adjusted` separately when their retained values are needed.
-Remove items absent from the newest snapshot. Ignore lines starting with `:`;
-they are idle keepalives. Reconnect and replace state when the app process or
-socket changes.
+The first event is the complete current active list. Every later `event: tweaks` is also a complete, ordered replacement snapshot of active values and actions, not a delta. Historical inactive tweaks are not included in event snapshots; request `GET /tweaks?include=adjusted` separately when their retained values are needed. Remove items absent from the newest snapshot. Ignore lines starting with `:`; they are idle keepalives. Reconnect and replace state when the app process or socket changes.
 
 For a browser, serve a same-origin proxy that forwards these routes to the ADB-forwarded target:
 

--- a/snapo-app-mac/AGENTS.md
+++ b/snapo-app-mac/AGENTS.md
@@ -8,9 +8,7 @@ For automated contributors:
   - SwiftFormat: `.swiftformat`
 - Never add a `deinit`; rely on SwiftUI/Observation lifecycle instead.
 - Never run `git` commands; leave version control to the user.
-- Do not modify these config files without explicit approval. If a change is needed,
-  propose it with a short rationale in a separate PR (or commit) so it’s easy to review
-  and doesn’t mix with code changes.
+- Do not modify these config files without explicit approval. If a change is needed, propose it with a short rationale in a separate PR (or commit) so it’s easy to review and doesn’t mix with code changes.
 - To build the app, use `xcodebuild`:
   ```sh
   xcodebuild -project Snap-O.xcodeproj \

--- a/snapo-link-android/samples/demo-tweaks/panel/README.md
+++ b/snapo-link-android/samples/demo-tweaks/panel/README.md
@@ -1,11 +1,8 @@
 # Snap-O Tweaks inspector demo
 
-A model built this inspector as one way to find running apps and change live
-values. Each app must use Snap-O Tweaks.
+A model built this inspector as one way to find running apps and change live values. Each app must use Snap-O Tweaks.
 
-This is only a demo, not part of the feature or the expected way to use it.
-You do not need this inspector. Any tool can use `/app`, `/tweaks`,
-`/tweaks?include=adjusted`, and `/tweaks/events` to build its own live UI.
+This is only a demo, not part of the feature or the expected way to use it. You do not need this inspector. Any tool can use `/app`, `/tweaks`, `/tweaks?include=adjusted`, and `/tweaks/events` to build its own live UI.
 
 ## What you need
 
@@ -41,25 +38,15 @@ npm start
 
 Open `http://127.0.0.1:4175`.
 
-To preview the app and inspector menu without a device, open
-`http://127.0.0.1:4175/?mock`. The mock stays in the browser and does not
-run `adb` or connect to an Android app. Apps appear under **Network** and
-**Tweaks**. Each row shows the app and its phone or emulator. Hover over a
-row to see the app's package name.
+To preview the app and inspector menu without a device, open `http://127.0.0.1:4175/?mock`. The mock stays in the browser and does not run `adb` or connect to an Android app. Apps appear under **Network** and **Tweaks**. Each row shows the app and its phone or emulator. Hover over a row to see the app's package name.
 
-To compare a second layout with compact app headings and larger inspector
-rows, open `http://127.0.0.1:4175/?mock=apps`.
+To compare a second layout with compact app headings and larger inspector rows, open `http://127.0.0.1:4175/?mock=apps`.
 
-There is no install or build step. The inspector sets up its own `adb` port
-forwards. It can also start before an Android app is open.
+There is no install or build step. The inspector sets up its own `adb` port forwards. It can also start before an Android app is open.
 
 ## Find and switch apps
 
-The inspector finds every running Snap-O Tweaks app on each connected device.
-The app picker shows the app name, icon, and device. Its menu shows each app
-once, with a short app-and-device heading above a **Tweaks** row. Select that
-row to see and change the app's values. The picker becomes a menu only when
-more than one app is available.
+The inspector finds every running Snap-O Tweaks app on each connected device. The app picker shows the app name, icon, and device. Its menu shows each app once, with a short app-and-device heading above a **Tweaks** row. Select that row to see and change the app's values. The picker becomes a menu only when more than one app is available.
 
 To find apps, the inspector:
 
@@ -69,12 +56,9 @@ To find apps, the inspector:
 4. Uses or creates an `adb` port forward.
 5. Reads `/app` to get the app name and package.
 
-It checks for new apps every few seconds. Tweak and screen changes stream from
-the app as they happen. If an app starts again, the inspector keeps the same app
-selected when possible. If no app is running, it shows an empty state and waits.
+It checks for new apps every few seconds. Tweak and screen changes stream from the app as they happen. If an app starts again, the inspector keeps the same app selected when possible. If no app is running, it shows an empty state and waits.
 
-App discovery and selection belong to this demo server. `/apps` and
-`/apps/selection` are not part of the Android Snap-O Tweaks protocol.
+App discovery and selection belong to this demo server. `/apps` and `/apps/selection` are not part of the Android Snap-O Tweaks protocol.
 
 ## Group tweaks
 
@@ -87,12 +71,9 @@ val animationDuration by tweak(400, "Motion/Duration", 100..1500)
 val markerShape by tweak(MotionMarkerShape.Circle, "Motion/Marker shape")
 ```
 
-The part before `/` is the section. The part after `/` is the label. A tweak
-without `/` has no section. The full name is still used for changes.
+The part before `/` is the section. The part after `/` is the label. A tweak without `/` has no section. The full name is still used for changes.
 
-Sections and tweaks keep the order in which the app first shows them. If one
-goes away and comes back, it returns to the same place. On wide screens,
-sections stack in two stable columns and do not move between them.
+Sections and tweaks keep the order in which the app first shows them. If one goes away and comes back, it returns to the same place. On wide screens, sections stack in two stable columns and do not move between them.
 
 ## Use a different device or app
 
@@ -121,8 +102,7 @@ To use a local endpoint:
 npm start -- --target http://127.0.0.1:43817
 ```
 
-A target set this way will not follow an app that starts again. To use a
-different port:
+A target set this way will not follow an app that starts again. To use a different port:
 
 ```bash
 npm start -- --port 4176
@@ -130,25 +110,17 @@ npm start -- --port 4176
 
 ## Change a live value
 
-Move a slider, choose a color, or select a marker shape by its enum name. The
-app changes at once. The inspector waits for each request before it sends the
-next value or switches to another app. You can set one value or all values
-back.
+Move a slider, choose a color, or select a marker shape by its enum name. The app changes at once. The inspector waits for each request before it sends the next value or switches to another app. You can set one value or all values back.
 
-Turn off **Show** in the **Motion** section to hide the motion preview in the
-sample app. Its animation tweaks leave the composition and vanish from the
-inspector. Turn it back on to see them appear again.
+Turn off **Show** in the **Motion** section to hide the motion preview in the sample app. Its animation tweaks leave the composition and vanish from the inspector. Turn it back on to see them appear again.
 
-The inspector continues to display only active tweaks. To inspect retained
-values the user previously adjusted, including tweaks that have since left
-composition, request the expanded view through the demo server:
+The inspector continues to display only active tweaks. To inspect retained values the user previously adjusted, including tweaks that have since left composition, request the expanded view through the demo server:
 
 ```bash
 curl -fsS 'http://127.0.0.1:4175/tweaks?include=adjusted'
 ```
 
-Inactive historical tweaks can be inspected, but cannot be changed or reset
-until they return to composition.
+Inactive historical tweaks can be inspected, but cannot be changed or reset until they return to composition.
 
 ## Test the panel
 

--- a/snapo-network-inspector-web/README.md
+++ b/snapo-network-inspector-web/README.md
@@ -1,9 +1,6 @@
 # Snap-O App Inspector Web UI
 
-This project contains the App Inspector renderer embedded in Snap-O's native
-macOS app. The Swift app hosts the built files in a `WKWebView` and provides
-device, Network Inspector, and Snap-O Tweaks operations through the WebKit
-message bridge in `src/network/client.ts`.
+This project contains the App Inspector renderer embedded in Snap-O's native macOS app. The Swift app hosts the built files in a `WKWebView` and provides device, Network Inspector, and Snap-O Tweaks operations through the WebKit message bridge in `src/network/client.ts`.
 
 The renderer also retains its HTTP transport so it can run in a browser-hosted environment. It contains only portable web UI code.
 
@@ -19,9 +16,7 @@ npm install --registry=https://openai.firewall.socket.dev/npm/
 npm run dev
 ```
 
-Running the renderer by itself uses the HTTP endpoints under `/api/network/...`
-and `/api/inspector/...`. To use the native WebKit bridge and inspect a connected
-device, build and run the Swift app in `snapo-app-mac`.
+Running the renderer by itself uses the HTTP endpoints under `/api/network/...` and `/api/inspector/...`. To use the native WebKit bridge and inspect a connected device, build and run the Swift app in `snapo-app-mac`.
 
 ## Validation
 


### PR DESCRIPTION
## Summary

- Keep Markdown paragraphs and list items on a single physical line so line-based readers receive complete concepts.
- Preserve fenced code blocks, tables, YAML frontmatter, nested lists, raw HTML, and GitHub templates.

## Verification

- Compared parsed Markdown syntax trees before and after reflow.
- `git diff --check`
- Ran the complete Prettier formatting check for the web inspector.