### PR TITLE
Render tweak overlay as a standalone composable

### DIFF
--- a/contracts/tweaks/README.md
+++ b/contracts/tweaks/README.md
@@ -375,22 +375,26 @@ dependencies {
 :tweaks                 Compose API, live registry, HTTP, and abstract socket.
 :tweaks-noop            Matching Compose API that returns default values.
 :tweaks-overlay         Optional floating Compose tweak inspector.
-:tweaks-overlay-noop    Matching overlay wrapper without the inspector.
+:tweaks-overlay-noop    Matching no-op overlay without the inspector.
 :samples:demo-tweaks    Standalone Compose sample with no network integration.
 ```
 
 ### Optional in-app overlay
 
-Wrap the app's root content with `SnapOTweakOverlay`:
+Place `SnapOTweakOverlay` after the app content in a fullscreen `Box`:
 
 ```kotlin
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
 import com.openai.snapo.tweaks.overlay.SnapOTweakOverlay
 
 @Composable
 fun App() {
-    SnapOTweakOverlay {
+    Box(modifier = Modifier.fillMaxSize()) {
         AppContent()
+        SnapOTweakOverlay(modifier = Modifier.fillMaxSize())
     }
 }
 ```
@@ -413,7 +417,7 @@ fun DeveloperSettings() {
 }
 ```
 
-The setting persists between app launches. When enabled, a movable button appears only while at least one tweak is in composition. Tap it to inspect or edit the active tweaks, run registered actions, and minimize the panel to return to the button. Conflicted actions are visible but cannot be run. The panel stays synchronized with host-side changes, remembers its position, and disappears when the last tweak or action leaves composition. The no-op overlay keeps the same wrapper and settings APIs without showing a panel in release builds.
+The setting persists between app launches. When enabled, a movable button appears only while at least one tweak is in composition. Tap it to inspect or edit the active tweaks, run registered actions, and minimize the panel to return to the button. Conflicted actions are visible but cannot be run. The panel stays synchronized with host-side changes, remembers its position, and disappears when the last tweak or action leaves composition. The no-op overlay keeps the same composable and settings APIs without showing a panel in release builds.
 
 Install the standalone debug sample on a connected Android device:
 

--- a/skills/snap-o-tweaks/references/interaction-surfaces.md
+++ b/skills/snap-o-tweaks/references/interaction-surfaces.md
@@ -28,15 +28,20 @@ dependencies {
 }
 ```
 
-Wrap the app root with the optional overlay:
+Place the optional overlay after the app content in a fullscreen `Box`:
 
 ```kotlin
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
 import com.openai.snapo.tweaks.overlay.SnapOTweakOverlay
 
 @Composable
 fun App() {
-    SnapOTweakOverlay {
+    Box(modifier = Modifier.fillMaxSize()) {
         AppContent()
+        SnapOTweakOverlay(modifier = Modifier.fillMaxSize())
     }
 }
 ```
@@ -54,7 +59,7 @@ Switch(
 )
 ```
 
-The setting persists across launches in live builds. When enabled, the floating inspector appears only while at least one tweak is active. The release no-op overlay preserves the same wrapper and settings API but never displays a panel. It is separate from release server activation; avoid enabling live release tweaks unless explicitly required.
+The setting persists across launches in live builds. When enabled, the floating inspector appears only while at least one tweak is active. The release no-op overlay preserves the same composable and settings API but never displays a panel. It is separate from release server activation; avoid enabling live release tweaks unless explicitly required.
 
 ## Transport ownership
 

--- a/snapo-link-android/samples/demo-tweaks/src/main/java/com/openai/snapo/demo/tweaks/MainActivity.kt
+++ b/snapo-link-android/samples/demo-tweaks/src/main/java/com/openai/snapo/demo/tweaks/MainActivity.kt
@@ -5,6 +5,7 @@ import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
 import androidx.activity.enableEdgeToEdge
 import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.WindowInsets
@@ -67,8 +68,9 @@ private fun TweakDemo() {
             onSurface = DefaultTextColor,
         ),
     ) {
-        SnapOTweakOverlay {
+        Box(modifier = Modifier.fillMaxSize()) {
             TweakDemoScreen()
+            SnapOTweakOverlay(modifier = Modifier.fillMaxSize())
         }
     }
 }

--- a/snapo-link-android/tweaks-overlay-noop/src/main/java/com/openai/snapo/tweaks/overlay/TweakOverlay.kt
+++ b/snapo-link-android/tweaks-overlay-noop/src/main/java/com/openai/snapo/tweaks/overlay/TweakOverlay.kt
@@ -1,19 +1,11 @@
 package com.openai.snapo.tweaks.overlay
 
-import androidx.compose.foundation.layout.Box
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 
-/** Renders application content without including the in-app tweak inspector. */
+/** Does not render an in-app tweak inspector in release builds. */
 @Composable
 fun SnapOTweakOverlay(
+    @Suppress("UNUSED_PARAMETER")
     modifier: Modifier = Modifier,
-    content: @Composable () -> Unit,
-) {
-    Box(
-        modifier = modifier,
-        propagateMinConstraints = true,
-    ) {
-        content()
-    }
-}
+) = Unit

--- a/snapo-link-android/tweaks-overlay/src/main/java/com/openai/snapo/tweaks/overlay/TweakOverlay.kt
+++ b/snapo-link-android/tweaks-overlay/src/main/java/com/openai/snapo/tweaks/overlay/TweakOverlay.kt
@@ -75,33 +75,19 @@ internal object TweakOverlayColors {
 
 /** Draws a compact, movable tweak inspector over application content. */
 @Composable
-fun SnapOTweakOverlay(
-    modifier: Modifier = Modifier,
-    content: @Composable () -> Unit,
-) {
+fun SnapOTweakOverlay(modifier: Modifier = Modifier) {
     val appContext = LocalContext.current.applicationContext
     LaunchedEffect(appContext) {
         SnapOTweakOverlaySettings.initialize(appContext)
     }
 
-    Box(
-        modifier = modifier,
-        propagateMinConstraints = true,
-    ) {
-        content()
-        TweakOverlayPresence()
-    }
-}
-
-@Composable
-private fun BoxScope.TweakOverlayPresence() {
     if (!SnapOTweakOverlaySettings.isEnabled) return
 
     val tweaks = rememberActiveOverlayTweaks()
     if (tweaks.isNotEmpty()) {
         TweakOverlayLayer(
             tweaks = tweaks,
-            modifier = Modifier.matchParentSize(),
+            modifier = modifier.fillMaxSize(),
         )
     }
 }


### PR DESCRIPTION
## Summary
- Render `SnapOTweakOverlay` as a standalone composable instead of wrapping application content.
- Keep the live and no-op overlay APIs aligned; the release implementation emits no layout.
- Update the demo and integration guides to mount the overlay after app content inside a fullscreen `Box`.

## Validation
- `./gradlew :tweaks-overlay:testDebugUnitTest :tweaks-overlay:assembleDebug :tweaks-overlay-noop:assembleRelease :samples:demo-tweaks:assembleDebug :samples:demo-tweaks:assembleRelease`