### PR TITLE
Update Snap-O 4.1.0 appcast and documentation

### DIFF
--- a/appcast.xml
+++ b/appcast.xml
@@ -8,6 +8,15 @@
     <description>Software updates for Snap‑O</description>
 
     <item>
+        <title>Snap‑O 4.1.0</title>
+        <pubDate>Fri, 07 Aug 2026 15:36:21 +0000</pubDate>
+        <sparkle:minimumSystemVersion>15.0</sparkle:minimumSystemVersion>
+        <sparkle:version>20260807.00</sparkle:version>
+        <sparkle:shortVersionString>4.1.0</sparkle:shortVersionString>
+        <enclosure url="https://github.com/openai/snap-o/releases/download/4.1.0/Snap-O.dmg" length="2307349" type="application/octet-stream" sparkle:edSignature="aBFvNS57UO5NSTSPa5womFKVpB0iyDuIrykM/K2Nqkn/ORIxclpc80OrqHMzORQTcN/Zp079ggoACb1XF8FsAA==" />
+    </item>
+
+    <item>
         <title>Snap‑O 4.0.0</title>
         <pubDate>Thu, 30 Jul 2026 22:53:52 +0000</pubDate>
         <sparkle:minimumSystemVersion>15.0</sparkle:minimumSystemVersion>

--- a/index.html
+++ b/index.html
@@ -358,7 +358,8 @@
             <h2 class="product-title">Tweaks (Alpha)</h2>
             <div>
               <p class="product-copy">
-                Adjust Compose UI values live with App Inspector, an optional
+                Adjust Compose UI values and app-owned settings or run
+                app-defined actions through App Inspector, an optional
                 on-device panel, the REST API, or an agent.
               </p>
               <a class="section-link" href="tweaks.html">

--- a/network-inspector.html
+++ b/network-inspector.html
@@ -685,8 +685,8 @@
                         <button class="copy-button" type="button">Copy</button>
                       </div>
                       <pre><code class="syntax-code" data-language="kotlin" data-emphasis-lines="2,3">dependencies {
-    debugImplementation("com.openai.snapo:network-okhttp3:4.0.0")
-    releaseImplementation("com.openai.snapo:network-okhttp3-noop:4.0.0")
+    debugImplementation("com.openai.snapo:network-okhttp3:4.1.0")
+    releaseImplementation("com.openai.snapo:network-okhttp3-noop:4.1.0")
 }</code></pre>
                     </div>
                   </div>
@@ -697,7 +697,7 @@
                         <button class="copy-button" type="button">Copy</button>
                       </div>
                       <pre><code class="syntax-code" data-language="toml" data-emphasis-lines="2,5,6">[versions]
-snapo = "4.0.0"
+snapo = "4.1.0"
 
 [libraries]
 snapo-network-okhttp3 = { module = "com.openai.snapo:network-okhttp3", version.ref = "snapo" }
