### PR TITLE
Apply tweak batch updates independently

### DIFF
--- a/contracts/tweaks/README.md
+++ b/contracts/tweaks/README.md
@@ -37,11 +37,11 @@ Return the app's user-facing Android label, package name, and Tweaks protocol ve
 {
   "name": "Snap-O Tweaks Demo",
   "packageName": "com.openai.snapo.demo.tweaks",
-  "protocolVersion": 2
+  "protocolVersion": 3
 }
 ```
 
-Resolve `name` from the actual Android app label. An absent `protocolVersion` identifies the original version 1, which exposes value tweaks only. Version 2 adds action descriptors and `POST /tweaks/action`. The Tweaks protocol version is independent of the Network Inspector protocol version; hosts can use it to identify newer versions they do not support.
+Resolve `name` from the actual Android app label. An absent `protocolVersion` identifies the original version 1, which exposes value tweaks only. Version 2 adds action descriptors and `POST /tweaks/action`. Version 3 adds best-effort batch updates with per-item errors. The Tweaks protocol version is independent of the Network Inspector protocol version; hosts can use it to select compatible behavior.
 
 ### GET /app/icon
 
@@ -178,9 +178,9 @@ curl -fsS 'http://127.0.0.1:43817/tweaks?include=adjusted'
 
 The response uses the same `{"tweaks":[...]}` shape and complete tweak descriptors as `GET /tweaks`. Include every currently active tweak, whether or not it has been adjusted, and every inactive tweak whose value was actually changed by a successful user adjustment. Preserve the tweak's original declaration, constraints, and latest value after its final usage leaves composition. Separate screens may reuse a name with different declarations; include each independently adjusted complete descriptor, even when names repeat. Repeated names occur only for distinct complete descriptors; active-only listings and updates still resolve at most one active descriptor per name. Order names by first observation, regardless of later activation or adjustment. For repeated names, list the active declaration first, followed by historical declarations in stable adjustment order.
 
-An adjusted tweak remains in this history even after its value is reset to its default. An inactive tweak that was never changed, a no-op update that leaves its value unchanged, and a rejected or atomically rolled-back update do not create history entries. Adjustment history exists only for the current app process and is discarded when that process exits.
+An adjusted tweak remains in this history even after its value is reset to its default. An inactive tweak that was never changed, a no-op update that leaves its value unchanged, and a rejected update do not create history entries. Adjustment history exists only for the current app process and is discarded when that process exits.
 
-Historical inactive tweaks are read-only: `PATCH /tweaks` still accepts only currently active names and returns `404` for an inactive name. Actions appear while active but never create adjusted-history entries because they have no editable or retained value. Plain `GET /tweaks` and `GET /tweaks/events` remain active-only. The only supported query is exactly `include=adjusted` on `GET /tweaks`; unsupported, repeated, or additional query parameters and queries on other endpoints or methods return `400`.
+Historical inactive tweaks are read-only: `PATCH /tweaks` still accepts only currently active names. Versions 1 and 2 return `404` for an inactive name; later versions report a named per-item error. Actions appear while active but never create adjusted-history entries because they have no editable or retained value. Plain `GET /tweaks` and `GET /tweaks/events` remain active-only. The only supported query is exactly `include=adjusted` on `GET /tweaks`; unsupported, repeated, or additional query parameters and queries on other endpoints or methods return `400`.
 
 ### GET /tweaks/events
 
@@ -237,7 +237,23 @@ curl -fsS -X PATCH http://127.0.0.1:43817/tweaks \
 }
 ```
 
-Validate all values before changing any of them. Return `400` for malformed requests, `404` when an endpoint or requested tweak does not exist, `405` for an unsupported method, `413` for an oversized body, and `422` when a value has the wrong type, violates a constraint, or is not one of the declared enum option values. Errors use a small JSON body:
+In protocol version 3, each value is applied separately on the Android main thread. A valid request returns HTTP 200 with successful changes in `tweaks` and any rejected changes in `errors`; earlier successful changes are not rolled back. Each error contains only its tweak `name` and `error` message. The `errors` field is omitted when every change succeeds:
+
+```json
+{
+  "tweaks": [
+    { "name": "Font size", "value": 48 }
+  ],
+  "errors": [
+    {
+      "name": "Font weight",
+      "error": "Invalid value for Font weight: Expected an integer."
+    }
+  ]
+}
+```
+
+Return `400` for malformed requests, `404` when an endpoint does not exist, `405` for an unsupported method, `413` for an oversized body, and `422` for invalid numeric literals or nonprimitive values. In protocol versions 1 and 2, an unknown tweak returns `404`, an invalid value returns `422`, and the entire batch is rejected. In version 3, unknown tweaks, invalid values, and action targets are reported as per-item errors without preventing other changes. Request-level errors use a small JSON body:
 
 ```json
 {
@@ -245,7 +261,7 @@ Validate all values before changing any of them. Return `400` for malformed requ
 }
 ```
 
-Apply changes on the Android main thread. If any value is invalid, do not update any tweaks in that request. Reset a value by patching it with its default. Actions are not valid patch targets; attempting to patch one returns `422` without changing any value in the same request.
+Reset a value by patching it with its default. Actions are not valid patch targets. In version 3, an action target produces a named per-item error while other valid changes are applied.
 
 ### POST /tweaks/action
 

--- a/scripts/snapo
+++ b/scripts/snapo
@@ -1189,13 +1189,28 @@ def tweak_listing_path(options):
     return "/tweaks?include=adjusted" if options.all else "/tweaks"
 
 
+def require_successful_tweak_updates(document):
+    errors = document.get("errors", [])
+    if not isinstance(errors, list):
+        raise SnapOError("Snap-O tweaks server returned invalid update errors")
+    if not errors:
+        return
+
+    details = []
+    for error in errors:
+        if not isinstance(error, dict) or not isinstance(error.get("name"), str) or not isinstance(error.get("error"), str):
+            raise SnapOError("Snap-O tweaks server returned an invalid update error")
+        details.append(f"{error['name']}: {error['error']}")
+    raise SnapOError("Some tweak updates failed: " + "; ".join(details))
+
+
 def run_tweak_set(adb, options):
     server = choose_tweak_server(adb, options)
     with TweakConnection(adb, server) as connection:
         descriptors = tweak_descriptors(connection.request("GET", "/tweaks"))
         descriptor = find_tweak(descriptors, options.name)
         values = {options.name: parse_tweak_value(descriptor, options.value)}
