### PR TITLE
Fix network inspector keyboard navigation

### DIFF
--- a/snapo-network-inspector-web/package-lock.json
+++ b/snapo-network-inspector-web/package-lock.json
@@ -17,6 +17,7 @@
         "eslint-config-prettier": "^10.1.8",
         "eslint-plugin-react-hooks": "^7.1.1",
         "globals": "^17.5.0",
+        "jsdom": "^27.4.0",
         "lucide-react": "^0.468.0",
         "prettier": "^3.8.3",
         "react": "^18.2.0",
@@ -31,6 +32,163 @@
       "engines": {
         "node": ">=22.12.0"
       }
+    },
+    "node_modules/@acemir/cssom": {
+      "version": "0.9.31",
+      "resolved": "https://openai.firewall.socket.dev/npm/@acemir/cssom/-/cssom-0.9.31.tgz",
+      "integrity": "sha512-ZnR3GSaH+/vJ0YlHau21FjfLYjMpYVIzTD8M8vIEQvIGxeOXyXdzCI140rrCY862p/C/BbzWsjc1dgnM9mkoTA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@asamuzakjp/css-color": {
+      "version": "4.1.2",
+      "resolved": "https://openai.firewall.socket.dev/npm/@asamuzakjp/css-color/-/css-color-4.1.2.tgz",
+      "integrity": "sha512-NfBUvBaYgKIuq6E/RBLY1m0IohzNHAYyaJGuTK79Z23uNwmz2jl1mPsC5ZxCCxylinKhT1Amn5oNTlx1wN8cQg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@csstools/css-calc": "^3.0.0",
+        "@csstools/css-color-parser": "^4.0.1",
+        "@csstools/css-parser-algorithms": "^4.0.0",
+        "@csstools/css-tokenizer": "^4.0.0",
+        "lru-cache": "^11.2.5"
+      }
+    },
+    "node_modules/@asamuzakjp/css-color/node_modules/@csstools/css-calc": {
+      "version": "3.3.0",
+      "resolved": "https://openai.firewall.socket.dev/npm/@csstools/css-calc/-/css-calc-3.3.0.tgz",
+      "integrity": "sha512-c5ihYsPkdG6JCkU2zTMm4+k6r7RXuGxtWYhu5DHMIiF1FHzrfmHL5so11AoFpUv/tu61xfcmT4AmKoFfMPoqdQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^4.0.0",
+        "@csstools/css-tokenizer": "^4.0.0"
+      }
+    },
+    "node_modules/@asamuzakjp/css-color/node_modules/@csstools/css-color-parser": {
+      "version": "4.1.10",
+      "resolved": "https://openai.firewall.socket.dev/npm/@csstools/css-color-parser/-/css-color-parser-4.1.10.tgz",
+      "integrity": "sha512-UZhQLIUyJaaMepqehrCODwCg2KW25vFvLWBmqYFaPclYvvxzj/sG8LBOhBFCp11i9uE7t1EyS+RAoV9tztPFyw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@csstools/color-helpers": "^6.1.0",
+        "@csstools/css-calc": "^3.3.0"
+      },
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^4.0.0",
+        "@csstools/css-tokenizer": "^4.0.0"
+      }
+    },
+    "node_modules/@asamuzakjp/css-color/node_modules/@csstools/css-parser-algorithms": {
+      "version": "4.0.0",
+      "resolved": "https://openai.firewall.socket.dev/npm/@csstools/css-parser-algorithms/-/css-parser-algorithms-4.0.0.tgz",
+      "integrity": "sha512-+B87qS7fIG3L5h3qwJ/IFbjoVoOe/bpOdh9hAjXbvx0o8ImEmUsGXN0inFOnk2ChCFgqkkGFQ+TpM5rbhkKe4w==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "peerDependencies": {
+        "@csstools/css-tokenizer": "^4.0.0"
+      }
+    },
+    "node_modules/@asamuzakjp/css-color/node_modules/@csstools/css-tokenizer": {
+      "version": "4.0.0",
+      "resolved": "https://openai.firewall.socket.dev/npm/@csstools/css-tokenizer/-/css-tokenizer-4.0.0.tgz",
+      "integrity": "sha512-QxULHAm7cNu72w97JUNCBFODFaXpbDg+dP8b/oWFAZ2MTRppA3U00Y2L1HqaS4J6yBqxwa/Y3nMBaxVKbB/NsA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.19.0"
+      }
+    },
+    "node_modules/@asamuzakjp/css-color/node_modules/lru-cache": {
+      "version": "11.5.2",
+      "resolved": "https://openai.firewall.socket.dev/npm/lru-cache/-/lru-cache-11.5.2.tgz",
+      "integrity": "sha512-4pfM1Ff0x50o0tQwb5ucw/RzNyD0/YJME6IVcStalZuMWxdt3sR3huStTtxz4PUmvZfRguvDejasvQ2kifR11g==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": "20 || >=22"
+      }
+    },
+    "node_modules/@asamuzakjp/dom-selector": {
+      "version": "6.8.1",
+      "resolved": "https://openai.firewall.socket.dev/npm/@asamuzakjp/dom-selector/-/dom-selector-6.8.1.tgz",
+      "integrity": "sha512-MvRz1nCqW0fsy8Qz4dnLIvhOlMzqDVBabZx6lH+YywFDdjXhMY37SmpV1XFX3JzG5GWHn63j6HX6QPr3lZXHvQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@asamuzakjp/nwsapi": "^2.3.9",
+        "bidi-js": "^1.0.3",
+        "css-tree": "^3.1.0",
+        "is-potential-custom-element-name": "^1.0.1",
+        "lru-cache": "^11.2.6"
+      }
+    },
+    "node_modules/@asamuzakjp/dom-selector/node_modules/lru-cache": {
+      "version": "11.5.2",
+      "resolved": "https://openai.firewall.socket.dev/npm/lru-cache/-/lru-cache-11.5.2.tgz",
+      "integrity": "sha512-4pfM1Ff0x50o0tQwb5ucw/RzNyD0/YJME6IVcStalZuMWxdt3sR3huStTtxz4PUmvZfRguvDejasvQ2kifR11g==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": "20 || >=22"
+      }
+    },
+    "node_modules/@asamuzakjp/nwsapi": {
+      "version": "2.3.9",
+      "resolved": "https://openai.firewall.socket.dev/npm/@asamuzakjp/nwsapi/-/nwsapi-2.3.9.tgz",
+      "integrity": "sha512-n8GuYSrI9bF7FFZ/SjhwevlHc8xaVlb/7HmHelnc/PZXBD2ZR49NnN9sMMuDdEGPeeRQ5d0hqlSlEpgCX3Wl0Q==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@babel/code-frame": {
       "version": "7.29.7",
@@ -333,6 +491,26 @@
         "@keyv/serialize": "^1.1.1"
       }
     },
