### PR TITLE
Add app-owned, observable Compose tweak sources

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,14 +75,14 @@ Note: Snap‑O uses the macOS Hardened Runtime. It will run the `adb` binary you
 
 ### Previously adjusted Tweaks
 
-Include previously adjusted values even after their declarations leave composition:
+Include previously adjusted ordinary or app-owned values even after their declarations leave composition:
 
 ```bash
 snapo tweaks list --all -s <serial> -n <socket> --json
 snapo tweaks get 'Motion/Duration' --all -s <serial> -n <socket> --json
 ```
 
-The equivalent API is `GET /tweaks?include=adjusted`. Inactive tweaks remain read-only. See the [Tweaks protocol guide](contracts/tweaks/README.md) for descriptors and updates.
+The equivalent API is `GET /tweaks?include=adjusted`. Inactive tweaks remain read-only; app-owned history retains a value snapshot, not its source. See the [Tweaks protocol guide](contracts/tweaks/README.md) for descriptors and updates.
 
 ### Drag and Drop
 

--- a/contracts/tweaks/README.md
+++ b/contracts/tweaks/README.md
@@ -144,11 +144,11 @@ Return a flat list of currently registered tweaks:
 }
 ```
 
-A tweak name represents one shared value, not one composable. Multiple active composables may register the same name; the tweak appears only once, and an update changes the value observed by every usage. A tweak remains registered until its last usage leaves composition. Its most recently edited value remains available if the same complete declaration later returns, but inactive tweaks do not appear in default responses or event snapshots.
+A tweak name represents one shared value, not one composable. Multiple active composables may register the same name; the tweak appears only once, and an update changes the value observed by every usage. A tweak remains registered until its last usage leaves composition. Registry-owned tweaks restore their most recently edited value if the same complete declaration returns. App-owned sources remain authoritative and control their own persistence; historical snapshots are never replayed into a returning source. Inactive tweaks do not appear in default responses or event snapshots.
 
-Usages with the same name must agree on the tweak type, default, constraints, and ordered enum options. Conflicting declarations are a configuration error.
+Registry-owned usages with the same name must agree on the tweak type, default, constraints, and ordered enum options. App-owned sources with the same name must use the same setting and value type.
 
-In protocol version 4, only modified value tweaks include `"modified": true`; otherwise the field is absent. A missing field always means false. A tweak is modified when its value differs from its default. Versions 1, 2, and 3 omit this field; determine their modification status by comparing `value` with `default`. Action descriptors never include `modified`.
+In protocol version 4, only modified value tweaks include `"modified": true`; otherwise the field is absent. A missing field always means false, even when `value` differs from `default`. Standard tweaks compare value and default. App-owned tweaks report whether their own override exists. Versions 1, 2, and 3 omit this field; determine their modification status by comparing `value` with `default`. Action descriptors never include `modified`.
 
 Supported value types are `int`, `float`, `boolean`, `color`, `string`, and `enum`. The `action` type describes an explicitly registered parameterless app-owned callback. Actions do not have `value`, `default`, options, or numeric constraints; clients must not attempt to patch or reset them. Integer tweaks accept only whole numbers; float tweaks accept whole or fractional numbers. Numeric tweaks may include `min`, `max`, and `step`. Only include constraints actually supplied by the app. A `step` is relative to `min`, or to `default` if no `min` is supplied. Colors use `#RRGGBB`, or `#RRGGBBAA` when translucent.
 
@@ -172,15 +172,15 @@ Numeric JSON values may contain at most 128 characters and 64 significant digits
 
 ### GET /tweaks?include=adjusted
 
-Opt in to a complete list of active tweaks and previously adjusted tweaks that have since left composition:
+Opt in to a complete list of active tweaks and previously adjusted ordinary or app-owned tweaks that have since left composition:
 
 ```bash
 curl -fsS 'http://127.0.0.1:43817/tweaks?include=adjusted'
 ```
 
-The response uses the same `{"tweaks":[...]}` shape and complete tweak descriptors as `GET /tweaks`. Include every currently active tweak, whether or not it has been adjusted, and every inactive tweak whose value was actually changed by a successful user adjustment. Preserve the tweak's original declaration, constraints, and latest value after its final usage leaves composition. Separate screens may reuse a name with different declarations; include each independently adjusted complete descriptor, even when names repeat. Repeated names occur only for distinct complete descriptors; active-only listings and updates still resolve at most one active descriptor per name. Order names by first observation, regardless of later activation or adjustment. For repeated names, list the active declaration first, followed by historical declarations in stable adjustment order.
+The response uses the same `{"tweaks":[...]}` shape and complete tweak descriptors as `GET /tweaks`. Include every currently active tweak, whether or not it has been adjusted, and every inactive ordinary or app-owned tweak whose effective value or modification status changed after a successful inspector adjustment. Preserve its complete descriptor, last effective value, and authoritative modification status after its final usage leaves composition. App-owned history retains only an immutable snapshot, never its source, callbacks, or observers; a returning source supplies its own current value. Separate screens may reuse a name with different declarations; include each independently adjusted complete descriptor, even when names repeat. An active descriptor takes precedence over its matching historical snapshot. Order names by first observation, regardless of later activation or adjustment. For repeated names, list the active declaration first, followed by historical declarations in stable adjustment order.
 
-An adjusted tweak remains in this history even after it is reset. An inactive tweak that was never changed, a no-op update that leaves its value unchanged, and a rejected update do not create history entries. Adjustment history exists only for the current app process and is discarded when that process exits.
+An adjusted tweak remains in this history even after it is reset. An app-owned reset can leave an effective value different from the captured default while its modification status is false. An inactive tweak that was never adjusted, a no-op update that changes neither its value nor its modification status, and a rejected update do not create history entries. Adjustment history exists only for the current app process and is discarded when that process exits.
 
 Historical inactive tweaks are read-only: `PATCH /tweaks` still accepts only currently active names. Versions 1 and 2 return `404` for an inactive name; later versions report a named per-item error. Actions appear while active but never create adjusted-history entries because they have no editable or retained value. Plain `GET /tweaks` and `GET /tweaks/events` remain active-only. The only supported query is exactly `include=adjusted` on `GET /tweaks`; unsupported, repeated, or additional query parameters and queries on other endpoints or methods return `400`.
 
@@ -272,7 +272,7 @@ curl -fsS -X PATCH http://127.0.0.1:43817/tweaks \
 }
 ```
 
-For protocol version 4, use `null` to reset a tweak; a request can mix changes and resets. Reset all only active, non-action tweaks marked `"modified": true`. For versions 1, 2, and 3, reset each changed tweak by sending its `default` value instead.
+For protocol version 4, use `null` to reset a tweak; a request can mix changes and resets. App-owned tweaks call their source's `reset()` method and return the current effective value. Reset all only active, non-action tweaks marked `"modified": true`. For versions 1, 2, and 3, reset each changed tweak by sending its `default` value instead.
 
 Return `400` for malformed requests, `404` when an endpoint does not exist, `405` for an unsupported method, `413` for an oversized body, and `422` for invalid numeric literals or nonprimitive values. In protocol versions 1 and 2, an unknown tweak returns `404`, an invalid value returns `422`, and the entire batch is rejected. In versions 3 and later, unknown tweaks, invalid values, and action targets are reported as per-item errors without preventing other changes. Request-level errors use a small JSON body:
 
@@ -389,11 +389,58 @@ Box(
 )
 ```
 
-Each remembered usage registers with composition and removes the tweak from the active list only after its final usage leaves. Returning declarations restore their previously edited values. Screen navigation therefore determines what appears in the default response without discarding edits; request `GET /tweaks?include=adjusted` to also recover previously adjusted values from screens that are no longer in composition.
+Each remembered usage registers with composition and removes the tweak from the active list only after its final usage leaves. Returning registry-owned declarations restore their previously edited values; app-owned sources control their own persistence. Request `GET /tweaks?include=adjusted` to inspect prior ordinary or app-owned adjustments from screens no longer in composition.
 
 Provide overloaded `tweak(default, name)` functions for `Int`, `Float`, `Color`, `Boolean`, `String`, and enum defaults; each returns its corresponding `State<T>`. For strings, name the second argument to distinguish the label from the default, as in `tweak("Hello", name = "Greeting")`. Numeric tweaks accept an optional range and `step` of the same type. Enum tweaks infer their options from declaration order and use each constant's name everywhere. Convert delegated integer values into Compose units at the call site, such as `fontSize.sp`. The real and no-op artifacts expose the same package and public Compose API.
 
 Declare a parameterless action with the `TweakAction(name) { ... }` composable. It returns `Unit` and does not execute its callback during composition or return a callable function. The action is available only while its owning composable is in composition, always uses its most recent callback, and is exposed with its explicit name rather than an inferred or generated identifier. Register each action exactly once at the composable that owns the state or operation; multiple owners using the same name produce a visible conflict and all invocation attempts fail closed. The release/no-op implementation accepts the same API without retaining or invoking the callback.
+
+App-owned tweaks implement `TweakSource<T>`, supporting `Boolean`, `Int`, `Float`, `String`, and `Color`. The source owns its current value, reset behavior, modification status, and change notifications:
+
+```kotlin
+private class SharedPreferencesBooleanSource(
+    private val preferences: SharedPreferences,
+    private val key: String,
+    private val default: Boolean,
+) : TweakSource<Boolean> {
+    override var value: Boolean
+        get() = preferences.getBoolean(key, default)
+        set(value) {
+            preferences.edit().putBoolean(key, value).apply()
+        }
+
+    override val isModified: Boolean
+        get() = preferences.contains(key)
+
+    override fun reset() {
+        preferences.edit().remove(key).apply()
+    }
+
+    override fun observe(): Flow<Unit> = callbackFlow {
+        val listener = SharedPreferences.OnSharedPreferenceChangeListener { _, changedKey ->
+            if (changedKey == key || changedKey == null) trySend(Unit)
+        }
+        preferences.registerOnSharedPreferenceChangeListener(listener)
+        awaitClose { preferences.unregisterOnSharedPreferenceChangeListener(listener) }
+    }
+}
+
+@Composable
+private fun SharedPreferences.tweak(
+    key: String,
+    default: Boolean,
+    name: String = key,
+): State<Boolean> {
+    val source = remember(this, key, default) {
+        SharedPreferencesBooleanSource(this, key, default)
+    }
+    return tweak(source, name)
+}
+```
+
+The inspector captures the source's initial value when first observed. Snap-O accesses the source and updates its observable value and modification status on the Android main thread. The first app read or inspector request initializes this snapshot and may wait for the main thread; later inspector requests use cached values without accessing the source, even when the main thread is blocked. Reset calls `reset()`, and `isModified` reports whether the setting is stored. Source changes update the snapshot and stream when `observe()` emits; no polling is needed. Previously adjusted sources leave immutable history without retaining their sources or restoring values into returning sources. Both live and no-op artifacts defer reading the source until its value or default is observed. The no-op artifact never registers a tweak, edits the source, or observes it.
+
+Multiple composables can expose the same app-owned tweak. The first active source handles its value, updates, resets, and modification status. Only its `observe()` flow is collected. When it leaves composition, the next active source takes over. Sources with the same name must use the same setting and value type. Conflicts are not checked and can cause wrong values or runtime errors.
 
 ## Setup
 

--- a/skills/snap-o-tweaks/SKILL.md
+++ b/skills/snap-o-tweaks/SKILL.md
@@ -46,14 +46,14 @@ ADB resolves from `PATH`, `ANDROID_SDK_ROOT`, or `ANDROID_HOME`. Use `--adb <pat
 
    Select devices with `-s <serial>`, `-d` (USB), or `-e` (emulator). Use `-n <socket>` for every subcommand except `apps` when selection is ambiguous.
 
-3. Include every tweak the user has adjusted, even when its declaration is not currently in composition:
+3. Include ordinary or app-owned tweaks the user has adjusted, even when their declarations are not currently in composition:
 
    ```bash
    "$SNAPO_BIN" tweaks list --all -s <serial> -n <socket> --json
    "$SNAPO_BIN" tweaks get 'Typography/Font size' --all -s <serial> -n <socket> --json
    ```
 
-   The expanded list combines current tweaks and actions with retained, previously adjusted tweaks. In protocol version 4, use `"modified": true` to identify outstanding changes; a missing field always means false. For versions 1, 2, and 3, compare `value` with `default` instead. Actions never include `modified`. Separate screens can reuse tweak names with different declarations; preserve every descriptor from `list --all` instead of deduplicating by name. `get NAME --all` reports an error when multiple declarations match; use `list --all --json` to inspect them. Historical tweaks can be inspected while inactive, but can only be changed or reset when their declaration is active. Actions are active-only.
+   The expanded list combines current tweaks and actions with retained snapshots of previously adjusted ordinary or app-owned tweaks. App-owned history preserves the effective value and modification status, not the source, callbacks, or observers. In protocol version 4, use `"modified": true` to identify outstanding changes; a missing field always means false, even when `value` differs from `default`. For versions 1, 2, and 3, compare `value` with `default` instead. Actions never include `modified`. Separate screens can reuse tweak names with different declarations; preserve every descriptor from `list --all` instead of deduplicating by name. `get NAME --all` reports an error when multiple declarations match; use `list --all --json` to inspect them. Historical tweaks can be inspected while inactive, but can only be changed or reset when their declaration is active. Actions are active-only.
 
 4. Observe live complete snapshots:
 

--- a/skills/snap-o-tweaks/references/interaction-surfaces.md
+++ b/skills/snap-o-tweaks/references/interaction-surfaces.md
@@ -4,7 +4,7 @@ The same active Compose tweak registry can be inspected from several surfaces. C
 
 ## Command line: agents, automation, and repeatable checks
 
-Use the dependency-free Snap-O CLI when a terminal, Codex agent, test script, or Linux/macOS workflow needs app discovery, typed value inspection or updates, batched changes, resets, app-owned action invocation, or live snapshots. Invoke an explicitly requested action with `snapo tweaks action NAME`; actions have no editable value, default, or arguments. Use `snapo tweaks list --all` or `snapo tweaks get NAME --all` to include previously adjusted tweaks no longer in composition; inactive historical tweaks are inspectable but not writable. Its tweaks workflow documents command selection and options. The CLI owns temporary local forwarding and cleanup; explicit remote ADB endpoints use direct smart-socket transport.
+Use the dependency-free Snap-O CLI when a terminal, Codex agent, test script, or Linux/macOS workflow needs app discovery, typed value inspection or updates, batched changes, resets, app-owned action invocation, or live snapshots. Invoke an explicitly requested action with `snapo tweaks action NAME`; actions have no editable value, default, or arguments. Use `snapo tweaks list --all` or `snapo tweaks get NAME --all` to include previously adjusted ordinary or app-owned tweaks no longer in composition; inactive historical snapshots are inspectable but not writable. Its tweaks workflow documents command selection and options. The CLI owns temporary local forwarding and cleanup; explicit remote ADB endpoints use direct smart-socket transport.
 
 ## Snap-O macOS app: an existing desktop inspector
 
@@ -67,7 +67,7 @@ The CLI and Snap-O macOS app own socket discovery, forwarding, and cleanup. The 
 
 ## Custom interfaces: browsers, Node, Swift, and Compose
 
-Build a custom surface when an existing CLI, desktop inspector, or in-app overlay does not match the desired controls or workflow. All external hosts should discover the tweak socket, establish an accessible ADB transport, read `/app` and `/tweaks`, send batched `PATCH /tweaks` value updates, invoke explicitly requested actions with `POST /tweaks/action`, and consume full active snapshots from `/tweaks/events`. Render actions without assuming `value` or `default`; disable invocation when `conflicted` is true. Request `/tweaks?include=adjusted` when a workflow needs every retained user value adjustment, including inactive declarations.
+Build a custom surface when an existing CLI, desktop inspector, or in-app overlay does not match the desired controls or workflow. All external hosts should discover the tweak socket, establish an accessible ADB transport, read `/app` and `/tweaks`, send batched `PATCH /tweaks` value updates, invoke explicitly requested actions with `POST /tweaks/action`, and consume full active snapshots from `/tweaks/events`. Render actions without assuming `value` or `default`; disable invocation when `conflicted` is true. Request `/tweaks?include=adjusted` when a workflow needs retained ordinary or app-owned adjustment snapshots, including inactive declarations.
 
 - A browser interface can use `fetch` and `EventSource` through a same-origin proxy; see [protocol.md](protocol.md) for browser transport restrictions.
 - A Node host or terminal tool can use built-in `fetch` for requests and parse the response body as a standard SSE stream.

--- a/skills/snap-o-tweaks/references/protocol.md
+++ b/skills/snap-o-tweaks/references/protocol.md
@@ -35,7 +35,7 @@ For remote ADB servers, an `adb forward` is local to the ADB server's host, not 
 | `GET /app` | JSON app metadata: `{"name":"Example","packageName":"com.example","protocolVersion":4}`. |
 | `GET /app/icon` | Optional application icon image; `404` if unavailable. Use its response `Content-Type` without assuming a particular format or size. |
 | `GET /tweaks` | Current active tweak and app-owned action descriptors. |
-| `GET /tweaks?include=adjusted` | Active descriptors plus all previously adjusted value tweaks retained outside composition. |
+| `GET /tweaks?include=adjusted` | Active descriptors plus previously adjusted ordinary or app-owned value snapshots retained outside composition. |
 | `PATCH /tweaks` | One update containing one or more named values. Version 3 and later apply valid entries and report individual errors. |
 | `POST /tweaks/action` | Invoke one explicitly registered parameterless app-owned action by name. |
 | `GET /tweaks/events` | Server-sent events containing complete current tweak and action snapshots. |
@@ -91,7 +91,7 @@ The tweak response has this shape:
 }
 ```
 