-        connection.request("PATCH", "/tweaks", {"values": values})
+        require_successful_tweak_updates(connection.request("PATCH", "/tweaks", {"values": values}))
     return 0
 
 
@@ -1226,7 +1241,7 @@ def run_tweak_reset(adb, options):
                 raise SnapOError(f"Tweak '{descriptor['name']}' does not provide a default value")
             values[descriptor["name"]] = descriptor["default"]
         if values:
-            connection.request("PATCH", "/tweaks", {"values": values})
+            require_successful_tweak_updates(connection.request("PATCH", "/tweaks", {"values": values}))
     return 0
 
 

--- a/skills/snap-o-tweaks/SKILL.md
+++ b/skills/snap-o-tweaks/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: snap-o-tweaks
-description: Inspect, stream, and explicitly adjust live Android UI tweak values or invoke app-owned actions through Snap-O. Use when a request mentions Snap-O Tweaks, tweak-enabled Android apps, runtime UI parameters, Compose tweak or action controls, tweak discovery, previously adjusted or currently inactive tweaks, applying all user-made tweak changes, typed values, defaults or resets, atomic tweak batches, explicitly registered actions, the Tweaks REST/SSE API, or selecting between CLI, macOS inspector, in-app overlay, and custom tweak interfaces.
+description: Inspect, stream, and explicitly adjust live Android UI tweak values or invoke app-owned actions through Snap-O. Use when a request mentions Snap-O Tweaks, tweak-enabled Android apps, runtime UI parameters, Compose tweak or action controls, tweak discovery, previously adjusted or currently inactive tweaks, applying all user-made tweak changes, typed values, defaults or resets, tweak batches, explicitly registered actions, the Tweaks REST/SSE API, or selecting between CLI, macOS inspector, in-app overlay, and custom tweak interfaces.
 ---
 
 # Snap-O Tweaks
@@ -10,7 +10,7 @@ Inspect live values and app-owned actions exposed by a debug-enabled Android app
 ## Choose the interaction surface
 
 - **Agents, shells, automation, or CI:** Default to the shared `snapo` CLI; it requires only Python 3 and Android Platform Tools on macOS or Linux.
-- **Direct integration:** Use REST and server-sent events. See [references/protocol.md](references/protocol.md) for ADB forwarding, endpoints, typed values, atomic updates, and streaming.
+- **Direct integration:** Use REST and server-sent events. See [references/protocol.md](references/protocol.md) for ADB forwarding, endpoints, typed values, batched updates, and streaming.
 - **Desktop inspection:** Use Snap-O's macOS Tweaks inspector.
 - **In-app controls:** Integrate `SnapOTweakOverlay`.
 - **Custom interfaces:** Build a browser, native, or Compose UI; browsers require a same-origin proxy.

--- a/skills/snap-o-tweaks/references/interaction-surfaces.md
+++ b/skills/snap-o-tweaks/references/interaction-surfaces.md
@@ -4,7 +4,7 @@ The same active Compose tweak registry can be inspected from several surfaces. C
 
 ## Command line: agents, automation, and repeatable checks
 
-Use the dependency-free Snap-O CLI when a terminal, Codex agent, test script, or Linux/macOS workflow needs app discovery, typed value inspection or updates, atomic batches, resets, app-owned action invocation, or live snapshots. Invoke an explicitly requested action with `snapo tweaks action NAME`; actions have no editable value, default, or arguments. Use `snapo tweaks list --all` or `snapo tweaks get NAME --all` to include previously adjusted tweaks no longer in composition; inactive historical tweaks are inspectable but not writable. Its tweaks workflow documents command selection and options. The CLI owns temporary local forwarding and cleanup; explicit remote ADB endpoints use direct smart-socket transport.
+Use the dependency-free Snap-O CLI when a terminal, Codex agent, test script, or Linux/macOS workflow needs app discovery, typed value inspection or updates, batched changes, resets, app-owned action invocation, or live snapshots. Invoke an explicitly requested action with `snapo tweaks action NAME`; actions have no editable value, default, or arguments. Use `snapo tweaks list --all` or `snapo tweaks get NAME --all` to include previously adjusted tweaks no longer in composition; inactive historical tweaks are inspectable but not writable. Its tweaks workflow documents command selection and options. The CLI owns temporary local forwarding and cleanup; explicit remote ADB endpoints use direct smart-socket transport.
 
 ## Snap-O macOS app: an existing desktop inspector
 
@@ -67,7 +67,7 @@ The CLI and Snap-O macOS app own socket discovery, forwarding, and cleanup. The 
 
 ## Custom interfaces: browsers, Node, Swift, and Compose
 
-Build a custom surface when an existing CLI, desktop inspector, or in-app overlay does not match the desired controls or workflow. All external hosts should discover the tweak socket, establish an accessible ADB transport, read `/app` and `/tweaks`, send atomic `PATCH /tweaks` value updates, invoke explicitly requested actions with `POST /tweaks/action`, and consume full active snapshots from `/tweaks/events`. Render actions without assuming `value` or `default`; disable invocation when `conflicted` is true. Request `/tweaks?include=adjusted` when a workflow needs every retained user value adjustment, including inactive declarations.
+Build a custom surface when an existing CLI, desktop inspector, or in-app overlay does not match the desired controls or workflow. All external hosts should discover the tweak socket, establish an accessible ADB transport, read `/app` and `/tweaks`, send batched `PATCH /tweaks` value updates, invoke explicitly requested actions with `POST /tweaks/action`, and consume full active snapshots from `/tweaks/events`. Render actions without assuming `value` or `default`; disable invocation when `conflicted` is true. Request `/tweaks?include=adjusted` when a workflow needs every retained user value adjustment, including inactive declarations.
 
 - A browser interface can use `fetch` and `EventSource` through a same-origin proxy; see [protocol.md](protocol.md) for browser transport restrictions.
 - A Node host or terminal tool can use built-in `fetch` for requests and parse the response body as a standard SSE stream.