+    "node_modules/@csstools/color-helpers": {
+      "version": "6.1.0",
+      "resolved": "https://openai.firewall.socket.dev/npm/@csstools/color-helpers/-/color-helpers-6.1.0.tgz",
+      "integrity": "sha512-064IFJdjTfUqnjpCVpMOdbr8FLQBhinbZj6yRv2An2E41O/pLEXqfFRWqGq/SxlE5PEUYTlvWsG2r8MswAVvkg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT-0",
+      "engines": {
+        "node": ">=20.19.0"
+      }
+    },
     "node_modules/@csstools/css-parser-algorithms": {
       "version": "3.0.5",
       "resolved": "https://registry.npmjs.org/@csstools/css-parser-algorithms/-/css-parser-algorithms-3.0.5.tgz",
@@ -357,9 +535,9 @@
       }
     },
     "node_modules/@csstools/css-syntax-patches-for-csstree": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/@csstools/css-syntax-patches-for-csstree/-/css-syntax-patches-for-csstree-1.1.4.tgz",
-      "integrity": "sha512-wgsqt92b7C7tQhIdPNxj0n9zuUbQlvAuI1exyzeNrOKOi62SD7ren8zqszmpVREjAOqg8cD2FqYhQfAuKjk4sw==",
+      "version": "1.1.7",
+      "resolved": "https://openai.firewall.socket.dev/npm/@csstools/css-syntax-patches-for-csstree/-/css-syntax-patches-for-csstree-1.1.7.tgz",
+      "integrity": "sha512-fQ+05118eQS1cofO3aJpB5efgpBZMvIzwr/sbC8kDLVA5XLG8q1kJV5yzrUAI1f7lvhPnm8fgIjzFB8/O/5Dig==",
       "dev": true,
       "funding": [
         {
@@ -619,6 +797,24 @@
       },
       "engines": {
         "node": "^20.19.0 || ^22.13.0 || >=24"
+      }
+    },
+    "node_modules/@exodus/bytes": {
+      "version": "1.15.1",
+      "resolved": "https://openai.firewall.socket.dev/npm/@exodus/bytes/-/bytes-1.15.1.tgz",
+      "integrity": "sha512-S6mL0yNB/Abt9Ei4tq8gDhcczc4S3+vQ4ra7vxnAf+YHC02srtqxKKZghx2Dq6p0e66THKwR6r8N6P95wEty7Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      },
+      "peerDependencies": {
+        "@noble/hashes": "^1.8.0 || ^2.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@noble/hashes": {
+          "optional": true
+        }
       }
     },
     "node_modules/@humanfs/core": {
@@ -1655,6 +1851,16 @@
         "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
       }
     },
+    "node_modules/agent-base": {
+      "version": "7.1.4",
+      "resolved": "https://openai.firewall.socket.dev/npm/agent-base/-/agent-base-7.1.4.tgz",
+      "integrity": "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14"
+      }
+    },
     "node_modules/ajv": {
       "version": "6.15.0",
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.15.0.tgz",
@@ -1756,6 +1962,16 @@
       },
       "engines": {
         "node": ">=6.0.0"
+      }
+    },
+    "node_modules/bidi-js": {
+      "version": "1.0.3",
+      "resolved": "https://openai.firewall.socket.dev/npm/bidi-js/-/bidi-js-1.0.3.tgz",
+      "integrity": "sha512-RKshQI1R3YQ+n9YJz2QQ147P66ELpa1FQEg20Dk8oW9t2KgLbpDLLp9aGZ7y8WHSshDknG0bknqGw5/tyCs5tw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "require-from-string": "^2.0.2"
       }
     },
     "node_modules/brace-expansion": {
@@ -1996,12 +2212,62 @@
         "node": ">=4"
       }
     },
+    "node_modules/cssstyle": {
+      "version": "5.3.7",
+      "resolved": "https://openai.firewall.socket.dev/npm/cssstyle/-/cssstyle-5.3.7.tgz",
+      "integrity": "sha512-7D2EPVltRrsTkhpQmksIu+LxeWAIEk6wRDMJ1qljlv+CKHJM+cJLlfhWIzNA44eAsHXSNe3+vO6DW1yCYx8SuQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@asamuzakjp/css-color": "^4.1.1",
+        "@csstools/css-syntax-patches-for-csstree": "^1.0.21",
+        "css-tree": "^3.1.0",
+        "lru-cache": "^11.2.4"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/cssstyle/node_modules/lru-cache": {
+      "version": "11.5.2",
+      "resolved": "https://openai.firewall.socket.dev/npm/lru-cache/-/lru-cache-11.5.2.tgz",
+      "integrity": "sha512-4pfM1Ff0x50o0tQwb5ucw/RzNyD0/YJME6IVcStalZuMWxdt3sR3huStTtxz4PUmvZfRguvDejasvQ2kifR11g==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": "20 || >=22"
+      }
+    },
     "node_modules/csstype": {
       "version": "3.2.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
       "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/data-urls": {
+      "version": "6.0.1",
+      "resolved": "https://openai.firewall.socket.dev/npm/data-urls/-/data-urls-6.0.1.tgz",
+      "integrity": "sha512-euIQENZg6x8mj3fO6o9+fOW8MimUI4PpD/fZBhJfeioZVy9TUpM4UY7KjQNVZFlqwJ0UdzRDzkycB997HEq1BQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-mimetype": "^5.0.0",
+        "whatwg-url": "^15.1.0"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/data-urls/node_modules/whatwg-mimetype": {
+      "version": "5.0.0",
+      "resolved": "https://openai.firewall.socket.dev/npm/whatwg-mimetype/-/whatwg-mimetype-5.0.0.tgz",
+      "integrity": "sha512-sXcNcHOC51uPGF0P/D4NVtrkjSU2fNsm9iog4ZvZJsL3rjoDAzXZhkm2MWt1y+PUdggKAYVoMAIYcs78wJ51Cw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20"
+      }
     },
     "node_modules/debug": {
       "version": "4.3.7",
@@ -2020,6 +2286,13 @@
           "optional": true
         }
       }