-In protocol version 4, only modified value tweaks include `"modified": true`. A missing `modified` field always means false; never infer version-4 status by comparing `value` and `default`. In versions 1, 2, and 3, `modified` is absent; compare `value` with `default` instead. Actions never include `modified`.
+In protocol version 4, only modified value tweaks include `"modified": true`. A missing `modified` field always means false, even when `value` differs from `default`; never infer version-4 status by comparing those fields. Registry-owned tweaks compare their current value with their default, while app-owned tweaks report whether their owner has an override. In versions 1, 2, and 3, `modified` is absent; compare `value` with `default` instead. Actions never include `modified`.
 
 The available value types are `int`, `float`, `boolean`, `color`, `string`, and `enum`. Preserve actual JSON types: booleans are not strings, integer values cannot be fractional, and floats accept whole or fractional finite numbers. Colors are strings in `#RRGGBB` or `#RRGGBBAA` format. Numeric descriptors may include `min`, `max`, and `step`; step alignment starts at `min`, or at `default` if there is no minimum. Actions use `"type":"action"` and have no `value`, `default`, or `options`.
 
@@ -99,9 +99,9 @@ Enum descriptors include a nonempty, ordered `options` array containing unique, 
 
 An action descriptor with `"conflicted":true` has multiple live registrations for the same name. It remains visible so clients can surface the conflict, but the server rejects invocation instead of choosing a callback, merging owners, or inventing unstable names. Register a shared action once at its owner, or use explicit, stable, unique names for distinct actions.
 
-Plain `GET /tweaks` includes only value and action declarations active in Compose. Add `?include=adjusted` to include every tweak successfully adjusted by the user, including retained descriptors whose declarations have since left composition. The expanded response uses the same descriptor shape and also includes current active tweaks and actions; actions have no adjustment history. Separate screens can reuse a value tweak name with different complete declarations; preserve every returned descriptor instead of deduplicating by name. A tweak that was adjusted and later reset can still appear with its default value. In version 4, use `"modified": true` to identify outstanding changes; a missing field always means false. Retention lasts for the current app process and is cleared with the registry; it is not persistent storage across app restarts.
+Plain `GET /tweaks` includes only value and action declarations active in Compose. An app-owned tweak's first observation initializes its value and modification status on the Android main thread; subsequent inspector requests read an immutable cached snapshot without accessing its source. Add `?include=adjusted` to include ordinary or app-owned tweaks successfully adjusted through the inspector, including immutable snapshots whose declarations have since left composition. Each snapshot preserves its complete descriptor, effective value, and authoritative modification status; app-owned sources, callbacks, and observers are not retained, and values are not replayed into returning sources. Untouched tweaks, no-op adjustments, and rejected updates do not create history. The expanded response also includes current active tweaks and actions; actions have no adjustment history. Separate screens can reuse a value tweak name with different complete declarations; preserve every returned descriptor instead of deduplicating by name. An active descriptor takes precedence over its matching historical snapshot. An adjusted tweak that was later reset can remain in the history without `modified`, even if its effective value differs from its captured default. Retention lasts for the current app process and is cleared with the registry.
 
-Names may contain spaces and `/`; send the entire name unchanged. Two active declarations of the same complete value descriptor observe the same value. Repeated value names in expanded results represent distinct complete descriptors; active-only snapshots and updates still resolve at most one currently active value descriptor per name. Historical descriptors are read-only while inactive: `PATCH /tweaks` still rejects their names until their declarations return. Separate active callbacks with the same action name are not interchangeable and are reported as conflicted.
+Names may contain spaces and `/`; send the entire name unchanged. Two active declarations of the same complete value descriptor observe the same value. App-owned sources with the same name must use the same setting and value type. The first active source handles their value, updates, resets, and modification status. Only its `observe()` flow is collected. When it leaves composition, the next active source takes over. Conflicts are not checked and can cause wrong values or runtime errors. Repeated value names in expanded results represent distinct complete descriptors; active-only snapshots and updates still resolve at most one currently active value descriptor per name. Historical descriptors are read-only while inactive: `PATCH /tweaks` still rejects their names until their declarations return. Separate active callbacks with the same action name are not interchangeable and are reported as conflicted.
 
 ### Update or reset values
 
