### PR TITLE
Add explicit tweak resets and change tracking

### DIFF
--- a/contracts/tweaks/README.md
+++ b/contracts/tweaks/README.md
@@ -37,11 +37,11 @@ Return the app's user-facing Android label, package name, and Tweaks protocol ve
 {
   "name": "Snap-O Tweaks Demo",
   "packageName": "com.openai.snapo.demo.tweaks",
-  "protocolVersion": 3
+  "protocolVersion": 4
 }
 ```
 
-Resolve `name` from the actual Android app label. An absent `protocolVersion` identifies the original version 1, which exposes value tweaks only. Version 2 adds action descriptors and `POST /tweaks/action`. Version 3 adds best-effort batch updates with per-item errors. The Tweaks protocol version is independent of the Network Inspector protocol version; hosts can use it to select compatible behavior.
+Resolve `name` from the actual Android app label. An absent `protocolVersion` identifies the original version 1, which exposes value tweaks only. Version 2 adds action descriptors and `POST /tweaks/action`. Version 3 adds best-effort batch updates with per-item errors. Version 4 adds explicit null resets and authoritative modification status. The Tweaks protocol version is independent of the Network Inspector protocol version; hosts can use it to select compatible behavior.
 
 ### GET /app/icon
 
@@ -148,6 +148,8 @@ A tweak name represents one shared value, not one composable. Multiple active co
 
 Usages with the same name must agree on the tweak type, default, constraints, and ordered enum options. Conflicting declarations are a configuration error.
 
+In protocol version 4, only modified value tweaks include `"modified": true`; otherwise the field is absent. A missing field always means false. A tweak is modified when its value differs from its default. Versions 1, 2, and 3 omit this field; determine their modification status by comparing `value` with `default`. Action descriptors never include `modified`.
+
 Supported value types are `int`, `float`, `boolean`, `color`, `string`, and `enum`. The `action` type describes an explicitly registered parameterless app-owned callback. Actions do not have `value`, `default`, options, or numeric constraints; clients must not attempt to patch or reset them. Integer tweaks accept only whole numbers; float tweaks accept whole or fractional numbers. Numeric tweaks may include `min`, `max`, and `step`. Only include constraints actually supplied by the app. A `step` is relative to `min`, or to `default` if no `min` is supplied. Colors use `#RRGGBB`, or `#RRGGBBAA` when translucent.
 
 Enum tweaks include an ordered, nonempty `options` array containing the unique enum constant names. The descriptor's `default`, current `value`, picker text, and `PATCH` values all use those exact names. Preserve declaration order when rendering pickers; reject any value not present in `options`.
@@ -164,7 +166,7 @@ Action names must be explicit, stable, and unique among live registrations. Regi
 
 Conflicting actions remain discoverable but cannot be invoked until exactly one owner remains. Callbacks are never silently deduplicated, replaced, or renamed with generated suffixes.
 
-Compose color defaults keep their exact in-process identity, including color space, component precision, and `Color.Unspecified`. The HTTP protocol still presents colors as sRGB hex; non-sRGB defaults are projected, and `Color.Unspecified` appears as `#00000000`. Patching a color with that presented default remains the legacy reset operation, so the same projected hex cannot also express a distinct sRGB edit for a non-round-trippable default.
+Compose color defaults keep their exact in-process identity, including color space, component precision, and `Color.Unspecified`. The HTTP protocol still presents colors as sRGB hex; non-sRGB defaults are projected, and `Color.Unspecified` appears as `#00000000`. An explicit reset restores the original in-process color, even when its wire representation is projected.
 
 Numeric JSON values may contain at most 128 characters and 64 significant digits, with a decimal scale between -64 and 64. Reject values outside those limits with `422` before changing any tweaks.
 
@@ -178,7 +180,7 @@ curl -fsS 'http://127.0.0.1:43817/tweaks?include=adjusted'
 
 The response uses the same `{"tweaks":[...]}` shape and complete tweak descriptors as `GET /tweaks`. Include every currently active tweak, whether or not it has been adjusted, and every inactive tweak whose value was actually changed by a successful user adjustment. Preserve the tweak's original declaration, constraints, and latest value after its final usage leaves composition. Separate screens may reuse a name with different declarations; include each independently adjusted complete descriptor, even when names repeat. Repeated names occur only for distinct complete descriptors; active-only listings and updates still resolve at most one active descriptor per name. Order names by first observation, regardless of later activation or adjustment. For repeated names, list the active declaration first, followed by historical declarations in stable adjustment order.
 
-An adjusted tweak remains in this history even after its value is reset to its default. An inactive tweak that was never changed, a no-op update that leaves its value unchanged, and a rejected update do not create history entries. Adjustment history exists only for the current app process and is discarded when that process exits.
+An adjusted tweak remains in this history even after it is reset. An inactive tweak that was never changed, a no-op update that leaves its value unchanged, and a rejected update do not create history entries. Adjustment history exists only for the current app process and is discarded when that process exits.
 
 Historical inactive tweaks are read-only: `PATCH /tweaks` still accepts only currently active names. Versions 1 and 2 return `404` for an inactive name; later versions report a named per-item error. Actions appear while active but never create adjusted-history entries because they have no editable or retained value. Plain `GET /tweaks` and `GET /tweaks/events` remain active-only. The only supported query is exactly `include=adjusted` on `GET /tweaks`; unsupported, repeated, or additional query parameters and queries on other endpoints or methods return `400`.
 
@@ -195,7 +197,7 @@ event: tweaks
 data: {"tweaks":[{"name":"Motion/Show","type":"boolean","default":true,"value":true},{"name":"Motion/Duration","type":"int","default":400,"value":400,"min":100,"max":1500,"step":50}]}
 
 event: tweaks