+    },
+    "node_modules/decimal.js": {
+      "version": "10.6.0",
+      "resolved": "https://openai.firewall.socket.dev/npm/decimal.js/-/decimal.js-10.6.0.tgz",
+      "integrity": "sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/deep-is": {
       "version": "0.1.4",
@@ -2071,6 +2344,19 @@
       "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/entities": {
+      "version": "8.0.0",
+      "resolved": "https://openai.firewall.socket.dev/npm/entities/-/entities-8.0.0.tgz",
+      "integrity": "sha512-zwfzJecQ/Uej6tusMqwAqU/6KL2XaB2VZ2Jg54Je6ahNBGNH6Ek6g3jjNCF0fG9EWQKGZNddNjU5F1ZQn/sBnA==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
     },
     "node_modules/env-paths": {
       "version": "2.2.1",
@@ -2667,6 +2953,19 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/html-encoding-sniffer": {
+      "version": "6.0.0",
+      "resolved": "https://openai.firewall.socket.dev/npm/html-encoding-sniffer/-/html-encoding-sniffer-6.0.0.tgz",
+      "integrity": "sha512-CV9TW3Y3f8/wT0BRFc1/KAVQ3TUHiXmaAb6VW9vtiMFf7SLoMd1PdAc4W3KFOFETBJUb90KatHqlsZMWV+R9Gg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@exodus/bytes": "^1.6.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
     "node_modules/html-tags": {
       "version": "3.3.1",
       "resolved": "https://registry.npmjs.org/html-tags/-/html-tags-3.3.1.tgz",
@@ -2678,6 +2977,34 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/http-proxy-agent": {
+      "version": "7.0.2",
+      "resolved": "https://openai.firewall.socket.dev/npm/http-proxy-agent/-/http-proxy-agent-7.0.2.tgz",
+      "integrity": "sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.0",
+        "debug": "^4.3.4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/https-proxy-agent": {
+      "version": "7.0.6",
+      "resolved": "https://openai.firewall.socket.dev/npm/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
+      "integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.2",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 14"
       }
     },
     "node_modules/ignore": {
@@ -2794,6 +3121,13 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/is-potential-custom-element-name": {
+      "version": "1.0.1",
+      "resolved": "https://openai.firewall.socket.dev/npm/is-potential-custom-element-name/-/is-potential-custom-element-name-1.0.1.tgz",
+      "integrity": "sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/isexe": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
@@ -2829,6 +3163,46 @@
       },
       "bin": {
         "js-yaml": "bin/js-yaml.js"
+      }
+    },
+    "node_modules/jsdom": {
+      "version": "27.4.0",
+      "resolved": "https://openai.firewall.socket.dev/npm/jsdom/-/jsdom-27.4.0.tgz",
+      "integrity": "sha512-mjzqwWRD9Y1J1KUi7W97Gja1bwOOM5Ug0EZ6UDK3xS7j7mndrkwozHtSblfomlzyB4NepioNt+B2sOSzczVgtQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@acemir/cssom": "^0.9.28",
+        "@asamuzakjp/dom-selector": "^6.7.6",
+        "@exodus/bytes": "^1.6.0",
+        "cssstyle": "^5.3.4",
+        "data-urls": "^6.0.0",
+        "decimal.js": "^10.6.0",
+        "html-encoding-sniffer": "^6.0.0",
+        "http-proxy-agent": "^7.0.2",
+        "https-proxy-agent": "^7.0.6",
+        "is-potential-custom-element-name": "^1.0.1",
+        "parse5": "^8.0.0",
+        "saxes": "^6.0.0",
+        "symbol-tree": "^3.2.4",
+        "tough-cookie": "^6.0.0",
+        "w3c-xmlserializer": "^5.0.0",
+        "webidl-conversions": "^8.0.0",
+        "whatwg-mimetype": "^4.0.0",
+        "whatwg-url": "^15.1.0",
+        "ws": "^8.18.3",
+        "xml-name-validator": "^5.0.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      },
+      "peerDependencies": {
+        "canvas": "^3.0.0"
+      },
+      "peerDependenciesMeta": {
+        "canvas": {
+          "optional": true
+        }
       }
     },
     "node_modules/jsesc": {
@@ -3493,6 +3867,19 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/parse5": {
+      "version": "8.0.1",
+      "resolved": "https://openai.firewall.socket.dev/npm/parse5/-/parse5-8.0.1.tgz",
+      "integrity": "sha512-z1e/HMG90obSGeidlli3hj7cbocou0/wa5HacvI3ASx34PecNjNQeaHNo5WIZpWofN9kgkqV1q5YvXe3F0FoPw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "entities": "^8.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/inikulin/parse5?sponsor=1"
+      }
+    },
     "node_modules/path-exists": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
@@ -3832,6 +4219,19 @@
       "license": "MIT",
       "dependencies": {
         "queue-microtask": "^1.2.2"
+      }
+    },
+    "node_modules/saxes": {
+      "version": "6.0.0",
+      "resolved": "https://openai.firewall.socket.dev/npm/saxes/-/saxes-6.0.0.tgz",
+      "integrity": "sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "xmlchars": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=v12.22.7"
       }
     },
     "node_modules/scheduler": {
@@ -4183,6 +4583,13 @@
       "integrity": "sha512-ovssysQTa+luh7A5Weu3Rta6FJlFBBbInjOh722LIt6klpU2/HtdUbszju/G4devcvk8PGt7FCLv5wftu3THUA==",
       "dev": true
     },
+    "node_modules/symbol-tree": {
+      "version": "3.2.4",
+      "resolved": "https://openai.firewall.socket.dev/npm/symbol-tree/-/symbol-tree-3.2.4.tgz",
+      "integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/table": {
       "version": "6.9.0",
       "resolved": "https://registry.npmjs.org/table/-/table-6.9.0.tgz",
@@ -4268,6 +4675,26 @@
         "node": ">=14.0.0"
       }
     },