--- a/skills/snap-o-tweaks/references/protocol.md
+++ b/skills/snap-o-tweaks/references/protocol.md
@@ -32,17 +32,17 @@ For remote ADB servers, an `adb forward` is local to the ADB server's host, not 
 
 | Request | Result |
 | --- | --- |
-| `GET /app` | JSON app metadata: `{"name":"Example","packageName":"com.example","protocolVersion":2}`. |
+| `GET /app` | JSON app metadata: `{"name":"Example","packageName":"com.example","protocolVersion":3}`. |
 | `GET /app/icon` | Optional application icon image; `404` if unavailable. Use its response `Content-Type` without assuming a particular format or size. |
 | `GET /tweaks` | Current active tweak and app-owned action descriptors. |
 | `GET /tweaks?include=adjusted` | Active descriptors plus all previously adjusted value tweaks retained outside composition. |
-| `PATCH /tweaks` | One atomic update containing one or more named values. |
+| `PATCH /tweaks` | One update containing one or more named values. Version 3 applies valid entries and reports individual errors. |
 | `POST /tweaks/action` | Invoke one explicitly registered parameterless app-owned action by name. |
 | `GET /tweaks/events` | Server-sent events containing complete current tweak and action snapshots. |
 
 Ordinary responses close their connection and include a content length. The event response stays open and uses `Content-Type: text/event-stream`.
 
-`protocolVersion` is specific to Tweaks and independent of the Network Inspector protocol. Version 1 predates this field and supports only value tweaks; treat a missing version as 1. Version 2 adds app-owned action descriptors and `POST /tweaks/action`. A version newer than the host supports may require a compatibility warning.
+`protocolVersion` is specific to Tweaks and independent of the Network Inspector protocol. Version 1 predates this field and supports only value tweaks; treat a missing version as 1. Version 2 adds app-owned action descriptors and `POST /tweaks/action`. Version 3 adds best-effort batch updates with per-item errors. Use the reported version to select compatible update behavior.
 
 ### Read metadata and active values
 
@@ -98,7 +98,7 @@ Plain `GET /tweaks` includes only value and action declarations active in Compos
 
 Names may contain spaces and `/`; send the entire name unchanged. Two active declarations of the same complete value descriptor observe the same value. Repeated value names in expanded results represent distinct complete descriptors; active-only snapshots and updates still resolve at most one currently active value descriptor per name. Historical descriptors are read-only while inactive: `PATCH /tweaks` still rejects their names until their declarations return. Separate active callbacks with the same action name are not interchangeable and are reported as conflicted.
 
-### Update or reset values atomically
+### Update or reset values
 
 ```bash
 curl -fsS -X PATCH "$base/tweaks" \
@@ -112,7 +112,13 @@ The response contains the changed names and their resulting values:
 {"tweaks":[{"name":"Motion/Duration","value":550},{"name":"Motion/Enabled","value":false},{"name":"Appearance/Theme","value":"Dark"}]}
 ```
 
-Every value is validated before any update is applied. An invalid, unknown, or inactive entry prevents the entire batch from changing. Reset by fetching `GET /tweaks` and sending the target descriptor's `default` value back in a patch; reset all by patching every active value name to its own default in one request. Actions cannot be patched or reset and are excluded from reset-all. There is no separate get-by-name, reset, delete, or grouping endpoint.
+Protocol version 3 applies valid entries independently. Invalid, unknown, inactive, or action entries appear in `errors` with their tweak names and error messages, while successful changes remain applied:
+
+```json
+{"tweaks":[{"name":"Motion/Duration","value":550}],"errors":[{"name":"Motion/Enabled","error":"Invalid value for Motion/Enabled: Expected a boolean."}]}
+```
+
+The `errors` field is absent when every entry succeeds. Versions 1 and 2 reject the entire batch if any entry is invalid. Reset by fetching `GET /tweaks` and sending the target descriptor's `default` value back in a patch; reset all by patching every active value name to its own default in one request. Actions cannot be patched or reset and are excluded from reset-all. There is no separate get-by-name, reset, delete, or grouping endpoint.
 
 ### Invoke an app-owned action
 
@@ -168,6 +174,6 @@ These relative URLs assume your host serves both the page and the proxy. The And
 
 ## Errors and security
 
-Errors use `{"error":"description"}`. Expect `400` for malformed input, `404` for missing endpoints or inactive tweak names, `405` for unsupported methods, `409` for conflicting action registrations, `413` for oversized bodies, and `422` for invalid JSON value types, numeric bounds, numeric steps, color formats, or unknown enum option names.
+Request-level errors use `{"error":"description"}`. Expect `400` for malformed input, `404` for missing endpoints, `405` for unsupported methods, `409` for conflicting action registrations, `413` for oversized bodies, and `422` for invalid numeric literals or nonprimitive values. Versions 1 and 2 also return `404` for inactive tweaks and `422` for invalid values. Versions 3 and later report unknown or invalid tweaks as named per-item errors in an HTTP 200 response.
 
 The socket is app-local and normally enabled only when the Android app is debuggable. Release activation requires an explicit `snapo.tweaks.allow_release` manifest opt-in; release no-op artifacts are preferred. There is no HTTP bearer-token layer: access is controlled by the local socket and the connected ADB boundary. Do not expose a forwarded port or proxy publicly, and treat tweak names and values as potentially sensitive.

--- a/snapo-app-mac/Snap-O/NetworkInspector/NetworkInspectorBridgeModels.swift
+++ b/snapo-app-mac/Snap-O/NetworkInspector/NetworkInspectorBridgeModels.swift
@@ -103,8 +103,14 @@ struct TweakUpdate: Codable {
   let value: TweakValue
 }
 
