### PR TITLE
Fix clipboard actions in the network inspector

### DIFF
--- a/snapo-network-inspector-web/src/features/network-inspector/components/DetailPane.tsx
+++ b/snapo-network-inspector-web/src/features/network-inspector/components/DetailPane.tsx
@@ -45,7 +45,7 @@ export const DetailContent = memo(function DetailContent({
     );
   }
 
-  if (record.kind === "websocket") return <WebSocketDetail record={record} uiState={uiState} />;
+  if (record.kind === "websocket") return <WebSocketDetail client={client} record={record} uiState={uiState} />;
   return <RequestDetail client={client} record={record} uiState={uiState} />;
 });
 

--- a/snapo-network-inspector-web/src/features/network-inspector/components/PayloadView.tsx
+++ b/snapo-network-inspector-web/src/features/network-inspector/components/PayloadView.tsx
@@ -26,10 +26,13 @@ export function BodySection({
   uiState: InspectorUiState;
 }): JSX.Element {
   if (isImagePayload(payload)) return <ImagePreview client={client} payload={payload} />;
-  return <PayloadView payload={payload} storageKey={storageKey} uiState={uiState} prettyInitiallyExpanded />;
+  return (
+    <PayloadView client={client} payload={payload} storageKey={storageKey} uiState={uiState} prettyInitiallyExpanded />
+  );
 }
 
 export function PayloadView({
+  client,
   payload,
   storageKey,
   uiState,
@@ -38,6 +41,7 @@ export function PayloadView({
   prettyInitiallyExpanded = true,
   embedded = false
 }: {
+  client: NetworkClient;
   payload: BodyPayload;
   storageKey: string;
   uiState: InspectorUiState;
@@ -56,7 +60,7 @@ export function PayloadView({
         : null,
     [payload.jsonFormat, payload.prettyText, pretty]
   );
-  const copyFeedback = useCopyFeedback(displayText);
+  const copyFeedback = useCopyFeedback(client, displayText);
   const hasToggle = showsToggle && payload.prettyText != null;
   const hasCopy = showsCopyButton && displayText.length > 0;
   const controls =
@@ -89,6 +93,7 @@ export function PayloadView({
           )
         ) : (
           <JsonOutline
+            client={client}
             node={jsonRoot}
             storageKey={`${storageKey}:json`}
             uiState={uiState}
@@ -138,6 +143,7 @@ export function InlineCopyButton({
 export { payloadMetadata };
 
 function JsonOutline({
+  client,
   node,
   storageKey,
   uiState,
@@ -145,6 +151,7 @@ function JsonOutline({
   initiallyExpanded,
   trailing
 }: {
+  client: NetworkClient;
   node: JsonNode;
   storageKey: string;
   uiState: InspectorUiState;
@@ -190,6 +197,7 @@ function JsonOutline({
             x: event.clientX,
             y: event.clientY,
             items: jsonContextMenuItems({
+              client,
               node,
               rowKey,
               descendantRowKeys,
@@ -229,6 +237,7 @@ function JsonOutline({
           {node.children.map((child) => (
             <JsonOutline
               key={child.key}
+              client={client}
               node={child}
               storageKey={storageKey}
               uiState={uiState}
@@ -384,6 +393,7 @@ function jsonStringLineForDisplay(value: string): string {
 }
 
 function jsonContextMenuItems({
+  client,
   node,
   rowKey,
   descendantRowKeys,
@@ -391,6 +401,7 @@ function jsonContextMenuItems({
   expandable,
   uiState
 }: {
+  client: NetworkClient;
   node: JsonNode;
   rowKey: string;
   descendantRowKeys: string[];
@@ -403,7 +414,7 @@ function jsonContextMenuItems({
   const items: ContextMenuItem[] = [
     {
       label: "Copy Value",
-      action: () => void navigator.clipboard.writeText(jsonNodeCopyText(node))
+      action: () => void client.copyText(jsonNodeCopyText(node))
     }
   ];
 
@@ -447,8 +458,8 @@ function jsonNodeCopyText(node: JsonNode): string {
 
 function ImagePreview({ client, payload }: { client: NetworkClient; payload: BodyPayload }): JSX.Element | null {
   const dataUrl = dataUrlForImage(payload);
-  const copyFeedback = useCopyFeedback("image");
-  const saveFeedback = useCopyFeedback("save-image");
+  const copyFeedback = useCopyFeedback(client, "image");
+  const saveFeedback = useCopyFeedback(client, "save-image");
   const [menu, setMenu] = useState<ContextMenuState | null>(null);
 
   useEffect(() => {

--- a/snapo-network-inspector-web/src/features/network-inspector/components/RequestDetail.tsx
+++ b/snapo-network-inspector-web/src/features/network-inspector/components/RequestDetail.tsx
@@ -92,9 +92,10 @@ export const RequestDetail = memo(function RequestDetail({
           title="Server-Sent Events"
           storageKey={`${prefix}:stream`}
           uiState={uiState}
-          trailing={<SseCopyAllButton events={record.streamEvents} />}
+          trailing={<SseCopyAllButton client={client} events={record.streamEvents} />}
         >
           <SseEventList
+            client={client}
             events={record.streamEvents}
             closed={record.streamClosed}
             storageKey={`${prefix}:stream`}

--- a/snapo-network-inspector-web/src/features/network-inspector/components/StreamEvents.tsx
+++ b/snapo-network-inspector-web/src/features/network-inspector/components/StreamEvents.tsx
@@ -1,4 +1,5 @@
 import { memo } from "react";
+import type { NetworkClient } from "../../../network/client";
 import type { RequestRecord } from "../../../network/cdp";
 import { makeBodyPayload } from "../../../network/payload";
 import { streamEventsRaw } from "../../../network/exporters";
@@ -8,12 +9,14 @@ import { formatTime } from "../lib/format";
 import { InlineCopyButton, InlineTextToggle, PayloadView } from "./PayloadView";
 
 export const SseCopyAllButton = memo(function SseCopyAllButton({
+  client,
   events
 }: {
+  client: NetworkClient;
   events: RequestRecord["streamEvents"];
 }): JSX.Element {
   const text = streamEventsRaw(events);
-  const copyFeedback = useCopyFeedback(text);
+  const copyFeedback = useCopyFeedback(client, text);
   return (
     <button
       className="inline-action section-action"
@@ -27,11 +30,13 @@ export const SseCopyAllButton = memo(function SseCopyAllButton({
 });
 
 export const SseEventList = memo(function SseEventList({
+  client,
   events,
   closed,
   storageKey,
   uiState
 }: {
+  client: NetworkClient;
   events: RequestRecord["streamEvents"];
   closed?: RequestRecord["streamClosed"];
   storageKey: string;
@@ -45,6 +50,7 @@ export const SseEventList = memo(function SseEventList({
         events.map((event) => (
           <SseEventCard
             key={event.sequence}
+            client={client}
             event={event}
             storageKey={`${storageKey}:event:${event.sequence}`}
             uiState={uiState}
@@ -57,10 +63,12 @@ export const SseEventList = memo(function SseEventList({
 });
 
 const SseEventCard = memo(function SseEventCard({
+  client,
   event,
   storageKey,
   uiState
 }: {
+  client: NetworkClient;
   event: RequestRecord["streamEvents"][number];
   storageKey: string;
   uiState: InspectorUiState;
@@ -70,7 +78,7 @@ const SseEventCard = memo(function SseEventCard({
   const prettyText = payload?.prettyText ?? null;
   const pretty = uiState.prettyEnabled(storageKey, prettyText != null);
   const displayText = pretty && prettyText != null ? prettyText : rawText;
-  const copyFeedback = useCopyFeedback(displayText);
+  const copyFeedback = useCopyFeedback(client, displayText);
 
   return (
     <div className="event-row">
@@ -92,6 +100,7 @@ const SseEventCard = memo(function SseEventCard({
         <pre>{event.raw || "<empty>"}</pre>
       ) : (
         <PayloadView
+          client={client}
           payload={payload}
           storageKey={storageKey}
           uiState={uiState}

--- a/snapo-network-inspector-web/src/features/network-inspector/components/WebSocketDetail.tsx
+++ b/snapo-network-inspector-web/src/features/network-inspector/components/WebSocketDetail.tsx
@@ -1,4 +1,5 @@
 import { memo } from "react";
+import type { NetworkClient } from "../../../network/client";
 import { recordId, type WebSocketRecord } from "../../../network/cdp";
 import type { InspectorUiState } from "../hooks/useInspectorUiState";
 import { useAdaptiveTimingText } from "../hooks/useAdaptiveTimingText";
@@ -7,9 +8,11 @@ import { FailureMessage, StatusBadge } from "./Status";
 import { WebSocketMessageCard } from "./WebSocketMessages";
 
 export const WebSocketDetail = memo(function WebSocketDetail({
+  client,
   record,
   uiState
 }: {
+  client: NetworkClient;
   record: WebSocketRecord;
   uiState: InspectorUiState;
 }): JSX.Element {
@@ -52,6 +55,7 @@ export const WebSocketDetail = memo(function WebSocketDetail({
             {record.messages.map((message) => (
               <WebSocketMessageCard
                 key={message.id}
+                client={client}
                 message={message}
                 storageKey={`${prefix}:message:${message.id}`}
                 uiState={uiState}

--- a/snapo-network-inspector-web/src/features/network-inspector/components/WebSocketMessages.tsx
+++ b/snapo-network-inspector-web/src/features/network-inspector/components/WebSocketMessages.tsx
@@ -1,5 +1,6 @@
 import { Inbox, Send } from "lucide-react";
 import { memo } from "react";
+import type { NetworkClient } from "../../../network/client";
 import type { WebSocketMessageRecord } from "../../../network/cdp";
 import { formatBytes, makeBodyPayload } from "../../../network/payload";
 import { useCopyFeedback } from "../hooks/useCopyFeedback";
@@ -8,10 +9,12 @@ import { formatTime } from "../lib/format";
 import { InlineCopyButton, InlineTextToggle, PayloadView } from "./PayloadView";
 
 export const WebSocketMessageCard = memo(function WebSocketMessageCard({
+  client,
   message,
   storageKey,
   uiState
 }: {
+  client: NetworkClient;
   message: WebSocketMessageRecord;
   storageKey: string;
   uiState: InspectorUiState;
@@ -21,7 +24,7 @@ export const WebSocketMessageCard = memo(function WebSocketMessageCard({
   const prettyText = payload?.prettyText ?? null;
   const pretty = uiState.prettyEnabled(storageKey, prettyText != null);
   const displayText = pretty && prettyText != null ? prettyText : preview;
-  const copyFeedback = useCopyFeedback(displayText);
+  const copyFeedback = useCopyFeedback(client, displayText);
 
   return (
     <div className="message-card">
@@ -53,6 +56,7 @@ export const WebSocketMessageCard = memo(function WebSocketMessageCard({
       </div>
       {payload == null ? null : (
         <PayloadView
+          client={client}
           payload={payload}
           storageKey={storageKey}
           uiState={uiState}

--- a/snapo-network-inspector-web/src/features/network-inspector/hooks/useCopyFeedback.ts
+++ b/snapo-network-inspector-web/src/features/network-inspector/hooks/useCopyFeedback.ts
@@ -1,6 +1,10 @@
 import { useEffect, useState } from "react";
+import type { NetworkClient } from "../../../network/client";
 
-export function useCopyFeedback(text: string): { copied: boolean; copy: () => void; copyWithoutClipboard: () => void } {
+export function useCopyFeedback(
+  client: NetworkClient,
+  text: string
+): { copied: boolean; copy: () => void; copyWithoutClipboard: () => void } {
   const [token, setToken] = useState(0);
 
   useEffect(() => {
@@ -15,8 +19,7 @@ export function useCopyFeedback(text: string): { copied: boolean; copy: () => vo
   return {
     copied: token !== 0,
     copy: () => {
-      void navigator.clipboard.writeText(text);
-      setToken((current) => current + 1);
+      void client.copyText(text).then(() => setToken((current) => current + 1));
     },
     copyWithoutClipboard: () => setToken((current) => current + 1)
   };


### PR DESCRIPTION
## Summary
- Route network inspector text-copy actions through the native-aware network client so JSON response bodies copy correctly in the macOS web view.
- Apply the same clipboard fix to request bodies, JSON value context menus, server-sent events, and WebSocket messages.
- Show copy confirmation only after the clipboard operation succeeds.

## Testing
- `npm run build`
- `npm run typecheck`
- `npm run lint`
- `npm run format:check`
- `npm test` (124 tests passed)