+    "node_modules/tldts": {
+      "version": "7.4.10",
+      "resolved": "https://openai.firewall.socket.dev/npm/tldts/-/tldts-7.4.10.tgz",
+      "integrity": "sha512-GgouD1B+sWwvkaEq8vXC15DjQitxbvs12oIXELpconwm+Tg3zfcEv4jgzq3vtKverDXsg3VI8aRgNL2Nra0Iog==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tldts-core": "^7.4.10"
+      },
+      "bin": {
+        "tldts": "bin/cli.js"
+      }
+    },
+    "node_modules/tldts-core": {
+      "version": "7.4.10",
+      "resolved": "https://openai.firewall.socket.dev/npm/tldts-core/-/tldts-core-7.4.10.tgz",
+      "integrity": "sha512-KnQjp53ZekKgm/r3l+u8kJGGzYgrWdP8+Mql7a4vijh2WE0IrZWspQj/TpTxDho/YxO+AnOZnIjQcCD+q6iJsw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/to-regex-range": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
@@ -4279,6 +4706,32 @@
       },
       "engines": {
         "node": ">=8.0"
+      }
+    },
+    "node_modules/tough-cookie": {
+      "version": "6.0.2",
+      "resolved": "https://openai.firewall.socket.dev/npm/tough-cookie/-/tough-cookie-6.0.2.tgz",
+      "integrity": "sha512-exgYmnmL/sJpR3upZfXG5PoatXQii55xAiXGXzY+sROLZ/Y+SLcp9PgJNI9Vz37HpQ74WvDcLT8eqm+kV3FzrA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "tldts": "^7.0.5"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/tr46": {
+      "version": "6.0.0",
+      "resolved": "https://openai.firewall.socket.dev/npm/tr46/-/tr46-6.0.0.tgz",
+      "integrity": "sha512-bLVMLPtstlZ4iMQHpFHTR7GAGj2jxi8Dg0s2h2MafAE4uSWF98FC/3MomU51iQAMf8/qDUbKWf5GxuvvVcXEhw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "punycode": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=20"
       }
     },
     "node_modules/ts-api-utils": {
@@ -4569,6 +5022,53 @@
         }
       }
     },