+struct TweakUpdateError: Codable {
+  let name: String
+  let error: String
+}
+
 struct TweakUpdates: Codable {
   let tweaks: [TweakUpdate]
+  let errors: [TweakUpdateError]?
 }
 
 struct TweakPatch: Codable {

--- a/snapo-link-android/samples/demo-tweaks/panel/app.js
+++ b/snapo-link-android/samples/demo-tweaks/panel/app.js
@@ -24,9 +24,9 @@ const isAppGroupedMock = isMockMode &&
 
 const mockApps = [
   {
-    id: "mock:chatgpt",
-    name: "ChatGPT",
-    packageName: "com.openai.chatgpt",
+    id: "mock:notes",
+    name: "Notes Demo",
+    packageName: "com.example.notes",
     deviceName: "Pixel 9 Pro XL",
     views: ["network", "tweaks"],
   },
@@ -38,9 +38,9 @@ const mockApps = [
     views: ["tweaks"],
   },
   {
-    id: "mock:emulator:chatgpt",
-    name: "ChatGPT",
-    packageName: "com.openai.chatgpt",
+    id: "mock:emulator:notes",
+    name: "Notes Demo",
+    packageName: "com.example.notes",
     deviceName: "Android Emulator",
     views: ["network"],
   },
@@ -103,6 +103,11 @@ function setStatus(value, label = value) {
 function setError(message) {
   elements.error.hidden = !message;
   elements.error.textContent = message ?? "";
+}
+
+function updateError(result) {
+  if (!result.errors?.length) return undefined;
+  return result.errors.map(({ name, error }) => `${name}: ${error}`).join("; ");
 }
 
 async function request(path, options) {
@@ -473,8 +478,15 @@ async function flushPending() {
       }
     }
 
-    setError();
-    setStatus("connected", "Connected");
+    const error = updateError(result);
+    if (error) {
+      await reloadTweaks();
+      setError(error);
+      setStatus("error", "Some updates failed");
+    } else {
+      setError();
+      setStatus("connected", "Connected");
+    }
   } catch (error) {
     setError(error.message);
     setStatus("error", "Update failed");
@@ -1049,15 +1061,21 @@ async function resetTweaks() {
       state.tweaks.map((tweak) => [tweak.name, tweak.default]),
     );
 
-    await request("/tweaks", {
+    const result = await request("/tweaks", {
       method: "PATCH",
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify({ values }),
     });
 
     await reloadTweaks();
-    setError();
-    setStatus("connected", "Connected");
+    const error = updateError(result);
+    if (error) {
+      setError(error);
+      setStatus("error", "Some resets failed");
+    } else {
+      setError();
+      setStatus("connected", "Connected");
+    }
   } catch (error) {
     setError(error.message);
     setStatus("error", "Reset failed");

--- a/snapo-link-android/samples/demo-tweaks/panel/app.test.mjs
+++ b/snapo-link-android/samples/demo-tweaks/panel/app.test.mjs
@@ -1344,3 +1344,117 @@ test("streams batched composition changes without polling tweak values", async (
     }
   }
 });
+
+test("mixed tweak updates keep successful changes and restore rejected rows", async () => {
+  const document = makeDocument();
+  const tweaks = [
+    { name: "Settings/First label", type: "string", default: "before", value: "before" },
+    { name: "Settings/Second label", type: "string", default: "before", value: "before" },
+  ];
+  const patches = [];
+  const originalDocument = globalThis.document;
+  const originalFetch = globalThis.fetch;
+
+  globalThis.document = document;
+  globalThis.fetch = async (pathname, options) => {
+    if (pathname === "/apps") return jsonResponse({ apps: [demoApp], selectedAppId: demoApp.id });
+    if (pathname === "/app") return jsonResponse(demoApp);
+    if (pathname === "/tweaks" && options?.method === "PATCH") {
+      const { values } = JSON.parse(options.body);
+      patches.push(values);
+      tweaks[0].value = values[tweaks[0].name];
+      return jsonResponse({
+        tweaks: [{ name: tweaks[0].name, value: tweaks[0].value }],
+        errors: [{
+          name: tweaks[1].name,
+          error: "This setting could not be changed.",
+        }],
+      });
+    }
+    if (pathname === "/tweaks") return jsonResponse({ tweaks });
+    return jsonResponse({ error: "Not found." }, 404);
+  };
+
+  try {
+    await import(`./app.js?foundation-partial-update-${Date.now()}`);
+    await delay(0);
+    const settings = findTweakList(document, "Settings");
+    const first = findInput(settings, tweaks[0].name);
+    const second = findInput(settings, tweaks[1].name);
+    first.value = "first changed";
+    await first.emit("input");
+    second.value = "second changed";
+    await second.emit("input");
+    await delay(160);
+
+    assert.deepEqual(patches, [{
+      "Settings/First label": "first changed",
+      "Settings/Second label": "second changed",
+    }]);
+    assert.equal(findInput(findTweakList(document, "Settings"), tweaks[0].name).value, "first changed");
+    assert.equal(findInput(findTweakList(document, "Settings"), tweaks[1].name).value, "before");
+    assert.equal(document.querySelector("#status-text").textContent, "Some updates failed");
+    assert.equal(
+      document.querySelector("#error-message").textContent,
+      "Settings/Second label: This setting could not be changed.",
+    );
+  } finally {
+    globalThis.document = originalDocument;
+    globalThis.fetch = originalFetch;
+  }
+});
+
+test("mixed tweak resets keep successful changes and report rejected names", async () => {
+  const document = makeDocument();
+  const tweaks = [
+    { name: "Settings/First option", type: "boolean", default: false, value: true },
+    { name: "Settings/Second option", type: "boolean", default: false, value: true },
+  ];
+  const patches = [];
+  const originalDocument = globalThis.document;
+  const originalFetch = globalThis.fetch;
+
+  globalThis.document = document;
+  globalThis.fetch = async (pathname, options) => {
+    if (pathname === "/apps") return jsonResponse({ apps: [demoApp], selectedAppId: demoApp.id });
+    if (pathname === "/app") return jsonResponse(demoApp);
+    if (pathname === "/tweaks" && options?.method === "PATCH") {
+      const { values } = JSON.parse(options.body);
+      patches.push(values);
+      tweaks[0].value = false;
+      return jsonResponse({
+        tweaks: [{ name: tweaks[0].name, value: false }],
+        errors: [{
+          name: tweaks[1].name,
+          error: "This setting could not be reset.",
+        }],
+      });
+    }
+    if (pathname === "/tweaks") return jsonResponse({ tweaks });
+    return jsonResponse({ error: "Not found." }, 404);
+  };
+
+  try {
+    await import(`./app.js?foundation-partial-reset-${Date.now()}`);
+    await delay(0);
+    await document.querySelector("#reset-button").emit("click");
+
+    assert.deepEqual(patches, [{
+      "Settings/First option": false,
+      "Settings/Second option": false,
+    }]);
+    const settings = findTweakList(document, "Settings");
+    assert.equal(findInput(settings, tweaks[0].name).checked, false);
+    assert.equal(findInput(settings, tweaks[1].name).checked, true);
+    assert.equal(findInput(settings, `Reset ${tweaks[0].name}`).hidden, true);
+    assert.equal(findInput(settings, `Reset ${tweaks[1].name}`).hidden, false);
+    assert.equal(document.querySelector("#status-text").textContent, "Some resets failed");
+    assert.equal(
+      document.querySelector("#error-message").textContent,
+      "Settings/Second option: This setting could not be reset.",
+    );
+  } finally {
+    globalThis.document = originalDocument;
+    globalThis.fetch = originalFetch;
+  }
+});

--- a/snapo-link-android/tweaks/src/main/java/com/openai/snapo/tweaks/internal/TweakHttpServer.kt
+++ b/snapo-link-android/tweaks/src/main/java/com/openai/snapo/tweaks/internal/TweakHttpServer.kt
@@ -28,7 +28,37 @@ import java.util.concurrent.TimeUnit
 import java.util.concurrent.TimeoutException
 import kotlin.concurrent.thread
 
-internal const val TweaksProtocolVersion: Int = 2
+internal const val TweaksProtocolVersion: Int = 3
+
+internal data class TweakBatchError(
+    val name: String,
+    val error: String,
+)
+
+internal data class TweakBatchResult(
+    val tweaks: List<TweakSnapshot>,
+    val errors: List<TweakBatchError>,
+)
+
+internal fun applyTweakBatch(
+    values: Map<String, Any?>,
+    update: (Map<String, Any?>) -> List<TweakSnapshot> = TweakRegistry::update,
+): TweakBatchResult {
+    val tweaks = ArrayList<TweakSnapshot>(values.size)
+    val errors = ArrayList<TweakBatchError>()
+
+    values.forEach { (name, value) ->
+        try {
+            tweaks.add(update(mapOf(name to value)).single())
+        } catch (failure: TweakUpdateException) {
+            errors.add(TweakBatchError(name, failure.message ?: "Invalid tweak update."))
+        } catch (_: Exception) {
+            errors.add(TweakBatchError(name, "The tweak could not be updated."))
+        }
+    }
+
+    return TweakBatchResult(tweaks, errors)
+}
 
 private const val MaxHeaderBytes = 16 * 1024
 private const val MaxBodyBytes = 64 * 1024
@@ -239,7 +269,12 @@ internal class TweakHttpServer(
         "PATCH" -> {
             requireJsonRequest(request)
             val changes = readPatchValues(request.body)
-            tweaksResponse(updateOnMainThread(changes), includeDescriptors = false)
+            val result = updateOnMainThread(changes)
+            tweaksResponse(
+                result.tweaks,
+                includeDescriptors = false,
+                errors = result.errors,
+            )
         }
 
         else -> throw HttpFailure(
@@ -445,8 +480,8 @@ internal class TweakHttpServer(
         else -> throw HttpFailure(422, "Tweak values must be primitive JSON values.")
     }
 
-    private fun updateOnMainThread(values: Map<String, Any?>): List<TweakSnapshot> =
-        runOnMainThread("update", "applied") { TweakRegistry.update(values) }
+    private fun updateOnMainThread(values: Map<String, Any?>): TweakBatchResult =
+        runOnMainThread("update", "applied") { applyTweakBatch(values) }
 
     private fun invokeActionOnMainThread(name: String) =
         runOnMainThread("action", "invoked") { TweakRegistry.invokeAction(name) }
@@ -498,6 +533,7 @@ internal class TweakHttpServer(
     private fun tweaksResponse(
         tweaks: List<TweakSnapshot>,
         includeDescriptors: Boolean,
+        errors: List<TweakBatchError> = emptyList(),
     ): HttpResponse {
         val output = StringWriter()
         JsonWriter(output).use { writer ->
@@ -509,6 +545,16 @@ internal class TweakHttpServer(
             }
 
             writer.endArray()
+            if (errors.isNotEmpty()) {
+                writer.name("errors").beginArray()
+                errors.forEach { error ->
+                    writer.beginObject()
+                    writer.name("name").value(error.name)
+                    writer.name("error").value(error.error)
+                    writer.endObject()
+                }
+                writer.endArray()
+            }
             writer.endObject()
         }
 

--- a/snapo-link-android/tweaks/src/test/java/com/openai/snapo/tweaks/internal/TweakActionRegistryTest.kt
+++ b/snapo-link-android/tweaks/src/test/java/com/openai/snapo/tweaks/internal/TweakActionRegistryTest.kt
@@ -16,6 +16,11 @@ class TweakActionRegistryTest {
     }
 
     @Test
+    fun `protocol version distinguishes best effort tweak batches`() {
+        assertEquals(3, TweaksProtocolVersion)
+    }
+
+    @Test
     fun `registered actions appear alongside value tweaks in composition order`() {
         val first = TweakDescriptor("Typography/Size", TweakType.INT, 16)
         val second = TweakDescriptor("Motion/Enabled", TweakType.BOOLEAN, true)

--- a/snapo-link-android/tweaks/src/test/java/com/openai/snapo/tweaks/internal/TweakBatchUpdateTest.kt
+++ b/snapo-link-android/tweaks/src/test/java/com/openai/snapo/tweaks/internal/TweakBatchUpdateTest.kt
@@ -1,0 +1,170 @@
+package com.openai.snapo.tweaks.internal
+
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class TweakBatchUpdateTest {
+
+    @After
+    fun clearRegistry() {
+        TweakRegistry.clear()
+    }
+
+    @Test
+    fun `valid values survive invalid missing action and enum entries`() {
+        val size = TweakDescriptor("Typography/Size", TweakType.INT, 16)
+        val enabled = TweakDescriptor("Motion/Enabled", TweakType.BOOLEAN, false)
+        val duration = TweakDescriptor("Motion/Duration", TweakType.INT, 400)
+        val appearance = TweakDescriptor(
+            name = "Appearance/Theme",
+            type = TweakType.ENUM,
+            default = "System",
+            options = listOf("System", "Dark"),
+        )
+        val sizeState = TweakRegistry.register(size)
+        val enabledState = TweakRegistry.register(enabled)
+        val durationState = TweakRegistry.register(duration)
+        val appearanceState = TweakRegistry.register(appearance)
+        TweakRegistry.registerAction("Playback/Restart") {}
+
+        val result = applyTweakBatch(
+            linkedMapOf(
+                size.name to 20,
+                enabled.name to "invalid",
+                "Missing/Value" to true,
+                "Playback/Restart" to true,
+                appearance.name to "Stale",
+                duration.name to 500,
+            ),
+        )
+
+        assertEquals(listOf(size.name, duration.name), result.tweaks.map { it.descriptor.name })
+        assertEquals(
+            listOf(enabled.name, "Missing/Value", "Playback/Restart", appearance.name),
+            result.errors.map(TweakBatchError::name),
+        )
+        assertTrue(result.errors.all { it.error.isNotBlank() })
+        assertEquals(20, sizeState.value)
+        assertEquals(false, enabledState.value)
+        assertEquals(500, durationState.value)
+        assertEquals("System", appearanceState.value)
+    }
+
+    @Test
+    fun `all failed values return errors without mutating active tweaks`() {
+        val descriptor = TweakDescriptor("Motion/Enabled", TweakType.BOOLEAN, false)
+        val state = TweakRegistry.register(descriptor)
+
+        val result = applyTweakBatch(
+            linkedMapOf(
+                descriptor.name to "invalid",
+                "Missing/Value" to true,
+            ),
+        )
+
+        assertTrue(result.tweaks.isEmpty())
+        assertEquals(
+            listOf(
+                "Invalid value for Motion/Enabled: Expected a boolean.",
+                "Unknown tweak: Missing/Value",
+            ),
+            result.errors.map(TweakBatchError::error),
+        )
+        assertEquals(false, state.value)
+
+        TweakRegistry.unregister(descriptor.name)
+
+        assertTrue(TweakRegistry.snapshot(includeAdjusted = true).isEmpty())
+    }
+
+    @Test
+    fun `successful entries preserve adjusted history and coalesce publications`() {
+        val size = TweakDescriptor("Typography/Size", TweakType.INT, 16)
+        val duration = TweakDescriptor("Motion/Duration", TweakType.INT, 400)
+        TweakRegistry.register(size)
+        TweakRegistry.register(duration)
+        val scheduled = mutableListOf<Runnable>()
+        val publisher = TweakChangePublisher { runnable -> scheduled.add(runnable) }
+        val observer = TweakRegistry.observeChanges(publisher::notifyChanged)
+
+        publisher.subscribe().use { subscription ->
+            val result = applyTweakBatch(
+                linkedMapOf(
+                    size.name to 20,
+                    "Missing/Value" to true,
+                    duration.name to 500,
+                ),
+            )
+
+            assertEquals(2, result.tweaks.size)
+            assertEquals(1, result.errors.size)
+            assertEquals(1, scheduled.size)
+
+            scheduled.single().run()
+
+            assertEquals(
+                listOf(20, 500),
+                subscription.events.poll()?.map(TweakSnapshot::value),
+            )
+        }
+
+        observer.close()
+        publisher.close()
+        TweakRegistry.unregister(size.name)
+        TweakRegistry.unregister(duration.name)
+
+        assertEquals(
+            listOf(20, 500),
+            TweakRegistry.snapshot(includeAdjusted = true).map(TweakSnapshot::value),
+        )
+    }
+
+    @Test
+    fun `unexpected owner failures are sanitized and do not stop later entries`() {
+        val size = TweakDescriptor("Typography/Size", TweakType.INT, 16)
+        val duration = TweakDescriptor("Motion/Duration", TweakType.INT, 400)
+        TweakRegistry.register(size)
+        TweakRegistry.register(duration)
+
+        val result = applyTweakBatch(
+            linkedMapOf(
+                size.name to 20,
+                "Settings/Unavailable" to true,
+                duration.name to 500,
+            ),
+            update = { values ->
+                if (values.containsKey("Settings/Unavailable")) {
+                    error("Application owner details")
+                }
+                TweakRegistry.update(values)
+            },
+        )
+
+        assertEquals(listOf(size.name, duration.name), result.tweaks.map { it.descriptor.name })
+        assertEquals(
+            listOf(TweakBatchError("Settings/Unavailable", "The tweak could not be updated.")),
+            result.errors,
+        )
+    }
+
+    @Test
+    fun `successful unchanged values remain in the response without errors`() {
+        val descriptor = TweakDescriptor("Motion/Enabled", TweakType.BOOLEAN, false)
+        TweakRegistry.register(descriptor)
+
+        val result = applyTweakBatch(mapOf(descriptor.name to false))
+
+        assertEquals(false, result.tweaks.single().value)
+        assertTrue(result.errors.isEmpty())
+    }
+
+    @Test
+    fun `empty batches have no values or errors`() {
+        val result = applyTweakBatch(emptyMap())
+
+        assertTrue(result.tweaks.isEmpty())
+        assertTrue(result.errors.isEmpty())
+    }
+}

--- a/snapo-network-inspector-web/src/features/tweaks-inspector/TweaksInspectorApp.tsx
+++ b/snapo-network-inspector-web/src/features/tweaks-inspector/TweaksInspectorApp.tsx
@@ -69,6 +69,18 @@ export function TweaksInspectorApp({
             })
           );
         },
+        onRejected(_errors, pending, inFlight, isCurrent) {
+          void client
+            .listTweaks(server)
+            .then((response) => {
+              if (!isCurrent()) return;
+              setTweaks((current) => reconcileStreamedTweaks(current, response.tweaks, pending, inFlight));
+            })
+            .catch((cause: unknown) => {
+              if (!isCurrent()) return;
+              setError(cause instanceof Error ? cause.message : "Unable to reload tweaks.");
+            });
+        },
         onError: setError,
         onSavingChange: setSaving
       }),

--- a/snapo-network-inspector-web/src/features/tweaks-inspector/tweak-update-queue.test.ts
+++ b/snapo-network-inspector-web/src/features/tweaks-inspector/tweak-update-queue.test.ts
@@ -74,6 +74,58 @@ describe("app-scoped tweak updates", () => {
     await flush;
   });
 
+  it("applies successful values and reports each rejected value in the same batch", async () => {
+    const first = { name: "Motion/Duration", error: "Value exceeds the maximum." };
+    const second = { name: "Motion/Show", error: "Unknown tweak." };
+    const update = { name: "Typography/Font size", value: 24 };
+    const client = { updateTweaks: vi.fn().mockResolvedValue({ tweaks: [update], errors: [first, second] }) };
+    const handlers = callbacks();
+    const queue = new TweakUpdateQueue(client, { deviceId: "pixel", socketName: "snapo_tweaks_demo" }, handlers);
+
+    queue.enqueue(update.name, update.value);
+    queue.enqueue(first.name, 1_000);
+    queue.enqueue(second.name, true);
+    await queue.flush();
+
+    expect(handlers.onUpdate).toHaveBeenCalledWith([update], new Map());
+    expect(handlers.onRejected).toHaveBeenCalledWith([first, second], new Map(), new Set(), expect.any(Function));
+    expect(handlers.onError).toHaveBeenLastCalledWith(
+      "Motion/Duration: Value exceeds the maximum.; Motion/Show: Unknown tweak."
+    );
+    expect(queue.inFlight.size).toBe(0);
+  });
+
+  it("reports a batch with no successful values without leaving rejected values in flight", async () => {
+    const error = { name: "Motion/Duration", error: "Invalid value." };
+    const client = { updateTweaks: vi.fn().mockResolvedValue({ tweaks: [], errors: [error] }) };
+    const handlers = callbacks();
+    const queue = new TweakUpdateQueue(client, { deviceId: "pixel", socketName: "snapo_tweaks_demo" }, handlers);
+
+    queue.enqueue(error.name, 900);
+    await queue.flush();
+
+    expect(handlers.onUpdate).toHaveBeenCalledWith([], new Map());
+    expect(handlers.onRejected).toHaveBeenCalledOnce();
+    expect(handlers.onError).toHaveBeenLastCalledWith("Motion/Duration: Invalid value.");
+    expect(queue.pending.size).toBe(0);
+    expect(queue.inFlight.size).toBe(0);
+  });
+
+  it("invalidates an authoritative reload when the selected app changes", async () => {
+    const error = { name: "Motion/Duration", error: "Invalid value." };
+    const client = { updateTweaks: vi.fn().mockResolvedValue({ tweaks: [], errors: [error] }) };
+    const handlers = callbacks();
+    const queue = new TweakUpdateQueue(client, { deviceId: "pixel", socketName: "snapo_tweaks_demo" }, handlers);
+
+    queue.enqueue(error.name, 900);
+    await queue.flush();
+    const isCurrent = handlers.onRejected.mock.calls[0]?.[3] as () => boolean;
+
+    expect(isCurrent()).toBe(true);
+    queue.cancel();
+    expect(isCurrent()).toBe(false);
+  });
+
   it("does not report an old app's request failure after switching apps", async () => {
     const request = deferred<TweakUpdates>();
     const client = { updateTweaks: vi.fn().mockReturnValue(request.promise) };
@@ -94,6 +146,7 @@ describe("app-scoped tweak updates", () => {
 function callbacks() {
   return {
     onUpdate: vi.fn(),
+    onRejected: vi.fn(),
     onError: vi.fn(),
     onSavingChange: vi.fn()
   };

--- a/snapo-network-inspector-web/src/features/tweaks-inspector/tweak-update-queue.ts
+++ b/snapo-network-inspector-web/src/features/tweaks-inspector/tweak-update-queue.ts
@@ -1,8 +1,14 @@
-import type { InspectorServerReference, TweakUpdate, TweakValue } from "../../network/bridge-types";
+import type { InspectorServerReference, TweakUpdate, TweakUpdateError, TweakValue } from "../../network/bridge-types";
 import type { NetworkClient } from "../../network/client";
 
 interface TweakUpdateQueueCallbacks {
   onUpdate(tweaks: TweakUpdate[], pending: ReadonlyMap<string, TweakValue>): void;
+  onRejected?(
+    errors: TweakUpdateError[],
+    pending: ReadonlyMap<string, TweakValue>,
+    inFlight: ReadonlySet<string>,
+    isCurrent: () => boolean
+  ): void;
   onError(error: string | null): void;
   onSavingChange(saving: boolean): void;
 }
@@ -34,6 +40,7 @@ export class TweakUpdateQueue {
     if (this.saving || this.pending.size === 0) return;
 
     const generation = this.generation;
+    const errors: TweakUpdateError[] = [];
     this.saving = true;
     this.callbacks.onSavingChange(true);
 
@@ -53,9 +60,15 @@ export class TweakUpdateQueue {
 
         if (generation !== this.generation) return;
         this.callbacks.onUpdate(result.tweaks, this.pending);
+        if (result.errors?.length) {
+          errors.push(...result.errors);
+          this.callbacks.onRejected?.(result.errors, this.pending, this.inFlight, () => generation === this.generation);
+        }
       }
 
-      if (generation === this.generation) this.callbacks.onError(null);
+      if (generation === this.generation) {
+        this.callbacks.onError(errors.length ? errors.map(({ name, error }) => `${name}: ${error}`).join("; ") : null);
+      }
     } catch (cause: unknown) {
       if (generation !== this.generation) return;
       this.pending.clear();

--- a/snapo-network-inspector-web/src/network/bridge-types.ts
+++ b/snapo-network-inspector-web/src/network/bridge-types.ts
@@ -85,8 +85,14 @@ export interface TweakUpdate {
   value: TweakValue;
 }
 
+export interface TweakUpdateError {
+  name: string;
+  error: string;
+}
+
 export interface TweakUpdates {
   tweaks: TweakUpdate[];
+  errors?: TweakUpdateError[];
 }
 
 export interface UpdateTweaksInput {

--- a/tests/snapo_cli/test_snapo.py
+++ b/tests/snapo_cli/test_snapo.py
@@ -219,15 +219,24 @@ def tweak_descriptors():
 
 
 class TweakHTTPServer:
-    def __init__(self, descriptors=None, app=None, error=None, stream_events=None, adjusted_descriptors=None):
+    def __init__(
+        self,
+        descriptors=None,
+        app=None,
+        error=None,
+        stream_events=None,
+        adjusted_descriptors=None,
+        update_errors=None,
+    ):
         self.descriptors = json.loads(json.dumps(descriptors or tweak_descriptors()))
         self.adjusted_descriptors = self.descriptors if adjusted_descriptors is None else adjusted_descriptors
         self.app = app or {
             "name": "Snap-O Tweaks Demo",
             "packageName": "com.example.tweaks",
-            "protocolVersion": 2,
+            "protocolVersion": 3,
         }
         self.error = error
+        self.update_errors = update_errors or {}
         self.stream_events = stream_events
         self.requests = []
         owner = self
@@ -270,18 +279,28 @@ class TweakHTTPServer:
                     return
 
                 descriptors = {item["name"]: item for item in owner.descriptors}
-                unknown = next((name for name in payload["values"] if name not in descriptors), None)
-                if unknown is not None:
-                    self.send_json(404, {"error": f"Unknown tweak: {unknown}"})
-                    return
-
                 updates = []
+                errors = []
                 for name, value in payload["values"].items():
+                    if name not in descriptors:
+                        message = f"Unknown tweak: {name}"
+                        if owner.app.get("protocolVersion", 1) < 3:
+                            self.send_json(404, {"error": message})
+                            return
+                        errors.append({"name": name, "error": message})
+                        continue
+                    if name in owner.update_errors:
+                        message = owner.update_errors[name]
+                        errors.append({"name": name, "error": message})
+                        continue
                     if descriptors[name]["type"] == "color":
                         value = value.upper()
                     descriptors[name]["value"] = value
                     updates.append({"name": name, "value": value})
-                self.send_json(200, {"tweaks": updates})
+                response = {"tweaks": updates}
+                if errors:
+                    response["errors"] = errors
+                self.send_json(200, response)
 
             def do_POST(self):
                 length = int(self.headers.get("Content-Length", "0"))
@@ -1245,7 +1264,7 @@ class TweakCommandTests(unittest.TestCase):
         self.assertEqual(app["socketName"], "snapo_tweaks_42")
         self.assertEqual(app["appName"], "Snap-O Tweaks Demo")
         self.assertEqual(app["packageName"], "com.example.tweaks")
-        self.assertEqual(app["protocolVersion"], 2)
+        self.assertEqual(app["protocolVersion"], 3)
         self.assertEqual(wire.requests, [("GET", "/app", None)])
         self.assertEqual(adb.calls[-1], ("emulator-5554", ("forward", "--remove", f"tcp:{wire.port}")))
 
@@ -1526,6 +1545,34 @@ class TweakCommandTests(unittest.TestCase):
                 self.assertEqual(wire.requests, [("POST", "/tweaks/action", {"name": name})])
                 self.assertEqual(adb.calls[-1], ("emulator-5554", ("forward", "--remove", f"tcp:{wire.port}")))
 
+    def test_set_reports_a_named_batch_error(self):
+        name = "Motion/Enabled"
+        with TweakHTTPServer(update_errors={name: "The value could not be changed."}) as wire:
+            result, output, errors, _ = self.run_command(["set", name, "false"], wire)
+
+        self.assertEqual(result, 1)
+        self.assertEqual(output, "")
+        self.assertIn(name, errors)
+        self.assertIn("The value could not be changed.", errors)
+
+    def test_reset_all_keeps_successful_changes_and_reports_named_batch_errors(self):
+        descriptors = tweak_descriptors()
+        descriptors[0]["value"] = 24
+        descriptors[2]["value"] = False
+        failed_name = descriptors[2]["name"]
+        with TweakHTTPServer(
+            descriptors=descriptors,
+            update_errors={failed_name: "This value could not be reset."},
+        ) as wire:
+            result, output, errors, _ = self.run_command(["reset", "--all"], wire)
+
+        self.assertEqual(result, 1)
+        self.assertEqual(output, "")
+        self.assertIn(failed_name, errors)
+        self.assertIn("This value could not be reset.", errors)
+        self.assertEqual(wire.descriptors[0]["value"], 16)
+        self.assertFalse(wire.descriptors[2]["value"])
+
     def test_reset_one_tweak_patches_its_declared_default(self):
         descriptors = tweak_descriptors()
         descriptors[0]["value"] = 24
@@ -1551,7 +1598,7 @@ class TweakCommandTests(unittest.TestCase):
         self.assertEqual(wire.requests[1], ("PATCH", "/tweaks", {"values": {"Appearance/Theme": "System"}}))
         self.assertEqual(output, "")
 
-    def test_reset_all_patches_every_default_in_one_atomic_request(self):
+    def test_reset_all_patches_every_default_in_one_request(self):
         descriptors = tweak_descriptors()
         descriptors[0]["value"] = 24
         descriptors[2]["value"] = False


### PR DESCRIPTION
## Summary

- Introduce Tweaks protocol version 3 for best-effort batch updates.
- Apply valid entries independently and report rejected entries as `{"name":"...","error":"..."}` without rolling back successful changes.
- Preserve request-level HTTP errors and compatibility with protocol versions 1 and 2.
- Update the Android server, macOS bridge, web inspector, CLI, browser panel, and protocol documentation.
- Preserve existing action behavior, default-based resets, and modification detection.

## Verification

- Android: 187 unit tests, static checks, debug build, minified release build, and no-op release build.
- Web inspector: 108 tests.
- CLI: 102 tests.
- Browser panel: 44 tests.
- macOS application build.