-data: {"tweaks":[{"name":"Motion/Show","type":"boolean","default":true,"value":false}]}
+data: {"tweaks":[{"name":"Motion/Show","type":"boolean","default":true,"value":false,"modified":true}]}
 
 ```
 
@@ -225,24 +227,24 @@ curl -fsS -X PATCH http://127.0.0.1:43817/tweaks \
 ```json
 {
   "tweaks": [
-    { "name": "Font size", "value": 48 },
-    { "name": "Font weight", "value": 700 },
-    { "name": "Accent color", "value": "#3B82F6" },
-    { "name": "Animation duration", "value": 550 },
-    { "name": "Spring damping", "value": 0.8 },
-    { "name": "Use spring", "value": false },
-    { "name": "Preview text", "value": "A calmer direction." },
-    { "name": "Marker shape", "value": "RoundedSquare" }
+    { "name": "Font size", "value": 48, "modified": true },
+    { "name": "Font weight", "value": 700, "modified": true },
+    { "name": "Accent color", "value": "#3B82F6", "modified": true },
+    { "name": "Animation duration", "value": 550, "modified": true },
+    { "name": "Spring damping", "value": 0.8, "modified": true },
+    { "name": "Use spring", "value": false, "modified": true },
+    { "name": "Preview text", "value": "A calmer direction.", "modified": true },
+    { "name": "Marker shape", "value": "RoundedSquare", "modified": true }
   ]
 }
 ```
 
-In protocol version 3, each value is applied separately on the Android main thread. A valid request returns HTTP 200 with successful changes in `tweaks` and any rejected changes in `errors`; earlier successful changes are not rolled back. Each error contains only its tweak `name` and `error` message. The `errors` field is omitted when every change succeeds:
+In protocol versions 3 and later, each value is applied separately on the Android main thread. A valid request returns HTTP 200 with successful changes in `tweaks` and any rejected changes in `errors`; earlier successful changes are not rolled back. Each error contains only its tweak `name` and `error` message. The `errors` field is omitted when every change succeeds:
 
 ```json
 {
   "tweaks": [
-    { "name": "Font size", "value": 48 }
+    { "name": "Font size", "value": 48, "modified": true }
   ],
   "errors": [
     {
@@ -253,7 +255,26 @@ In protocol version 3, each value is applied separately on the Android main thre
 }
 ```
 
-Return `400` for malformed requests, `404` when an endpoint does not exist, `405` for an unsupported method, `413` for an oversized body, and `422` for invalid numeric literals or nonprimitive values. In protocol versions 1 and 2, an unknown tweak returns `404`, an invalid value returns `422`, and the entire batch is rejected. In version 3, unknown tweaks, invalid values, and action targets are reported as per-item errors without preventing other changes. Request-level errors use a small JSON body:
+Reset tweaks explicitly:
+
+```bash
+curl -fsS -X PATCH http://127.0.0.1:43817/tweaks \
+  -H 'Content-Type: application/json' \
+  -d '{"values":{"Accent color":null,"Use spring":null}}'
+```
+
+```json
+{
+  "tweaks": [
+    { "name": "Accent color", "value": "#5468FF" },
+    { "name": "Use spring", "value": true }
+  ]
+}
+```
+
+For protocol version 4, use `null` to reset a tweak; a request can mix changes and resets. Reset all only active, non-action tweaks marked `"modified": true`. For versions 1, 2, and 3, reset each changed tweak by sending its `default` value instead.
+
+Return `400` for malformed requests, `404` when an endpoint does not exist, `405` for an unsupported method, `413` for an oversized body, and `422` for invalid numeric literals or nonprimitive values. In protocol versions 1 and 2, an unknown tweak returns `404`, an invalid value returns `422`, and the entire batch is rejected. In versions 3 and later, unknown tweaks, invalid values, and action targets are reported as per-item errors without preventing other changes. Request-level errors use a small JSON body:
 
 ```json
 {
@@ -261,7 +282,7 @@ Return `400` for malformed requests, `404` when an endpoint does not exist, `405
 }
 ```
 
-Reset a value by patching it with its default. Actions are not valid patch targets. In version 3, an action target produces a named per-item error while other valid changes are applied.
+Actions are not valid patch or reset targets. For versions 3 and later, an action target produces a named per-item error while other valid changes are applied.
 
 ### POST /tweaks/action
 

--- a/scripts/snapo
+++ b/scripts/snapo
@@ -1230,16 +1230,35 @@ def run_tweak_reset(adb, options):
             if options.all
             else [find_tweak(descriptors, options.name)]
         )
-        values = {}
         for descriptor in selected:
             if descriptor["type"] == "action":
                 raise SnapOError(
                     f"Action '{descriptor['name']}' cannot be reset; "
                     "use 'snapo tweaks action NAME' to invoke it"
                 )
-            if "default" not in descriptor:
-                raise SnapOError(f"Tweak '{descriptor['name']}' does not provide a default value")
-            values[descriptor["name"]] = descriptor["default"]
+        if not selected:
+            return 0
+
+        app = connection.request("GET", "/app")
+        protocol_version = app.get("protocolVersion", 1)
+        if type(protocol_version) is not int or protocol_version < 1:
+            raise SnapOError("Snap-O tweaks server returned an invalid protocol version")
+
+        explicit_resets = protocol_version >= 4
+        if options.all:
+            selected = [
+                descriptor
+                for descriptor in selected
+                if (
+                    descriptor.get("modified") is True
+                    if explicit_resets
+                    else descriptor.get("value") != descriptor.get("default")
+                )
+            ]
+        values = {
+            descriptor["name"]: None if explicit_resets else descriptor["default"]
+            for descriptor in selected
+        }
         if values:
             require_successful_tweak_updates(connection.request("PATCH", "/tweaks", {"values": values}))
     return 0
@@ -1387,10 +1406,10 @@ def parser():
     action.add_argument("name", metavar="NAME")
     action.set_defaults(handler=run_tweak_action)
 
-    reset = tweaks_commands.add_parser("reset", help="reset one tweak or all tweaks to their defaults")
+    reset = tweaks_commands.add_parser("reset", help="reset one tweak or all tweaks")
     add_common_options(reset, socket_option=True, json_option=False)
     reset.add_argument("name", metavar="NAME", nargs="?")
-    reset.add_argument("--all", action="store_true", help="reset every currently registered tweak")
+    reset.add_argument("--all", action="store_true", help="reset every modified tweak")
     reset.set_defaults(handler=run_tweak_reset)
 
     watch = tweaks_commands.add_parser("watch", help="stream current tweak snapshots")

--- a/skills/snap-o-tweaks/SKILL.md
+++ b/skills/snap-o-tweaks/SKILL.md
@@ -53,7 +53,7 @@ ADB resolves from `PATH`, `ANDROID_SDK_ROOT`, or `ANDROID_HOME`. Use `--adb <pat
    "$SNAPO_BIN" tweaks get 'Typography/Font size' --all -s <serial> -n <socket> --json
    ```
 
-   The expanded list combines current tweaks and actions with retained, previously adjusted tweaks. Compare each value descriptor's `value` with its `default` when the user asks to apply all changes they made; action descriptors have neither field. Separate screens can reuse tweak names with different declarations; preserve every descriptor from `list --all` instead of deduplicating by name. `get NAME --all` reports an error when multiple declarations match; use `list --all --json` to inspect them. Historical tweaks can be inspected while inactive, but can only be changed or reset when their declaration is active. Actions are active-only.
+   The expanded list combines current tweaks and actions with retained, previously adjusted tweaks. In protocol version 4, use `"modified": true` to identify outstanding changes; a missing field always means false. For versions 1, 2, and 3, compare `value` with `default` instead. Actions never include `modified`. Separate screens can reuse tweak names with different declarations; preserve every descriptor from `list --all` instead of deduplicating by name. `get NAME --all` reports an error when multiple declarations match; use `list --all --json` to inspect them. Historical tweaks can be inspected while inactive, but can only be changed or reset when their declaration is active. Actions are active-only.
 
 4. Observe live complete snapshots:
 
@@ -77,7 +77,7 @@ Inspect the descriptor first: the CLI parses `int`, `float`, `boolean`, `color`,
 
 Successful updates and resets produce no output.
 
-Reset only the explicitly requested value, or use `--all` only for an explicit reset-everything request:
+Reset only the explicitly requested value, or use `--all` only when the user explicitly requests resetting every modified tweak:
 
 ```bash
 "$SNAPO_BIN" tweaks reset 'Typography/Font size' -s <serial> -n <socket>

--- a/skills/snap-o-tweaks/references/protocol.md
+++ b/skills/snap-o-tweaks/references/protocol.md
@@ -32,17 +32,17 @@ For remote ADB servers, an `adb forward` is local to the ADB server's host, not 
 
 | Request | Result |
 | --- | --- |
-| `GET /app` | JSON app metadata: `{"name":"Example","packageName":"com.example","protocolVersion":3}`. |
+| `GET /app` | JSON app metadata: `{"name":"Example","packageName":"com.example","protocolVersion":4}`. |
 | `GET /app/icon` | Optional application icon image; `404` if unavailable. Use its response `Content-Type` without assuming a particular format or size. |
 | `GET /tweaks` | Current active tweak and app-owned action descriptors. |
 | `GET /tweaks?include=adjusted` | Active descriptors plus all previously adjusted value tweaks retained outside composition. |
-| `PATCH /tweaks` | One update containing one or more named values. Version 3 applies valid entries and reports individual errors. |
+| `PATCH /tweaks` | One update containing one or more named values. Version 3 and later apply valid entries and report individual errors. |
 | `POST /tweaks/action` | Invoke one explicitly registered parameterless app-owned action by name. |
 | `GET /tweaks/events` | Server-sent events containing complete current tweak and action snapshots. |
 
 Ordinary responses close their connection and include a content length. The event response stays open and uses `Content-Type: text/event-stream`.
 
-`protocolVersion` is specific to Tweaks and independent of the Network Inspector protocol. Version 1 predates this field and supports only value tweaks; treat a missing version as 1. Version 2 adds app-owned action descriptors and `POST /tweaks/action`. Version 3 adds best-effort batch updates with per-item errors. Use the reported version to select compatible update behavior.
+`protocolVersion` is specific to Tweaks and independent of the Network Inspector protocol. Version 1 predates this field and supports only value tweaks; treat a missing version as 1. Version 2 adds app-owned action descriptors and `POST /tweaks/action`. Version 3 adds best-effort batch updates with per-item errors. Version 4 adds explicit null resets and authoritative modification status. Use the reported version to select compatible update, status, and reset behavior.
 
 ### Read metadata and active values
 
@@ -63,6 +63,7 @@ The tweak response has this shape:
       "type": "int",
       "default": 400,
       "value": 550,
+      "modified": true,
       "min": 100,
       "max": 1500,
       "step": 50
@@ -71,13 +72,15 @@ The tweak response has this shape:
       "name": "Motion/Enabled",
       "type": "boolean",
       "default": true,
-      "value": false
+      "value": false,
+      "modified": true
     },
     {
       "name": "Appearance/Theme",
       "type": "enum",
       "default": "System",
       "value": "Dark",
+      "modified": true,
       "options": ["System", "Light", "Dark"]
     },
     {
@@ -88,13 +91,15 @@ The tweak response has this shape:
 }
 ```
 
+In protocol version 4, only modified value tweaks include `"modified": true`. A missing `modified` field always means false; never infer version-4 status by comparing `value` and `default`. In versions 1, 2, and 3, `modified` is absent; compare `value` with `default` instead. Actions never include `modified`.
+
 The available value types are `int`, `float`, `boolean`, `color`, `string`, and `enum`. Preserve actual JSON types: booleans are not strings, integer values cannot be fractional, and floats accept whole or fractional finite numbers. Colors are strings in `#RRGGBB` or `#RRGGBBAA` format. Numeric descriptors may include `min`, `max`, and `step`; step alignment starts at `min`, or at `default` if there is no minimum. Actions use `"type":"action"` and have no `value`, `default`, or `options`.
 
 Enum descriptors include a nonempty, ordered `options` array containing unique, nonblank enum name strings. The `default` and current `value` are names from that list. Send an exact option name in `PATCH /tweaks`.
 
 An action descriptor with `"conflicted":true` has multiple live registrations for the same name. It remains visible so clients can surface the conflict, but the server rejects invocation instead of choosing a callback, merging owners, or inventing unstable names. Register a shared action once at its owner, or use explicit, stable, unique names for distinct actions.
 
-Plain `GET /tweaks` includes only value and action declarations active in Compose. Add `?include=adjusted` to include every tweak successfully adjusted by the user, including retained descriptors whose declarations have since left composition. The expanded response uses the same descriptor shape and also includes current active tweaks and actions; actions have no adjustment history. Separate screens can reuse a value tweak name with different complete declarations; preserve every returned descriptor instead of deduplicating by name. A tweak that was adjusted and later reset can still appear with its default value; compare `value` and `default` to identify outstanding user changes. Retention lasts for the current app process and is cleared with the registry; it is not persistent storage across app restarts.
+Plain `GET /tweaks` includes only value and action declarations active in Compose. Add `?include=adjusted` to include every tweak successfully adjusted by the user, including retained descriptors whose declarations have since left composition. The expanded response uses the same descriptor shape and also includes current active tweaks and actions; actions have no adjustment history. Separate screens can reuse a value tweak name with different complete declarations; preserve every returned descriptor instead of deduplicating by name. A tweak that was adjusted and later reset can still appear with its default value. In version 4, use `"modified": true` to identify outstanding changes; a missing field always means false. Retention lasts for the current app process and is cleared with the registry; it is not persistent storage across app restarts.
 
 Names may contain spaces and `/`; send the entire name unchanged. Two active declarations of the same complete value descriptor observe the same value. Repeated value names in expanded results represent distinct complete descriptors; active-only snapshots and updates still resolve at most one currently active value descriptor per name. Historical descriptors are read-only while inactive: `PATCH /tweaks` still rejects their names until their declarations return. Separate active callbacks with the same action name are not interchangeable and are reported as conflicted.
 
@@ -109,16 +114,24 @@ curl -fsS -X PATCH "$base/tweaks" \
 The response contains the changed names and their resulting values:
 
 ```json
-{"tweaks":[{"name":"Motion/Duration","value":550},{"name":"Motion/Enabled","value":false},{"name":"Appearance/Theme","value":"Dark"}]}
+{"tweaks":[{"name":"Motion/Duration","value":550,"modified":true},{"name":"Motion/Enabled","value":false,"modified":true},{"name":"Appearance/Theme","value":"Dark","modified":true}]}
 ```
 
-Protocol version 3 applies valid entries independently. Invalid, unknown, inactive, or action entries appear in `errors` with their tweak names and error messages, while successful changes remain applied:
+Protocol versions 3 and later apply valid entries independently. Invalid, unknown, inactive, or action entries appear in `errors` with their tweak names and error messages, while successful changes remain applied:
 
 ```json
-{"tweaks":[{"name":"Motion/Duration","value":550}],"errors":[{"name":"Motion/Enabled","error":"Invalid value for Motion/Enabled: Expected a boolean."}]}
+{"tweaks":[{"name":"Motion/Duration","value":550,"modified":true}],"errors":[{"name":"Motion/Enabled","error":"Invalid value for Motion/Enabled: Expected a boolean."}]}
 ```
 
-The `errors` field is absent when every entry succeeds. Versions 1 and 2 reject the entire batch if any entry is invalid. Reset by fetching `GET /tweaks` and sending the target descriptor's `default` value back in a patch; reset all by patching every active value name to its own default in one request. Actions cannot be patched or reset and are excluded from reset-all. There is no separate get-by-name, reset, delete, or grouping endpoint.
+The `errors` field is absent when every entry succeeds. Versions 1 and 2 reject the entire batch if any entry is invalid. In version 4, reset a value by sending `null` instead of a replacement value:
+
+```bash
+curl -fsS -X PATCH "$base/tweaks" \
+  -H 'Content-Type: application/json' \
+  -d '{"values":{"Motion/Enabled":null}}'
+```
+
+A version-4 reset restores the original default. Reset all by sending `null` only for active, non-action descriptors with `"modified": true`. For versions 1, 2, and 3, compare each value with its default and reset changed values by sending their defaults. Actions cannot be patched or reset. There is no separate get-by-name, reset, delete, or grouping endpoint.
 
 ### Invoke an app-owned action
 
@@ -149,7 +162,7 @@ data: {"tweaks":[{"name":"Motion/Enabled","type":"boolean","default":true,"value
 : keep-alive
 
 event: tweaks
-data: {"tweaks":[{"name":"Motion/Enabled","type":"boolean","default":true,"value":false}]}
+data: {"tweaks":[{"name":"Motion/Enabled","type":"boolean","default":true,"value":false,"modified":true}]}
 
 ```
 

--- a/snapo-app-mac/Snap-O/NetworkInspector/NetworkInspectorBridgeModels.swift
+++ b/snapo-app-mac/Snap-O/NetworkInspector/NetworkInspectorBridgeModels.swift
@@ -35,6 +35,7 @@ struct SelectedAppInspector: Codable {
   let appId: String
   let kind: AppInspectorKind
   let server: InspectorServerReference
+  let protocolVersion: Int?
 }
 
 enum TweakValue: Codable {
@@ -76,6 +77,7 @@ struct TweakDescriptor: Codable {
   let type: String
   let `default`: TweakValue?
   let value: TweakValue?
+  let modified: Bool?
   let min: TweakValue?
   let max: TweakValue?
   let step: TweakValue?
@@ -101,6 +103,7 @@ struct TweaksInspectorNativeState: Codable {
 struct TweakUpdate: Codable {
   let name: String
   let value: TweakValue
+  let modified: Bool?
 }
 
 struct TweakUpdateError: Codable {
@@ -114,12 +117,12 @@ struct TweakUpdates: Codable {
 }
 
 struct TweakPatch: Codable {
-  let values: [String: TweakValue]
+  let values: [String: TweakValue?]
 }
 
 struct UpdateTweaksInput: Codable {
   let server: InspectorServerReference
-  let values: [String: TweakValue]
+  let values: [String: TweakValue?]
 }
 
 struct InvokeTweakActionInput: Codable {

--- a/snapo-app-mac/Snap-O/NetworkInspector/NetworkInspectorHostModel.swift
+++ b/snapo-app-mac/Snap-O/NetworkInspector/NetworkInspectorHostModel.swift
@@ -59,7 +59,8 @@ final class NetworkInspectorHostModel {
     let selection = SelectedAppInspector(
       appId: app.id,
       kind: option.kind,
-      server: option.server
+      server: option.server,
+      protocolVersion: option.protocolVersion
     )
     if selectedInspector?.appId != selection.appId
       || selectedInspector?.kind != selection.kind
@@ -141,11 +142,13 @@ final class NetworkInspectorHostModel {
     inspectorApps = apps
 
     if let selection = selectedInspector,
-       apps.contains(where: { app in
-         app.id == selection.appId && app.inspectors.contains {
-           $0.kind == selection.kind && $0.server == selection.server
-         }
+       let app = apps.first(where: { $0.id == selection.appId }),
+       let option = app.inspectors.first(where: {
+         $0.kind == selection.kind && $0.server == selection.server
        }) {
+      if selection.protocolVersion != option.protocolVersion {
+        selectInspector(app, option: option)
+      }
       return
     }
 

--- a/snapo-link-android/samples/demo-tweaks/panel/app.js
+++ b/snapo-link-android/samples/demo-tweaks/panel/app.js
@@ -2,6 +2,7 @@ const state = {
   apps: [],
   selectedAppId: undefined,
   selectedView: "tweaks",
+  protocolVersion: 1,
   tweaks: [],
   rows: new Map(),
   orderingByApp: new Map(),
@@ -29,6 +30,7 @@ const mockApps = [
     packageName: "com.example.notes",
     deviceName: "Pixel 9 Pro XL",
     views: ["network", "tweaks"],
+    protocolVersion: 4,
   },
   {
     id: "mock:tweaks-demo",
@@ -36,6 +38,7 @@ const mockApps = [
     packageName: "com.openai.snapo.demo.tweaks",
     deviceName: "Pixel 9 Pro XL",
     views: ["tweaks"],
+    protocolVersion: 4,
   },
   {
     id: "mock:emulator:notes",
@@ -43,6 +46,7 @@ const mockApps = [
     packageName: "com.example.notes",
     deviceName: "Android Emulator",
     views: ["network"],
+    protocolVersion: 4,
   },
 ];
 
@@ -105,11 +109,6 @@ function setError(message) {
   elements.error.textContent = message ?? "";
 }
 
-function updateError(result) {
-  if (!result.errors?.length) return undefined;
-  return result.errors.map(({ name, error }) => `${name}: ${error}`).join("; ");
-}
-
 async function request(path, options) {
   if (isMockMode) return mockRequest(path, options);
 
@@ -149,11 +148,27 @@ function mockRequest(path, options) {
     const { values } = JSON.parse(options.body);
 
     for (const tweak of mockTweaks) {
-      if (Object.hasOwn(values, tweak.name)) tweak.value = values[tweak.name];
+      if (!Object.hasOwn(values, tweak.name)) continue;
+
+      const value = values[tweak.name];
+      tweak.value = value ?? tweak.default;
+
+      if (tweak.value !== tweak.default) {
+        tweak.modified = true;
+      } else {
+        delete tweak.modified;
+      }
     }
 
     return {
-      tweaks: Object.entries(values).map(([name, value]) => ({ name, value })),
+      tweaks: Object.keys(values).map((name) => {
+        const tweak = mockTweaks.find((candidate) => candidate.name === name);
+        return {
+          name,
+          value: tweak.value,
+          ...(tweak.modified === true ? { modified: true } : {}),
+        };
+      }),
     };
   }
 
@@ -169,12 +184,29 @@ function mockRequest(path, options) {
   throw new Error("The mock route is not available.");
 }
 
+function isModified(tweak) {
+  return tweak.type !== "action" && (
+    state.protocolVersion >= 4
+      ? tweak.modified === true
+      : tweak.value !== tweak.default
+  );
+}
+
+function resetValue(tweak) {
+  return state.protocolVersion >= 4 ? null : tweak.default;
+}
+
+function updateError(result) {
+  if (!result.errors?.length) return undefined;
+  return result.errors.map(({ name, error }) => `${name}: ${error}`).join("; ");
+}
+
 function updateResetButton() {
   elements.reset.disabled =
     state.saving ||
     state.switching ||
     state.tweaks.length === 0 ||
-    state.tweaks.every((tweak) => tweak.value === tweak.default);
+    state.tweaks.every((tweak) => !isModified(tweak));
 }
 
 function setAppMenuOpen(open) {
@@ -421,7 +453,7 @@ function updateTweakRow(tweak) {
   const fields = state.rows.get(tweak.name);
   if (!fields) return;
 
-  const changed = tweak.value !== tweak.default;
+  const changed = isModified(tweak);
   fields.row.dataset.changed = String(changed);
   fields.reset.hidden = !changed;
 
@@ -436,7 +468,10 @@ function updateTweakRow(tweak) {
 
 function updateValue(tweak, value, delay = 75) {
   if (state.switching) return;
-  tweak.value = value;
+  if (value !== null) tweak.value = value;
+  tweak.modified = value !== null && (
+    state.protocolVersion >= 4 || tweak.value !== tweak.default
+  );
   state.pending.set(tweak.name, value);
   updateTweakRow(tweak);
   updateResetButton();
@@ -474,6 +509,9 @@ async function flushPending() {
       const tweak = state.tweaks.find((item) => item.name === update.name);
       if (tweak && !state.pending.has(update.name)) {
         tweak.value = update.value;
+        tweak.modified = state.protocolVersion >= 4
+          ? update.modified === true
+          : update.value !== tweak.default;
         updateTweakRow(tweak);
       }
     }
@@ -510,12 +548,12 @@ function makeTweakLine(tweak) {
   const actions = node("div", "tweak-actions");
   const reset = node("button", "tweak-reset");
   reset.type = "button";
-  reset.hidden = tweak.value === tweak.default;
+  reset.hidden = !isModified(tweak);
   reset.setAttribute("aria-label", `Reset ${tweak.name}`);
   reset.setAttribute("title", `Reset ${tweakLabel(tweak.name)}`);
   reset.append(mockIcon("rotate-ccw", "tweak-reset-icon"));
   reset.addEventListener("click", () => {
-    updateValue(tweak, tweak.default, 0);
+    updateValue(tweak, resetValue(tweak), 0);
   });
 
   content.append(node("span", "tweak-label", tweakLabel(tweak.name)), reset, actions);
@@ -853,7 +891,7 @@ function applyTweakSnapshot(incoming) {
       current &&
       (state.pending.has(next.name) || state.inFlight.has(next.name))
     ) {
-      return { ...next, value: current.value };
+      return { ...next, value: current.value, modified: current.modified };
     }
 
     const fields = state.rows.get(next.name);
@@ -876,8 +914,14 @@ function applyTweakSnapshot(incoming) {
 
   for (const next of nextTweaks) {
     const current = existing.get(next.name);
-    if (current && current.value !== next.value) {
+    if (
+      current &&
+      (current.value !== next.value || isModified(current) !== isModified(next))
+    ) {
       current.value = next.value;
+      current.modified = state.protocolVersion >= 4
+        ? next.modified === true
+        : next.value !== next.default;
       updateTweakRow(current);
     }
   }
@@ -989,6 +1033,7 @@ async function load({ refreshApps = true } = {}) {
     ]);
 
     const selected = state.apps.find((candidate) => candidate.id === state.selectedAppId);
+    state.protocolVersion = app.protocolVersion ?? selected?.protocolVersion ?? 1;
     updateAppIdentity({ ...selected, ...app });
     state.tweaks = result.tweaks;
     renderTweaks();
@@ -1050,15 +1095,25 @@ async function selectApp(id) {
 }
 
 async function resetTweaks() {
+  const tweaksToReset = state.tweaks.filter(
+    (tweak) => isModified(tweak),
+  );
+  if (state.saving || state.switching || tweaksToReset.length === 0) return;
+
   clearTimeout(state.timer);
   state.pending.clear();
+  for (const tweak of tweaksToReset) {
+    tweak.modified = false;
+    state.inFlight.add(tweak.name);
+    updateTweakRow(tweak);
+  }
   state.saving = true;
   setStatus("connected", "Resetting…");
   updateResetButton();
 
   try {
     const values = Object.fromEntries(
-      state.tweaks.map((tweak) => [tweak.name, tweak.default]),
+      tweaksToReset.map((tweak) => [tweak.name, resetValue(tweak)]),
     );
 
     const result = await request("/tweaks", {
@@ -1066,6 +1121,17 @@ async function resetTweaks() {
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify({ values }),
     });
+
+    for (const update of result.tweaks) {
+      const tweak = state.tweaks.find((item) => item.name === update.name);
+      if (!tweak) continue;
+
+      tweak.value = update.value;
+      tweak.modified = state.protocolVersion >= 4
+        ? update.modified === true
+        : update.value !== tweak.default;
+      updateTweakRow(tweak);
+    }
 
     await reloadTweaks();
     const error = updateError(result);
@@ -1079,7 +1145,9 @@ async function resetTweaks() {
   } catch (error) {
     setError(error.message);
     setStatus("error", "Reset failed");
+    await reloadTweaks();
   } finally {
+    for (const tweak of tweaksToReset) state.inFlight.delete(tweak.name);
     state.saving = false;
     updateResetButton();
   }

--- a/snapo-link-android/samples/demo-tweaks/panel/app.test.mjs
+++ b/snapo-link-android/samples/demo-tweaks/panel/app.test.mjs
@@ -86,6 +86,7 @@ const demoApp = {
   packageName: "com.openai.snapo.demo.tweaks",
   deviceName: "Pixel 9 Pro XL",
   deviceSerial: "PIXEL123",
+  protocolVersion: 4,
 };
 
 class FakeElement {
@@ -276,6 +277,27 @@ function jsonResponse(payload, status = 200) {
   };
 }
 
+function applyTweakUpdates(tweaks, values) {
+  return Object.entries(values).map(([name, value]) => {
+    const tweak = tweaks.find((candidate) => candidate.name === name);
+    assert.ok(tweak);
+
+    if (value === null) {
+      tweak.value = tweak.default;
+      delete tweak.modified;
+    } else {
+      tweak.value = value;
+      tweak.modified = true;
+    }
+
+    return {
+      name,
+      value: tweak.value,
+      ...(tweak.modified === true ? { modified: true } : {}),
+    };
+  });
+}
+
 test("browser panel renders, streams, validates, and resets live tweaks", async () => {
   const document = makeDocument();
   const markerShape = {
@@ -310,17 +332,8 @@ test("browser panel renders, streams, validates, and resets live tweaks", async 
       const { values } = JSON.parse(options.body);
       patches.push(values);
 
-      for (const tweak of tweaks) {
-        if (Object.hasOwn(values, tweak.name)) {
-          tweak.value = values[tweak.name];
-        }
-      }
-
       return jsonResponse({
-        tweaks: Object.entries(values).map(([name, value]) => ({
-          name,
-          value,
-        })),
+        tweaks: applyTweakUpdates(tweaks, values),
       });
     }
 
@@ -470,7 +483,7 @@ test("browser panel renders, streams, validates, and resets live tweaks", async 
     assert.equal(resetAccent.hidden, false);
     await resetAccent.emit("click");
     await delay(0);
-    assert.deepEqual(patches.at(-1), { "Accent color": "#5468FF" });
+    assert.deepEqual(patches.at(-1), { "Accent color": null });
     assert.equal(resetAccent.hidden, true);
     assert.equal(document.properties.has("--accent"), false);
 
@@ -478,7 +491,7 @@ test("browser panel renders, streams, validates, and resets live tweaks", async 
     assert.equal(resetMarker.hidden, false);
     await resetMarker.emit("click");
     await delay(0);
-    assert.deepEqual(patches.at(-1), { "Motion/Marker shape": "Circle" });
+    assert.deepEqual(patches.at(-1), { "Motion/Marker shape": null });
     assert.equal(marker.value, "Circle");
     assert.equal(resetMarker.hidden, true);
 
@@ -490,12 +503,13 @@ test("browser panel renders, streams, validates, and resets live tweaks", async 
     assert.equal(patches.length, patchesBeforeInvalid);
 
     const patchesBeforeReset = patches.length;
+    const modifiedTweaks = tweaks.filter((tweak) => tweak.modified === true);
     await document.querySelector("#reset-button").emit("click");
 
     assert.equal(patches.length, patchesBeforeReset + 1);
     assert.deepEqual(
       patches.at(-1),
-      Object.fromEntries(tweaks.map((tweak) => [tweak.name, tweak.default])),
+      Object.fromEntries(modifiedTweaks.map((tweak) => [tweak.name, null])),
     );
     assert.equal(document.querySelector("#reset-button").disabled, true);
     assert.equal(document.properties.has("--accent"), false);
@@ -504,6 +518,433 @@ test("browser panel renders, streams, validates, and resets live tweaks", async 
   } finally {
     globalThis.document = originalDocument;
     globalThis.fetch = originalFetch;
+  }
+});
+
+test("mock tweaks clear modified status when written or reset to their defaults", async () => {
+  const document = makeDocument();
+  const originalDocument = globalThis.document;
+  const originalWindow = globalThis.window;
+
+  globalThis.document = document;
+  globalThis.window = {
+    location: { search: "?mock" },
+    addEventListener() {},
+  };
+
+  try {
+    await import(`./app.js?mock-default-status=${Date.now()}`);
+    await delay(0);
+
+    const typography = findTweakList(document, "Typography");
+    const fontSize = findInput(typography, "Typography/Font size");
+    const resetFontSize = findInput(typography, "Reset Typography/Font size");
+    const fontSizeRow = typography.children.find((row) =>
+      findInput(row, "Typography/Font size")
+    );
+
+    assert.equal(fontSizeRow.dataset.changed, "false");
+    assert.equal(resetFontSize.hidden, true);
+
+    fontSize.value = "48";
+    await fontSize.emit("input");
+    await delay(0);
+
+    assert.equal(fontSizeRow.dataset.changed, "true");
+    assert.equal(resetFontSize.hidden, false);
+    assert.equal(document.querySelector("#reset-button").disabled, false);
+
+    fontSize.value = "36";
+    await fontSize.emit("input");
+    await delay(0);
+
+    assert.equal(fontSizeRow.dataset.changed, "false");
+    assert.equal(resetFontSize.hidden, true);
+    assert.equal(document.querySelector("#reset-button").disabled, true);
+
+    fontSize.value = "48";
+    await fontSize.emit("input");
+    await delay(0);
+    await resetFontSize.emit("click");
+    await delay(0);
+
+    assert.equal(fontSize.value, "36");
+    assert.equal(fontSizeRow.dataset.changed, "false");
+    assert.equal(resetFontSize.hidden, true);
+    assert.equal(document.querySelector("#reset-button").disabled, true);
+  } finally {
+    globalThis.document = originalDocument;
+
+    if (originalWindow === undefined) delete globalThis.window;
+    else globalThis.window = originalWindow;
+  }
+});
+
+test("legacy tweak protocols reset changed values using their defaults", async () => {
+  for (const protocolVersion of [undefined, 2, 3]) {
+    const document = makeDocument();
+    const app = { ...demoApp };
+    if (protocolVersion === undefined) delete app.protocolVersion;
+    else app.protocolVersion = protocolVersion;
+
+    const tweaks = [
+      { name: "Settings/Show hints", type: "boolean", default: false, value: true },
+      { name: "Settings/Use compact layout", type: "boolean", default: true, value: false },
+      { name: "Settings/Show labels", type: "boolean", default: true, value: true },
+    ];
+    const patches = [];
+    const originalDocument = globalThis.document;
+    const originalFetch = globalThis.fetch;
+
+    globalThis.document = document;
+    globalThis.fetch = async (pathname, options) => {
+      if (pathname === "/apps") {
+        return jsonResponse({ apps: [app], selectedAppId: app.id });
+      }
+
+      if (pathname === "/app") return jsonResponse(app);
+
+      if (pathname === "/tweaks" && options?.method === "PATCH") {
+        const { values } = JSON.parse(options.body);
+        patches.push(values);
+
+        return jsonResponse({
+          tweaks: Object.entries(values).map(([name, value]) => {
+            assert.notEqual(value, null);
+            const tweak = tweaks.find((candidate) => candidate.name === name);
+            tweak.value = value;
+            return { name, value };
+          }),
+        });
+      }
+
+      if (pathname === "/tweaks") return jsonResponse({ tweaks });
+
+      return jsonResponse({ error: "Not found." }, 404);
+    };
+
+    try {
+      await import(`./app.js?legacy-reset-${protocolVersion}-${Date.now()}`);
+      await delay(0);
+
+      const settings = findTweakList(document, "Settings");
+      const hintsReset = findInput(settings, "Reset Settings/Show hints");
+      const compactReset = findInput(settings, "Reset Settings/Use compact layout");
+      const labelsReset = findInput(settings, "Reset Settings/Show labels");
+
+      assert.equal(hintsReset.hidden, false);
+      assert.equal(compactReset.hidden, false);
+      assert.equal(labelsReset.hidden, true);
+      assert.equal(document.querySelector("#reset-button").disabled, false);
+
+      await hintsReset.emit("click");
+      await delay(0);
+
+      assert.deepEqual(patches, [{ "Settings/Show hints": false }]);
+      assert.equal(hintsReset.hidden, true);
+      assert.equal(compactReset.hidden, false);
+
+      await document.querySelector("#reset-button").emit("click");
+
+      assert.deepEqual(patches.at(-1), { "Settings/Use compact layout": true });
+      assert.equal(document.querySelector("#reset-button").disabled, true);
+    } finally {
+      globalThis.document = originalDocument;
+      globalThis.fetch = originalFetch;
+    }
+  }
+});
+
+test("mixed tweak updates keep successful changes and restore rejected rows", async () => {
+  for (const protocolVersion of [3, 4]) {
+    const document = makeDocument();
+    const app = { ...demoApp, protocolVersion };
+    const tweaks = [
+      { name: "Settings/First label", type: "string", default: "before", value: "before" },
+      { name: "Settings/Second label", type: "string", default: "before", value: "before" },
+    ];
+    const patches = [];
+    const originalDocument = globalThis.document;
+    const originalFetch = globalThis.fetch;
+
+    globalThis.document = document;
+    globalThis.fetch = async (pathname, options) => {
+      if (pathname === "/apps") {
+        return jsonResponse({ apps: [app], selectedAppId: app.id });
+      }
+      if (pathname === "/app") return jsonResponse(app);
+      if (pathname === "/tweaks" && options?.method === "PATCH") {
+        const { values } = JSON.parse(options.body);
+        patches.push(values);
+        tweaks[0].value = values[tweaks[0].name];
+        if (protocolVersion >= 4) tweaks[0].modified = true;
+        return jsonResponse({
+          tweaks: [{
+            name: tweaks[0].name,
+            value: tweaks[0].value,
+            ...(protocolVersion >= 4 ? { modified: true } : {}),
+          }],
+          errors: [{
+            name: tweaks[1].name,
+            error: "This setting could not be changed.",
+          }],
+        });
+      }
+      if (pathname === "/tweaks") return jsonResponse({ tweaks });
+      return jsonResponse({ error: "Not found." }, 404);
+    };
+
+    try {
+      await import(`./app.js?partial-update-${protocolVersion}-${Date.now()}`);
+      await delay(0);
+
+      const settings = findTweakList(document, "Settings");
+      const first = findInput(settings, tweaks[0].name);
+      const second = findInput(settings, tweaks[1].name);
+      first.value = "first changed";
+      await first.emit("input");
+      second.value = "second changed";
+      await second.emit("input");
+      await delay(160);
+
+      assert.deepEqual(patches, [{
+        "Settings/First label": "first changed",
+        "Settings/Second label": "second changed",
+      }]);
+      assert.equal(findInput(findTweakList(document, "Settings"), tweaks[0].name).value, "first changed");
+      assert.equal(findInput(findTweakList(document, "Settings"), tweaks[1].name).value, "before");
+      assert.equal(document.querySelector("#status-text").textContent, "Some updates failed");
+      assert.equal(
+        document.querySelector("#error-message").textContent,
+        "Settings/Second label: This setting could not be changed.",
+      );
+    } finally {
+      globalThis.document = originalDocument;
+      globalThis.fetch = originalFetch;
+    }
+  }
+});
+
+test("mixed tweak resets keep successful changes and report rejected names", async () => {
+  for (const protocolVersion of [3, 4]) {
+    const document = makeDocument();
+    const app = { ...demoApp, protocolVersion };
+    const tweaks = [
+      { name: "Settings/First option", type: "boolean", default: false, value: true },
+      { name: "Settings/Second option", type: "boolean", default: false, value: true },
+    ];
+    if (protocolVersion >= 4) {
+      tweaks[0].modified = true;
+      tweaks[1].modified = true;
+    }
+    const patches = [];
+    const originalDocument = globalThis.document;
+    const originalFetch = globalThis.fetch;
+
+    globalThis.document = document;
+    globalThis.fetch = async (pathname, options) => {
+      if (pathname === "/apps") {
+        return jsonResponse({ apps: [app], selectedAppId: app.id });
+      }
+      if (pathname === "/app") return jsonResponse(app);
+      if (pathname === "/tweaks" && options?.method === "PATCH") {
+        const { values } = JSON.parse(options.body);
+        patches.push(values);
+        tweaks[0].value = false;
+        delete tweaks[0].modified;
+        return jsonResponse({
+          tweaks: [{ name: tweaks[0].name, value: false }],
+          errors: [{
+            name: tweaks[1].name,
+            error: "This setting could not be reset.",
+          }],
+        });
+      }
+      if (pathname === "/tweaks") return jsonResponse({ tweaks });
+      return jsonResponse({ error: "Not found." }, 404);
+    };
+
+    try {
+      await import(`./app.js?partial-reset-${protocolVersion}-${Date.now()}`);
+      await delay(0);
+      await document.querySelector("#reset-button").emit("click");
+
+      assert.deepEqual(patches, [{
+        "Settings/First option": protocolVersion >= 4 ? null : false,
+        "Settings/Second option": protocolVersion >= 4 ? null : false,
+      }]);
+      const settings = findTweakList(document, "Settings");
+      assert.equal(findInput(settings, tweaks[0].name).checked, false);
+      assert.equal(findInput(settings, tweaks[1].name).checked, true);
+      assert.equal(findInput(settings, `Reset ${tweaks[0].name}`).hidden, true);
+      assert.equal(findInput(settings, `Reset ${tweaks[1].name}`).hidden, false);
+      assert.equal(document.querySelector("#status-text").textContent, "Some resets failed");
+      assert.equal(
+        document.querySelector("#error-message").textContent,
+        "Settings/Second option: This setting could not be reset.",
+      );
+    } finally {
+      globalThis.document = originalDocument;
+      globalThis.fetch = originalFetch;
+    }
+  }
+});
+
+test("owner status controls null resets independently of the initial default", async () => {
+  const document = makeDocument();
+  const ownedSetting = {
+    name: "Settings/Show hints",
+    type: "boolean",
+    default: false,
+    value: false,
+    modified: true,
+  };
+  const upstreamSetting = {
+    name: "Settings/Use compact layout",
+    type: "boolean",
+    default: false,
+    value: true,
+  };
+  const tweaks = [ownedSetting, upstreamSetting];
+  const patches = [];
+  const sources = [];
+  const originalDocument = globalThis.document;
+  const originalFetch = globalThis.fetch;
+  const originalEventSource = globalThis.EventSource;
+  let finishFirstReset;
+
+  class FakeEventSource {
+    constructor() {
+      this.listeners = new Map();
+      sources.push(this);
+    }
+
+    addEventListener(name, listener) {
+      this.listeners.set(name, listener);
+    }
+
+    emitTweaks(snapshot) {
+      this.listeners.get("tweaks")?.({
+        data: JSON.stringify({ tweaks: snapshot }),
+      });
+    }
+
+    close() {}
+  }
+
+  globalThis.document = document;
+  globalThis.EventSource = FakeEventSource;
+  globalThis.fetch = async (pathname, options) => {
+    if (pathname === "/apps") {
+      return jsonResponse({ apps: [demoApp], selectedAppId: demoApp.id });
+    }
+
+    if (pathname === "/app") {
+      return jsonResponse({ name: demoApp.name, packageName: demoApp.packageName });
+    }
+
+    if (pathname === "/tweaks" && options?.method === "PATCH") {
+      const { values } = JSON.parse(options.body);
+      patches.push(values);
+
+      const respond = () => jsonResponse({
+        tweaks: Object.entries(values).map(([name, value]) => {
+          const tweak = tweaks.find((candidate) => candidate.name === name);
+          assert.ok(tweak);
+
+          if (value === null) {
+            tweak.value = true;
+            delete tweak.modified;
+          } else {
+            tweak.value = value;
+            tweak.modified = true;
+          }
+
+          return {
+            name,
+            value: tweak.value,
+            ...(tweak.modified === true ? { modified: true } : {}),
+          };
+        }),
+      });
+
+      if (patches.length === 1) {
+        return new Promise((resolve) => {
+          finishFirstReset = () => resolve(respond());
+        });
+      }
+
+      return respond();
+    }
+
+    if (pathname === "/tweaks") return jsonResponse({ tweaks });
+
+    return jsonResponse({ error: "Not found." }, 404);
+  };
+
+  try {
+    await import(`./app.js?owner-reset-status-test=${Date.now()}`);
+    await delay(0);
+
+    const settings = findTweakList(document, "Settings");
+    const ownedRow = settings.children[0];
+    const upstreamRow = settings.children[1];
+    const ownedToggle = findInput(settings, ownedSetting.name);
+    const ownedReset = findInput(settings, `Reset ${ownedSetting.name}`);
+    const upstreamReset = findInput(settings, `Reset ${upstreamSetting.name}`);
+
+    assert.equal(ownedRow.dataset.changed, "true");
+    assert.equal(ownedReset.hidden, false);
+    assert.equal(upstreamRow.dataset.changed, "false");
+    assert.equal(upstreamReset.hidden, true);
+    assert.equal(document.querySelector("#reset-button").disabled, false);
+
+    await ownedReset.emit("click");
+    assert.deepEqual(patches, [{ [ownedSetting.name]: null }]);
+    assert.equal(ownedReset.hidden, true);
+    assert.equal(ownedToggle.checked, false);
+
+    sources[0].emitTweaks(structuredClone(tweaks));
+    assert.equal(ownedRow.dataset.changed, "false");
+    assert.equal(ownedReset.hidden, true);
+
+    finishFirstReset();
+    finishFirstReset = undefined;
+    await delay(0);
+
+    assert.equal(ownedToggle.checked, true);
+    assert.equal(ownedRow.dataset.changed, "false");
+    assert.equal(upstreamRow.dataset.changed, "false");
+    assert.equal(document.querySelector("#reset-button").disabled, true);
+
+    ownedToggle.checked = false;
+    await ownedToggle.emit("change");
+    await delay(0);
+
+    assert.deepEqual(patches.at(-1), { [ownedSetting.name]: false });
+    assert.equal(ownedToggle.checked, false);
+    assert.equal(ownedRow.dataset.changed, "true");
+    assert.equal(ownedReset.hidden, false);
+    assert.equal(document.querySelector("#reset-button").disabled, false);
+
+    await document.querySelector("#reset-button").emit("click");
+
+    assert.deepEqual(patches.at(-1), { [ownedSetting.name]: null });
+    assert.equal(findInput(findTweakList(document, "Settings"), ownedSetting.name).checked, true);
+    assert.equal(document.querySelector("#reset-button").disabled, true);
+  } finally {
+    if (finishFirstReset) {
+      finishFirstReset();
+      await delay(0);
+    }
+
+    globalThis.document = originalDocument;
+    globalThis.fetch = originalFetch;
+    if (originalEventSource === undefined) {
+      delete globalThis.EventSource;
+    } else {
+      globalThis.EventSource = originalEventSource;
+    }
   }
 });
 
@@ -594,18 +1035,9 @@ test("sliders stream immediately and wait for each request before sending the la
       );
 
       const finish = () => {
-        for (const tweak of tweaks) {
-          if (Object.hasOwn(values, tweak.name)) {
-            tweak.value = values[tweak.name];
-          }
-        }
-
         requestsInFlight -= 1;
         return jsonResponse({
-          tweaks: Object.entries(values).map(([name, value]) => ({
-            name,
-            value,
-          })),
+          tweaks: applyTweakUpdates(tweaks, values),
         });
       };
 
@@ -717,12 +1149,8 @@ test("groups tweaks only by explicit folder paths and patches their full names",
       const { values } = JSON.parse(options.body);
       patches.push(values);
 
-      for (const tweak of tweaks) {
-        if (Object.hasOwn(values, tweak.name)) tweak.value = values[tweak.name];
-      }
-
       return jsonResponse({
-        tweaks: Object.entries(values).map(([name, value]) => ({ name, value })),
+        tweaks: applyTweakUpdates(tweaks, values),
       });
     }
 
@@ -980,7 +1408,11 @@ test("switches apps only after pending slider updates finish", async () => {
       patches.push({ appId: selectedId, values });
 
       const result = jsonResponse({
-        tweaks: Object.entries(values).map(([name, value]) => ({ name, value })),
+        tweaks: Object.entries(values).map(([name, value]) => ({
+          name,
+          value,
+          modified: true,
+        })),
       });
 
       if (patches.length === 1) {
@@ -1105,6 +1537,7 @@ test("automatic refresh replaces tweaks when the app changes screens", async () 
         type: "int",
         default: 300,
         value: 450,
+        modified: true,
         min: 100,
         max: 1_000,
         step: 50,
@@ -1151,13 +1584,8 @@ test("motion tweaks appear and disappear as the visibility tweak changes composi
 
     if (pathname === "/tweaks" && options?.method === "PATCH") {
       const { values } = JSON.parse(options.body);
-
-      if (Object.hasOwn(values, visibility.name)) {
-        visibility.value = values[visibility.name];
-      }
-
       return jsonResponse({
-        tweaks: Object.entries(values).map(([name, value]) => ({ name, value })),
+        tweaks: applyTweakUpdates([visibility], values),
       });
     }
 
@@ -1342,119 +1770,5 @@ test("streams batched composition changes without polling tweak values", async (
     } else {
       globalThis.EventSource = originalEventSource;
     }
-  }
-});
-
-test("mixed tweak updates keep successful changes and restore rejected rows", async () => {
-  const document = makeDocument();
-  const tweaks = [
-    { name: "Settings/First label", type: "string", default: "before", value: "before" },
-    { name: "Settings/Second label", type: "string", default: "before", value: "before" },
-  ];
-  const patches = [];
-  const originalDocument = globalThis.document;
-  const originalFetch = globalThis.fetch;
-
-  globalThis.document = document;
-  globalThis.fetch = async (pathname, options) => {
-    if (pathname === "/apps") return jsonResponse({ apps: [demoApp], selectedAppId: demoApp.id });
-    if (pathname === "/app") return jsonResponse(demoApp);
-    if (pathname === "/tweaks" && options?.method === "PATCH") {
-      const { values } = JSON.parse(options.body);
-      patches.push(values);
-      tweaks[0].value = values[tweaks[0].name];
-      return jsonResponse({
-        tweaks: [{ name: tweaks[0].name, value: tweaks[0].value }],
-        errors: [{
-          name: tweaks[1].name,
-          error: "This setting could not be changed.",
-        }],
-      });
-    }
-    if (pathname === "/tweaks") return jsonResponse({ tweaks });
-    return jsonResponse({ error: "Not found." }, 404);
-  };
-
-  try {
-    await import(`./app.js?foundation-partial-update-${Date.now()}`);
-    await delay(0);
-    const settings = findTweakList(document, "Settings");
-    const first = findInput(settings, tweaks[0].name);
-    const second = findInput(settings, tweaks[1].name);
-    first.value = "first changed";
-    await first.emit("input");
-    second.value = "second changed";
-    await second.emit("input");
-    await delay(160);
-
-    assert.deepEqual(patches, [{
-      "Settings/First label": "first changed",
-      "Settings/Second label": "second changed",
-    }]);
-    assert.equal(findInput(findTweakList(document, "Settings"), tweaks[0].name).value, "first changed");
-    assert.equal(findInput(findTweakList(document, "Settings"), tweaks[1].name).value, "before");
-    assert.equal(document.querySelector("#status-text").textContent, "Some updates failed");
-    assert.equal(
-      document.querySelector("#error-message").textContent,
-      "Settings/Second label: This setting could not be changed.",
-    );
-  } finally {
-    globalThis.document = originalDocument;
-    globalThis.fetch = originalFetch;
-  }
-});
-
-test("mixed tweak resets keep successful changes and report rejected names", async () => {
-  const document = makeDocument();
-  const tweaks = [
-    { name: "Settings/First option", type: "boolean", default: false, value: true },
-    { name: "Settings/Second option", type: "boolean", default: false, value: true },
-  ];
-  const patches = [];
-  const originalDocument = globalThis.document;
-  const originalFetch = globalThis.fetch;
-
-  globalThis.document = document;
-  globalThis.fetch = async (pathname, options) => {
-    if (pathname === "/apps") return jsonResponse({ apps: [demoApp], selectedAppId: demoApp.id });
-    if (pathname === "/app") return jsonResponse(demoApp);
-    if (pathname === "/tweaks" && options?.method === "PATCH") {
-      const { values } = JSON.parse(options.body);
-      patches.push(values);
-      tweaks[0].value = false;
-      return jsonResponse({
-        tweaks: [{ name: tweaks[0].name, value: false }],
-        errors: [{
-          name: tweaks[1].name,
-          error: "This setting could not be reset.",
-        }],
-      });
-    }
-    if (pathname === "/tweaks") return jsonResponse({ tweaks });
-    return jsonResponse({ error: "Not found." }, 404);
-  };
-
-  try {
-    await import(`./app.js?foundation-partial-reset-${Date.now()}`);
-    await delay(0);
-    await document.querySelector("#reset-button").emit("click");
-
-    assert.deepEqual(patches, [{
-      "Settings/First option": false,
-      "Settings/Second option": false,
-    }]);
-    const settings = findTweakList(document, "Settings");
-    assert.equal(findInput(settings, tweaks[0].name).checked, false);
-    assert.equal(findInput(settings, tweaks[1].name).checked, true);
-    assert.equal(findInput(settings, `Reset ${tweaks[0].name}`).hidden, true);
-    assert.equal(findInput(settings, `Reset ${tweaks[1].name}`).hidden, false);
-    assert.equal(document.querySelector("#status-text").textContent, "Some resets failed");
-    assert.equal(
-      document.querySelector("#error-message").textContent,
-      "Settings/Second option: This setting could not be reset.",
-    );
-  } finally {
-    globalThis.document = originalDocument;
-    globalThis.fetch = originalFetch;
   }
 });

--- a/snapo-link-android/tweaks-noop/src/main/java/com/openai/snapo/tweaks/SnapOTweaks.kt
+++ b/snapo-link-android/tweaks-noop/src/main/java/com/openai/snapo/tweaks/SnapOTweaks.kt
@@ -6,6 +6,7 @@ import androidx.annotation.RestrictTo
 import androidx.compose.runtime.Immutable
 import androidx.compose.runtime.Stable
 import androidx.compose.runtime.State
+import androidx.compose.runtime.derivedStateOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.ui.graphics.Color
 
@@ -26,6 +27,9 @@ object SnapOTweaks {
 
     /** Ignores action invocations in a no-op build. */
     fun invokeAction(name: String) = Unit
+
+    /** Ignores tweak resets in a no-op build. */
+    fun reset(name: String) = Unit
 }
 
 /** The matching observable tweak shape from the live implementation. */
@@ -35,7 +39,9 @@ class SnapOTweakEntry internal constructor(
     val name: String,
     val value: State<SnapOTweakValue>,
     val defaultValue: SnapOTweakValue,
-)
+) {
+    val modified: State<Boolean> = derivedStateOf { value.value != defaultValue }
+}
 
 /** A tweak value exposed by the matching live implementation. */
 @Immutable

--- a/snapo-link-android/tweaks-overlay/src/main/java/com/openai/snapo/tweaks/overlay/TweakOverlay.kt
+++ b/snapo-link-android/tweaks-overlay/src/main/java/com/openai/snapo/tweaks/overlay/TweakOverlay.kt
@@ -280,7 +280,7 @@ private fun TweakOverlayActions(
         hasChanges = hasChanges,
         onReset = {
             tweaks.filter { tweak -> tweak.isChanged }.forEach { tweak ->
-                SnapOTweaks.update(tweak.name, tweak.defaultValue)
+                SnapOTweaks.reset(tweak.name)
             }
         },
         resetContentDescription = "Reset all tweaks",
@@ -304,7 +304,7 @@ private fun TweakColorOverlayActions(
     TweakOverlayHeader(
         title = tweak.name.substringAfter('/'),
         hasChanges = hasChanges,
-        onReset = { SnapOTweaks.update(tweak.name, tweak.defaultValue) },
+        onReset = { SnapOTweaks.reset(tweak.name) },
         resetContentDescription = "Reset ${tweak.name}",
         onTrailingAction = onClose,
         trailingIcon = R.drawable.snapo_tweaks_check,

--- a/snapo-link-android/tweaks-overlay/src/main/java/com/openai/snapo/tweaks/overlay/TweakOverlayControls.kt
+++ b/snapo-link-android/tweaks-overlay/src/main/java/com/openai/snapo/tweaks/overlay/TweakOverlayControls.kt
@@ -241,7 +241,7 @@ private fun TweakOverlayLabelRow(
                     contentAlignment = Alignment.CenterStart,
                 ) {
                     IconButton(
-                        onClick = { SnapOTweaks.update(tweak.name, tweak.defaultValue) },
+                        onClick = { SnapOTweaks.reset(tweak.name) },
                         modifier = Modifier
                             .size(48.dp)
                             .offset(x = spacing - 12.dp),

--- a/snapo-link-android/tweaks-overlay/src/main/java/com/openai/snapo/tweaks/overlay/TweakOverlayRegistry.kt
+++ b/snapo-link-android/tweaks-overlay/src/main/java/com/openai/snapo/tweaks/overlay/TweakOverlayRegistry.kt
@@ -68,4 +68,4 @@ internal class TweakOverlaySectionOrder {
 }
 
 internal val SnapOTweakEntry.isChanged: Boolean
-    get() = value.value !is SnapOTweakValue.Action && value.value != defaultValue
+    get() = value.value !is SnapOTweakValue.Action && modified.value

--- a/snapo-link-android/tweaks/src/main/java/com/openai/snapo/tweaks/SnapOTweaks.kt
+++ b/snapo-link-android/tweaks/src/main/java/com/openai/snapo/tweaks/SnapOTweaks.kt
@@ -4,6 +4,7 @@ import androidx.annotation.RestrictTo
 import androidx.compose.runtime.Immutable
 import androidx.compose.runtime.Stable
 import androidx.compose.runtime.State
+import androidx.compose.runtime.derivedStateOf
 import androidx.compose.ui.graphics.Color
 import com.openai.snapo.tweaks.internal.TweakDescriptor
 import com.openai.snapo.tweaks.internal.TweakRegistry
@@ -36,6 +37,13 @@ object SnapOTweaks {
 
         TweakRegistry.invokeAction(name)
     }
+
+    /** Resets an active tweak through the same registry used by the host inspector. */
+    fun reset(name: String) {
+        if (!TweaksRuntimePolicy.isAllowed) return
+
+        TweakRegistry.update(mapOf(name to null))
+    }
 }
 
 /** A stable active tweak whose current value can be observed independently. */
@@ -45,7 +53,11 @@ class SnapOTweakEntry internal constructor(
     val name: String,
     val value: State<SnapOTweakValue>,
     val defaultValue: SnapOTweakValue,
-)
+) {
+    val modified: State<Boolean> = derivedStateOf {
+        value.value !is SnapOTweakValue.Action && value.value != defaultValue
+    }
+}
 
 /** A tweak currently available in the composed application. */
 @Immutable

--- a/snapo-link-android/tweaks/src/main/java/com/openai/snapo/tweaks/internal/TweakHttpServer.kt
+++ b/snapo-link-android/tweaks/src/main/java/com/openai/snapo/tweaks/internal/TweakHttpServer.kt
@@ -28,7 +28,7 @@ import java.util.concurrent.TimeUnit
 import java.util.concurrent.TimeoutException
 import kotlin.concurrent.thread
 
-internal const val TweaksProtocolVersion: Int = 3
+internal const val TweaksProtocolVersion: Int = 4
 
 internal data class TweakBatchError(
     val name: String,
@@ -593,6 +593,9 @@ internal class TweakHttpServer(
         if (tweak.descriptor.type != TweakType.ACTION) {
             writer.name("value")
             writeJsonValue(writer, tweak.value)
+            if (tweak.modified) {
+                writer.name("modified").value(true)
+            }
         }
 
         if (includeDescriptor) {

--- a/snapo-link-android/tweaks/src/main/java/com/openai/snapo/tweaks/internal/TweakRegistry.kt
+++ b/snapo-link-android/tweaks/src/main/java/com/openai/snapo/tweaks/internal/TweakRegistry.kt
@@ -37,6 +37,7 @@ internal data class TweakDescriptor(
 internal data class TweakSnapshot(
     val descriptor: TweakDescriptor,
     val value: Any,
+    val modified: Boolean,
 )
 
 internal open class TweakUpdateException(
@@ -198,7 +199,14 @@ internal object TweakRegistry {
             tweaks.values
         }
 
-        registeredTweaks.map { tweak -> TweakSnapshot(tweak.descriptor, tweak.state.value) }
+        registeredTweaks.map { tweak ->
+            val value = tweak.state.value
+            TweakSnapshot(
+                tweak.descriptor,
+                value,
+                tweak.descriptor.type != TweakType.ACTION && value != tweak.descriptor.default,
+            )
+        }
     }
 
     fun update(values: Map<String, Any?>): List<TweakSnapshot> {
@@ -207,7 +215,14 @@ internal object TweakRegistry {
             val changes = values.map { (name, value) ->
                 val tweak = tweaks[name]
                     ?: throw UnknownTweakException(name)
-                tweak to validateValue(tweak.descriptor, value)
+                val descriptor = tweak.descriptor
+                if (descriptor.type == TweakType.ACTION) {
+                    invalidValue(
+                        descriptor,
+                        "Actions cannot be patched. Invoke the registered action instead.",
+                    )
+                }
+                tweak to (value?.let { validateValue(descriptor, it) } ?: descriptor.default)
             }
 
             val changedTweaks = ArrayList<RegisteredTweak>()
@@ -225,7 +240,8 @@ internal object TweakRegistry {
             }
 
             changes.map { (tweak, _) ->
-                TweakSnapshot(tweak.descriptor, tweak.state.value)
+                val value = tweak.state.value
+                TweakSnapshot(tweak.descriptor, value, value != tweak.descriptor.default)
             }
         }
         if (changed) notifyObservers()

--- a/snapo-link-android/tweaks/src/test/java/com/openai/snapo/tweaks/SnapOTweaksTest.kt
+++ b/snapo-link-android/tweaks/src/test/java/com/openai/snapo/tweaks/SnapOTweaksTest.kt
@@ -111,6 +111,26 @@ class SnapOTweaksTest {
     }
 
     @Test
+    fun `overlay reset restores the original value and clears modified state`() {
+        val descriptor = TweakDescriptor(
+            name = "Typography/Reset font size",
+            type = TweakType.INT,
+            default = 16,
+        )
+        val state = TweakRegistry.register(descriptor)
+        val entry = SnapOTweaks.activeTweakEntries().value.single()
+
+        assertEquals(false, entry.modified.value)
+        SnapOTweaks.update(descriptor.name, SnapOTweakValue.Integer(20))
+        assertEquals(true, entry.modified.value)
+
+        SnapOTweaks.reset(descriptor.name)
+
+        assertEquals(16, state.value)
+        assertEquals(false, entry.modified.value)
+    }
+
+    @Test
     fun `overlay updates remain available as adjusted history after leaving composition`() {
         val descriptor = TweakDescriptor(
             name = "Typography/Historical font size",
@@ -131,6 +151,15 @@ class SnapOTweaksTest {
         TweaksRuntimePolicy.configure(isDebuggable = false, allowRelease = false)
 
         SnapOTweaks.update("Typography/Unavailable font size", SnapOTweakValue.Integer(20))
+
+        assertTrue(SnapOTweaks.activeTweaks().isEmpty())
+    }
+
+    @Test
+    fun `release resets without an override ignore unavailable tweaks`() {
+        TweaksRuntimePolicy.configure(isDebuggable = false, allowRelease = false)
+
+        SnapOTweaks.reset("Typography/Unavailable font size")
 
         assertTrue(SnapOTweaks.activeTweaks().isEmpty())
     }

--- a/snapo-link-android/tweaks/src/test/java/com/openai/snapo/tweaks/internal/TweakActionRegistryTest.kt
+++ b/snapo-link-android/tweaks/src/test/java/com/openai/snapo/tweaks/internal/TweakActionRegistryTest.kt
@@ -16,8 +16,8 @@ class TweakActionRegistryTest {
     }
 
     @Test
-    fun `protocol version distinguishes best effort tweak batches`() {
-        assertEquals(3, TweaksProtocolVersion)
+    fun `protocol version distinguishes reset and modification aware clients`() {
+        assertEquals(4, TweaksProtocolVersion)
     }
 
     @Test
@@ -37,10 +37,12 @@ class TweakActionRegistryTest {
         )
         assertEquals(TweakType.ACTION, snapshots[1].descriptor.type)
         assertEquals(SnapOTweakValue.Action(), snapshots[1].value)
+        assertEquals(false, snapshots[1].modified)
         assertEquals(
             SnapOTweakValue.Action(),
             TweakRegistry.activeEntries().value[1].value.value,
         )
+        assertEquals(false, TweakRegistry.activeEntries().value[1].modified.value)
     }
 
     @Test
@@ -175,6 +177,22 @@ class TweakActionRegistryTest {
         val error = assertThrows(InvalidTweakValueException::class.java) {
             TweakRegistry.update(
                 linkedMapOf(value.name to 20, "Playback/Restart" to "run"),
+            )
+        }
+
+        assertEquals(422, error.statusCode)
+        assertEquals(16, TweakRegistry.snapshot().first().value)
+    }
+
+    @Test
+    fun `actions reject reset patches without changing other tweaks`() {
+        val value = TweakDescriptor("Typography/Size", TweakType.INT, 16)
+        TweakRegistry.register(value)
+        TweakRegistry.registerAction("Playback/Restart") {}
+
+        val error = assertThrows(InvalidTweakValueException::class.java) {
+            TweakRegistry.update(
+                linkedMapOf(value.name to 20, "Playback/Restart" to null),
             )
         }
 

--- a/snapo-link-android/tweaks/src/test/java/com/openai/snapo/tweaks/internal/TweakEnumValidationTest.kt
+++ b/snapo-link-android/tweaks/src/test/java/com/openai/snapo/tweaks/internal/TweakEnumValidationTest.kt
@@ -24,8 +24,13 @@ class TweakEnumValidationTest {
         assertInvalidUpdate(descriptor.name, "DARK")
         assertInvalidUpdate(descriptor.name, "Stale")
         assertInvalidUpdate(descriptor.name, true)
-        assertInvalidUpdate(descriptor.name, null)
         assertEquals("Dark", state.value)
+
+        val reset = TweakRegistry.update(mapOf(descriptor.name to null)).single()
+
+        assertEquals("System", state.value)
+        assertEquals("System", reset.value)
+        assertEquals(false, reset.modified)
     }
 
     @Test

--- a/snapo-link-android/tweaks/src/test/java/com/openai/snapo/tweaks/internal/TweakRegistryLifecycleTest.kt
+++ b/snapo-link-android/tweaks/src/test/java/com/openai/snapo/tweaks/internal/TweakRegistryLifecycleTest.kt
@@ -220,7 +220,7 @@ class TweakRegistryLifecycleTest {
         TweakRegistry.unregister(descriptor.name)
 
         assertEquals(
-            TweakSnapshot(descriptor, descriptor.default),
+            TweakSnapshot(descriptor, descriptor.default, modified = false),
             TweakRegistry.snapshot(includeAdjusted = true).single(),
         )
     }
@@ -281,7 +281,10 @@ class TweakRegistryLifecycleTest {
         TweakRegistry.unregister(replacement.name)
 
         assertEquals(
-            listOf(TweakSnapshot(original, 20), TweakSnapshot(replacement, 32)),
+            listOf(
+                TweakSnapshot(original, 20, modified = true),
+                TweakSnapshot(replacement, 32, modified = true),
+            ),
             TweakRegistry.snapshot(includeAdjusted = true),
         )
     }
@@ -298,22 +301,28 @@ class TweakRegistryLifecycleTest {
 
         assertEquals(
             listOf(
-                TweakSnapshot(replacement, replacement.default),
-                TweakSnapshot(original, 20),
+                TweakSnapshot(replacement, replacement.default, modified = false),
+                TweakSnapshot(original, 20, modified = true),
             ),
             TweakRegistry.snapshot(includeAdjusted = true),
         )
 
         TweakRegistry.update(mapOf(replacement.name to 32))
         assertEquals(
-            listOf(TweakSnapshot(replacement, 32), TweakSnapshot(original, 20)),
+            listOf(
+                TweakSnapshot(replacement, 32, modified = true),
+                TweakSnapshot(original, 20, modified = true),
+            ),
             TweakRegistry.snapshot(includeAdjusted = true),
         )
 
         TweakRegistry.unregister(replacement.name)
 
         assertEquals(
-            listOf(TweakSnapshot(original, 20), TweakSnapshot(replacement, 32)),
+            listOf(
+                TweakSnapshot(original, 20, modified = true),
+                TweakSnapshot(replacement, 32, modified = true),
+            ),
             TweakRegistry.snapshot(includeAdjusted = true),
         )
     }
@@ -334,8 +343,8 @@ class TweakRegistryLifecycleTest {
 
         assertEquals(
             listOf(
-                TweakSnapshot(original, original.default),
-                TweakSnapshot(replacement, replacement.default),
+                TweakSnapshot(original, original.default, modified = false),
+                TweakSnapshot(replacement, replacement.default, modified = false),
             ),
             TweakRegistry.snapshot(includeAdjusted = true),
         )

--- a/snapo-link-android/tweaks/src/test/java/com/openai/snapo/tweaks/internal/TweakValidationTest.kt
+++ b/snapo-link-android/tweaks/src/test/java/com/openai/snapo/tweaks/internal/TweakValidationTest.kt
@@ -276,7 +276,7 @@ class TweakValidationTest {
     }
 
     @Test
-    fun `string tweaks accept only strings`() {
+    fun `string tweaks accept strings and reset when the update is null`() {
         val descriptor = TweakDescriptor(
             name = "Validation string",
             type = TweakType.STRING,
@@ -288,8 +288,13 @@ class TweakValidationTest {
 
         assertEquals("after", state.value)
         assertInvalidUpdate(descriptor.name, false)
-        assertInvalidUpdate(descriptor.name, null)
         assertEquals("after", state.value)
+
+        val reset = TweakRegistry.update(mapOf(descriptor.name to null)).single()
+
+        assertEquals("before", state.value)
+        assertEquals("before", reset.value)
+        assertEquals(false, reset.modified)
     }
 
     @Test

--- a/snapo-network-inspector-web/src/App.tsx
+++ b/snapo-network-inspector-web/src/App.tsx
@@ -10,7 +10,7 @@ export function App(): JSX.Element {
   const [selection, setSelection] = useState<SelectedAppInspector | null>(null);
 
   const selectInspector = useCallback((app: InspectableApp, option: AppInspectorOption) => {
-    setSelection({ appId: app.id, kind: option.kind, server: option.server });
+    setSelection({ appId: app.id, kind: option.kind, server: option.server, protocolVersion: option.protocolVersion });
   }, []);
 
   useEffect(() => {
@@ -23,25 +23,26 @@ export function App(): JSX.Element {
 
         setApps(discovered);
         setSelection((current) => {
-          if (
-            current &&
-            discovered.some(
-              (app) =>
-                app.id === current.appId &&
-                app.inspectors.some(
-                  (option) =>
-                    option.kind === current.kind &&
-                    option.server.deviceId === current.server.deviceId &&
-                    option.server.socketName === current.server.socketName
-                )
-            )
-          ) {
-            return current;
+          if (current) {
+            const selectedApp = discovered.find((app) => app.id === current.appId);
+            const selectedOption = selectedApp?.inspectors.find(
+              (option) =>
+                option.kind === current.kind &&
+                option.server.deviceId === current.server.deviceId &&
+                option.server.socketName === current.server.socketName
+            );
+            if (selectedOption) {
+              return selectedOption.protocolVersion === current.protocolVersion
+                ? current
+                : { ...current, protocolVersion: selectedOption.protocolVersion };
+            }
           }
 
           const app = discovered[0];
           const option = app?.inspectors[0];
-          return app && option ? { appId: app.id, kind: option.kind, server: option.server } : null;
+          return app && option
+            ? { appId: app.id, kind: option.kind, server: option.server, protocolVersion: option.protocolVersion }
+            : null;
         });
       } catch {
         if (!disposed) setApps([]);

--- a/snapo-network-inspector-web/src/features/tweaks-inspector/TweaksInspectorApp.test.ts
+++ b/snapo-network-inspector-web/src/features/tweaks-inspector/TweaksInspectorApp.test.ts
@@ -9,6 +9,7 @@ import type {
 } from "../../network/bridge-types";
 import { createNetworkClient, type NetworkClient } from "../../network/client";
 import {
+  applyTweakUpdates,
   canResetTweaks,
   groupTweaks,
   hasLoadedTweaksForServer,
@@ -21,13 +22,14 @@ import {
   TweakField,
   TweaksEmptyState,
   TweaksInspectorApp,
-  tweakColorWithPreservedAlpha
+  tweakColorWithPreservedAlpha,
+  tweakResetValue
 } from "./TweaksInspectorApp";
 
 describe("empty tweaks inspector", () => {
   const client = { usesNativeServerPicker: true, openExternal: async () => {} } as unknown as NetworkClient;
   const selection: SelectedAppInspector = {
-    appId: "pixel:com.openai.chatgpt",
+    appId: "pixel:com.example.settings",
     kind: "tweaks",
     server: { deviceId: "pixel", socketName: "snapo_tweaks_10" }
   };
@@ -263,11 +265,11 @@ describe("enumerated tweak values", () => {
 
   it("recognizes changed and reset enum values", () => {
     expect(canResetTweaks([enumTweak()])).toBe(false);
-    expect(canResetTweaks([{ ...enumTweak(), value: "Dark" }])).toBe(true);
+    expect(canResetTweaks([{ ...enumTweak(), value: "Dark", modified: true }])).toBe(true);
   });
 
   it("preserves updated enum options while a local selection is pending", () => {
-    const current = [{ ...enumTweak(), value: "Dark" }];
+    const current = [{ ...enumTweak(), value: "Dark", modified: true }];
     const incoming = [
       {
         ...enumTweak(),
@@ -276,7 +278,7 @@ describe("enumerated tweak values", () => {
     ];
 
     expect(reconcileStreamedTweaks(current, incoming, new Map([["Appearance/Theme", "Dark"]]), new Set())).toEqual([
-      { ...incoming[0], value: "Dark" }
+      { ...incoming[0], value: "Dark", modified: true }
     ]);
   });
 });
@@ -286,19 +288,40 @@ describe("native reset toolbar state", () => {
     expect(canResetTweaks([])).toBe(false);
   });
 
-  it("disables reset when all tweaks are at their defaults", () => {
+  it("disables reset when no tweaks are modified", () => {
     expect(canResetTweaks([tweak("Typography/Font size"), tweak("Motion/Duration")])).toBe(false);
   });
 
-  it("enables reset immediately when a tweak changes", () => {
-    expect(canResetTweaks([{ ...tweak("Typography/Font size"), value: 2 }])).toBe(true);
+  it("enables reset when a tweak is marked modified", () => {
+    expect(canResetTweaks([{ ...tweak("Typography/Font size"), value: 2, modified: true }])).toBe(true);
   });
 
-  it("disables reset when every changed tweak returns to its default", () => {
+  it("uses explicit modification status when the value equals its default", () => {
     const fontSize = tweak("Typography/Font size");
 
-    expect(canResetTweaks([{ ...fontSize, value: 2 }])).toBe(true);
+    expect(canResetTweaks([{ ...fontSize, modified: true }])).toBe(true);
+    expect(canResetTweaks([{ ...fontSize, value: 2, modified: false }])).toBe(false);
     expect(canResetTweaks([fontSize])).toBe(false);
+  });
+
+  it("infers modification status from legacy tweak values", () => {
+    const fontSize = tweak("Typography/Font size");
+
+    expect(canResetTweaks([{ ...fontSize, value: 2 }], 2)).toBe(true);
+    expect(canResetTweaks([{ ...fontSize, modified: true }], 2)).toBe(false);
+  });
+
+  it("resets legacy tweaks by restoring their descriptor defaults", () => {
+    const fontSize = { ...tweak("Typography/Font size"), value: 2 };
+
+    expect(tweakResetValue(fontSize, undefined)).toBe(fontSize.default);
+    expect(tweakResetValue(fontSize, 1)).toBe(fontSize.default);
+    expect(tweakResetValue(fontSize, 2)).toBe(fontSize.default);
+    expect(tweakResetValue(fontSize, 3)).toBe(fontSize.default);
+  });
+
+  it("resets current tweaks using the owner-aware null operation", () => {
+    expect(tweakResetValue(tweak("Typography/Font size"), 4)).toBeNull();
   });
 
   it("does not treat an action without a value or default as resettable", () => {
@@ -306,7 +329,22 @@ describe("native reset toolbar state", () => {
   });
 
   it("keeps changed value tweaks resettable when actions are present", () => {
-    expect(canResetTweaks([action("Motion/Toggle animation"), { ...tweak("Motion/Duration"), value: 2 }])).toBe(true);
+    expect(
+      canResetTweaks([action("Motion/Toggle animation"), { ...tweak("Motion/Duration"), value: 2, modified: true }])
+    ).toBe(true);
+  });
+
+  it("treats an omitted modification flag as false even when the value changed", () => {
+    const upstreamSetting: TweakDescriptor = {
+      name: "Settings/Show hints",
+      type: "boolean",
+      default: false,
+      value: true
+    };
+
+    expect(canResetTweaks([upstreamSetting], 4)).toBe(false);
+    expect(canResetTweaks([upstreamSetting], 3)).toBe(true);
+    expect(canResetTweaks([upstreamSetting], 2)).toBe(true);
   });
 });
 
@@ -439,6 +477,44 @@ describe("registered tweak actions", () => {
 });
 
 describe("streamed tweak snapshots", () => {
+  it("treats an omitted modification flag in mutation responses as false", () => {
+    const current: TweakDescriptor = {
+      name: "Settings/Show hints",
+      type: "boolean",
+      default: false,
+      value: true,
+      modified: true
+    };
+
+    expect(applyTweakUpdates([current], [{ name: current.name, value: true }], new Map())).toEqual([
+      { ...current, modified: false }
+    ]);
+  });
+
+  it("infers legacy modification status from an authoritative mutation response", () => {
+    const current = { ...tweak("Motion/Duration"), value: 2, modified: true };
+
+    expect(applyTweakUpdates([current], [{ name: current.name, value: current.default }], new Map(), 3)).toEqual([
+      { ...current, value: current.default, modified: false }
+    ]);
+    expect(applyTweakUpdates([current], [{ name: current.name, value: 3 }], new Map(), 3)).toEqual([
+      { ...current, value: 3, modified: true }
+    ]);
+  });
+
+  it("restores rejected optimistic values without discarding successful batch updates", () => {
+    const current = [
+      { ...tweak("Motion/Duration"), value: 550, modified: true },
+      { ...tweak("Typography/Font size"), value: 32, modified: true }
+    ];
+    const authoritative = [
+      { ...tweak("Motion/Duration"), value: 550, modified: true },
+      { ...tweak("Typography/Font size"), value: 1 }
+    ];
+
+    expect(reconcileStreamedTweaks(current, authoritative, new Map(), new Set())).toEqual(authoritative);
+  });
+
   it("adds and removes a section in one update", () => {
     const current = [tweak("Typography/Font size"), tweak("Motion/Duration")];
     const incoming = [tweak("Typography/Font size"), tweak("Colors/Accent")];
@@ -468,11 +544,11 @@ describe("streamed tweak snapshots", () => {
   });
 
   it("preserves new descriptor metadata while keeping a pending local value", () => {
-    const current = [{ ...tweak("Motion/Duration"), value: 700 }];
+    const current = [{ ...tweak("Motion/Duration"), value: 700, modified: true }];
     const incoming: TweakDescriptor[] = [{ ...tweak("Motion/Duration"), value: 550, max: 1500 }];
 
     expect(reconcileStreamedTweaks(current, incoming, new Map([["Motion/Duration", 700]]), new Set())).toEqual([
-      { ...incoming[0], value: 700 }
+      { ...incoming[0], value: 700, modified: true }
     ]);
   });
 
@@ -492,6 +568,24 @@ describe("streamed tweak snapshots", () => {
       incoming
     );
   });
+
+  it("preserves a pending reset until its authoritative response arrives", () => {
+    const current = [{ ...tweak("Motion/Duration"), value: 700, modified: true }];
+    const incoming = [{ ...tweak("Motion/Duration"), value: 550, modified: false }];
+
+    expect(reconcileStreamedTweaks(current, incoming, new Map([["Motion/Duration", null]]), new Set())).toEqual(
+      current
+    );
+    expect(canResetTweaks(current)).toBe(true);
+    expect(applyTweakUpdates(current, [{ name: "Motion/Duration", value: 550 }], new Map())).toEqual(incoming);
+  });
+
+  it("accepts owner modification status from a streamed update", () => {
+    const current = [{ ...tweak("Motion/Duration"), modified: false }];
+    const incoming = [{ ...tweak("Motion/Duration"), modified: true }];
+
+    expect(reconcileStreamedTweaks(current, incoming, new Map(), new Set())).toEqual(incoming);
+  });
 });
 
 describe("stable tweak section columns", () => {
@@ -499,7 +593,7 @@ describe("stable tweak section columns", () => {
     const ordering = new Map();
     const columns = groupTweaks(
       [tweak("Colors/Text"), tweak("Motion/Duration"), tweak("Typography/Font size")],
-      "pixel:chatgpt",
+      "pixel:settings",
       ordering
     );
 
@@ -511,7 +605,7 @@ describe("stable tweak section columns", () => {
 
   it("keeps sections in their original columns when another section disappears", () => {
     const ordering = new Map();
-    const app = "pixel:chatgpt";
+    const app = "pixel:settings";
 
     groupTweaks([tweak("Colors/Text"), tweak("Motion/Duration"), tweak("Typography/Font size")], app, ordering);
 
@@ -522,7 +616,7 @@ describe("stable tweak section columns", () => {
 
   it("restores a returning section to its original column", () => {
     const ordering = new Map();
-    const app = "pixel:chatgpt";
+    const app = "pixel:settings";
 
     groupTweaks([tweak("Colors/Text"), tweak("Motion/Duration"), tweak("Typography/Font size")], app, ordering);
     groupTweaks([tweak("Colors/Text"), tweak("Typography/Font size")], app, ordering);
@@ -542,7 +636,7 @@ describe("stable tweak section columns", () => {
   it("remembers section order independently for each app", () => {
     const ordering = new Map();
 
-    groupTweaks([tweak("Colors/Text"), tweak("Motion/Duration")], "pixel:chatgpt", ordering);
+    groupTweaks([tweak("Colors/Text"), tweak("Motion/Duration")], "pixel:settings", ordering);
 
     const columns = groupTweaks([tweak("Motion/Duration"), tweak("Colors/Text")], "pixel:demo", ordering);
 
@@ -564,7 +658,8 @@ function tweak(name: string): TweakValueDescriptor {
     name,
     type: "int",
     default: 1,
-    value: 1
+    value: 1,
+    modified: false
   };
 }
 
@@ -573,7 +668,8 @@ function colorTweak(): TweakValueDescriptor {
     name: "Colors/Accent",
     type: "color",
     default: "#5468FF80",
-    value: "#5468FF80"
+    value: "#5468FF80",
+    modified: false
   };
 }
 
@@ -583,6 +679,7 @@ function enumTweak(): TweakValueDescriptor {
     type: "enum",
     default: "System",
     value: "System",
+    modified: false,
     options: ["System", "Dark"]
   };
 }

--- a/snapo-network-inspector-web/src/features/tweaks-inspector/TweaksInspectorApp.tsx
+++ b/snapo-network-inspector-web/src/features/tweaks-inspector/TweaksInspectorApp.tsx
@@ -7,6 +7,7 @@ import type {
   SelectedAppInspector,
   TweakActionDescriptor,
   TweakDescriptor,
+  TweakUpdate,
   TweakValue,
   TweakValueDescriptor
 } from "../../network/bridge-types";
@@ -32,6 +33,7 @@ interface ActiveColorPanelSession {
 
 let nextColorPanelSession = 0;
 const docsUrl = "https://openai.github.io/snap-o/tweaks.html#expose-values";
+const modifiedTweakProtocolVersion = 4;
 
 export function TweaksInspectorApp({
   client,
@@ -52,6 +54,7 @@ export function TweaksInspectorApp({
   const [orderByApp] = useState(() => new Map<string, TweakOrdering>());
   const activeColorPanel = useRef<ActiveColorPanelSession | null>(null);
   const server = selection.server;
+  const protocolVersion = selection.protocolVersion ?? 1;
   const hasNativeColorPanel =
     client.usesNativeServerPicker &&
     typeof client.openNativeColorPanel === "function" &&
@@ -60,14 +63,7 @@ export function TweaksInspectorApp({
     () =>
       new TweakUpdateQueue(client, server, {
         onUpdate(updates, pending) {
-          setTweaks((current) =>
-            current.map((tweak) => {
-              const update = updates.find((candidate) => candidate.name === tweak.name);
-              return tweak.type !== "action" && update && !pending.has(tweak.name)
-                ? { ...tweak, value: update.value }
-                : tweak;
-            })
-          );
+          setTweaks((current) => applyTweakUpdates(current, updates, pending, protocolVersion));
         },
         onRejected(_errors, pending, inFlight, isCurrent) {
           void client
@@ -84,7 +80,7 @@ export function TweaksInspectorApp({
         onError: setError,
         onSavingChange: setSaving
       }),
-    [client, server]
+    [client, protocolVersion, server]
   );
 
   useEffect(() => {
@@ -167,7 +163,9 @@ export function TweaksInspectorApp({
       }
 
       setTweaks((current) =>
-        current.map((item) => (item.name === tweak.name && item.type !== "action" ? { ...item, value } : item))
+        current.map((item) =>
+          item.name === tweak.name && item.type !== "action" ? { ...item, value, modified: true } : item
+        )
       );
       queue.enqueue(tweak.name, value);
       void queue.flush();
@@ -241,16 +239,22 @@ export function TweaksInspectorApp({
     [client, server]
   );
 
+  const resetTweak = useCallback(
+    (tweak: TweakValueDescriptor) => {
+      queue.enqueue(tweak.name, tweakResetValue(tweak, protocolVersion));
+      void queue.flush();
+    },
+    [protocolVersion, queue]
+  );
+
   const resetAll = useCallback(() => {
     for (const tweak of tweaks) {
-      if (tweak.type === "action") continue;
-      queue.enqueue(tweak.name, tweak.default);
+      if (tweak.type !== "action" && isModified(tweak, protocolVersion)) {
+        queue.enqueue(tweak.name, tweakResetValue(tweak, protocolVersion));
+      }
     }
-    setTweaks((current) =>
-      current.map((tweak) => (tweak.type === "action" ? tweak : { ...tweak, value: tweak.default }))
-    );
     void queue.flush();
-  }, [queue, tweaks]);
+  }, [protocolVersion, queue, tweaks]);
 
   useEffect(() => client.onNativeTweaksReset(resetAll), [client, resetAll]);
 
@@ -258,7 +262,7 @@ export function TweaksInspectorApp({
     () => groupTweaks(tweaks, selection.appId, orderByApp),
     [orderByApp, selection.appId, tweaks]
   );
-  const hasChanges = canResetTweaks(tweaks);
+  const hasChanges = canResetTweaks(tweaks, protocolVersion);
 
   useEffect(() => {
     client.nativeTweaksStateChanged({
@@ -307,9 +311,11 @@ export function TweaksInspectorApp({
                         <TweakControl
                           key={tweak.name}
                           tweak={tweak}
+                          protocolVersion={protocolVersion}
                           onChange={updateTweak}
                           onInvoke={invokeAction}
                           invoking={invokingActions.has(tweak.name)}
+                          onReset={resetTweak}
                           onOpenColorPanel={hasNativeColorPanel ? openNativeColorPanel : undefined}
                         />
                       ))}
@@ -344,14 +350,46 @@ export function hasLoadedTweaksForServer(
   return loadedServer?.deviceId === server.deviceId && loadedServer.socketName === server.socketName;
 }
 
-export function canResetTweaks(tweaks: TweakDescriptor[]): boolean {
-  return tweaks.some((tweak) => tweak.type !== "action" && tweak.value !== tweak.default);
+export function canResetTweaks(tweaks: TweakDescriptor[], protocolVersion = modifiedTweakProtocolVersion): boolean {
+  return tweaks.some((tweak) => tweak.type !== "action" && isModified(tweak, protocolVersion));
+}
+
+function isModified(tweak: TweakValueDescriptor, protocolVersion: number): boolean {
+  return protocolVersion < modifiedTweakProtocolVersion ? tweak.value !== tweak.default : tweak.modified === true;
+}
+
+export function tweakResetValue(
+  tweak: TweakValueDescriptor,
+  protocolVersion: number | null | undefined
+): TweakValue | null {
+  return (protocolVersion ?? 1) < modifiedTweakProtocolVersion ? tweak.default : null;
+}
+
+export function applyTweakUpdates(
+  tweaks: TweakDescriptor[],
+  updates: TweakUpdate[],
+  pending: ReadonlyMap<string, TweakValue | null>,
+  protocolVersion = modifiedTweakProtocolVersion
+): TweakDescriptor[] {
+  return tweaks.map((tweak) => {
+    if (tweak.type === "action") return tweak;
+
+    const update = updates.find((candidate) => candidate.name === tweak.name);
+    return update && !pending.has(tweak.name)
+      ? {
+          ...tweak,
+          value: update.value,
+          modified:
+            protocolVersion < modifiedTweakProtocolVersion ? update.value !== tweak.default : update.modified === true
+        }
+      : tweak;
+  });
 }
 
 export function reconcileStreamedTweaks(
   current: TweakDescriptor[],
   incoming: TweakDescriptor[],
-  pending: ReadonlyMap<string, TweakValue>,
+  pending: ReadonlyMap<string, TweakValue | null>,
   inFlight: ReadonlySet<string>
 ): TweakDescriptor[] {
   const currentByName = new Map(current.map((tweak) => [tweak.name, tweak]));
@@ -364,7 +402,7 @@ export function reconcileStreamedTweaks(
       tweak.type !== "action" &&
       (pending.has(tweak.name) || inFlight.has(tweak.name))
     ) {
-      return { ...tweak, value: existing.value };
+      return { ...tweak, value: existing.value, modified: existing.modified };
     }
     return tweak;
   });
@@ -424,15 +462,19 @@ function tweakLabel(name: string): string {
 
 function TweakControl({
   tweak,
+  protocolVersion,
   onChange,
   onInvoke,
   invoking,
+  onReset,
   onOpenColorPanel
 }: {
   tweak: TweakDescriptor;
+  protocolVersion: number;
   onChange(tweak: TweakValueDescriptor, value: TweakValue): void;
   onInvoke(action: TweakActionDescriptor): void;
   invoking: boolean;
+  onReset(tweak: TweakValueDescriptor): void;
   onOpenColorPanel?(tweak: TweakValueDescriptor): void;
 }): JSX.Element {
   if (tweak.type === "action") {
@@ -440,7 +482,7 @@ function TweakControl({
   }
 
   const label = tweakLabel(tweak.name);
-  const changed = tweak.value !== tweak.default;
+  const changed = isModified(tweak, protocolVersion);
 
   return (
     <div className="tweaks-control">
@@ -452,7 +494,7 @@ function TweakControl({
             type="button"
             aria-label={`Reset ${tweak.name}`}
             title={`Reset ${label}`}
-            onClick={() => onChange(tweak, tweak.default)}
+            onClick={() => onReset(tweak)}
           >
             <RotateCcw size={13} aria-hidden="true" />
           </button>

--- a/snapo-network-inspector-web/src/features/tweaks-inspector/tweak-update-queue.test.ts
+++ b/snapo-network-inspector-web/src/features/tweaks-inspector/tweak-update-queue.test.ts
@@ -32,10 +32,10 @@ describe("app-scoped tweak updates", () => {
       values: { "Typography/Font size": 36 }
     });
 
-    secondRequest.resolve({ tweaks: [{ name: "Typography/Font size", value: 36 }] });
+    secondRequest.resolve({ tweaks: [{ name: "Typography/Font size", value: 36, modified: true }] });
     await secondFlush;
 
-    firstRequest.resolve({ tweaks: [{ name: "Typography/Font size", value: 24 }] });
+    firstRequest.resolve({ tweaks: [{ name: "Typography/Font size", value: 24, modified: true }] });
     await firstFlush;
 
     expect(client.updateTweaks).toHaveBeenCalledTimes(2);
@@ -60,7 +60,7 @@ describe("app-scoped tweak updates", () => {
 
     expect(client.updateTweaks).toHaveBeenCalledTimes(1);
 
-    firstRequest.resolve({ tweaks: [{ name: "Motion/Duration", value: 400 }] });
+    firstRequest.resolve({ tweaks: [{ name: "Motion/Duration", value: 400, modified: true }] });
     await vi.waitFor(() => {
       expect(client.updateTweaks).toHaveBeenCalledTimes(2);
     });
@@ -70,8 +70,129 @@ describe("app-scoped tweak updates", () => {
       values: { "Motion/Duration": 500 }
     });
 
-    secondRequest.resolve({ tweaks: [{ name: "Motion/Duration", value: 500 }] });
+    secondRequest.resolve({ tweaks: [{ name: "Motion/Duration", value: 500, modified: true }] });
     await flush;
+  });
+
+  it("sends a null value to reset a tweak", async () => {
+    const client = {
+      updateTweaks: vi.fn().mockResolvedValue({
+        tweaks: [{ name: "Motion/Duration", value: 300, modified: false }]
+      })
+    };
+    const server = { deviceId: "pixel", socketName: "snapo_tweaks_demo" };
+    const handlers = callbacks();
+    const queue = new TweakUpdateQueue(client, server, handlers);
+
+    queue.enqueue("Motion/Duration", null);
+    await queue.flush();
+
+    expect(client.updateTweaks).toHaveBeenCalledWith({
+      server,
+      values: { "Motion/Duration": null }
+    });
+    expect(handlers.onUpdate).toHaveBeenCalledWith(
+      [{ name: "Motion/Duration", value: 300, modified: false }],
+      new Map()
+    );
+  });
+
+  it("reports a rejected reset without leaving the request in flight", async () => {
+    const client = { updateTweaks: vi.fn().mockRejectedValue(new Error("Invalid tweak value for Motion/Duration.")) };
+    const server = { deviceId: "pixel", socketName: "snapo_tweaks_demo" };
+    const handlers = callbacks();
+    const queue = new TweakUpdateQueue(client, server, handlers);
+
+    queue.enqueue("Motion/Duration", null);
+    await expect(queue.flush()).resolves.toBeUndefined();
+
+    expect(handlers.onError).toHaveBeenCalledWith("Invalid tweak value for Motion/Duration.");
+    expect(queue.pending.size).toBe(0);
+    expect(queue.inFlight.size).toBe(0);
+    expect(handlers.onSavingChange).toHaveBeenLastCalledWith(false);
+  });
+
+  it("retries a rejected reset", async () => {
+    const result = { tweaks: [{ name: "Motion/Duration", value: 300 }] };
+    const client = {
+      updateTweaks: vi.fn().mockRejectedValueOnce(new Error("Reset failed.")).mockResolvedValueOnce(result)
+    };
+    const handlers = callbacks();
+    const queue = new TweakUpdateQueue(client, { deviceId: "pixel", socketName: "snapo_tweaks_demo" }, handlers);
+
+    queue.enqueue("Motion/Duration", null);
+    await queue.flush();
+    queue.enqueue("Motion/Duration", null);
+    await queue.flush();
+
+    expect(client.updateTweaks).toHaveBeenCalledTimes(2);
+    expect(handlers.onUpdate).toHaveBeenCalledWith(result.tweaks, new Map());
+  });
+
+  it("lets a reset replace a queued value update", async () => {
+    const client = { updateTweaks: vi.fn().mockResolvedValue({ tweaks: [] }) };
+    const server = { deviceId: "pixel", socketName: "snapo_tweaks_demo" };
+    const queue = new TweakUpdateQueue(client, server, callbacks());
+
+    queue.enqueue("Motion/Duration", 500);
+    queue.enqueue("Motion/Duration", null);
+    await queue.flush();
+
+    expect(client.updateTweaks).toHaveBeenCalledOnce();
+    expect(client.updateTweaks).toHaveBeenCalledWith({ server, values: { "Motion/Duration": null } });
+  });
+
+  it("lets a new value replace a queued reset", async () => {
+    const client = { updateTweaks: vi.fn().mockResolvedValue({ tweaks: [] }) };
+    const server = { deviceId: "pixel", socketName: "snapo_tweaks_demo" };
+    const queue = new TweakUpdateQueue(client, server, callbacks());
+
+    queue.enqueue("Motion/Duration", null);
+    queue.enqueue("Motion/Duration", 500);
+    await queue.flush();
+
+    expect(client.updateTweaks).toHaveBeenCalledOnce();
+    expect(client.updateTweaks).toHaveBeenCalledWith({ server, values: { "Motion/Duration": 500 } });
+  });
+
+  it("waits for an in-flight value update before resetting it", async () => {
+    const firstRequest = deferred<TweakUpdates>();
+    const secondRequest = deferred<TweakUpdates>();
+    const client = {
+      updateTweaks: vi.fn().mockReturnValueOnce(firstRequest.promise).mockReturnValueOnce(secondRequest.promise)
+    };
+    const server = { deviceId: "pixel", socketName: "snapo_tweaks_demo" };
+    const queue = new TweakUpdateQueue(client, server, callbacks());
+
+    queue.enqueue("Motion/Duration", 500);
+    const flush = queue.flush();
+    queue.enqueue("Motion/Duration", null);
+    void queue.flush();
+
+    firstRequest.resolve({ tweaks: [{ name: "Motion/Duration", value: 500, modified: true }] });
+    await vi.waitFor(() => {
+      expect(client.updateTweaks).toHaveBeenCalledTimes(2);
+    });
+
+    expect(client.updateTweaks).toHaveBeenNthCalledWith(2, { server, values: { "Motion/Duration": null } });
+    secondRequest.resolve({ tweaks: [{ name: "Motion/Duration", value: 300, modified: false }] });
+    await flush;
+  });
+
+  it("sends value changes and resets together", async () => {
+    const client = { updateTweaks: vi.fn().mockResolvedValue({ tweaks: [] }) };
+    const server = { deviceId: "pixel", socketName: "snapo_tweaks_demo" };
+    const queue = new TweakUpdateQueue(client, server, callbacks());
+
+    queue.enqueue("Motion/Duration", 500);
+    queue.enqueue("Motion/Show", null);
+    await queue.flush();
+
+    expect(client.updateTweaks).toHaveBeenCalledOnce();
+    expect(client.updateTweaks).toHaveBeenCalledWith({
+      server,
+      values: { "Motion/Duration": 500, "Motion/Show": null }
+    });
   });
 
   it("applies successful values and reports each rejected value in the same batch", async () => {

--- a/snapo-network-inspector-web/src/features/tweaks-inspector/tweak-update-queue.ts
+++ b/snapo-network-inspector-web/src/features/tweaks-inspector/tweak-update-queue.ts
@@ -2,10 +2,10 @@ import type { InspectorServerReference, TweakUpdate, TweakUpdateError, TweakValu
 import type { NetworkClient } from "../../network/client";
 
 interface TweakUpdateQueueCallbacks {
-  onUpdate(tweaks: TweakUpdate[], pending: ReadonlyMap<string, TweakValue>): void;
+  onUpdate(tweaks: TweakUpdate[], pending: ReadonlyMap<string, TweakValue | null>): void;
   onRejected?(
     errors: TweakUpdateError[],
-    pending: ReadonlyMap<string, TweakValue>,
+    pending: ReadonlyMap<string, TweakValue | null>,
     inFlight: ReadonlySet<string>,
     isCurrent: () => boolean
   ): void;
@@ -14,7 +14,7 @@ interface TweakUpdateQueueCallbacks {
 }
 
 export class TweakUpdateQueue {
-  readonly pending = new Map<string, TweakValue>();
+  readonly pending = new Map<string, TweakValue | null>();
   readonly inFlight = new Set<string>();
 
   private saving = false;
@@ -26,7 +26,7 @@ export class TweakUpdateQueue {
     private readonly callbacks: TweakUpdateQueueCallbacks
   ) {}
 
-  enqueue(name: string, value: TweakValue): void {
+  enqueue(name: string, value: TweakValue | null): void {
     this.pending.set(name, value);
   }
 

--- a/snapo-network-inspector-web/src/network/bridge-types.ts
+++ b/snapo-network-inspector-web/src/network/bridge-types.ts
@@ -43,6 +43,7 @@ export interface SelectedAppInspector {
   appId: string;
   kind: AppInspectorKind;
   server: InspectorServerReference;
+  protocolVersion?: number | null;
 }
 
 export type TweakValue = boolean | number | string;
@@ -52,6 +53,7 @@ export interface TweakValueDescriptor {
   type: "int" | "float" | "boolean" | "color" | "string" | "enum";
   default: TweakValue;
   value: TweakValue;
+  modified?: boolean;
   min?: number;
   max?: number;
   step?: number;
@@ -83,6 +85,7 @@ export interface NativeTweaksState {
 export interface TweakUpdate {
   name: string;
   value: TweakValue;
+  modified?: boolean;
 }
 
 export interface TweakUpdateError {
@@ -97,7 +100,7 @@ export interface TweakUpdates {
 
 export interface UpdateTweaksInput {
   server: InspectorServerReference;
-  values: Record<string, TweakValue>;
+  values: Record<string, TweakValue | null>;
 }
 
 export interface InvokeTweakActionInput {

--- a/tests/snapo_cli/test_snapo.py
+++ b/tests/snapo_cli/test_snapo.py
@@ -206,7 +206,12 @@ def tweak_descriptors():
             "step": 0.1,
         },
         {"name": "Motion/Enabled", "type": "boolean", "default": True, "value": True},
-        {"name": "Palette/Accent color", "type": "color", "default": "#5468FF", "value": "#5468FF"},
+        {
+            "name": "Palette/Accent color",
+            "type": "color",
+            "default": "#5468FF",
+            "value": "#5468FF",
+        },
         {"name": "Preview/Text value", "type": "string", "default": "true", "value": "true"},
         {
             "name": "Appearance/Theme",
@@ -233,7 +238,7 @@ class TweakHTTPServer:
         self.app = app or {
             "name": "Snap-O Tweaks Demo",
             "packageName": "com.example.tweaks",
-            "protocolVersion": 3,
+            "protocolVersion": 4,
         }
         self.error = error
         self.update_errors = update_errors or {}
@@ -279,12 +284,17 @@ class TweakHTTPServer:
                     return
 
                 descriptors = {item["name"]: item for item in owner.descriptors}
+                if set(payload) != {"values"} or not isinstance(payload["values"], dict):
+                    self.send_json(400, {"error": "Invalid tweak mutation request"})
+                    return
+
+                protocol_version = owner.app.get("protocolVersion", 1)
                 updates = []
                 errors = []
                 for name, value in payload["values"].items():
                     if name not in descriptors:
                         message = f"Unknown tweak: {name}"
-                        if owner.app.get("protocolVersion", 1) < 3:
+                        if protocol_version < 3:
                             self.send_json(404, {"error": message})
                             return
                         errors.append({"name": name, "error": message})
@@ -293,10 +303,26 @@ class TweakHTTPServer:
                         message = owner.update_errors[name]
                         errors.append({"name": name, "error": message})
                         continue
+                    if value is None:
+                        if protocol_version < 4:
+                            message = "Expected a non-null tweak value."
+                            if protocol_version < 3:
+                                self.send_json(422, {"error": message})
+                                return
+                            errors.append({"name": name, "error": message})
+                            continue
+                        value = descriptors[name]["default"]
                     if descriptors[name]["type"] == "color":
                         value = value.upper()
                     descriptors[name]["value"] = value
-                    updates.append({"name": name, "value": value})
+                    modified = value != descriptors[name]["default"]
+                    update = {"name": name, "value": value}
+                    if modified and protocol_version >= 4:
+                        descriptors[name]["modified"] = True
+                        update["modified"] = True
+                    else:
+                        descriptors[name].pop("modified", None)
+                    updates.append(update)
                 response = {"tweaks": updates}
                 if errors:
                     response["errors"] = errors
@@ -1264,7 +1290,7 @@ class TweakCommandTests(unittest.TestCase):
         self.assertEqual(app["socketName"], "snapo_tweaks_42")
         self.assertEqual(app["appName"], "Snap-O Tweaks Demo")
         self.assertEqual(app["packageName"], "com.example.tweaks")
-        self.assertEqual(app["protocolVersion"], 3)
+        self.assertEqual(app["protocolVersion"], 4)
         self.assertEqual(wire.requests, [("GET", "/app", None)])
         self.assertEqual(adb.calls[-1], ("emulator-5554", ("forward", "--remove", f"tcp:{wire.port}")))
 
@@ -1333,7 +1359,7 @@ class TweakCommandTests(unittest.TestCase):
 
     def test_list_all_includes_previously_adjusted_inactive_tweaks(self):
         active = tweak_descriptors()[0]
-        inactive = {**tweak_descriptors()[1], "name": "Motion/Historical duration", "value": 0.7}
+        inactive = {**tweak_descriptors()[1], "name": "Motion/Historical duration", "value": 0.7, "modified": True}
 
         with TweakHTTPServer(descriptors=[active], adjusted_descriptors=[active, inactive]) as wire:
             result, output, errors, adb = self.run_command(["list", "--all", "--json"], wire)
@@ -1345,7 +1371,7 @@ class TweakCommandTests(unittest.TestCase):
 
     def test_list_all_preserves_independently_adjusted_tweaks_with_the_same_name(self):
         active = tweak_descriptors()[1]
-        first = {**tweak_descriptors()[0], "value": 20}
+        first = {**tweak_descriptors()[0], "value": 20, "modified": True}
         second = {**first, "default": 24, "value": 32, "max": 64}
         expanded = [active, first, second]
 
@@ -1393,6 +1419,28 @@ class TweakCommandTests(unittest.TestCase):
         self.assertEqual(result, 0, errors)
         self.assertEqual(json.loads(output), {"tweaks": descriptors})
 
+    def test_list_does_not_infer_missing_modified_state_from_value(self):
+        descriptors = tweak_descriptors()
+        descriptors[0]["value"] = 20
+
+        with TweakHTTPServer(descriptors=descriptors) as wire:
+            result, output, errors, _ = self.run_command(["list", "--json"], wire)
+
+        self.assertEqual(result, 0, errors)
+        self.assertEqual(json.loads(output), {"tweaks": descriptors})
+        self.assertNotIn("modified", json.loads(output)["tweaks"][0])
+
+    def test_list_preserves_modified_state_when_value_matches_default(self):
+        descriptors = tweak_descriptors()
+        descriptors[0]["modified"] = True
+
+        with TweakHTTPServer(descriptors=descriptors) as wire:
+            result, output, errors, _ = self.run_command(["list", "--json"], wire)
+
+        self.assertEqual(result, 0, errors)
+        self.assertEqual(json.loads(output), {"tweaks": descriptors})
+        self.assertTrue(json.loads(output)["tweaks"][0]["modified"])
+
     def test_get_accepts_tweak_names_with_slashes_and_spaces(self):
         with TweakHTTPServer() as wire:
             result, output, errors, _ = self.run_command(["get", "Typography/Font size", "--json"], wire)
@@ -1412,7 +1460,7 @@ class TweakCommandTests(unittest.TestCase):
 
     def test_get_all_finds_a_previously_adjusted_inactive_tweak(self):
         active = tweak_descriptors()[0]
-        inactive = {**tweak_descriptors()[1], "name": "Motion/Historical duration", "value": 0.7}
+        inactive = {**tweak_descriptors()[1], "name": "Motion/Historical duration", "value": 0.7, "modified": True}
 
         with TweakHTTPServer(descriptors=[active], adjusted_descriptors=[active, inactive]) as wire:
             result, output, errors, adb = self.run_command(
@@ -1427,7 +1475,7 @@ class TweakCommandTests(unittest.TestCase):
 
     def test_get_all_rejects_independently_adjusted_tweaks_with_the_same_name(self):
         active = tweak_descriptors()[1]
-        first = {**tweak_descriptors()[0], "value": 20}
+        first = {**tweak_descriptors()[0], "value": 20, "modified": True}
         second = {**first, "default": 24, "value": 32, "max": 64}
 
         with TweakHTTPServer(descriptors=[active], adjusted_descriptors=[active, first, second]) as wire:
@@ -1545,37 +1593,40 @@ class TweakCommandTests(unittest.TestCase):
                 self.assertEqual(wire.requests, [("POST", "/tweaks/action", {"name": name})])
                 self.assertEqual(adb.calls[-1], ("emulator-5554", ("forward", "--remove", f"tcp:{wire.port}")))
 
+    def test_set_updates_the_modified_state(self):
+        with TweakHTTPServer() as wire:
+            result, output, errors, _ = self.run_command(["set", "Typography/Font size", "24"], wire)
+
+        self.assertEqual(result, 0, errors)
+        self.assertEqual(output, "")
+        self.assertEqual(wire.descriptors[0]["value"], 24)
+        self.assertTrue(wire.descriptors[0]["modified"])
+
     def test_set_reports_a_named_batch_error(self):
         name = "Motion/Enabled"
-        with TweakHTTPServer(update_errors={name: "The value could not be changed."}) as wire:
-            result, output, errors, _ = self.run_command(["set", name, "false"], wire)
+        for version in (3, 4):
+            with self.subTest(version=version):
+                app = {
+                    "name": "Snap-O Tweaks Demo",
+                    "packageName": "com.example.tweaks",
+                    "protocolVersion": version,
+                }
+                with TweakHTTPServer(
+                    app=app,
+                    update_errors={name: "The value could not be changed."},
+                ) as wire:
+                    result, output, errors, _ = self.run_command(["set", name, "false"], wire)
 
-        self.assertEqual(result, 1)
-        self.assertEqual(output, "")
-        self.assertIn(name, errors)
-        self.assertIn("The value could not be changed.", errors)
+                self.assertEqual(result, 1)
+                self.assertEqual(output, "")
+                self.assertIn(name, errors)
+                self.assertIn("The value could not be changed.", errors)
+                self.assertTrue(next(item for item in wire.descriptors if item["name"] == name)["value"])
 
-    def test_reset_all_keeps_successful_changes_and_reports_named_batch_errors(self):
+    def test_reset_one_tweak_sends_a_null_value(self):
         descriptors = tweak_descriptors()
         descriptors[0]["value"] = 24
-        descriptors[2]["value"] = False
-        failed_name = descriptors[2]["name"]
-        with TweakHTTPServer(
-            descriptors=descriptors,
-            update_errors={failed_name: "This value could not be reset."},
-        ) as wire:
-            result, output, errors, _ = self.run_command(["reset", "--all"], wire)
-
-        self.assertEqual(result, 1)
-        self.assertEqual(output, "")
-        self.assertIn(failed_name, errors)
-        self.assertIn("This value could not be reset.", errors)
-        self.assertEqual(wire.descriptors[0]["value"], 16)
-        self.assertFalse(wire.descriptors[2]["value"])
-
-    def test_reset_one_tweak_patches_its_declared_default(self):
-        descriptors = tweak_descriptors()
-        descriptors[0]["value"] = 24
+        descriptors[0]["modified"] = True
         with TweakHTTPServer(descriptors=descriptors) as wire:
             result, output, errors, _ = self.run_command(
                 ["reset", "Typography/Font size"],
@@ -1583,10 +1634,12 @@ class TweakCommandTests(unittest.TestCase):
             )
 
         self.assertEqual(result, 0, errors)
-        self.assertEqual(wire.requests[1], ("PATCH", "/tweaks", {"values": {"Typography/Font size": 16}}))
+        self.assertEqual(wire.requests[2], ("PATCH", "/tweaks", {"values": {"Typography/Font size": None}}))
+        self.assertEqual(wire.descriptors[0]["value"], 16)
+        self.assertNotIn("modified", wire.descriptors[0])
         self.assertEqual(output, "")
 
-    def test_reset_enum_patches_its_declared_default_name(self):
+    def test_reset_enum_sends_a_null_value(self):
         descriptors = tweak_descriptors()
         descriptor = next(item for item in descriptors if item["name"] == "Appearance/Theme")
         descriptor["value"] = "Dark"
@@ -1595,19 +1648,138 @@ class TweakCommandTests(unittest.TestCase):
             result, output, errors, _ = self.run_command(["reset", "Appearance/Theme"], wire)
 
         self.assertEqual(result, 0, errors)
-        self.assertEqual(wire.requests[1], ("PATCH", "/tweaks", {"values": {"Appearance/Theme": "System"}}))
+        self.assertEqual(wire.requests[2], ("PATCH", "/tweaks", {"values": {"Appearance/Theme": None}}))
+        self.assertEqual(
+            next(item for item in wire.descriptors if item["name"] == "Appearance/Theme")["value"],
+            "System",
+        )
         self.assertEqual(output, "")
 
-    def test_reset_all_patches_every_default_in_one_request(self):
+    def test_reset_legacy_tweak_sends_its_default_value(self):
+        for version in (None, 2, 3):
+            with self.subTest(version=version):
+                descriptors = tweak_descriptors()
+                descriptors[0]["value"] = 24
+                app = {"name": "Snap-O Tweaks Demo", "packageName": "com.example.tweaks"}
+                if version is not None:
+                    app["protocolVersion"] = version
+
+                with TweakHTTPServer(descriptors=descriptors, app=app) as wire:
+                    result, output, errors, _ = self.run_command(
+                        ["reset", "Typography/Font size"],
+                        wire,
+                    )
+
+                self.assertEqual(result, 0, errors)
+                self.assertEqual(
+                    wire.requests,
+                    [
+                        ("GET", "/tweaks", None),
+                        ("GET", "/app", None),
+                        ("PATCH", "/tweaks", {"values": {"Typography/Font size": 16}}),
+                    ],
+                )
+                self.assertEqual(wire.descriptors[0]["value"], 16)
+                self.assertEqual(output, "")
+
+    def test_reset_all_legacy_tweaks_uses_only_changed_defaults(self):
+        for version in (2, 3):
+            with self.subTest(version=version):
+                descriptors = tweak_descriptors()
+                descriptors[0]["value"] = 24
+                descriptors[2]["value"] = False
+                descriptors.append({"name": "Preview/Refresh", "type": "action"})
+                app = {
+                    "name": "Snap-O Tweaks Demo",
+                    "packageName": "com.example.tweaks",
+                    "protocolVersion": version,
+                }
+
+                with TweakHTTPServer(descriptors=descriptors, app=app) as wire:
+                    result, output, errors, _ = self.run_command(["reset", "--all"], wire)
+
+                self.assertEqual(result, 0, errors)
+                self.assertEqual(
+                    wire.requests,
+                    [
+                        ("GET", "/tweaks", None),
+                        ("GET", "/app", None),
+                        (
+                            "PATCH",
+                            "/tweaks",
+                            {"values": {"Typography/Font size": 16, "Motion/Enabled": True}},
+                        ),
+                    ],
+                )
+                self.assertEqual(wire.descriptors[0]["value"], 16)
+                self.assertTrue(wire.descriptors[2]["value"])
+                self.assertEqual(output, "")
+
+    def test_reset_all_keeps_successful_changes_and_reports_named_batch_errors(self):
+        for version in (3, 4):
+            with self.subTest(version=version):
+                descriptors = tweak_descriptors()
+                descriptors[0]["value"] = 24
+                descriptors[2]["value"] = False
+                if version >= 4:
+                    descriptors[0]["modified"] = True
+                    descriptors[2]["modified"] = True
+                app = {
+                    "name": "Snap-O Tweaks Demo",
+                    "packageName": "com.example.tweaks",
+                    "protocolVersion": version,
+                }
+                failed_name = descriptors[2]["name"]
+
+                with TweakHTTPServer(
+                    descriptors=descriptors,
+                    app=app,
+                    update_errors={failed_name: "The owner rejected this value."},
+                ) as wire:
+                    result, output, errors, _ = self.run_command(["reset", "--all"], wire)
+
+                self.assertEqual(result, 1)
+                self.assertEqual(output, "")
+                self.assertIn(failed_name, errors)
+                self.assertIn("The owner rejected this value.", errors)
+                self.assertEqual(wire.descriptors[0]["value"], 16)
+                self.assertFalse(wire.descriptors[2]["value"])
+                self.assertEqual(
+                    wire.requests[-1],
+                    (
+                        "PATCH",
+                        "/tweaks",
+                        {
+                            "values": {
+                                "Typography/Font size": None if version >= 4 else 16,
+                                failed_name: None if version >= 4 else True,
+                            },
+                        },
+                    ),
+                )
+
+    def test_reset_all_sends_only_modified_names_with_null_values(self):
         descriptors = tweak_descriptors()
         descriptors[0]["value"] = 24
+        descriptors[0]["modified"] = True
+        descriptors[1]["value"] = 0.7
         descriptors[2]["value"] = False
-        defaults = {descriptor["name"]: descriptor["default"] for descriptor in descriptors}
+        descriptors[2]["modified"] = True
+        values = {
+            descriptor["name"]: None
+            for descriptor in descriptors
+            if descriptor.get("modified") is True
+        }
         with TweakHTTPServer(descriptors=descriptors) as wire:
             result, output, errors, _ = self.run_command(["reset", "--all"], wire)
 
         self.assertEqual(result, 0, errors)
-        self.assertEqual(wire.requests, [("GET", "/tweaks", None), ("PATCH", "/tweaks", {"values": defaults})])
+        self.assertEqual(
+            wire.requests,
+            [("GET", "/tweaks", None), ("GET", "/app", None), ("PATCH", "/tweaks", {"values": values})],
+        )
+        self.assertEqual(wire.descriptors[1]["value"], 0.7)
+        self.assertTrue(all("modified" not in descriptor for descriptor in wire.descriptors))
         self.assertEqual(output, "")
 
     def test_reset_all_ignores_actions_without_defaults(self):
@@ -1616,16 +1788,48 @@ class TweakCommandTests(unittest.TestCase):
             {"name": "Preview/Refresh", "type": "action"},
             {"name": "Preview/Reload", "type": "action", "conflicted": True},
         ]
-        defaults = {
-            descriptor["name"]: descriptor["default"]
+        descriptors[0]["value"] = 24
+        descriptors[0]["modified"] = True
+        values = {
+            descriptor["name"]: None
             for descriptor in descriptors
-            if descriptor["type"] != "action"
+            if descriptor["type"] != "action" and descriptor.get("modified") is True
         }
         with TweakHTTPServer(descriptors=descriptors) as wire:
             result, output, errors, _ = self.run_command(["reset", "--all"], wire)
 
         self.assertEqual(result, 0, errors)
-        self.assertEqual(wire.requests, [("GET", "/tweaks", None), ("PATCH", "/tweaks", {"values": defaults})])
+        self.assertEqual(
+            wire.requests,
+            [("GET", "/tweaks", None), ("GET", "/app", None), ("PATCH", "/tweaks", {"values": values})],
+        )
+        self.assertEqual(output, "")
+
+    def test_reset_all_with_no_modified_tweaks_sends_no_patch(self):
+        descriptors = tweak_descriptors()
+        descriptors[0]["value"] = 24
+        with TweakHTTPServer(descriptors=descriptors) as wire:
+            result, output, errors, _ = self.run_command(["reset", "--all"], wire)
+
+        self.assertEqual(result, 0, errors)
+        self.assertEqual(wire.requests, [("GET", "/tweaks", None), ("GET", "/app", None)])
+        self.assertEqual(wire.descriptors[0]["value"], 24)
+        self.assertEqual(output, "")
+
+    def test_reset_one_unmodified_tweak_still_sends_a_null_value(self):
+        descriptors = tweak_descriptors()
+        with TweakHTTPServer(descriptors=descriptors) as wire:
+            result, output, errors, _ = self.run_command(["reset", "Typography/Font size"], wire)
+
+        self.assertEqual(result, 0, errors)
+        self.assertEqual(
+            wire.requests,
+            [
+                ("GET", "/tweaks", None),
+                ("GET", "/app", None),
+                ("PATCH", "/tweaks", {"values": {"Typography/Font size": None}}),
+            ],
+        )
         self.assertEqual(output, "")
 
     def test_reset_all_with_only_actions_sends_no_patch(self):


### PR DESCRIPTION
## Summary

- Introduce Tweaks protocol version 4 with explicit resets using `PATCH /tweaks` and `null`.
- Add sparse, authoritative modification status: `"modified": true` indicates a changed value; an omitted field means unmodified.
- Reset only modified, non-action values across the CLI, macOS bridge, web inspector, in-app overlay, and browser panel.
- Preserve best-effort batch updates and named `{"name":"...","error":"..."}` failures.
- Maintain compatibility with older apps: protocol versions 1–3 use concrete default values for resets and derive modification status by comparing values with defaults.

## Verification

- Android: 190 unit tests, static checks, debug build, minified release build, and no-op release build.
- Web inspector: 124 tests.
- CLI: 109 tests.
- Browser panel: 47 tests.
- macOS application build.

## Notes

- Stacked on #236.