+    "node_modules/w3c-xmlserializer": {
+      "version": "5.0.0",
+      "resolved": "https://openai.firewall.socket.dev/npm/w3c-xmlserializer/-/w3c-xmlserializer-5.0.0.tgz",
+      "integrity": "sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "xml-name-validator": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/webidl-conversions": {
+      "version": "8.0.1",
+      "resolved": "https://openai.firewall.socket.dev/npm/webidl-conversions/-/webidl-conversions-8.0.1.tgz",
+      "integrity": "sha512-BMhLD/Sw+GbJC21C/UgyaZX41nPt8bUTg+jWyDeg7e7YN4xOM05YPSIXceACnXVtqyEw/LMClUQMtMZ+PGGpqQ==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/whatwg-mimetype": {
+      "version": "4.0.0",
+      "resolved": "https://openai.firewall.socket.dev/npm/whatwg-mimetype/-/whatwg-mimetype-4.0.0.tgz",
+      "integrity": "sha512-QaKxh0eNIi2mE9p2vEdzfagOKHCcj1pJ56EEHGQOVxp8r9/iszLUUV7v89x9O1p/T+NlTM5W7jW6+cz4Fq1YVg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/whatwg-url": {
+      "version": "15.1.0",
+      "resolved": "https://openai.firewall.socket.dev/npm/whatwg-url/-/whatwg-url-15.1.0.tgz",
+      "integrity": "sha512-2ytDk0kiEj/yu90JOAp44PVPUkO9+jVhyf+SybKlRHSDlvOOZhdPIrr7xTH64l4WixO2cP+wQIcgujkGBPPz6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tr46": "^6.0.0",
+        "webidl-conversions": "^8.0.0"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
     "node_modules/which": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
@@ -4625,6 +5125,45 @@
       "engines": {
         "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
       }
+    },
+    "node_modules/ws": {
+      "version": "8.21.3",
+      "resolved": "https://openai.firewall.socket.dev/npm/ws/-/ws-8.21.3.tgz",
+      "integrity": "sha512-201TZ/kPWxoPr/OKWjquZR1SWKXcvxdH+e1xrx89b3YbmzLMFCLfnaG1HFIgWzJOEWZ7MvpK++odZufgYR50Rw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/xml-name-validator": {
+      "version": "5.0.0",
+      "resolved": "https://openai.firewall.socket.dev/npm/xml-name-validator/-/xml-name-validator-5.0.0.tgz",
+      "integrity": "sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/xmlchars": {
+      "version": "2.2.0",
+      "resolved": "https://openai.firewall.socket.dev/npm/xmlchars/-/xmlchars-2.2.0.tgz",
+      "integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/yallist": {
       "version": "3.1.1",

--- a/snapo-network-inspector-web/package.json
+++ b/snapo-network-inspector-web/package.json
@@ -33,6 +33,7 @@
     "eslint-config-prettier": "^10.1.8",
     "eslint-plugin-react-hooks": "^7.1.1",
     "globals": "^17.5.0",
+    "jsdom": "^27.4.0",
     "lucide-react": "^0.468.0",
     "prettier": "^3.8.3",
     "react": "^18.2.0",

--- a/snapo-network-inspector-web/src/features/network-inspector/components/ContextMenu.tsx
+++ b/snapo-network-inspector-web/src/features/network-inspector/components/ContextMenu.tsx
@@ -1,4 +1,4 @@
-import { useLayoutEffect, useRef } from "react";
+import { useLayoutEffect, useRef, type KeyboardEvent } from "react";
 
 export interface ContextMenuState {
   x: number;
@@ -35,8 +35,60 @@ export function contextMenuPosition({
   };
 }
 
-export function ContextMenu({ menu, onClose }: { menu: ContextMenuState; onClose: () => void }): JSX.Element {
+export function ContextMenu({
+  menu,
+  autoFocus = false,
+  onClose
+}: {
+  menu: ContextMenuState;
+  autoFocus?: boolean;
+  onClose: () => void;
+}): JSX.Element {
   const menuRef = useRef<HTMLDivElement>(null);
+
+  useLayoutEffect(() => {
+    if (autoFocus) menuRef.current?.querySelector<HTMLButtonElement>("button:not(:disabled)")?.focus();
+  }, [autoFocus, menu]);
+
+  const handleKeyDown = (event: KeyboardEvent<HTMLDivElement>) => {
+    // Callers dismiss menus on window keydown. Let the menu finish handling its own keys first.
+    event.stopPropagation();
+    if (event.defaultPrevented || event.nativeEvent.isComposing || event.altKey || event.ctrlKey || event.metaKey)
+      return;
+
+    if (event.key === "Escape" || event.key === "Tab") {
+      if (event.key === "Escape") event.preventDefault();
+      onClose();
+      return;
+    }
+
+    const items = [...event.currentTarget.querySelectorAll<HTMLButtonElement>("button:not(:disabled)")];
+    const current = items.findIndex((item) => item === document.activeElement);
+    let next: number;
+    switch (event.key) {
+      case "ArrowDown":
+        next = (current + 1) % items.length;
+        break;
+      case "ArrowUp":
+        next = current < 0 ? items.length - 1 : (current + items.length - 1) % items.length;
+        break;
+      case "Home":
+        next = 0;
+        break;
+      case "End":
+        next = items.length - 1;
+        break;
+      case "Enter":
+      case " ":
+        event.preventDefault();
+        items[current]?.click();
+        return;
+      default:
+        return;
+    }
+    event.preventDefault();
+    items[next]?.focus();
+  };
 
   useLayoutEffect(() => {
     const element = menuRef.current;
@@ -65,13 +117,17 @@ export function ContextMenu({ menu, onClose }: { menu: ContextMenuState; onClose
     <div
       ref={menuRef}
       className="context-menu"
+      role="menu"
       style={{ left: menu.x, top: menu.y }}
       onPointerDown={(event) => event.stopPropagation()}
+      onKeyDown={handleKeyDown}
     >
       {menu.items.map((item) => (
         <button
           className="context-menu-item"
           type="button"
+          role="menuitem"
+          tabIndex={autoFocus ? -1 : undefined}
           disabled={item.disabled}
           key={item.label}
           onClick={() => {

--- a/snapo-network-inspector-web/src/features/network-inspector/components/RecordList.test.tsx
+++ b/snapo-network-inspector-web/src/features/network-inspector/components/RecordList.test.tsx
@@ -8,7 +8,8 @@ import { recordId, type RequestRecord } from "../../../network/cdp";
 import { RecordList } from "./RecordList";
 
 const records = [request("first"), request("second"), request("third")];
-const client = {} as NetworkClient;
+const copyText = vi.fn().mockResolvedValue(undefined);
+const client = { copyText } as unknown as NetworkClient;
 const onSelect = vi.fn();
 const scrollIntoView = vi.fn();
 let container: HTMLDivElement;
@@ -18,6 +19,7 @@ beforeEach(() => {
   vi.stubGlobal("IS_REACT_ACT_ENVIRONMENT", true);
   Object.defineProperty(Element.prototype, "scrollIntoView", { configurable: true, value: scrollIntoView });
   onSelect.mockClear();
+  copyText.mockClear();
   scrollIntoView.mockClear();
   container = document.createElement("div");
   document.body.append(container);
@@ -58,6 +60,14 @@ function Harness({ records: visibleRecords, initialId }: { records: RequestRecor
 
 function press(target: Element, key: string, options: KeyboardEventInit = {}) {
   const event = new KeyboardEvent("keydown", { key, bubbles: true, cancelable: true, ...options });
+  act(() => {
+    target.dispatchEvent(event);
+  });
+  return event;
+}
+
+function openNativeContextMenu(target: Element, options: MouseEventInit = {}) {
+  const event = new MouseEvent("contextmenu", { bubbles: true, cancelable: true, ...options });
   act(() => {
     target.dispatchEvent(event);
   });
@@ -150,6 +160,79 @@ describe("network request keyboard selection", () => {
     expect(press(list, "ArrowDown").defaultPrevented).toBe(false);
     expect(onSelect).not.toHaveBeenCalled();
     expect(scrollIntoView).not.toHaveBeenCalled();
+  });
+
+  it.each(["Shift+F10", "ContextMenu", "native contextmenu"])(
+    "opens the active request's menu with %s and returns focus after an action",
+    (gesture) => {
+      const list = render();
+      list.focus();
+      press(list, "ArrowDown");
+      const option = list.querySelector('[aria-selected="true"]')!;
+      vi.spyOn(option, "getBoundingClientRect").mockReturnValue({ left: 24, bottom: 88 } as DOMRect);
+
+      const event =
+        gesture === "native contextmenu"
+          ? openNativeContextMenu(list)
+          : press(list, gesture === "Shift+F10" ? "F10" : "ContextMenu", { shiftKey: gesture === "Shift+F10" });
+
+      expect(event.defaultPrevented).toBe(true);
+      const menu = container.querySelector<HTMLElement>('[role="menu"]')!;
+      expect(menu).not.toBeNull();
+      expect(menu.style.left).toBe("24px");
+      expect(menu.style.top).toBe("88px");
+      const items = [...menu.querySelectorAll<HTMLButtonElement>('[role="menuitem"]')];
+      expect(items.map((item) => item.textContent)).toEqual(["Copy URL", "Copy as cURL", "Export HAR (sanitized)..."]);
+      expect(document.activeElement).toBe(items[0]);
+
+      expect(press(items[0], "ArrowDown").defaultPrevented).toBe(true);
+      expect(document.activeElement).toBe(items[1]);
+      press(items[1], "End");
+      expect(document.activeElement).toBe(items[2]);
+      press(items[2], "Home");
+      expect(document.activeElement).toBe(items[0]);
+      expectSelected(list, "second");
+
+      press(items[0], "Enter");
+      expect(copyText).toHaveBeenCalledWith(records[1].url);
+      expect(container.querySelector('[role="menu"]')).toBeNull();
+      expect(document.activeElement).toBe(list);
+      press(list, "ArrowDown");
+      expectSelected(list, "third");
+    }
+  );
+
+  it("dismisses the keyboard menu with Escape without invoking an action", () => {
+    const list = render();
+    list.focus();
+    press(list, "F10", { shiftKey: true });
+    const firstItem = container.querySelector('[role="menuitem"]')!;
+    press(firstItem, "ArrowUp");
+    expect(document.activeElement?.textContent).toBe("Export HAR (sanitized)...");
+    expect(press(document.activeElement!, "Escape").defaultPrevented).toBe(true);
+    expect(container.querySelector('[role="menu"]')).toBeNull();
+    expect(document.activeElement).toBe(list);
+    expect(copyText).not.toHaveBeenCalled();
+  });
+
+  it("keeps pointer context menus attached to the clicked request", () => {
+    const list = render();
+    const options = list.querySelectorAll('[role="option"]');
+    expect(openNativeContextMenu(options[2], { clientX: 70, clientY: 110 }).defaultPrevented).toBe(true);
+    expectSelected(list, "third");
+    const menu = container.querySelector<HTMLElement>('[role="menu"]')!;
+    expect(menu.style.left).toBe("70px");
+    expect(menu.style.top).toBe("110px");
+    act(() => menu.querySelector<HTMLButtonElement>('[role="menuitem"]')!.click());
+    expect(copyText).toHaveBeenCalledWith(records[2].url);
+  });
+
+  it("does not open a keyboard menu without an active request", () => {
+    const list = render([], null);
+    expect(press(list, "F10", { shiftKey: true }).defaultPrevented).toBe(false);
+    expect(press(list, "ContextMenu").defaultPrevented).toBe(false);
+    expect(openNativeContextMenu(list).defaultPrevented).toBe(false);
+    expect(container.querySelector('[role="menu"]')).toBeNull();
   });
 });
 

--- a/snapo-network-inspector-web/src/features/network-inspector/components/RecordList.test.tsx
+++ b/snapo-network-inspector-web/src/features/network-inspector/components/RecordList.test.tsx
@@ -1,0 +1,172 @@
+// @vitest-environment jsdom
+
+import { act, useState } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { NetworkClient } from "../../../network/client";
+import { recordId, type RequestRecord } from "../../../network/cdp";
+import { RecordList } from "./RecordList";
+
+const records = [request("first"), request("second"), request("third")];
+const client = {} as NetworkClient;
+const onSelect = vi.fn();
+const scrollIntoView = vi.fn();
+let container: HTMLDivElement;
+let root: Root;
+
+beforeEach(() => {
+  vi.stubGlobal("IS_REACT_ACT_ENVIRONMENT", true);
+  Object.defineProperty(Element.prototype, "scrollIntoView", { configurable: true, value: scrollIntoView });
+  onSelect.mockClear();
+  scrollIntoView.mockClear();
+  container = document.createElement("div");
+  document.body.append(container);
+  root = createRoot(container);
+});
+
+afterEach(() => {
+  act(() => root.unmount());
+  container.remove();
+  Reflect.deleteProperty(Element.prototype, "scrollIntoView");
+  vi.unstubAllGlobals();
+});
+
+function render(visibleRecords = records, initialId: string | null = recordId(records[0])) {
+  act(() => root.render(<Harness records={visibleRecords} initialId={initialId} />));
+  return container.querySelector<HTMLDivElement>('[role="listbox"]')!;
+}
+
+function Harness({ records: visibleRecords, initialId }: { records: RequestRecord[]; initialId: string | null }) {
+  const [selectedId, setSelectedId] = useState(initialId);
+  return (
+    <>
+      <input aria-label="Filter" />
+      <RecordList
+        records={visibleRecords}
+        allRecords={records}
+        placeholder={null}
+        selectedRecordId={selectedId}
+        onSelect={(id) => {
+          onSelect(id);
+          setSelectedId(id);
+        }}
+        client={client}
+      />
+    </>
+  );
+}
+
+function press(target: Element, key: string, options: KeyboardEventInit = {}) {
+  const event = new KeyboardEvent("keydown", { key, bubbles: true, cancelable: true, ...options });
+  act(() => {
+    target.dispatchEvent(event);
+  });
+  return event;
+}
+
+function expectSelected(list: HTMLElement, label: string) {
+  const selected = list.querySelector('[aria-selected="true"]')!;
+  expect(selected.textContent).toContain(label);
+  expect(list.getAttribute("aria-activedescendant")).toBe(selected.id);
+  expect(list.querySelectorAll('[aria-selected="true"]')).toHaveLength(1);
+}
+
+describe("network request keyboard selection", () => {
+  it("owns focus after a click and moves selection instead of scrolling", () => {
+    const list = render();
+    const options = list.querySelectorAll<HTMLButtonElement>('[role="option"]');
+
+    // A synthetic click does not focus the button, like a mouse click in macOS WebKit.
+    act(() => options[1].click());
+    expect(document.activeElement).toBe(list);
+    expectSelected(list, "second");
+    expect(list.tabIndex).toBe(0);
+    expect([...options].every((option) => option.tabIndex === -1)).toBe(true);
+
+    expect(press(list, "ArrowDown").defaultPrevented).toBe(true);
+    expectSelected(list, "third");
+    expect(scrollIntoView).toHaveBeenLastCalledWith({ block: "nearest" });
+    expect(scrollIntoView.mock.instances.at(-1)).toBe(options[2]);
+    expect(document.activeElement).toBe(list);
+
+    expect(press(list, "ArrowUp").defaultPrevented).toBe(true);
+    expectSelected(list, "second");
+  });
+
+  it("uses the current filtered and sorted order", () => {
+    const list = render();
+    render([records[2], records[0]]);
+    press(list, "ArrowUp");
+    expect(onSelect).toHaveBeenLastCalledWith(recordId(records[2]));
+    expectSelected(list, "third");
+    press(list, "ArrowDown");
+    expectSelected(list, "first");
+  });
+
+  it("clamps at each end and supports Home and End", () => {
+    const list = render();
+    expect(press(list, "ArrowUp").defaultPrevented).toBe(true);
+    expect(onSelect).not.toHaveBeenCalled();
+    expect(press(list, "End").defaultPrevented).toBe(true);
+    expectSelected(list, "third");
+    onSelect.mockClear();
+    expect(press(list, "ArrowDown").defaultPrevented).toBe(true);
+    expect(onSelect).not.toHaveBeenCalled();
+    expect(press(list, "Home").defaultPrevented).toBe(true);
+    expectSelected(list, "first");
+  });
+
+  it.each([
+    ["ArrowDown", "first"],
+    ["ArrowUp", "third"]
+  ])("starts at the appropriate end for %s without a selection", (key, label) => {
+    const list = render(records, null);
+    press(list, key);
+    expectSelected(list, label);
+  });
+
+  it("leaves unrelated controls, modified keys, and composition alone", () => {
+    const list = render();
+    const filter = container.querySelector("input")!;
+    filter.focus();
+    expect(press(filter, "ArrowDown").defaultPrevented).toBe(false);
+    expect(document.activeElement).toBe(filter);
+    for (const modifiers of [
+      { altKey: true },
+      { ctrlKey: true },
+      { metaKey: true },
+      { shiftKey: true },
+      { isComposing: true }
+    ]) {
+      expect(press(list, "ArrowDown", modifiers).defaultPrevented).toBe(false);
+    }
+    expect(press(list, "ArrowLeft").defaultPrevented).toBe(false);
+    expect(onSelect).not.toHaveBeenCalled();
+    expect(scrollIntoView).not.toHaveBeenCalled();
+  });
+
+  it("does nothing for an empty list", () => {
+    const list = render([], null);
+    expect(press(list, "ArrowDown").defaultPrevented).toBe(false);
+    expect(onSelect).not.toHaveBeenCalled();
+    expect(scrollIntoView).not.toHaveBeenCalled();
+  });
+});
+
+function request(id: string): RequestRecord {
+  return {
+    kind: "request",
+    server: { deviceId: "device", socketName: "socket", instanceId: "instance" },
+    requestId: id,
+    method: "GET",
+    url: `https://example.com/${id}`,
+    requestHeaders: [],
+    responseHeaders: [],
+    status: { kind: "success", code: 200 },
+    startedAt: 1,
+    endedAt: 2,
+    streamEvents: [],
+    streamEventCount: 0,
+    updatedAt: 2
+  };
+}

--- a/snapo-network-inspector-web/src/features/network-inspector/components/RecordList.tsx
+++ b/snapo-network-inspector-web/src/features/network-inspector/components/RecordList.tsx
@@ -34,7 +34,7 @@ export const RecordList = memo(function RecordList({
   const listId = useId();
   const listRef = useRef<HTMLDivElement>(null);
   const selectedIndex = records.findIndex((record) => recordId(record) === selectedRecordId);
-  const [menu, setMenu] = useState<ContextMenuState | null>(null);
+  const [menu, setMenu] = useState<(ContextMenuState & { keyboard: boolean }) | null>(null);
   const [showTopFade, setShowTopFade] = useState(false);
   const selectRecord = useCallback(
     (id: string) => {
@@ -44,16 +44,42 @@ export const RecordList = memo(function RecordList({
     },
     [onSelect]
   );
+  const openContextMenu = useCallback(
+    (record: InspectorRecord, x: number, y: number, keyboard: boolean) => {
+      selectRecord(recordId(record));
+      setMenu({
+        x,
+        y,
+        keyboard,
+        items: sidebarContextMenuItems(record, selectedRecordId, allRecords, client)
+      });
+    },
+    [allRecords, client, selectRecord, selectedRecordId]
+  );
+  const openActiveContextMenu = () => {
+    const record = records[selectedIndex];
+    const row = listRef.current?.children.item(selectedIndex);
+    if (record == null || row == null) return false;
+    row.scrollIntoView({ block: "nearest" });
+    const { left, bottom } = row.getBoundingClientRect();
+    openContextMenu(record, left, bottom, true);
+    return true;
+  };
+  const closeContextMenu = () => {
+    setMenu(null);
+    listRef.current?.focus({ preventScroll: true });
+  };
   const handleKeyDown = (event: KeyboardEvent<HTMLDivElement>) => {
-    if (
-      event.defaultPrevented ||
-      event.nativeEvent.isComposing ||
-      event.altKey ||
-      event.ctrlKey ||
-      event.metaKey ||
-      event.shiftKey
-    )
+    if (event.defaultPrevented || event.nativeEvent.isComposing || event.altKey || event.ctrlKey || event.metaKey)
       return;
+    if (event.key === "ContextMenu" || (event.key === "F10" && event.shiftKey)) {
+      if (openActiveContextMenu()) {
+        event.preventDefault();
+        event.stopPropagation();
+      }
+      return;
+    }
+    if (event.shiftKey) return;
     if (records.length === 0) return;
 
     let nextIndex: number;
@@ -81,16 +107,11 @@ export const RecordList = memo(function RecordList({
   };
   const handleContextMenu = useCallback(
     (record: InspectorRecord, event: MouseEvent) => {
-      const id = recordId(record);
       event.preventDefault();
-      selectRecord(id);
-      setMenu({
-        x: event.clientX,
-        y: event.clientY,
-        items: sidebarContextMenuItems(record, selectedRecordId, allRecords, client)
-      });
+      event.stopPropagation();
+      openContextMenu(record, event.clientX, event.clientY, false);
     },
-    [allRecords, client, selectRecord, selectedRecordId]
+    [openContextMenu]
   );
 
   useEffect(() => {
@@ -116,6 +137,12 @@ export const RecordList = memo(function RecordList({
         aria-activedescendant={selectedIndex < 0 ? undefined : `${listId}-${selectedIndex}`}
         tabIndex={0}
         onKeyDown={handleKeyDown}
+        onContextMenu={(event) => {
+          if (event.target === event.currentTarget && openActiveContextMenu()) {
+            event.preventDefault();
+            event.stopPropagation();
+          }
+        }}
         onScroll={(event) => handleRecordListScroll(event, setShowTopFade)}
       >
         {records.map((record, index) => {
@@ -134,7 +161,7 @@ export const RecordList = memo(function RecordList({
         })}
       </div>
       <div className={showTopFade ? "record-list-top-fade visible" : "record-list-top-fade"} />
-      {menu == null ? null : <ContextMenu menu={menu} onClose={() => setMenu(null)} />}
+      {menu == null ? null : <ContextMenu menu={menu} autoFocus={menu.keyboard} onClose={closeContextMenu} />}
     </div>
   );
 });

--- a/snapo-network-inspector-web/src/features/network-inspector/components/RecordList.tsx
+++ b/snapo-network-inspector-web/src/features/network-inspector/components/RecordList.tsx
@@ -1,4 +1,14 @@
-import { memo, useCallback, useEffect, useState, type MouseEvent, type UIEvent } from "react";
+import {
+  memo,
+  useCallback,
+  useEffect,
+  useId,
+  useRef,
+  useState,
+  type KeyboardEvent,
+  type MouseEvent,
+  type UIEvent
+} from "react";
 import type { NetworkClient } from "../../../network/client";
 import { recordId, type InspectorRecord } from "../../../network/cdp";
 import { ContextMenu, type ContextMenuItem, type ContextMenuState } from "./ContextMenu";
@@ -21,20 +31,66 @@ export const RecordList = memo(function RecordList({
   onSelect(id: string): void;
   client: NetworkClient;
 }): JSX.Element {
+  const listId = useId();
+  const listRef = useRef<HTMLDivElement>(null);
+  const selectedIndex = records.findIndex((record) => recordId(record) === selectedRecordId);
   const [menu, setMenu] = useState<ContextMenuState | null>(null);
   const [showTopFade, setShowTopFade] = useState(false);
+  const selectRecord = useCallback(
+    (id: string) => {
+      // WebKit does not always focus buttons on click. Keep keyboard ownership on the list.
+      listRef.current?.focus({ preventScroll: true });
+      onSelect(id);
+    },
+    [onSelect]
+  );
+  const handleKeyDown = (event: KeyboardEvent<HTMLDivElement>) => {
+    if (
+      event.defaultPrevented ||
+      event.nativeEvent.isComposing ||
+      event.altKey ||
+      event.ctrlKey ||
+      event.metaKey ||
+      event.shiftKey
+    )
+      return;
+    if (records.length === 0) return;
+
+    let nextIndex: number;
+    switch (event.key) {
+      case "ArrowDown":
+        nextIndex = Math.min(selectedIndex + 1, records.length - 1);
+        break;
+      case "ArrowUp":
+        nextIndex = selectedIndex < 0 ? records.length - 1 : Math.max(selectedIndex - 1, 0);
+        break;
+      case "Home":
+        nextIndex = 0;
+        break;
+      case "End":
+        nextIndex = records.length - 1;
+        break;
+      default:
+        return;
+    }
+
+    event.preventDefault();
+    const id = recordId(records[nextIndex]);
+    if (id !== selectedRecordId) selectRecord(id);
+    listRef.current?.children.item(nextIndex)?.scrollIntoView({ block: "nearest" });
+  };
   const handleContextMenu = useCallback(
     (record: InspectorRecord, event: MouseEvent) => {
       const id = recordId(record);
       event.preventDefault();
-      onSelect(id);
+      selectRecord(id);
       setMenu({
         x: event.clientX,
         y: event.clientY,
         items: sidebarContextMenuItems(record, selectedRecordId, allRecords, client)
       });
     },
-    [allRecords, client, onSelect, selectedRecordId]
+    [allRecords, client, selectRecord, selectedRecordId]
   );
 
   useEffect(() => {
@@ -52,16 +108,26 @@ export const RecordList = memo(function RecordList({
 
   return (
     <div className="record-list-frame">
-      <div className="record-list" onScroll={(event) => handleRecordListScroll(event, setShowTopFade)}>
-        {records.map((record) => {
+      <div
+        ref={listRef}
+        className="record-list"
+        role="listbox"
+        aria-label="Network requests"
+        aria-activedescendant={selectedIndex < 0 ? undefined : `${listId}-${selectedIndex}`}
+        tabIndex={0}
+        onKeyDown={handleKeyDown}
+        onScroll={(event) => handleRecordListScroll(event, setShowTopFade)}
+      >
+        {records.map((record, index) => {
           const id = recordId(record);
           return (
             <RecordRow
               key={id}
               id={id}
+              optionId={`${listId}-${index}`}
               record={record}
               selected={selectedRecordId === id}
-              onSelect={onSelect}
+              onSelect={selectRecord}
               onContextMenu={handleContextMenu}
             />
           );
@@ -79,12 +145,14 @@ function handleRecordListScroll(event: UIEvent<HTMLDivElement>, setShowTopFade: 
 
 const RecordRow = memo(function RecordRow({
   id,
+  optionId,
   record,
   selected,
   onSelect,
   onContextMenu
 }: {
   id: string;
+  optionId: string;
   record: InspectorRecord;
   selected: boolean;
   onSelect(id: string): void;
@@ -93,7 +161,11 @@ const RecordRow = memo(function RecordRow({
   const path = splitUrl(record.url);
   return (
     <button
+      id={optionId}
       type="button"
+      role="option"
+      aria-selected={selected}
+      tabIndex={-1}
       className={`record-row ${selected ? "selected" : ""}`}
       onClick={() => onSelect(id)}
       onContextMenu={(event) => onContextMenu(record, event)}

--- a/snapo-network-inspector-web/src/styles.css
+++ b/snapo-network-inspector-web/src/styles.css
@@ -1129,7 +1129,8 @@ pre {
   line-height: 16px;
 }
 
-.context-menu-item:hover {
+.context-menu-item:hover,
+.context-menu-item:focus-visible {
   background: var(--surface-container-high);
 }
 


### PR DESCRIPTION
## Summary
- Handle Up/Down and Home/End in the network request list so they change selection in the displayed order instead of triggering default scrolling.
- Keep keyboard focus on the list after mouse selection, expose the active option to accessibility tools, and scroll the selected request into view. Leave modified keys and other controls alone.
- Restore Shift+F10, Menu-key, and native context-menu access to the active request. Support keyboard menu navigation, activation, dismissal, and focus restoration.
- Add 13 DOM interaction regression tests with a Node-compatible jsdom development dependency.

## Testing
- [x] `npm run build`
- [x] `npm run typecheck`
- [x] `npm run lint`
- [x] `npm run format:check`
- [x] `npm test` — 137 tests passed
- [x] `git diff --check`
- [x] Built and ran Snap-O locally — live WebKit interaction was unavailable; focus, selection, and default-key handling were verified in DOM tests.
- [x] Added or updated tests

## Checklist
- [x] I have read the [Contributing guidelines](https://github.com/openai/snap-o?tab=contributing-ov-file#contributing-to-snap-o)
- [x] Documentation has been updated (if needed) — no documentation change needed.