@@ -131,7 +131,7 @@ curl -fsS -X PATCH "$base/tweaks" \
   -d '{"values":{"Motion/Enabled":null}}'
 ```
 
-A version-4 reset restores the original default. Reset all by sending `null` only for active, non-action descriptors with `"modified": true`. For versions 1, 2, and 3, compare each value with its default and reset changed values by sending their defaults. Actions cannot be patched or reset. There is no separate get-by-name, reset, delete, or grouping endpoint.
+A version-4 registry-owned reset restores its original default. An app-owned reset calls the source's `reset()` method and returns its current effective value, which may differ from the captured default. For version 4, reset all by sending `null` only for active, non-action descriptors with `"modified": true`. For versions 1, 2, and 3, compare each value with its default and reset changed values by sending their defaults. Actions cannot be patched or reset. There is no separate get-by-name, reset, delete, or grouping endpoint.
 
 ### Invoke an app-owned action
 

--- a/snapo-link-android/samples/demo-tweaks/src/main/java/com/openai/snapo/demo/tweaks/OverviewScreen.kt
+++ b/snapo-link-android/samples/demo-tweaks/src/main/java/com/openai/snapo/demo/tweaks/OverviewScreen.kt
@@ -1,5 +1,6 @@
 package com.openai.snapo.demo.tweaks
 
+import android.content.Context
 import androidx.compose.animation.core.FastOutSlowInEasing
 import androidx.compose.animation.core.FiniteAnimationSpec
 import androidx.compose.animation.core.animateFloatAsState
@@ -29,6 +30,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.State
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
 import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
@@ -39,6 +41,7 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.RectangleShape
 import androidx.compose.ui.graphics.Shape
 import androidx.compose.ui.layout.layout
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.semantics.Role
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
@@ -150,7 +153,15 @@ private fun TypographyDetails() {
 
 @Composable
 private fun MotionSection(dividerColor: Color) {
-    val isVisible by tweak(true, "Motion/Show")
+    val context = LocalContext.current
+    val settings = remember(context) {
+        context.getSharedPreferences("snapo_tweak_demo", Context.MODE_PRIVATE)
+    }
+    val isVisible by settings.tweak(
+        key = "motion_show",
+        default = true,
+        name = "Motion/Show",
+    )
     if (isVisible) {
         HorizontalDivider(color = dividerColor)
         MotionPreview()

--- a/snapo-link-android/samples/demo-tweaks/src/main/java/com/openai/snapo/demo/tweaks/SharedPreferencesBooleanSource.kt
+++ b/snapo-link-android/samples/demo-tweaks/src/main/java/com/openai/snapo/demo/tweaks/SharedPreferencesBooleanSource.kt
@@ -1,0 +1,51 @@
+package com.openai.snapo.demo.tweaks
+
+import android.content.SharedPreferences
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.State
+import androidx.compose.runtime.remember
+import com.openai.snapo.tweaks.TweakSource
+import com.openai.snapo.tweaks.tweak
+import kotlinx.coroutines.channels.awaitClose
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.callbackFlow
+
+internal class SharedPreferencesBooleanSource(
+    private val preferences: SharedPreferences,
+    private val key: String,
+    private val default: Boolean,
+) : TweakSource<Boolean> {
+
+    override var value: Boolean
+        get() = preferences.getBoolean(key, default)
+        set(value) {
+            preferences.edit().putBoolean(key, value).apply()
+        }
+
+    override val isModified: Boolean
+        get() = preferences.contains(key)
+
+    override fun reset() {
+        preferences.edit().remove(key).apply()
+    }
+
+    override fun observe(): Flow<Unit> = callbackFlow {
+        val listener = SharedPreferences.OnSharedPreferenceChangeListener { _, changedKey ->
+            if (changedKey == key || changedKey == null) trySend(Unit)
+        }
+        preferences.registerOnSharedPreferenceChangeListener(listener)
+        awaitClose { preferences.unregisterOnSharedPreferenceChangeListener(listener) }
+    }
+}
+
+@Composable
+internal fun SharedPreferences.tweak(
+    key: String,
+    default: Boolean,
+    name: String = key,
+): State<Boolean> {
+    val source = remember(this, key, default) {
+        SharedPreferencesBooleanSource(this, key, default)
+    }
+    return tweak(source, name)
+}

--- a/snapo-link-android/samples/demo-tweaks/src/main/java/com/openai/snapo/demo/tweaks/SharedScreen.kt
+++ b/snapo-link-android/samples/demo-tweaks/src/main/java/com/openai/snapo/demo/tweaks/SharedScreen.kt
@@ -1,5 +1,7 @@
 package com.openai.snapo.demo.tweaks
 
+import android.content.Context
+import android.content.SharedPreferences
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
@@ -16,15 +18,23 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import com.openai.snapo.tweaks.tweak
 
+private const val SharedHighlightKey = "shared_highlight"
+
 @Composable
 internal fun SharedScreen(modifier: Modifier) {
     val dividerColor = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.12f)
+    val context = LocalContext.current
+    val settings = remember(context) {
+        context.getSharedPreferences("snapo_tweak_demo", Context.MODE_PRIVATE)
+    }
 
     LazyColumn(
         modifier = modifier,
@@ -41,22 +51,27 @@ internal fun SharedScreen(modifier: Modifier) {
                     fontWeight = FontWeight.SemiBold,
                 )
                 Text(
-                    text = "Every row observes the same corner radius.",
+                    text = "Every row shares the same corner radius and highlight setting.",
                     style = MaterialTheme.typography.bodyMedium,
                     color = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.7f),
                 )
             }
         }
         items(count = 24) { index ->
-            SharedPropertyRow(index)
+            SharedPropertyRow(index, settings)
             HorizontalDivider(color = dividerColor)
         }
     }
 }
 
 @Composable
-private fun SharedPropertyRow(index: Int) {
+private fun SharedPropertyRow(index: Int, settings: SharedPreferences) {
     val cornerRadius by tweak(12, "Shared/Corner radius", 0..24, step = 1)
+    val isHighlighted by settings.tweak(
+        key = SharedHighlightKey,
+        default = true,
+        name = "Shared/Highlight",
+    )
 
     Row(
         modifier = Modifier
@@ -70,7 +85,7 @@ private fun SharedPropertyRow(index: Int) {
                 .size(width = 64.dp, height = 48.dp)
                 .background(
                     color = MaterialTheme.colorScheme.primary.copy(
-                        alpha = 0.4f + (index % 4) * 0.15f,
+                        alpha = if (isHighlighted) 0.4f + (index % 4) * 0.15f else 0.12f,
                     ),
                     shape = RoundedCornerShape(cornerRadius.dp),
                 ),

--- a/snapo-link-android/tweaks-noop/build.gradle.kts
+++ b/snapo-link-android/tweaks-noop/build.gradle.kts
@@ -19,4 +19,5 @@ dependencies {
     api(platform(libs.androidx.compose.bom))
     api("androidx.compose.runtime:runtime")
     api(libs.androidx.compose.ui.graphics)
+    api(libs.kotlinx.coroutines.core)
 }

--- a/snapo-link-android/tweaks-noop/src/main/java/com/openai/snapo/tweaks/TweakSource.kt
+++ b/snapo-link-android/tweaks-noop/src/main/java/com/openai/snapo/tweaks/TweakSource.kt
@@ -1,0 +1,23 @@
+package com.openai.snapo.tweaks
+
+import kotlinx.coroutines.flow.Flow
+
+/**
+ * An application-owned tweak whose changes can be observed while it is active.
+ *
+ * Snap-O reads and writes [value], reads [isModified], calls [reset], and collects [observe]
+ * on the Android main thread.
+ */
+interface TweakSource<T : Any> {
+    /** The current application-owned value, read only when its value is needed. */
+    var value: T
+
+    /** Whether this source currently has an application-owned override. */
+    val isModified: Boolean
+
+    /** Removes this source's override without changing unrelated values. */
+    fun reset()
+
+    /** Emits whenever [value] or [isModified] may have changed while this source is selected. */
+    fun observe(): Flow<Unit>
+}

--- a/snapo-link-android/tweaks-noop/src/main/java/com/openai/snapo/tweaks/Tweaks.kt
+++ b/snapo-link-android/tweaks-noop/src/main/java/com/openai/snapo/tweaks/Tweaks.kt
@@ -4,8 +4,31 @@ package com.openai.snapo.tweaks
 
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.State
+import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberUpdatedState
 import androidx.compose.ui.graphics.Color
+
+/**
+ * Returns the current application-owned value without observing or modifying its source.
+ *
+ * In live builds, sources with the same name must use the same setting and value type.
+ * The first active source handles values, updates, resets, status, and observation.
+ * When it leaves, the next active source takes over.
+ * Conflicts are not checked and can cause wrong values or runtime errors.
+ */
+@Composable
+fun <T : Any> tweak(
+    source: TweakSource<T>,
+    name: String,
+): State<T> {
+    val latestSource = rememberUpdatedState(source)
+    return remember {
+        object : State<T> {
+            override val value: T
+                get() = latestSource.value.value
+        }
+    }
+}
 
 /** Returns observable release-build state for the current floating-point default. */
 @Composable

--- a/snapo-link-android/tweaks/build.gradle.kts
+++ b/snapo-link-android/tweaks/build.gradle.kts
@@ -19,6 +19,7 @@ dependencies {
     api(platform(libs.androidx.compose.bom))
     api("androidx.compose.runtime:runtime")
     api(libs.androidx.compose.ui.graphics)
+    api(libs.kotlinx.coroutines.core)
 
     testImplementation(libs.junit4)
 }

--- a/snapo-link-android/tweaks/src/main/java/com/openai/snapo/tweaks/SnapOTweaks.kt
+++ b/snapo-link-android/tweaks/src/main/java/com/openai/snapo/tweaks/SnapOTweaks.kt
@@ -17,7 +17,7 @@ import com.openai.snapo.tweaks.internal.TweaksRuntimePolicy
 object SnapOTweaks {
 
     /** Returns observable active tweaks in the order in which they entered composition. */
-    fun activeTweakEntries(): State<List<SnapOTweakEntry>> = TweakRegistry.activeEntries()
+    fun activeTweakEntries(): State<List<SnapOTweakEntry>> = TweakRegistry.activeEntries
 
     /** Returns active tweaks in the order in which they entered composition. */
     internal fun activeTweaks(): List<SnapOTweak> = TweakRegistry.snapshot().map { snapshot ->
@@ -52,11 +52,11 @@ object SnapOTweaks {
 class SnapOTweakEntry internal constructor(
     val name: String,
     val value: State<SnapOTweakValue>,
-    val defaultValue: SnapOTweakValue,
+    defaultValue: () -> SnapOTweakValue,
+    isModified: () -> Boolean,
 ) {
-    val modified: State<Boolean> = derivedStateOf {
-        value.value !is SnapOTweakValue.Action && value.value != defaultValue
-    }
+    val defaultValue: SnapOTweakValue by lazy(LazyThreadSafetyMode.NONE, defaultValue)
+    val modified: State<Boolean> = derivedStateOf(isModified)
 }
 
 /** A tweak currently available in the composed application. */

--- a/snapo-link-android/tweaks/src/main/java/com/openai/snapo/tweaks/TweakSource.kt
+++ b/snapo-link-android/tweaks/src/main/java/com/openai/snapo/tweaks/TweakSource.kt
@@ -1,0 +1,23 @@
+package com.openai.snapo.tweaks
+
+import kotlinx.coroutines.flow.Flow
+
+/**
+ * An application-owned tweak whose changes can be observed while it is active.
+ *
+ * Snap-O reads and writes [value], reads [isModified], calls [reset], and collects [observe]
+ * on the Android main thread.
+ */
+interface TweakSource<T : Any> {
+    /** The current application-owned value, read only when its value is needed. */
+    var value: T
+
+    /** Whether this source currently has an application-owned override. */
+    val isModified: Boolean
+
+    /** Removes this source's override without changing unrelated values. */
+    fun reset()
+
+    /** Emits whenever [value] or [isModified] may have changed while this source is selected. */
+    fun observe(): Flow<Unit>
+}

--- a/snapo-link-android/tweaks/src/main/java/com/openai/snapo/tweaks/Tweaks.kt
+++ b/snapo-link-android/tweaks/src/main/java/com/openai/snapo/tweaks/Tweaks.kt
@@ -2,15 +2,60 @@ package com.openai.snapo.tweaks
 
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.DisposableEffect
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.RememberObserver
 import androidx.compose.runtime.State
+import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberUpdatedState
+import androidx.compose.runtime.snapshotFlow
 import androidx.compose.ui.graphics.Color
+import com.openai.snapo.tweaks.internal.ExternalTweakBacking
+import com.openai.snapo.tweaks.internal.SelectedTweakState
 import com.openai.snapo.tweaks.internal.TweakDescriptor
 import com.openai.snapo.tweaks.internal.TweakRegistry
 import com.openai.snapo.tweaks.internal.TweakType
 import com.openai.snapo.tweaks.internal.TweaksRuntimePolicy
+import kotlinx.coroutines.flow.collect
+import kotlinx.coroutines.flow.collectLatest
+
+/**
+ * Exposes an application-owned Boolean, Int, Float, String, or Color tweak.
+ *
+ * The first observed value is the inspector default; edits, resets, and status remain app-owned.
+ * Sources with the same name must use the same setting and value type.
+ * The first active source handles values, updates, resets, status, and observation.
+ * When it leaves, the next active source takes over.
+ * Conflicts are not checked and can cause wrong values or runtime errors.
+ */
+@Composable
+fun <T : Any> tweak(
+    source: TweakSource<T>,
+    name: String,
+): State<T> {
+    val latestSource = rememberUpdatedState(source)
+    if (!TweaksRuntimePolicy.isAllowed) {
+        return remember(name) {
+            object : State<T> {
+                override val value: T
+                    get() = latestSource.value.value
+            }
+        }
+    }
+
+    val registration = remember(name) {
+        TweakRegistration(
+            ExternalTweakBinding(
+                name = name,
+                latestSource = latestSource,
+            ),
+        )
+    }
+
+    LaunchedEffect(name, source) { registration.observeSource(source) }
+
+    return registration
+}
 
 /** Exposes a floating-point tweak as observable state. */
 @Composable
@@ -143,7 +188,7 @@ fun TweakAction(
 }
 
 @Composable
-private fun <T> rememberTweakState(
+private fun <T : Any> rememberTweakState(
     descriptor: TweakDescriptor,
     default: T,
     decode: (Any) -> T,
@@ -155,20 +200,68 @@ private fun <T> rememberTweakState(
     rememberUpdatedState(default)
 }
 
-internal class TweakRegistration<T>(
-    private val descriptor: TweakDescriptor,
+internal suspend fun <T : Any> TweakRegistration<T>.observeSource(source: TweakSource<T>) {
+    updateObservedSource(source)
+    snapshotFlow { isSelected }.collectLatest { selected ->
+        if (selected) {
+            source.observe().collect { notifyChanged() }
+        }
+    }
+}
+
+internal class TweakRegistration<T : Any> private constructor(
+    private val name: String,
+    private val descriptor: TweakDescriptor?,
     private val decode: (Any) -> T,
+    private val externalBinding: ExternalTweakBinding<T>?,
 ) : RememberObserver, State<T> {
 
-    private val state: State<Any> = TweakRegistry.stateFor(descriptor)
+    constructor(descriptor: TweakDescriptor, decode: (Any) -> T) : this(
+        descriptor.name,
+        descriptor,
+        decode,
+        null,
+    )
+
+    constructor(externalBinding: ExternalTweakBinding<T>) : this(
+        externalBinding.name,
+        null,
+        externalBinding::decode,
+        externalBinding,
+    )
+
+    private val state: State<Any> = externalBinding
+        ?: TweakRegistry.stateFor(requireNotNull(descriptor))
+    private val externalState = externalBinding?.let { mutableStateOf<State<Any>>(it) }
+    private var observedSource: TweakSource<T>? = null
     private var registered = false
 
     override val value: T
-        get() = decode(state.value)
+        get() = decode((externalState?.value ?: state).value)
+
+    val isSelected: Boolean
+        get() = (externalState?.value as? SelectedTweakState)
+            ?.isSelected(requireNotNull(externalBinding)) == true
+
+    fun notifyChanged() {
+        val binding = externalBinding ?: return
+        (externalState?.value as? SelectedTweakState)?.notifyChanged(binding)
+    }
+
+    fun updateObservedSource(source: TweakSource<T>) {
+        val previous = observedSource
+        observedSource = source
+        if (previous !== null && previous !== source && isSelected) notifyChanged()
+    }
 
     override fun onRemembered() {
         if (!registered) {
-            TweakRegistry.register(descriptor)
+            if (externalBinding == null) {
+                TweakRegistry.register(requireNotNull(descriptor))
+            } else {
+                val registeredState = TweakRegistry.register(externalBinding)
+                requireNotNull(externalState).value = registeredState
+            }
             registered = true
         }
     }
@@ -179,8 +272,63 @@ internal class TweakRegistration<T>(
 
     private fun unregister() {
         if (registered) {
-            TweakRegistry.unregister(descriptor.name)
+            TweakRegistry.unregister(name, externalBinding)
             registered = false
         }
     }
+}
+
+internal class ExternalTweakBinding<T : Any>(
+    override val name: String,
+    private val latestSource: State<TweakSource<T>>,
+) : ExternalTweakBacking {
+
+    private var initialValuePending = true
+
+    override val descriptor: TweakDescriptor by lazy {
+        val initial = latestSource.value.value
+        TweakDescriptor(
+            name = name,
+            type = when (initial) {
+                is Boolean -> TweakType.BOOLEAN
+                is Int -> TweakType.INT
+                is Float -> TweakType.FLOAT
+                is String -> TweakType.STRING
+                is Color -> TweakType.COLOR
+                else -> throw IllegalArgumentException(
+                    "Unsupported tweak value type: ${initial.javaClass.name}. " +
+                        "Supported types are Boolean, Int, Float, String, and Color.",
+                )
+            },
+            default = encode(initial),
+        )
+    }
+
+    override val value: Any
+        get() = synchronized(this) {
+            val initial = descriptor.default
+            if (initialValuePending) {
+                initialValuePending = false
+                initial
+            } else {
+                encode(latestSource.value.value)
+            }
+        }
+
+    override fun onValueChange(value: Any) {
+        latestSource.value.value = decode(value)
+    }
+
+    override fun onReset() {
+        latestSource.value.reset()
+    }
+
+    override fun isModified(): Boolean = latestSource.value.isModified
+
+    @Suppress("UNCHECKED_CAST")
+    fun decode(value: Any): T =
+        if (value is TweakColorValue) value.color as T else value as T
+
+    private fun encode(value: T): Any =
+        if (value is Color) value.toTweakColorValue() else value
 }

--- a/snapo-link-android/tweaks/src/main/java/com/openai/snapo/tweaks/internal/TweakChangePublisher.kt
+++ b/snapo-link-android/tweaks/src/main/java/com/openai/snapo/tweaks/internal/TweakChangePublisher.kt
@@ -22,12 +22,13 @@ internal class TweakChangePublisher(
     fun subscribe(): Subscription = synchronized(lock) {
         check(!closed) { "The tweak change publisher is closed." }
 
+        val initial = snapshot()
         val id = nextSubscriptionId++
         val events = LinkedBlockingDeque<List<TweakSnapshot>>(1)
         subscriptions[id] = events
 
         Subscription(
-            initial = snapshot(),
+            initial = initial,
             events = events,
             onClose = { synchronized(lock) { subscriptions.remove(id) } },
         )
@@ -61,7 +62,7 @@ internal class TweakChangePublisher(
 
     private fun publish() {
         synchronized(lock) {
-            if (closed) {
+            if (closed || subscriptions.isEmpty()) {
                 publicationScheduled = false
                 return
             }

--- a/snapo-link-android/tweaks/src/main/java/com/openai/snapo/tweaks/internal/TweakHttpServer.kt
+++ b/snapo-link-android/tweaks/src/main/java/com/openai/snapo/tweaks/internal/TweakHttpServer.kt
@@ -75,7 +75,14 @@ internal class TweakHttpServer(
     private val lifecycleLock = Any()
     private val connectionPermits = Semaphore(MaximumConcurrentConnections)
     private val activeSockets = LinkedHashSet<LocalSocket>()
-    private val changePublisher = TweakChangePublisher(mainHandler::post)
+    private val changePublisher = TweakChangePublisher(
+        schedule = mainHandler::post,
+        snapshot = {
+            TweakRegistry.snapshot(
+                cachedOnly = Looper.myLooper() != Looper.getMainLooper(),
+            )
+        },
+    )
 
     @Volatile
     private var running = false
@@ -194,7 +201,13 @@ internal class TweakHttpServer(
     }
 
     private fun streamTweaks(output: OutputStream) {
-        changePublisher.subscribe().use { subscription ->
+        val subscription = try {
+            changePublisher.subscribe()
+        } catch (_: UninitializedTweakSnapshotException) {
+            runOnMainThread("snapshot", "loaded", changePublisher::subscribe)
+        }
+
+        subscription.use {
             output.write(
                 (
                     "HTTP/1.1 200 OK\r\n" +
@@ -263,7 +276,7 @@ internal class TweakHttpServer(
 
     private fun routeTweaks(request: HttpRequest): HttpResponse = when (request.method) {
         "GET" -> tweaksResponse(
-            TweakRegistry.snapshot(includeAdjusted = request.path != "/tweaks"),
+            snapshotForRequest(includeAdjusted = request.path != "/tweaks"),
             includeDescriptors = true,
         )
         "PATCH" -> {
@@ -482,6 +495,14 @@ internal class TweakHttpServer(
 
     private fun updateOnMainThread(values: Map<String, Any?>): TweakBatchResult =
         runOnMainThread("update", "applied") { applyTweakBatch(values) }
+
+    private fun snapshotForRequest(includeAdjusted: Boolean): List<TweakSnapshot> = try {
+        TweakRegistry.snapshot(includeAdjusted = includeAdjusted, cachedOnly = true)
+    } catch (_: UninitializedTweakSnapshotException) {
+        runOnMainThread("snapshot", "loaded") {
+            TweakRegistry.snapshot(includeAdjusted = includeAdjusted)
+        }
+    }
 
     private fun invokeActionOnMainThread(name: String) =
         runOnMainThread("action", "invoked") { TweakRegistry.invokeAction(name) }

--- a/snapo-link-android/tweaks/src/main/java/com/openai/snapo/tweaks/internal/TweakRegistry.kt
+++ b/snapo-link-android/tweaks/src/main/java/com/openai/snapo/tweaks/internal/TweakRegistry.kt
@@ -40,6 +40,25 @@ internal data class TweakSnapshot(
     val modified: Boolean,
 )
 
+internal class UninitializedTweakSnapshotException : IllegalStateException()
+
+internal interface ExternalTweakBacking : State<Any> {
+    val name: String
+    val descriptor: TweakDescriptor
+
+    fun onValueChange(value: Any)
+
+    fun onReset()
+
+    fun isModified(): Boolean
+}
+
+internal interface SelectedTweakState : State<Any> {
+    fun isSelected(owner: State<Any>): Boolean
+
+    fun notifyChanged(owner: State<Any>)
+}
+
 internal open class TweakUpdateException(
     val statusCode: Int,
     message: String,
@@ -64,9 +83,11 @@ internal object TweakRegistry {
     private val lock = Any()
     private val tweaks = LinkedHashMap<String, RegisteredTweak>()
     private val observedTweakOrder = HashMap<String, Long>()
-    private val adjustedTweaks = LinkedHashMap<TweakDescriptor, RegisteredTweak>()
+    private val adjustedTweaks = LinkedHashMap<TweakDescriptor, TweakSnapshot>()
     private val tweakStates = HashMap<TweakDescriptor, MutableState<Any>>()
-    private val activeEntries = mutableStateOf<List<SnapOTweakEntry>>(emptyList())
+    private val mutableActiveEntries = mutableStateOf<List<SnapOTweakEntry>>(emptyList())
+    val activeEntries: State<List<SnapOTweakEntry>>
+        get() = mutableActiveEntries
     private val observers = LinkedHashMap<Long, () -> Unit>()
     private var nextObserverId = 0L
     private var nextTweakOrder = 0L
@@ -76,28 +97,58 @@ internal object TweakRegistry {
         tweakStates.getOrPut(descriptor) { mutableStateOf(descriptor.default) }
     }
 
-    fun register(descriptor: TweakDescriptor): State<Any> {
+    fun register(descriptor: TweakDescriptor): State<Any> = registerBacking(
+        name = descriptor.name,
+        descriptorFactory = { descriptor },
+    )
+
+    fun register(backing: ExternalTweakBacking): State<Any> = registerBacking(
+        name = backing.name,
+        descriptorFactory = { backing.descriptor },
+        externalBacking = backing,
+    )
+
+    private fun registerBacking(
+        name: String,
+        descriptorFactory: () -> TweakDescriptor,
+        externalBacking: ExternalTweakBacking? = null,
+    ): State<Any> {
         var changed = false
         val state = synchronized(lock) {
-            require(descriptor.type != TweakType.ACTION) {
-                "Actions must be registered with their composition owner: ${descriptor.name}"
+            require(name.isNotBlank()) { "Tweak names must not be blank." }
+            val ownedDescriptor = if (externalBacking == null) {
+                descriptorFactory().also { descriptor ->
+                    require(descriptor.type != TweakType.ACTION) {
+                        "Actions must be registered with their composition owner: $name"
+                    }
+                    validateDescriptor(descriptor)
+                }
+            } else {
+                null
             }
-            validateDescriptor(descriptor)
 
-            val existing = tweaks[descriptor.name]
+            val existing = tweaks[name]
             if (existing != null) {
-                require(existing.descriptor == descriptor) {
-                    "Conflicting declarations for tweak: ${descriptor.name}"
+                require(
+                    existing.actionCallbacks == null &&
+                        (existing.externalBacking != null) == (externalBacking != null),
+                ) {
+                    "Conflicting declarations for tweak: $name"
+                }
+                if (externalBacking == null) {
+                    require(existing.descriptor == ownedDescriptor) {
+                        "Conflicting declarations for tweak: $name"
+                    }
+                } else {
+                    existing.addExternalBacking(externalBacking)
                 }
                 existing.references += 1
                 existing.state
             } else {
                 val tweak = RegisteredTweak(
-                    descriptor = descriptor,
-                    state = tweakStates.getOrPut(descriptor) {
-                        mutableStateOf(descriptor.default)
-                    },
-                    references = 1,
+                    name = name,
+                    descriptorFactory = { ownedDescriptor ?: descriptorFactory() },
+                    initialExternalBacking = externalBacking,
                 )
                 addRegisteredTweak(tweak)
                 changed = true
@@ -108,16 +159,29 @@ internal object TweakRegistry {
         return state
     }
 
-    fun unregister(name: String) {
+    fun unregister(name: String, state: State<Any>? = null) {
         val changed = synchronized(lock) {
             val tweak = tweaks[name] ?: return@synchronized false
+            val previousBacking = tweak.externalBacking
+            if (previousBacking != null && !tweak.removeExternalBacking(state)) {
+                return@synchronized false
+            }
+            if (state != null && previousBacking == null) return@synchronized false
             tweak.references -= 1
             if (tweak.references == 0) {
+                if (previousBacking != null && tweak.wasAdjusted) {
+                    val value = previousBacking.value
+                    adjustedTweaks[tweak.descriptor] = TweakSnapshot(
+                        descriptor = tweak.descriptor,
+                        value = value,
+                        modified = previousBacking.isModified(),
+                    )
+                }
                 tweaks.remove(name)
                 publishActiveEntries()
                 true
             } else {
-                false
+                previousBacking !== tweak.externalBacking
             }
         }
         if (changed) notifyObservers()
@@ -135,13 +199,13 @@ internal object TweakRegistry {
             val existing = tweaks[name]
             if (existing == null) {
                 val action = RegisteredTweak(
-                    descriptor = descriptor,
-                    state = mutableStateOf<Any>(SnapOTweakValue.Action()),
+                    name = name,
+                    descriptorFactory = { descriptor },
                     actionCallbacks = linkedMapOf(owner to onInvoke),
                 )
                 addRegisteredTweak(action)
             } else {
-                require(existing.descriptor.type == TweakType.ACTION) {
+                require(existing.actionCallbacks != null) {
                     "An action cannot share the name of a value tweak: $name"
                 }
                 val callbacks = requireNotNull(existing.actionCallbacks)
@@ -188,24 +252,20 @@ internal object TweakRegistry {
         callback()
     }
 
-    fun activeEntries(): State<List<SnapOTweakEntry>> = activeEntries
-
-    fun snapshot(includeAdjusted: Boolean = false): List<TweakSnapshot> = synchronized(lock) {
-        val registeredTweaks = if (includeAdjusted) {
-            (tweaks.values + adjustedTweaks.values)
-                .distinctBy(RegisteredTweak::descriptor)
-                .sortedBy { tweak -> observedTweakOrder.getValue(tweak.descriptor.name) }
-        } else {
-            tweaks.values
+    fun snapshot(
+        includeAdjusted: Boolean = false,
+        cachedOnly: Boolean = false,
+    ): List<TweakSnapshot> = synchronized(lock) {
+        val activeSnapshots = tweaks.values.map { tweak ->
+            tweak.snapshot(cachedOnly)
         }
 
-        registeredTweaks.map { tweak ->
-            val value = tweak.state.value
-            TweakSnapshot(
-                tweak.descriptor,
-                value,
-                tweak.descriptor.type != TweakType.ACTION && value != tweak.descriptor.default,
-            )
+        if (includeAdjusted) {
+            (activeSnapshots + adjustedTweaks.values)
+                .distinctBy(TweakSnapshot::descriptor)
+                .sortedBy { snapshot -> observedTweakOrder.getValue(snapshot.descriptor.name) }
+        } else {
+            activeSnapshots
         }
     }
 
@@ -222,27 +282,32 @@ internal object TweakRegistry {
                         "Actions cannot be patched. Invoke the registered action instead.",
                     )
                 }
-                tweak to (value?.let { validateValue(descriptor, it) } ?: descriptor.default)
+                tweak to value?.let { validateValue(descriptor, it) }
             }
 
             val changedTweaks = ArrayList<RegisteredTweak>()
             Snapshot.withMutableSnapshot {
                 changes.forEach { (tweak, value) ->
-                    if (tweak.state.value != value) {
-                        tweak.state.value = value
-                        changedTweaks.add(tweak)
-                        changed = true
+                    val previous = tweak.snapshot(cachedOnly = false)
+                    if (tweak.externalBacking != null ||
+                        previous.value != (value ?: tweak.descriptor.default)
+                    ) {
+                        tweak.update(value)
+                        if (tweak.snapshot(cachedOnly = false) != previous) {
+                            changedTweaks.add(tweak)
+                            changed = true
+                        }
                     }
                 }
             }
+            val updatedSnapshots = changes.map { (tweak, _) ->
+                tweak.snapshot(cachedOnly = false)
+            }
             changedTweaks.forEach { tweak ->
-                adjustedTweaks[tweak.descriptor] = tweak
+                adjustedTweaks[tweak.descriptor] = tweak.snapshot(cachedOnly = false)
+                tweak.wasAdjusted = true
             }
-
-            changes.map { (tweak, _) ->
-                val value = tweak.state.value
-                TweakSnapshot(tweak.descriptor, value, value != tweak.descriptor.default)
-            }
+            updatedSnapshots
         }
         if (changed) notifyObservers()
         return snapshots
@@ -281,11 +346,11 @@ internal object TweakRegistry {
     }
 
     private fun publishActiveEntries() {
-        activeEntries.value = tweaks.values.map(RegisteredTweak::entry)
+        mutableActiveEntries.value = tweaks.values.map(RegisteredTweak::entry)
     }
 
     private fun addRegisteredTweak(tweak: RegisteredTweak) {
-        val name = tweak.descriptor.name
+        val name = tweak.name
         val wasObserved = observedTweakOrder.containsKey(name)
         if (!wasObserved) {
             observedTweakOrder[name] = nextTweakOrder++
@@ -302,7 +367,8 @@ internal object TweakRegistry {
         val current = action.state.value as SnapOTweakValue.Action
         if (current.conflicted != conflicted) {
             Snapshot.withMutableSnapshot {
-                action.state.value = SnapOTweakValue.Action(conflicted)
+                @Suppress("UNCHECKED_CAST")
+                (action.state as MutableState<Any>).value = SnapOTweakValue.Action(conflicted)
             }
         }
     }
@@ -572,16 +638,125 @@ internal object TweakRegistry {
         else -> runCatching { BigDecimal(toString()) }.getOrNull()
     }
 
-    private data class RegisteredTweak(
-        val descriptor: TweakDescriptor,
-        val state: MutableState<Any>,
-        var references: Int = 0,
+    private class RegisteredTweak(
+        val name: String,
+        descriptorFactory: () -> TweakDescriptor,
+        initialExternalBacking: ExternalTweakBacking? = null,
         val actionCallbacks: LinkedHashMap<Any, () -> Unit>? = null,
     ) {
+        private val externalBackings = initialExternalBacking?.let { arrayListOf(it) }
+        private val selectedExternalBacking = initialExternalBacking?.let { mutableStateOf(it) }
+        private val externalSnapshot = initialExternalBacking?.let {
+            mutableStateOf<TweakSnapshot?>(null)
+        }
+
+        val externalBacking: ExternalTweakBacking?
+            get() = selectedExternalBacking?.value
+
+        val descriptor: TweakDescriptor by lazy {
+            (externalBacking?.descriptor ?: descriptorFactory()).also { descriptor ->
+                require(descriptor.name == name) {
+                    "Tweak descriptor name does not match its registration: $name"
+                }
+                if (externalBacking != null) validateDescriptor(descriptor)
+            }
+        }
+        val state: State<Any> = when {
+            selectedExternalBacking != null -> object : SelectedTweakState {
+                override val value: Any
+                    get() = snapshot(cachedOnly = false).value
+
+                override fun isSelected(owner: State<Any>): Boolean =
+                    selectedExternalBacking.value === owner
+
+                override fun notifyChanged(owner: State<Any>) {
+                    val selected = synchronized(lock) {
+                        val active = tweaks[name] === this@RegisteredTweak && isSelected(owner)
+                        if (active && requireNotNull(externalSnapshot).value != null) {
+                            refreshExternalSnapshot()
+                        }
+                        active
+                    }
+                    if (selected) notifyObservers()
+                }
+            }
+            actionCallbacks != null -> mutableStateOf(SnapOTweakValue.Action())
+            else -> stateFor(descriptor)
+        }
+        var references = if (actionCallbacks == null) 1 else 0
+        var wasAdjusted = false
         val entry = SnapOTweakEntry(
-            name = descriptor.name,
+            name = name,
             value = derivedStateOf { descriptor.toSnapOTweakValue(state.value) },
-            defaultValue = descriptor.toSnapOTweakValue(descriptor.default),
+            defaultValue = { descriptor.toSnapOTweakValue(descriptor.default) },
+            isModified = when {
+                actionCallbacks != null -> { { false } }
+                selectedExternalBacking != null -> { { snapshot(cachedOnly = false).modified } }
+                else -> { { state.value != descriptor.default } }
+            },
         )
+
+        fun snapshot(cachedOnly: Boolean): TweakSnapshot {
+            val mirror = externalSnapshot
+            if (mirror != null) {
+                return mirror.value ?: if (cachedOnly) {
+                    throw UninitializedTweakSnapshotException()
+                } else {
+                    refreshExternalSnapshot()
+                }
+            }
+
+            val value = state.value
+            return TweakSnapshot(
+                descriptor,
+                value,
+                modified = actionCallbacks == null && value != descriptor.default,
+            )
+        }
+
+        fun addExternalBacking(backing: ExternalTweakBacking) {
+            requireNotNull(externalBackings).add(backing)
+        }
+
+        fun removeExternalBacking(state: State<Any>?): Boolean {
+            val backings = externalBackings ?: return false
+            val index = if (state == null) {
+                0
+            } else {
+                backings.indexOfFirst { backing -> backing === state }
+            }
+            if (index < 0) return false
+
+            backings.removeAt(index)
+            if (index == 0 && backings.isNotEmpty()) {
+                requireNotNull(selectedExternalBacking).value = backings.first()
+                if (requireNotNull(externalSnapshot).value != null) {
+                    refreshExternalSnapshot()
+                }
+            }
+            return true
+        }
+
+        fun update(value: Any?) {
+            val backing = externalBacking
+            if (backing == null) {
+                @Suppress("UNCHECKED_CAST")
+                (state as MutableState<Any>).value = value ?: descriptor.default
+            } else if (value == null) {
+                backing.onReset()
+                refreshExternalSnapshot()
+            } else {
+                backing.onValueChange(value)
+                refreshExternalSnapshot()
+            }
+        }
+
+        private fun refreshExternalSnapshot(): TweakSnapshot {
+            val backing = requireNotNull(externalBacking)
+            val value = backing.value
+            val snapshot = TweakSnapshot(descriptor, value, backing.isModified())
+            requireNotNull(externalSnapshot).value = snapshot
+            return snapshot
+        }
     }
 }

--- a/snapo-link-android/tweaks/src/test/java/com/openai/snapo/tweaks/SnapOTweaksTest.kt
+++ b/snapo-link-android/tweaks/src/test/java/com/openai/snapo/tweaks/SnapOTweaksTest.kt
@@ -1,5 +1,6 @@
 package com.openai.snapo.tweaks
 
+import androidx.compose.runtime.mutableStateOf
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.colorspace.ColorSpaces
 import com.openai.snapo.tweaks.internal.TweakDescriptor
@@ -131,6 +132,34 @@ class SnapOTweaksTest {
     }
 
     @Test
+    fun `overlay reset uses delegated owner reset and override status`() {
+        val name = "Settings/Delegated reset"
+        val override = mutableStateOf<Boolean?>(null)
+        TweakRegistry.register(
+            testTweakBinding(
+                name = name,
+                source = testTweakSource(
+                    read = { override.value ?: false },
+                    onValueChange = { override.value = it },
+                    onReset = { override.value = null },
+                    modified = { override.value != null },
+                ),
+            ),
+        )
+        val entry = SnapOTweaks.activeTweakEntries().value.single()
+
+        SnapOTweaks.update(name, SnapOTweakValue.Toggle(false))
+
+        assertEquals(true, entry.modified.value)
+        assertEquals(false, override.value)
+
+        SnapOTweaks.reset(name)
+
+        assertEquals(false, entry.modified.value)
+        assertEquals(null, override.value)
+    }
+
+    @Test
     fun `overlay updates remain available as adjusted history after leaving composition`() {
         val descriptor = TweakDescriptor(
             name = "Typography/Historical font size",
@@ -214,6 +243,31 @@ class SnapOTweaksTest {
         assertSame(entry, entries.value.single())
         assertSame(value, entry.value)
         assertEquals(SnapOTweakValue.Integer(20, 12, 32), value.value)
+    }
+
+    @Test
+    fun `observable entries defer and cache application owned defaults`() {
+        var defaultReads = 0
+        val value = mutableStateOf<SnapOTweakValue>(SnapOTweakValue.Toggle(true))
+        val entry = SnapOTweakEntry(
+            name = "Settings/Lazy default",
+            value = value,
+            defaultValue = {
+                defaultReads += 1
+                SnapOTweakValue.Toggle(false)
+            },
+            isModified = { value.value != SnapOTweakValue.Toggle(false) },
+        )
+
+        assertEquals("Settings/Lazy default", entry.name)
+        assertSame(value, entry.value)
+        assertEquals(0, defaultReads)
+
+        assertEquals(SnapOTweakValue.Toggle(false), entry.defaultValue)
+        assertEquals(1, defaultReads)
+
+        assertEquals(SnapOTweakValue.Toggle(false), entry.defaultValue)
+        assertEquals(1, defaultReads)
     }
 
     @Test

--- a/snapo-link-android/tweaks/src/test/java/com/openai/snapo/tweaks/TweakRegistrationTest.kt
+++ b/snapo-link-android/tweaks/src/test/java/com/openai/snapo/tweaks/TweakRegistrationTest.kt
@@ -1,5 +1,6 @@
 package com.openai.snapo.tweaks
 
+import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.snapshots.Snapshot
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.colorspace.ColorSpaces
@@ -240,6 +241,235 @@ class TweakRegistrationTest {
     }
 
     @Test
+    fun `the first application state read captures its default with one getter call`() {
+        var ownerValue = 16
+        var reads = 0
+        var secondaryReads = 0
+        val binding = testTweakBinding(
+            name = "Lifecycle lazy application state",
+            source = testTweakSource(
+                read = {
+                    reads += 1
+                    ownerValue
+                },
+                onValueChange = { ownerValue = it },
+                onReset = { ownerValue = 16 },
+                modified = { ownerValue != 16 },
+            ),
+        )
+        val registration = TweakRegistration(binding)
+        val secondary = TweakRegistration(
+            testTweakBinding(
+                name = binding.name,
+                source = testTweakSource(
+                    read = {
+                        secondaryReads += 1
+                        32
+                    },
+                ),
+            ),
+        )
+
+        assertEquals(0, reads)
+        registration.onRemembered()
+        secondary.onRemembered()
+
+        assertEquals(0, reads)
+        assertEquals(0, secondaryReads)
+        assertEquals(binding.name, TweakRegistry.activeEntries.value.single().name)
+        assertEquals(0, reads)
+        assertEquals(16, registration.value)
+        assertEquals(1, reads)
+        assertEquals(16, binding.descriptor.default)
+        assertEquals(1, reads)
+
+        ownerValue = 24
+        registration.notifyChanged()
+
+        assertEquals(24, registration.value)
+        assertEquals(2, reads)
+        assertEquals(16, binding.descriptor.default)
+        assertEquals(0, secondaryReads)
+
+        registration.onForgotten()
+
+        assertEquals(32, secondary.value)
+        assertEquals(1, secondaryReads)
+        secondary.onForgotten()
+    }
+
+    @Test
+    fun `externally backed registrations read and update application owned values`() {
+        var ownerValue = false
+        var secondaryValue = true
+        var setterCalls = 0
+        var secondarySetterCalls = 0
+        var secondaryResetCalls = 0
+        val state = testTweakBinding(
+            name = "Lifecycle application-owned tweak",
+            source = testTweakSource(
+                read = { ownerValue },
+                onValueChange = {
+                    setterCalls += 1
+                    ownerValue = it
+                },
+                onReset = { ownerValue = false },
+                modified = { ownerValue },
+            ),
+        )
+        val registration = TweakRegistration(state)
+        val secondary = TweakRegistration(
+            testTweakBinding(
+                name = state.name,
+                source = testTweakSource(
+                    read = { secondaryValue },
+                    onValueChange = {
+                        secondarySetterCalls += 1
+                        secondaryValue = it
+                    },
+                    onReset = {
+                        secondaryResetCalls += 1
+                        secondaryValue = true
+                    },
+                    modified = { !secondaryValue },
+                ),
+            ),
+        )
+
+        registration.onRemembered()
+        secondary.onRemembered()
+
+        assertEquals(false, secondary.value)
+
+        secondary.onForgotten()
+        secondary.onRemembered()
+
+        ownerValue = true
+        registration.notifyChanged()
+
+        assertEquals(true, secondary.value)
+
+        TweakRegistry.update(mapOf(state.descriptor.name to false))
+
+        assertEquals(1, setterCalls)
+
+        registration.onForgotten()
+
+        assertEquals(true, secondary.value)
+
+        val changed = TweakRegistry.update(mapOf(state.name to false)).single()
+
+        assertEquals(false, secondaryValue)
+        assertEquals(1, secondarySetterCalls)
+        assertEquals(true, changed.modified)
+
+        val reset = TweakRegistry.update(mapOf(state.name to null)).single()
+
+        assertEquals(true, secondaryValue)
+        assertEquals(1, secondaryResetCalls)
+        assertEquals(false, reset.modified)
+
+        secondary.onForgotten()
+        assertNoActiveTweaks()
+    }
+
+    @Test
+    fun `externally backed registrations use their latest owner source`() {
+        var firstOwner = 16
+        var secondOwner = 24
+        var firstResetCalls = 0
+        var secondResetCalls = 0
+        val latestSource = mutableStateOf(
+            testTweakSource(
+                read = { firstOwner },
+                onValueChange = { firstOwner = it },
+                onReset = {
+                    firstResetCalls += 1
+                    firstOwner = 16
+                },
+                modified = { firstOwner != 16 },
+            ),
+        )
+        val state = ExternalTweakBinding(
+            name = "Lifecycle latest source",
+            latestSource = latestSource,
+        )
+        val registration = TweakRegistration(state)
+        registration.onRemembered()
+
+        latestSource.value = testTweakSource(
+            read = { secondOwner },
+            onValueChange = { secondOwner = it },
+            onReset = {
+                secondResetCalls += 1
+                secondOwner = 24
+            },
+            modified = { secondOwner != 24 },
+        )
+
+        assertEquals(24, registration.value)
+
+        TweakRegistry.update(mapOf(state.descriptor.name to 32))
+
+        assertEquals(16, firstOwner)
+        assertEquals(32, secondOwner)
+        assertEquals(32, registration.value)
+        assertTrue(TweakRegistry.snapshot().single().modified)
+
+        val reset = TweakRegistry.update(mapOf(state.descriptor.name to null)).single()
+
+        assertEquals(0, firstResetCalls)
+        assertEquals(1, secondResetCalls)
+        assertEquals(24, secondOwner)
+        assertEquals(false, reset.modified)
+    }
+
+    @Test
+    fun `external tweak bindings support existing values and preserve exact colors`() {
+        val exactColor = Color(
+            red = 0.25f,
+            green = 0.5f,
+            blue = 0.75f,
+            alpha = 0.3f,
+            colorSpace = ColorSpaces.DisplayP3,
+        )
+        val supportedValues = listOf(
+            false to TweakType.BOOLEAN,
+            16 to TweakType.INT,
+            0.5f to TweakType.FLOAT,
+            "hello" to TweakType.STRING,
+            exactColor to TweakType.COLOR,
+        )
+
+        supportedValues.forEach { (default, type) ->
+            val state = ExternalTweakBinding(
+                name = "Lifecycle external $type",
+                latestSource = mutableStateOf(testTweakSource(read = { default })),
+            )
+
+            assertEquals(type, state.descriptor.type)
+            assertEquals(default, state.decode(state.value))
+            if (default is Color) {
+                assertEquals(default, (state.descriptor.default as TweakColorValue).color)
+            }
+        }
+    }
+
+    @Test
+    fun `unsupported externally backed value types fail with a clear error`() {
+        val binding = ExternalTweakBinding(
+            name = "Lifecycle unsupported external value",
+            latestSource = mutableStateOf(testTweakSource(read = { 16L })),
+        )
+        val error = assertThrows(IllegalArgumentException::class.java) {
+            binding.value
+        }
+
+        assertTrue(error.message.orEmpty().contains("java.lang.Long"))
+        assertTrue(error.message.orEmpty().contains("Boolean, Int, Float, String, and Color"))
+    }
+
+    @Test
     fun `new same-name registrations do not observe existing state during composition`() {
         val descriptor = descriptor()
         val existing = registration(descriptor)
@@ -410,7 +640,7 @@ class TweakRegistrationTest {
 
     private fun assertNoActiveTweaks() {
         assertTrue(TweakRegistry.snapshot().isEmpty())
-        assertTrue(TweakRegistry.activeEntries().value.isEmpty())
+        assertTrue(TweakRegistry.activeEntries.value.isEmpty())
         assertTrue(SnapOTweaks.activeTweaks().isEmpty())
         assertTrue(SnapOTweaks.activeTweakEntries().value.isEmpty())
     }

--- a/snapo-link-android/tweaks/src/test/java/com/openai/snapo/tweaks/TweakSourceObservationTest.kt
+++ b/snapo-link-android/tweaks/src/test/java/com/openai/snapo/tweaks/TweakSourceObservationTest.kt
@@ -1,0 +1,299 @@
+package com.openai.snapo.tweaks
+
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.snapshots.Snapshot
+import com.openai.snapo.tweaks.internal.TweakRegistry
+import kotlinx.coroutines.CoroutineStart
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.flow.emptyFlow
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.withTimeout
+import kotlinx.coroutines.yield
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class TweakSourceObservationTest {
+
+    @After
+    fun clearRegistry() {
+        TweakRegistry.clear()
+    }
+
+    @Test
+    fun `source observation follows the first owner and its promoted replacement`() = runBlocking {
+        var firstReads = 0
+        var secondReads = 0
+        val firstChanges = MutableSharedFlow<Unit>()
+        val secondChanges = MutableSharedFlow<Unit>()
+        val firstSource = testTweakSource(
+            read = {
+                firstReads += 1
+                false
+            },
+            changes = firstChanges,
+        )
+        val secondSource = testTweakSource(
+            read = { true.also { secondReads += 1 } },
+            changes = secondChanges,
+        )
+        val first = TweakRegistration(
+            ExternalTweakBinding("Lifecycle observed owner", mutableStateOf(firstSource)),
+        )
+        val second = TweakRegistration(
+            ExternalTweakBinding("Lifecycle observed owner", mutableStateOf(secondSource)),
+        )
+        first.onRemembered()
+        second.onRemembered()
+        val firstCollection = launch(start = CoroutineStart.UNDISPATCHED) {
+            first.observeSource(firstSource)
+        }
+        val secondCollection = launch(start = CoroutineStart.UNDISPATCHED) {
+            second.observeSource(secondSource)
+        }
+        firstChanges.awaitSubscriptions(1)
+
+        assertEquals(0, firstReads)
+        assertEquals(1, firstChanges.subscriptionCount.value)
+        assertEquals(0, secondChanges.subscriptionCount.value)
+
+        firstChanges.emit(Unit)
+        yield()
+
+        assertEquals(0, firstReads)
+        assertEquals(0, secondReads)
+
+        first.onForgotten()
+        Snapshot.sendApplyNotifications()
+        firstChanges.awaitSubscriptions(0)
+        secondChanges.awaitSubscriptions(1)
+
+        assertEquals(0, firstChanges.subscriptionCount.value)
+        assertEquals(1, secondChanges.subscriptionCount.value)
+        assertEquals(0, secondReads)
+
+        secondCollection.cancel()
+        secondChanges.awaitSubscriptions(0)
+
+        assertEquals(0, secondChanges.subscriptionCount.value)
+        second.onForgotten()
+        firstCollection.cancel()
+    }
+
+    @Test
+    fun `source observation publishes status changes without changing its value`() = runBlocking {
+        var modified = false
+        var reads = 0
+        var statusReads = 0
+        val changes = MutableSharedFlow<Unit>()
+        val owner = testTweakSource(
+            read = { false.also { reads += 1 } },
+            modified = { modified.also { statusReads += 1 } },
+            changes = changes,
+        )
+        val registration = TweakRegistration(
+            ExternalTweakBinding("Lifecycle observed status", mutableStateOf(owner)),
+        )
+        registration.onRemembered()
+        val collection = launch(start = CoroutineStart.UNDISPATCHED) {
+            registration.observeSource(owner)
+        }
+        changes.awaitSubscriptions(1)
+
+        assertEquals(0, reads)
+        assertEquals(0, statusReads)
+        assertEquals(false, registration.value)
+        assertEquals(1, reads)
+        assertEquals(1, statusReads)
+
+        var notifications = 0
+        val observer = TweakRegistry.observeChanges { notifications += 1 }
+
+        modified = true
+        changes.emit(Unit)
+        yield()
+
+        assertEquals(1, notifications)
+        assertEquals(false, registration.value)
+        assertTrue(TweakRegistry.snapshot().single().modified)
+        assertEquals(2, reads)
+        assertEquals(2, statusReads)
+
+        collection.cancel()
+        observer.close()
+        registration.onForgotten()
+    }
+
+    @Test
+    fun `replacing an observed source refreshes its cached value and status`() = runBlocking {
+        var firstReads = 0
+        var replacementReads = 0
+        var replacementStatusReads = 0
+        val firstChanges = MutableSharedFlow<Unit>()
+        val replacementChanges = MutableSharedFlow<Unit>()
+        val firstSource = testTweakSource(
+            read = { false.also { firstReads += 1 } },
+            changes = firstChanges,
+        )
+        val replacement = testTweakSource(
+            read = { true.also { replacementReads += 1 } },
+            modified = { true.also { replacementStatusReads += 1 } },
+            changes = replacementChanges,
+        )
+        val currentSource = mutableStateOf(firstSource)
+        val registration = TweakRegistration(
+            ExternalTweakBinding("Lifecycle replacement owner", currentSource),
+        )
+        registration.onRemembered()
+        var notifications = 0
+        val observer = TweakRegistry.observeChanges { notifications += 1 }
+        val firstCollection = launch(start = CoroutineStart.UNDISPATCHED) {
+            registration.observeSource(firstSource)
+        }
+        firstChanges.awaitSubscriptions(1)
+
+        assertEquals(0, notifications)
+        assertEquals(0, firstReads)
+        assertEquals(false, TweakRegistry.snapshot().single().value)
+        assertEquals(1, firstReads)
+
+        currentSource.value = replacement
+        firstCollection.cancel()
+        firstChanges.awaitSubscriptions(0)
+        val replacementCollection = launch(start = CoroutineStart.UNDISPATCHED) {
+            registration.observeSource(replacement)
+        }
+        replacementChanges.awaitSubscriptions(1)
+
+        assertEquals(1, notifications)
+        assertEquals(1, replacementReads)
+        assertEquals(1, replacementStatusReads)
+        val snapshot = TweakRegistry.snapshot().single()
+        assertEquals(true, snapshot.value)
+        assertTrue(snapshot.modified)
+        assertEquals(1, replacementReads)
+        assertEquals(1, replacementStatusReads)
+
+        replacementCollection.cancel()
+        observer.close()
+        registration.onForgotten()
+    }
+
+    @Test
+    fun `replacing and notifying an unobserved source does not initialize its owner`() = runBlocking {
+        var replacementReads = 0
+        var replacementStatusReads = 0
+        val firstChanges = MutableSharedFlow<Unit>()
+        val replacementChanges = MutableSharedFlow<Unit>()
+        val first = testTweakSource(read = { false }, changes = firstChanges)
+        val replacement = testTweakSource(
+            read = { true.also { replacementReads += 1 } },
+            modified = { true.also { replacementStatusReads += 1 } },
+            changes = replacementChanges,
+        )
+        val latestSource = mutableStateOf(first)
+        val registration = TweakRegistration(
+            ExternalTweakBinding("Lifecycle cold replacement", latestSource),
+        )
+        registration.onRemembered()
+        val firstCollection = launch(start = CoroutineStart.UNDISPATCHED) {
+            registration.observeSource(first)
+        }
+        firstChanges.awaitSubscriptions(1)
+        latestSource.value = replacement
+        firstCollection.cancel()
+        firstChanges.awaitSubscriptions(0)
+
+        val replacementCollection = launch(start = CoroutineStart.UNDISPATCHED) {
+            registration.observeSource(replacement)
+        }
+        replacementChanges.awaitSubscriptions(1)
+        replacementChanges.emit(Unit)
+        yield()
+
+        assertEquals(0, replacementReads)
+        assertEquals(0, replacementStatusReads)
+        assertEquals(true, registration.value)
+        assertEquals(1, replacementReads)
+        assertEquals(1, replacementStatusReads)
+
+        replacementCollection.cancel()
+        registration.onForgotten()
+    }
+
+    @Test
+    fun `owner edits and reset refresh the effective authoritative value`() {
+        var value = 3
+        var upstream = 3
+        var modified = false
+        val owner = testTweakSource(
+            read = { value },
+            onValueChange = { requested ->
+                value = requested.coerceIn(0, 10)
+                modified = true
+            },
+            onReset = {
+                value = upstream
+                modified = false
+            },
+            modified = { modified },
+        )
+        val name = "Lifecycle authoritative owner"
+        val registration = TweakRegistration(ExternalTweakBinding(name, mutableStateOf(owner)))
+        registration.onRemembered()
+
+        assertEquals(3, registration.value)
+
+        val edited = TweakRegistry.update(mapOf(name to 20)).single()
+
+        assertEquals(10, registration.value)
+        assertEquals(10, edited.value)
+        assertTrue(edited.modified)
+
+        upstream = 7
+        val reset = TweakRegistry.update(mapOf(name to null)).single()
+
+        assertEquals(7, registration.value)
+        assertEquals(7, reset.value)
+        assertEquals(false, reset.modified)
+
+        registration.onForgotten()
+    }
+}
+
+internal fun <T : Any> testTweakSource(
+    read: () -> T,
+    onValueChange: (T) -> Unit = {},
+    onReset: () -> Unit = {},
+    modified: () -> Boolean = { false },
+    changes: Flow<Unit> = emptyFlow(),
+): TweakSource<T> = object : TweakSource<T> {
+    override var value: T
+        get() = read()
+        set(updated) {
+            onValueChange(updated)
+        }
+
+    override val isModified: Boolean
+        get() = modified()
+
+    override fun reset() = onReset()
+
+    override fun observe(): Flow<Unit> = changes
+}
+
+internal fun <T : Any> testTweakBinding(
+    name: String,
+    source: TweakSource<T>,
+): ExternalTweakBinding<T> = ExternalTweakBinding(name, mutableStateOf(source))
+
+private suspend fun MutableSharedFlow<Unit>.awaitSubscriptions(expected: Int) {
+    withTimeout(1_000) {
+        while (subscriptionCount.value != expected) {
+            yield()
+        }
+    }
+}

--- a/snapo-link-android/tweaks/src/test/java/com/openai/snapo/tweaks/internal/TweakActionRegistryTest.kt
+++ b/snapo-link-android/tweaks/src/test/java/com/openai/snapo/tweaks/internal/TweakActionRegistryTest.kt
@@ -40,9 +40,9 @@ class TweakActionRegistryTest {
         assertEquals(false, snapshots[1].modified)
         assertEquals(
             SnapOTweakValue.Action(),
-            TweakRegistry.activeEntries().value[1].value.value,
+            TweakRegistry.activeEntries.value[1].value.value,
         )
-        assertEquals(false, TweakRegistry.activeEntries().value[1].modified.value)
+        assertEquals(false, TweakRegistry.activeEntries.value[1].modified.value)
     }
 
     @Test
@@ -78,7 +78,7 @@ class TweakActionRegistryTest {
         )
         assertEquals(
             SnapOTweakValue.Action(conflicted = true),
-            TweakRegistry.activeEntries().value.single().value.value,
+            TweakRegistry.activeEntries.value.single().value.value,
         )
     }
 
@@ -98,7 +98,7 @@ class TweakActionRegistryTest {
         assertEquals(SnapOTweakValue.Action(), TweakRegistry.snapshot().single().value)
         assertEquals(
             SnapOTweakValue.Action(),
-            TweakRegistry.activeEntries().value.single().value.value,
+            TweakRegistry.activeEntries.value.single().value.value,
         )
 
         TweakRegistry.invokeAction("Playback/Restart")
@@ -116,15 +116,15 @@ class TweakActionRegistryTest {
             }
         }
         TweakRegistry.registerAction("Playback/Restart") {}
-        val entry = TweakRegistry.activeEntries().value.single()
+        val entry = TweakRegistry.activeEntries.value.single()
 
         val duplicateRegistration = TweakRegistry.registerAction("Playback/Restart") {}
 
-        assertSame(entry, TweakRegistry.activeEntries().value.single())
+        assertSame(entry, TweakRegistry.activeEntries.value.single())
 
         duplicateRegistration.close()
 
-        assertSame(entry, TweakRegistry.activeEntries().value.single())
+        assertSame(entry, TweakRegistry.activeEntries.value.single())
         assertEquals(listOf(false, true, false), conflicts)
         observer.close()
     }

--- a/snapo-link-android/tweaks/src/test/java/com/openai/snapo/tweaks/internal/TweakChangePublisherTest.kt
+++ b/snapo-link-android/tweaks/src/test/java/com/openai/snapo/tweaks/internal/TweakChangePublisherTest.kt
@@ -1,10 +1,15 @@
 package com.openai.snapo.tweaks.internal
 
+import androidx.compose.runtime.State
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.snapshots.Snapshot
+import kotlinx.coroutines.flow.collect
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.runBlocking
 import org.junit.After
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNull
+import org.junit.Assert.assertThrows
 import org.junit.Assert.assertTrue
 import org.junit.Test
 
@@ -24,6 +29,77 @@ class TweakChangePublisherTest {
             assertEquals(listOf("Typography/Size"), subscription.initial.names())
             assertNull(subscription.events.poll())
         }
+    }
+
+    @Test
+    fun `cold cached subscriptions fail without retaining a subscriber or reading owners`() {
+        var reads = 0
+        val owner = object : State<Any> {
+            override val value: Any
+                get() = false.also { reads += 1 }
+        }
+        TweakRegistry.register(booleanBacking("Settings/Cold cached hints", owner))
+        val scheduled = mutableListOf<Runnable>()
+        val publisher = TweakChangePublisher(
+            schedule = { runnable -> scheduled.add(runnable) },
+            snapshot = { TweakRegistry.snapshot(cachedOnly = true) },
+        )
+
+        assertThrows(UninitializedTweakSnapshotException::class.java) {
+            publisher.subscribe()
+        }
+        publisher.notifyChanged()
+
+        assertEquals(0, reads)
+        assertTrue(scheduled.isEmpty())
+
+        TweakRegistry.snapshot()
+        publisher.subscribe().use { subscription ->
+            assertEquals(false, subscription.initial.single().value)
+        }
+        assertEquals(1, reads)
+    }
+
+    @Test
+    fun `lazy tweak registrations wait for scheduled publication`() {
+        var reads = 0
+        val initialValue = lazy {
+            reads += 1
+            false
+        }
+        val state = object : State<Any> {
+            override val value: Any
+                get() = initialValue.value
+        }
+        val scheduled = mutableListOf<Runnable>()
+        val publisher = TweakChangePublisher { runnable -> scheduled.add(runnable) }
+        val observer = TweakRegistry.observeChanges(publisher::notifyChanged)
+
+        publisher.subscribe().use { subscription ->
+            TweakRegistry.register(
+                booleanBacking(
+                    name = "Settings/Show hints later",
+                    owner = state,
+                    descriptorFactory = {
+                        TweakDescriptor(
+                            "Settings/Show hints later",
+                            TweakType.BOOLEAN,
+                            initialValue.value,
+                        )
+                    },
+                ),
+            )
+
+            assertEquals(0, reads)
+            assertEquals(1, scheduled.size)
+
+            scheduled.single().run()
+
+            assertEquals(1, reads)
+            assertEquals(false, subscription.events.poll()?.single()?.value)
+        }
+
+        observer.close()
     }
 
     @Test
@@ -221,6 +297,76 @@ class TweakChangePublisherTest {
     }
 
     @Test
+    fun `selected owner flow emissions publish external values and override status`() = runBlocking {
+        var current = false
+        var modified = false
+        var reads = 0
+        val owner = object : State<Any> {
+            override val value: Any
+                get() = current.also { reads += 1 }
+        }
+        val backing = booleanBacking(
+            name = "Settings/Observable hints",
+            owner = owner,
+            modified = { modified },
+        )
+        val selected = TweakRegistry.register(backing) as SelectedTweakState
+        val scheduled = mutableListOf<Runnable>()
+        val publisher = TweakChangePublisher { runnable -> scheduled.add(runnable) }
+        val observer = TweakRegistry.observeChanges(publisher::notifyChanged)
+        assertEquals(0, reads)
+
+        publisher.subscribe().use { subscription ->
+            assertEquals(1, reads)
+            current = true
+            assertTrue(scheduled.isEmpty())
+
+            flowOf(Unit).collect { selected.notifyChanged(backing) }
+            scheduled.removeAt(0).run()
+
+            val update = requireNotNull(subscription.events.poll()).single()
+            assertEquals(true, update.value)
+            assertEquals(false, update.modified)
+
+            modified = true
+            flowOf(Unit).collect { selected.notifyChanged(backing) }
+            scheduled.removeAt(0).run()
+
+            val statusOnly = requireNotNull(subscription.events.poll()).single()
+            assertEquals(true, statusOnly.value)
+            assertEquals(true, statusOnly.modified)
+        }
+
+        val readsAfterClose = reads
+        current = false
+        flowOf(Unit).collect { selected.notifyChanged(backing) }
+        assertEquals(readsAfterClose + 1, reads)
+        assertEquals(false, TweakRegistry.snapshot(cachedOnly = true).single().value)
+        assertTrue(scheduled.isEmpty())
+        observer.close()
+    }
+
+    @Test
+    fun `queued publications do not read owners after the last subscriber leaves`() {
+        var reads = 0
+        val owner = object : State<Any> {
+            override val value: Any
+                get() = false.also { reads += 1 }
+        }
+        TweakRegistry.register(booleanBacking("Settings/Queued hints", owner))
+        val scheduled = mutableListOf<Runnable>()
+        val publisher = TweakChangePublisher { runnable -> scheduled.add(runnable) }
+        val subscription = publisher.subscribe()
+
+        publisher.notifyChanged()
+        subscription.close()
+        scheduled.removeAt(0).run()
+
+        assertEquals(1, reads)
+        assertTrue(scheduled.isEmpty())
+    }
+
+    @Test
     fun `unrelated compose state changes do not publish tweak snapshots`() {
         TweakRegistry.register(descriptor("Motion/Duration", 400))
         val scheduled = mutableListOf<Runnable>()
@@ -249,6 +395,26 @@ class TweakChangePublisherTest {
         type = TweakType.INT,
         default = default,
     )
+
+    private fun booleanBacking(
+        name: String,
+        owner: State<Any>,
+        modified: () -> Boolean = { false },
+        descriptorFactory: () -> TweakDescriptor = {
+            TweakDescriptor(name, TweakType.BOOLEAN, false)
+        },
+    ): ExternalTweakBacking = object : ExternalTweakBacking {
+        override val name: String = name
+        override val descriptor: TweakDescriptor by lazy(descriptorFactory)
+        override val value: Any
+            get() = owner.value
+
+        override fun onValueChange(value: Any) = Unit
+
+        override fun onReset() = Unit
+
+        override fun isModified(): Boolean = modified()
+    }
 
     private fun List<TweakSnapshot>.names(): List<String> = map { it.descriptor.name }
 }

--- a/snapo-link-android/tweaks/src/test/java/com/openai/snapo/tweaks/internal/TweakRegistryExternalBackingTest.kt
+++ b/snapo-link-android/tweaks/src/test/java/com/openai/snapo/tweaks/internal/TweakRegistryExternalBackingTest.kt
@@ -1,0 +1,781 @@
+package com.openai.snapo.tweaks.internal
+
+import androidx.compose.runtime.State
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.snapshots.Snapshot
+import com.openai.snapo.tweaks.SnapOTweakValue
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertSame
+import org.junit.Assert.assertThrows
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import java.util.IdentityHashMap
+import java.util.concurrent.atomic.AtomicReference
+
+class TweakRegistryExternalBackingTest {
+
+    private val ownerBackings = IdentityHashMap<State<Any>, ExternalTweakBacking>()
+
+    @After
+    fun clearRegistry() {
+        TweakRegistry.clear()
+        ownerBackings.clear()
+    }
+
+    @Test
+    fun `external tweaks read and update their application-owned state`() {
+        val descriptor = descriptor("External application-owned state")
+        val ownerState = mutableStateOf(false)
+        val state = register(
+            descriptor = descriptor,
+            state = ownerState,
+            onValueChange = { ownerState.value = it as Boolean },
+        )
+
+        assertEquals(false, state.value)
+        Snapshot.withMutableSnapshot { ownerState.value = true }
+        (state as SelectedTweakState).notifyChanged(ownerBackings.getValue(ownerState))
+        assertEquals(true, TweakRegistry.snapshot().single().value)
+        assertEquals(
+            SnapOTweakValue.Toggle(true),
+            TweakRegistry.activeEntries.value.single().value.value,
+        )
+
+        TweakRegistry.update(mapOf(descriptor.name to descriptor.default))
+        assertEquals(false, ownerState.value)
+    }
+
+    @Test
+    fun `updates report the effective value written by the application owner`() {
+        val descriptor = TweakDescriptor("External clamped value", TweakType.INT, 10)
+        val ownerState = mutableStateOf(10)
+        register(
+            descriptor = descriptor,
+            state = ownerState,
+            onValueChange = { ownerState.value = (it as Int).coerceAtMost(20) },
+        )
+
+        val updated = TweakRegistry.update(mapOf(descriptor.name to 30))
+
+        assertEquals(20, ownerState.value)
+        assertEquals(20, updated.single().value)
+    }
+
+    @Test
+    fun `snapshots report modified state for externally owned values and resets`() {
+        val descriptor = descriptor("External modified state")
+        val ownerState = mutableStateOf(false)
+        register(descriptor, ownerState) { ownerState.value = it as Boolean }
+
+        assertEquals(false, TweakRegistry.snapshot().single().modified)
+        val updated = TweakRegistry.update(mapOf(descriptor.name to true)).single()
+        assertEquals(true, updated.modified)
+
+        val reset = TweakRegistry.update(mapOf(descriptor.name to null)).single()
+
+        assertEquals(false, ownerState.value)
+        assertEquals(false, reset.modified)
+    }
+
+    @Test
+    fun `unknown reset names fail before changing any registered values`() {
+        val descriptor = descriptor("External atomic reset")
+        val ownerState = mutableStateOf(true)
+        register(descriptor, ownerState) { ownerState.value = it as Boolean }
+
+        assertThrows(UnknownTweakException::class.java) {
+            TweakRegistry.update(mapOf(descriptor.name to null, "External missing reset" to null))
+        }
+
+        assertEquals(true, ownerState.value)
+    }
+
+    @Test
+    fun `mixed resets and invalid writes fail before changing any registered values`() {
+        val resetDescriptor = descriptor("External mixed reset")
+        val updatedDescriptor = descriptor("External mixed update")
+        val resetState = mutableStateOf(true)
+        val updatedState = mutableStateOf(false)
+        register(resetDescriptor, resetState) { resetState.value = it as Boolean }
+        register(updatedDescriptor, updatedState) {
+            updatedState.value = it as Boolean
+        }
+
+        assertThrows(InvalidTweakValueException::class.java) {
+            TweakRegistry.update(
+                linkedMapOf(resetDescriptor.name to null, updatedDescriptor.name to "invalid"),
+            )
+        }
+
+        assertEquals(true, resetState.value)
+        assertEquals(false, updatedState.value)
+
+        TweakRegistry.unregister(resetDescriptor.name)
+        TweakRegistry.unregister(updatedDescriptor.name)
+
+        assertTrue(TweakRegistry.snapshot(includeAdjusted = true).isEmpty())
+    }
+
+    @Test
+    fun `failed source writes and resets do not block later batch entries`() {
+        val first = descriptor("Settings/First")
+        val failing = descriptor("Settings/Unavailable")
+        val last = descriptor("Settings/Last")
+        val firstOwner = mutableStateOf(false)
+        val failingOwner = mutableStateOf(false)
+        val lastOwner = mutableStateOf(false)
+        register(first, firstOwner) { firstOwner.value = it as Boolean }
+        register(failing, failingOwner) { error("Application owner details") }
+        register(last, lastOwner) { lastOwner.value = it as Boolean }
+        var notifications = 0
+        val observer = TweakRegistry.observeChanges { notifications += 1 }
+
+        val updated = applyTweakBatch(
+            linkedMapOf(first.name to true, failing.name to true, last.name to true),
+        )
+
+        assertEquals(listOf(first.name, last.name), updated.tweaks.map { it.descriptor.name })
+        assertEquals(
+            listOf(TweakBatchError(failing.name, "The tweak could not be updated.")),
+            updated.errors,
+        )
+        assertEquals(true, firstOwner.value)
+        assertEquals(false, failingOwner.value)
+        assertEquals(true, lastOwner.value)
+        assertEquals(2, notifications)
+
+        val reset = applyTweakBatch(
+            linkedMapOf(first.name to null, failing.name to null, last.name to null),
+        )
+
+        assertEquals(listOf(first.name, last.name), reset.tweaks.map { it.descriptor.name })
+        assertEquals(updated.errors, reset.errors)
+        assertEquals(false, firstOwner.value)
+        assertEquals(false, lastOwner.value)
+        assertEquals(4, notifications)
+        observer.close()
+        TweakRegistry.unregister(first.name)
+        TweakRegistry.unregister(failing.name)
+        TweakRegistry.unregister(last.name)
+        val history = TweakRegistry.snapshot(includeAdjusted = true)
+
+        assertEquals(listOf(first.name, last.name), history.map { it.descriptor.name })
+        assertTrue(history.none(TweakSnapshot::modified))
+    }
+
+    @Test
+    fun `external owners share the first registration and retain independent lifetimes`() {
+        val descriptor = descriptor("External owner identity")
+        val firstOwner = mutableStateOf(false)
+        val secondOwner = mutableStateOf(false)
+        val first = register(descriptor, firstOwner) {
+            firstOwner.value = it as Boolean
+        }
+        val shared = register(descriptor, firstOwner) {
+            firstOwner.value = it as Boolean
+        }
+        val second = register(descriptor, secondOwner) {
+            secondOwner.value = it as Boolean
+        }
+
+        assertSame(first, shared)
+        assertSame(first, second)
+        assertThrows(IllegalArgumentException::class.java) {
+            TweakRegistry.register(descriptor)
+        }
+
+        TweakRegistry.unregister(descriptor.name, ownerBackings.getValue(secondOwner))
+        TweakRegistry.unregister(descriptor.name)
+        assertEquals(1, TweakRegistry.snapshot().size)
+        TweakRegistry.unregister(descriptor.name)
+        assertTrue(TweakRegistry.snapshot().isEmpty())
+    }
+
+    @Test
+    fun `host writes retain detached immutable snapshots after their owner leaves`() {
+        val descriptor = descriptor("External owner lifecycle")
+        val ownerState = mutableStateOf(false)
+        register(descriptor, ownerState) {
+            ownerState.value = it as Boolean
+        }
+        var notifications = 0
+        val observer = TweakRegistry.observeChanges { notifications += 1 }
+
+        TweakRegistry.update(mapOf(descriptor.name to true))
+        assertEquals(1, notifications)
+        TweakRegistry.unregister(descriptor.name)
+        assertEquals(
+            listOf(TweakSnapshot(descriptor, true, modified = true)),
+            TweakRegistry.snapshot(includeAdjusted = true),
+        )
+
+        ownerState.value = false
+
+        assertEquals(
+            listOf(TweakSnapshot(descriptor, true, modified = true)),
+            TweakRegistry.snapshot(includeAdjusted = true),
+        )
+        assertThrows(UnknownTweakException::class.java) {
+            TweakRegistry.update(mapOf(descriptor.name to false))
+        }
+
+        observer.close()
+    }
+
+    @Test
+    fun `equal external writes still reach the application owner`() {
+        val descriptor = descriptor("External equal value")
+        val ownerState = mutableStateOf(false)
+        var writes = 0
+        register(descriptor, ownerState) {
+            writes += 1
+            ownerState.value = it as Boolean
+        }
+
+        val snapshot = TweakRegistry.update(mapOf(descriptor.name to false)).single()
+
+        assertEquals(1, writes)
+        assertEquals(false, snapshot.value)
+        assertEquals(false, snapshot.modified)
+
+        TweakRegistry.unregister(descriptor.name)
+
+        assertTrue(TweakRegistry.snapshot(includeAdjusted = true).isEmpty())
+    }
+
+    @Test
+    fun `owner modification status publishes even when the effective value does not change`() {
+        val name = "External override matching upstream"
+        val override = mutableStateOf<Boolean?>(null)
+        val state = object : State<Any> {
+            override val value: Any
+                get() = override.value ?: false
+        }
+        var writes = 0
+        var resets = 0
+        TweakRegistry.register(
+            backing(
+                name = name,
+                state = state,
+                descriptorFactory = { descriptor(name) },
+                onValueChange = {
+                    writes += 1
+                    override.value = it as Boolean
+                },
+                onReset = {
+                    resets += 1
+                    override.value = null
+                },
+                isModified = { override.value != null },
+            ),
+        )
+        val entry = TweakRegistry.activeEntries.value.single()
+        var notifications = 0
+        val observer = TweakRegistry.observeChanges { notifications += 1 }
+
+        assertEquals(false, entry.modified.value)
+
+        val updated = TweakRegistry.update(mapOf(name to false)).single()
+
+        assertEquals(1, writes)
+        assertEquals(false, updated.value)
+        assertEquals(true, updated.modified)
+        assertEquals(true, entry.modified.value)
+        assertEquals(1, notifications)
+
+        val reset = TweakRegistry.update(mapOf(name to null)).single()
+
+        assertEquals(1, resets)
+        assertEquals(false, reset.value)
+        assertEquals(false, reset.modified)
+        assertEquals(false, entry.modified.value)
+        assertEquals(2, notifications)
+        TweakRegistry.unregister(name)
+        assertEquals(
+            listOf(TweakSnapshot(descriptor(name), false, modified = false)),
+            TweakRegistry.snapshot(includeAdjusted = true),
+        )
+        observer.close()
+    }
+
+    @Test
+    fun `owner resets restore the current upstream value instead of the captured default`() {
+        val name = "External dynamic upstream"
+        val upstream = mutableStateOf(false)
+        val override = mutableStateOf<Boolean?>(null)
+        val state = object : State<Any> {
+            override val value: Any
+                get() = override.value ?: upstream.value
+        }
+        TweakRegistry.register(
+            backing(
+                name = name,
+                state = state,
+                descriptorFactory = { descriptor(name, state.value as Boolean) },
+                onValueChange = { override.value = it as Boolean },
+                onReset = { override.value = null },
+                isModified = { override.value != null },
+            ),
+        )
+        val initial = TweakRegistry.snapshot().single()
+        TweakRegistry.update(mapOf(name to true))
+        upstream.value = true
+
+        val reset = TweakRegistry.update(mapOf(name to null)).single()
+
+        assertEquals(false, initial.descriptor.default)
+        assertEquals(true, reset.value)
+        assertEquals(false, reset.modified)
+        assertEquals(null, override.value)
+
+        TweakRegistry.unregister(name)
+        upstream.value = false
+
+        assertEquals(
+            listOf(TweakSnapshot(initial.descriptor, true, modified = false)),
+            TweakRegistry.snapshot(includeAdjusted = true),
+        )
+    }
+
+    @Test
+    fun `lazy registrations and active entry membership never evaluate their owner`() {
+        val name = "External lazy registration"
+        val backing = CountingBacking(false)
+
+        val first = register(name, backing)
+        val shared = register(name, backing)
+
+        assertSame(first, shared)
+        val entries = TweakRegistry.activeEntries.value
+        assertEquals(listOf(name), entries.map { it.name })
+        assertSame(entries.single().modified, entries.single().modified)
+        assertEquals(0, backing.reads)
+
+        TweakRegistry.unregister(name)
+        TweakRegistry.unregister(name)
+        assertTrue(TweakRegistry.activeEntries.value.isEmpty())
+        assertEquals(0, backing.reads)
+        assertTrue(TweakRegistry.snapshot(includeAdjusted = true).isEmpty())
+        assertEquals(0, backing.reads)
+    }
+
+    @Test
+    fun `the first lazy snapshot shares one owner read with its descriptor`() {
+        val name = "External lazy snapshot"
+        val backing = CountingBacking(false)
+        val selected = register(name, backing) as SelectedTweakState
+
+        val snapshot = TweakRegistry.snapshot().single()
+
+        assertEquals(false, snapshot.descriptor.default)
+        assertEquals(false, snapshot.value)
+        assertEquals(1, backing.reads)
+
+        backing.current = true
+        selected.notifyChanged(backing)
+        assertEquals(true, TweakRegistry.snapshot().single().value)
+        assertEquals(2, backing.reads)
+    }
+
+    @Test
+    fun `cold cached snapshots do not access owner values or modification status`() {
+        val backing = CountingBacking(false)
+        val selected = register("External cold cached snapshot", backing) as SelectedTweakState
+
+        assertThrows(UninitializedTweakSnapshotException::class.java) {
+            TweakRegistry.snapshot(cachedOnly = true)
+        }
+        selected.notifyChanged(backing)
+
+        assertEquals(0, backing.reads)
+        assertEquals(0, backing.statusReads)
+    }
+
+    @Test
+    fun `warm cached snapshots can be read on workers without accessing their owners`() {
+        val backing = CountingBacking(false)
+        register("External warm worker snapshot", backing)
+        val initial = TweakRegistry.snapshot()
+        val workerSnapshot = AtomicReference<List<TweakSnapshot>>()
+
+        val worker = Thread {
+            workerSnapshot.set(TweakRegistry.snapshot(cachedOnly = true))
+        }
+        worker.start()
+        worker.join()
+
+        assertEquals(initial, workerSnapshot.get())
+        assertEquals(1, backing.reads)
+        assertEquals(1, backing.statusReads)
+    }
+
+    @Test
+    fun `selected owner notifications refresh cached values and modification status`() {
+        val backing = CountingBacking(false)
+        val selected = register("External mirrored owner status", backing) as SelectedTweakState
+        TweakRegistry.snapshot()
+        backing.current = true
+
+        selected.notifyChanged(backing)
+
+        val updated = TweakRegistry.snapshot(cachedOnly = true).single()
+        assertEquals(true, updated.value)
+        assertEquals(true, updated.modified)
+        assertEquals(2, backing.reads)
+        assertEquals(2, backing.statusReads)
+    }
+
+    @Test
+    fun `promotion immediately refreshes a previously initialized owner mirror`() {
+        val name = "External mirrored owner promotion"
+        val first = CountingBacking(false)
+        val second = CountingBacking(true)
+        val selected = register(name, first)
+        register(name, second)
+        TweakRegistry.snapshot()
+
+        TweakRegistry.unregister(name, first)
+
+        assertEquals(true, selected.value)
+        assertEquals(true, TweakRegistry.snapshot(cachedOnly = true).single().value)
+        assertEquals(1, first.reads)
+        assertEquals(1, second.reads)
+    }
+
+    @Test
+    fun `distinct lazy owners share their first registration without evaluating either owner`() {
+        val name = "External lazy sharing"
+        val first = CountingBacking(false)
+        val second = CountingBacking(false)
+        val firstState = register(name, first)
+        val secondState = register(name, second)
+
+        assertSame(firstState, secondState)
+
+        assertEquals(0, first.reads)
+        assertEquals(0, second.reads)
+    }
+
+    @Test
+    fun `owner change notifications follow the selected backing without reading values`() {
+        val name = "External observed owner selection"
+        val first = CountingBacking(false)
+        val second = CountingBacking(true)
+        val selected = register(name, first) as SelectedTweakState
+        register(name, second)
+        var notifications = 0
+        val observer = TweakRegistry.observeChanges { notifications += 1 }
+
+        assertTrue(selected.isSelected(first))
+        assertEquals(false, selected.isSelected(second))
+        selected.notifyChanged(second)
+        assertEquals(0, notifications)
+
+        selected.notifyChanged(first)
+        assertEquals(1, notifications)
+
+        TweakRegistry.unregister(name, first)
+        assertEquals(2, notifications)
+        assertEquals(false, selected.isSelected(first))
+        assertTrue(selected.isSelected(second))
+
+        selected.notifyChanged(first)
+        assertEquals(2, notifications)
+        selected.notifyChanged(second)
+        assertEquals(3, notifications)
+
+        TweakRegistry.unregister(name, second)
+        assertEquals(4, notifications)
+        selected.notifyChanged(second)
+        assertEquals(4, notifications)
+        assertEquals(0, first.reads)
+        assertEquals(0, second.reads)
+        observer.close()
+    }
+
+    @Test
+    fun `removing the selected owner promotes the next backing and its callbacks`() {
+        val name = "External owner promotion"
+        val descriptor = descriptor(name)
+        val firstOwner = mutableStateOf(false)
+        val secondOwner = mutableStateOf(true)
+        var firstWrites = 0
+        var secondWrites = 0
+        val first = register(descriptor, firstOwner) {
+            firstWrites += 1
+            firstOwner.value = it as Boolean
+        }
+        val shared = register(descriptor, secondOwner) {
+            secondWrites += 1
+            secondOwner.value = it as Boolean
+        }
+        val entry = TweakRegistry.activeEntries.value.single()
+
+        assertSame(first, shared)
+        assertEquals(false, shared.value)
+        assertEquals(false, entry.modified.value)
+
+        TweakRegistry.update(mapOf(name to true))
+
+        assertEquals(1, firstWrites)
+        assertEquals(0, secondWrites)
+        assertEquals(true, firstOwner.value)
+        assertEquals(true, entry.modified.value)
+
+        TweakRegistry.update(mapOf(name to null))
+
+        assertEquals(2, firstWrites)
+        assertEquals(0, secondWrites)
+        assertEquals(false, firstOwner.value)
+        assertEquals(false, entry.modified.value)
+
+        var notifications = 0
+        val observer = TweakRegistry.observeChanges { notifications += 1 }
+
+        TweakRegistry.unregister(name, ownerBackings.getValue(firstOwner))
+
+        assertEquals(1, notifications)
+        assertEquals(true, first.value)
+        assertEquals(true, shared.value)
+        assertEquals(true, entry.modified.value)
+        assertEquals(false, TweakRegistry.snapshot().single().descriptor.default)
+
+        TweakRegistry.update(mapOf(name to false))
+
+        assertEquals(2, firstWrites)
+        assertEquals(1, secondWrites)
+        assertEquals(false, secondOwner.value)
+        assertEquals(false, entry.modified.value)
+
+        TweakRegistry.update(mapOf(name to null))
+
+        assertEquals(2, secondWrites)
+        assertEquals(2, firstWrites)
+
+        TweakRegistry.unregister(name, ownerBackings.getValue(secondOwner))
+
+        assertTrue(TweakRegistry.snapshot().isEmpty())
+        assertEquals(
+            listOf(TweakSnapshot(descriptor, false, modified = false)),
+            TweakRegistry.snapshot(includeAdjusted = true),
+        )
+        observer.close()
+    }
+
+    @Test
+    fun `returning untouched owners do not replace their prior adjusted snapshot`() {
+        val descriptor = descriptor("External returning history")
+        val original = mutableStateOf(false)
+        register(descriptor, original) { original.value = it as Boolean }
+        TweakRegistry.update(mapOf(descriptor.name to true))
+        TweakRegistry.unregister(descriptor.name)
+
+        val replacement = mutableStateOf(false)
+        register(descriptor, replacement) { replacement.value = it as Boolean }
+
+        assertEquals(
+            listOf(TweakSnapshot(descriptor, false, modified = false)),
+            TweakRegistry.snapshot(includeAdjusted = true),
+        )
+
+        TweakRegistry.unregister(descriptor.name)
+
+        assertEquals(
+            listOf(TweakSnapshot(descriptor, true, modified = true)),
+            TweakRegistry.snapshot(includeAdjusted = true),
+        )
+    }
+
+    @Test
+    fun `owner and registry histories preserve same-name declarations independently`() {
+        val owned = descriptor("External mixed declaration history")
+        TweakRegistry.register(owned)
+        TweakRegistry.update(mapOf(owned.name to true))
+        TweakRegistry.unregister(owned.name)
+
+        val ownerDescriptor = descriptor(owned.name, default = true)
+        val owner = mutableStateOf(true)
+        register(ownerDescriptor, owner) { owner.value = it as Boolean }
+        TweakRegistry.update(mapOf(ownerDescriptor.name to false))
+
+        assertEquals(
+            listOf(
+                TweakSnapshot(ownerDescriptor, false, modified = true),
+                TweakSnapshot(owned, true, modified = true),
+            ),
+            TweakRegistry.snapshot(includeAdjusted = true),
+        )
+
+        TweakRegistry.unregister(ownerDescriptor.name)
+
+        assertEquals(
+            listOf(
+                TweakSnapshot(owned, true, modified = true),
+                TweakSnapshot(ownerDescriptor, false, modified = true),
+            ),
+            TweakRegistry.snapshot(includeAdjusted = true),
+        )
+    }
+
+    @Test
+    fun `clearing the registry discards detached owner history`() {
+        val descriptor = descriptor("External cleared history")
+        val owner = mutableStateOf(false)
+        register(descriptor, owner) { owner.value = it as Boolean }
+        TweakRegistry.update(mapOf(descriptor.name to true))
+        TweakRegistry.unregister(descriptor.name)
+
+        assertEquals(1, TweakRegistry.snapshot(includeAdjusted = true).size)
+
+        TweakRegistry.clear()
+
+        assertTrue(TweakRegistry.snapshot(includeAdjusted = true).isEmpty())
+    }
+
+    @Test
+    fun `removing a secondary owner preserves the primary without publishing`() {
+        val name = "External secondary owner removal"
+        val first = CountingBacking(false)
+        val second = CountingBacking(true)
+        register(name, first)
+        register(name, second)
+        var notifications = 0
+        val observer = TweakRegistry.observeChanges { notifications += 1 }
+
+        TweakRegistry.unregister(name, second)
+
+        assertEquals(0, notifications)
+        assertEquals(0, first.reads)
+        assertEquals(0, second.reads)
+        assertEquals(false, TweakRegistry.snapshot().single().value)
+
+        TweakRegistry.unregister(name, first)
+
+        assertEquals(1, notifications)
+        assertTrue(TweakRegistry.snapshot().isEmpty())
+        observer.close()
+    }
+
+    @Test
+    fun `promotion before first observation captures the surviving owners default`() {
+        val name = "External unobserved owner promotion"
+        val first = CountingBacking(false)
+        val second = CountingBacking(true)
+        register(name, first)
+        register(name, second)
+
+        TweakRegistry.unregister(name, first)
+
+        assertEquals(0, first.reads)
+        assertEquals(0, second.reads)
+
+        val snapshot = TweakRegistry.snapshot().single()
+
+        assertEquals(true, snapshot.descriptor.default)
+        assertEquals(true, snapshot.value)
+        assertEquals(0, first.reads)
+        assertEquals(1, second.reads)
+    }
+
+    @Test
+    fun `actions reject conflicting lazy owners without evaluating them`() {
+        val name = "Settings/Conflicting action"
+        val owner = CountingBacking(false)
+        val action = TweakRegistry.registerAction(name) {}
+
+        assertThrows(IllegalArgumentException::class.java) {
+            register(name, owner)
+        }
+
+        assertEquals(0, owner.reads)
+        action.close()
+    }
+
+    private fun register(name: String, backing: CountingBacking): State<Any> {
+        backing.name = name
+        return TweakRegistry.register(backing)
+    }
+
+    private fun register(
+        descriptor: TweakDescriptor,
+        state: State<Any>,
+        onValueChange: (Any) -> Unit,
+    ): State<Any> {
+        val backing = backing(
+            name = descriptor.name,
+            state = state,
+            descriptorFactory = { descriptor },
+            onValueChange = onValueChange,
+            onReset = { onValueChange(descriptor.default) },
+            isModified = { state.value != descriptor.default },
+        )
+        ownerBackings[state] = backing
+        return TweakRegistry.register(backing)
+    }
+
+    private fun backing(
+        name: String,
+        state: State<Any>,
+        descriptorFactory: () -> TweakDescriptor,
+        onValueChange: (Any) -> Unit,
+        onReset: () -> Unit,
+        isModified: () -> Boolean,
+    ): ExternalTweakBacking {
+        val updateOwner = onValueChange
+        val resetOwner = onReset
+        val ownerModified = isModified
+        return object : ExternalTweakBacking {
+            override val name: String = name
+            override val descriptor: TweakDescriptor by lazy(descriptorFactory)
+            override val value: Any
+                get() = state.value
+
+            override fun onValueChange(value: Any) = updateOwner(value)
+
+            override fun onReset() = resetOwner()
+
+            override fun isModified(): Boolean = ownerModified()
+        }
+    }
+
+    private fun descriptor(name: String, default: Boolean = false) = TweakDescriptor(
+        name = name,
+        type = TweakType.BOOLEAN,
+        default = default,
+    )
+
+    private class CountingBacking(initialValue: Boolean) : ExternalTweakBacking {
+        override lateinit var name: String
+        override val descriptor: TweakDescriptor by lazy {
+            TweakDescriptor(name, TweakType.BOOLEAN, initial)
+        }
+        var reads = 0
+        var statusReads = 0
+        var current = initialValue
+        val initial: Boolean by lazy {
+            reads += 1
+            current
+        }
+        private var initialValuePending = true
+
+        override val value: Any
+            get() = if (initialValuePending) {
+                initialValuePending = false
+                initial
+            } else {
+                reads += 1
+                current
+            }
+
+        override fun onValueChange(value: Any) {
+            current = value as Boolean
+        }
+
+        override fun onReset() {
+            current = initial
+        }
+
+        override fun isModified(): Boolean = (current != initial).also { statusReads += 1 }
+    }
+}

--- a/snapo-link-android/tweaks/src/test/java/com/openai/snapo/tweaks/internal/TweakRegistryLifecycleTest.kt
+++ b/snapo-link-android/tweaks/src/test/java/com/openai/snapo/tweaks/internal/TweakRegistryLifecycleTest.kt
@@ -80,14 +80,14 @@ class TweakRegistryLifecycleTest {
         )
         var notifications = 0
         val subscription = TweakRegistry.observeChanges { notifications += 1 }
-        val initialEntries = TweakRegistry.activeEntries().value
+        val initialEntries = TweakRegistry.activeEntries.value
 
         val state = TweakRegistry.stateFor(descriptor)
 
         assertEquals(16, state.value)
         assertEquals(0, notifications)
         assertTrue(TweakRegistry.snapshot().isEmpty())
-        assertSame(initialEntries, TweakRegistry.activeEntries().value)
+        assertSame(initialEntries, TweakRegistry.activeEntries.value)
         assertTrue(SnapOTweaks.activeTweaks().isEmpty())
         assertTrue(SnapOTweaks.activeTweakEntries().value.isEmpty())
 
@@ -114,7 +114,7 @@ class TweakRegistryLifecycleTest {
         assertEquals(16, TweakRegistry.stateFor(descriptor).value)
         assertEquals(0, notifications)
         assertTrue(TweakRegistry.snapshot().isEmpty())
-        assertTrue(TweakRegistry.activeEntries().value.isEmpty())
+        assertTrue(TweakRegistry.activeEntries.value.isEmpty())
         assertTrue(SnapOTweaks.activeTweaks().isEmpty())
         assertTrue(SnapOTweaks.activeTweakEntries().value.isEmpty())
 
@@ -167,7 +167,7 @@ class TweakRegistryLifecycleTest {
         TweakRegistry.unregister(descriptor.name)
 
         assertTrue(TweakRegistry.snapshot().isEmpty())
-        assertTrue(TweakRegistry.activeEntries().value.isEmpty())
+        assertTrue(TweakRegistry.activeEntries.value.isEmpty())
         assertSame(original, TweakRegistry.stateFor(descriptor))
         assertEquals(24, TweakRegistry.stateFor(descriptor).value)
 
@@ -385,7 +385,7 @@ class TweakRegistryLifecycleTest {
         )
         val replacement = outgoing.copy(default = 24)
         TweakRegistry.register(outgoing)
-        val activeEntries = TweakRegistry.activeEntries().value
+        val activeEntries = TweakRegistry.activeEntries.value
         var notifications = 0
         val observer = TweakRegistry.observeChanges { notifications += 1 }
 
@@ -393,14 +393,14 @@ class TweakRegistryLifecycleTest {
 
         assertEquals(24, replacementState.value)
         assertEquals(16, TweakRegistry.snapshot().single().value)
-        assertSame(activeEntries, TweakRegistry.activeEntries().value)
+        assertSame(activeEntries, TweakRegistry.activeEntries.value)
         assertEquals(listOf(outgoing.name), SnapOTweaks.activeTweaks().map { it.name })
         assertEquals(0, notifications)
 
         TweakRegistry.unregister(outgoing.name)
 
         assertTrue(TweakRegistry.snapshot().isEmpty())
-        assertTrue(TweakRegistry.activeEntries().value.isEmpty())
+        assertTrue(TweakRegistry.activeEntries.value.isEmpty())
         assertTrue(SnapOTweaks.activeTweaks().isEmpty())
         assertEquals(1, notifications)
         assertSame(replacementState, TweakRegistry.register(replacement))
@@ -465,7 +465,7 @@ class TweakRegistryLifecycleTest {
             type = TweakType.INT,
             default = 16,
         )
-        val entries = TweakRegistry.activeEntries()
+        val entries = TweakRegistry.activeEntries
         val state = TweakRegistry.register(descriptor)
         val registeredEntries = entries.value
         val entry = registeredEntries.single()
@@ -506,7 +506,7 @@ class TweakRegistryLifecycleTest {
 
         assertEquals(
             listOf(first.name, third.name),
-            TweakRegistry.activeEntries().value.map { it.name },
+            TweakRegistry.activeEntries.value.map { it.name },
         )
 
         TweakRegistry.register(second)
@@ -517,7 +517,7 @@ class TweakRegistryLifecycleTest {
         )
         assertEquals(
             listOf(first.name, second.name, third.name),
-            TweakRegistry.activeEntries().value.map { it.name },
+            TweakRegistry.activeEntries.value.map { it.name },
         )
     }
 
@@ -535,7 +535,7 @@ class TweakRegistryLifecycleTest {
 
         assertEquals(
             listOf(first.name, second.name),
-            TweakRegistry.activeEntries().value.map { it.name },
+            TweakRegistry.activeEntries.value.map { it.name },
         )
     }
 
@@ -552,7 +552,7 @@ class TweakRegistryLifecycleTest {
 
         assertEquals(
             listOf(second.name, first.name),
-            TweakRegistry.activeEntries().value.map { it.name },
+            TweakRegistry.activeEntries.value.map { it.name },
         )
     }
 
@@ -568,7 +568,7 @@ class TweakRegistryLifecycleTest {
 
         TweakRegistry.clear()
 
-        assertTrue(TweakRegistry.activeEntries().value.isEmpty())
+        assertTrue(TweakRegistry.activeEntries.value.isEmpty())
     }
 
     @Test


### PR DESCRIPTION
## Summary

- Add `TweakSource<T>` and `tweak(source, name)` for application-owned values, resets, modification status, and `Flow<Unit>` change notifications.
- Share same-name tweaks across composables and transfer ownership automatically when the selected source leaves composition.
- Initialize sources lazily on the Android main thread and serve subsequent inspector requests from immutable cached snapshots.
- Preserve adjusted history without retaining sources or replaying values into returning owners.
- Add a reusable SharedPreferences example, matching release no-op APIs, and focused lifecycle, ownership, observation, reset, history, and threading coverage.
- Preserve protocol version 4 resets, sparse modification status, and named best-effort batch errors.

## Verification

- Android: 232 unit tests, static checks, debug build, minified release build, and no-op release build.
- Web inspector: 124 tests.
- CLI: 109 tests.
- Browser panel: 47 tests.
- macOS application build.

## Notes

- Stacked on #234.
- Sources sharing a name must use the same setting and value type; conflicts are not checked.
- Sources emit whenever their effective value or modification status changes.
- The first inspection of an unobserved source may briefly wait for the Android main thread.