@@ -735,8 +735,8 @@ snapo-network-okhttp3-noop = { module = "com.openai.snapo:network-okhttp3-noop",
                         <button class="copy-button" type="button">Copy</button>
                       </div>
                       <pre><code class="syntax-code" data-language="kotlin" data-emphasis-lines="2,3">dependencies {
-    debugImplementation("com.openai.snapo:network-httpurlconnection:4.0.0")
-    releaseImplementation("com.openai.snapo:network-httpurlconnection-noop:4.0.0")
+    debugImplementation("com.openai.snapo:network-httpurlconnection:4.1.0")
+    releaseImplementation("com.openai.snapo:network-httpurlconnection-noop:4.1.0")
 }</code></pre>
                     </div>
                   </div>
@@ -747,7 +747,7 @@ snapo-network-okhttp3-noop = { module = "com.openai.snapo:network-okhttp3-noop",
                         <button class="copy-button" type="button">Copy</button>
                       </div>
                       <pre><code class="syntax-code" data-language="toml" data-emphasis-lines="2,5,6">[versions]
-snapo = "4.0.0"
+snapo = "4.1.0"
 
 [libraries]
 snapo-network-httpurlconnection = { module = "com.openai.snapo:network-httpurlconnection", version.ref = "snapo" }

--- a/tweaks.html
+++ b/tweaks.html
@@ -696,7 +696,7 @@
                     <button class="copy-button" type="button">Copy</button>
                   </div>
                   <pre><code class="syntax-code" data-language="toml" data-emphasis-lines="2,5,6,8,9,10">[versions]
-snapo = "4.0.0"
+snapo = "4.1.0"
 
 [libraries]
 snapo-tweaks = { module = "com.openai.snapo:tweaks", version.ref = "snapo" }
@@ -735,12 +735,12 @@ snapo-tweaks-overlay-noop = { module = "com.openai.snapo:tweaks-overlay-noop", v
                     <button class="copy-button" type="button">Copy</button>
                   </div>
                   <pre><code class="syntax-code" data-language="kotlin" data-emphasis-lines="2,3,5,6,7">dependencies {
-    debugImplementation("com.openai.snapo:tweaks:4.0.0")
-    releaseImplementation("com.openai.snapo:tweaks-noop:4.0.0")
+    debugImplementation("com.openai.snapo:tweaks:4.1.0")
+    releaseImplementation("com.openai.snapo:tweaks-noop:4.1.0")
 
     // Optional: add both if you want the in-app overlay panel.
-    debugImplementation("com.openai.snapo:tweaks-overlay:4.0.0")
-    releaseImplementation("com.openai.snapo:tweaks-overlay-noop:4.0.0")
+    debugImplementation("com.openai.snapo:tweaks-overlay:4.1.0")
+    releaseImplementation("com.openai.snapo:tweaks-overlay-noop:4.1.0")
 }</code></pre>
                 </div>
               </div>
@@ -1369,10 +1369,19 @@ codex plugin add snap-o@snap-o</code></pre>
 
 "$SNAPO_BIN" tweaks apps --json
 "$SNAPO_BIN" tweaks list -s emulator-5554 -n snapo_tweaks_12345 --json
-"$SNAPO_BIN" tweaks set 'Typography/Font size' 42 -s emulator-5554 -n snapo_tweaks_12345 --json
-"$SNAPO_BIN" tweaks reset 'Typography/Font size' -s emulator-5554 -n snapo_tweaks_12345 --json
+"$SNAPO_BIN" tweaks set 'Typography/Font size' 42 -s emulator-5554 -n snapo_tweaks_12345
+"$SNAPO_BIN" tweaks action 'Motion/Toggle animation' -s emulator-5554 -n snapo_tweaks_12345
+"$SNAPO_BIN" tweaks reset 'Typography/Font size' -s emulator-5554 -n snapo_tweaks_12345
 "$SNAPO_BIN" tweaks watch -s emulator-5554 -n snapo_tweaks_12345 --once --json</code></pre>
               </div>
+
+              <p class="prose">
+                Successful <code>set</code>, <code>reset</code>, and
+                <code>action</code> commands produce no output and do not accept
+                <code>--json</code>. For batch updates, replace the former
+                <code>set --values-json</code> option with
+                <a href="tweaks-protocol.html#patch-tweaks">PATCH /tweaks</a>.
+              </p>
 
               <p class="notice">
                 The CLI manages Android socket discovery, forwarding, and
@@ -1443,6 +1452,14 @@ codex plugin add snap-o@snap-o</code></pre>
                 the current composition. Its matching no-op artifact draws
                 nothing in release, so this code belongs in your shared
                 source set.
+              </p>
+
+              <p class="notice">
+                <strong>Upgrading from 4.0.0?</strong> The overlay no longer
+                wraps app content. Replace
+                <code>SnapOTweakOverlay { ... }</code> with a fullscreen
+                <code>Box</code> containing your content followed by
+                <code>SnapOTweakOverlay()</code>.
               </p>
 
               <div class="code-block">


### PR DESCRIPTION
## Summary

- Publish the signed Sparkle update for Snap-O 4.1.0 while preserving all previous appcast entries.
- Update Android Network Inspector and Tweaks dependency examples to 4.1.0.
- Document app-owned settings and actions, the overlay migration, and current CLI mutation behavior.

## Verification

- The appcast contains the original signed 4.1.0 update item, correct build number, release URL, file size, and signature.
- The published macOS disk image matches its SHA-256 checksum.
- All updated HTML pages pass HTML5 parsing, and the appcast passes XML validation.
