### PR TITLE
Explain unavailable response bodies and retry failed loads

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,17 @@
+Snap-O is a public, open-source Android inspection tool.
+
+## Repository Layout
+
+- `snapo-app-mac/`: macOS app and shared Swift device client.
+- `snapo-network-inspector-web/`: React UI embedded in the macOS app.
+- `snapo-link-android/`: Android libraries and sample apps.
+- `contracts/`: shared protocol definitions and fixtures.
+- `scripts/snapo` and `tests/snapo_cli/`: command-line client and tests.
+
+## Public Repository
+
+Use synthetic data in tests and examples. Never publish credentials, captured private traffic, confidential implementation details, or private issue-tracker links, identifiers, or content. Review the full diff, commit message, and PR text for sensitive information before publishing.
+
+## Pull Request Descriptions
+
+Lead with a short paragraph explaining the problem, its impact, and why the PR is needed. Put it before `## Summary`, without a `## Why` heading. Follow the summary with `## Validation`, listing the checks performed and any remaining limitations. Keep the description concise and specific.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -12,6 +12,12 @@ Snap-O is a public, open-source Android inspection tool.
 
 Use synthetic data in tests and examples. Never publish credentials, captured private traffic, confidential implementation details, or private issue-tracker links, identifiers, or content. Review the full diff, commit message, and PR text for sensitive information before publishing.
 
+## Writing
+
+Use plain technical English in all prose, including READMEs, docs, code comments, UI text, commit messages, and PR descriptions. Prefer common words, active voice, and sentences of about 15 words, with one main idea each. Keep necessary technical terms, explain unfamiliar jargon for the intended reader, and preserve exact meaning. Remove repetition, but do not make the prose choppy or omit useful detail.
+
+Code comments should explain non-obvious reasons or constraints, not repeat what the code does. Before finishing, reread new or changed prose for clarity and accuracy.
+
 ## Pull Request Descriptions
 
 Lead with a short paragraph explaining the problem, its impact, and why the PR is needed. Put it before `## Summary`, without a `## Why` heading. Follow the summary with `## Validation`, listing the checks performed and any remaining limitations. Keep the description concise and specific.

--- a/snapo-app-mac/Snap-O/NetworkInspector/NetworkInspectorBridgeModels.swift
+++ b/snapo-app-mac/Snap-O/NetworkInspector/NetworkInspectorBridgeModels.swift
@@ -176,6 +176,22 @@ struct NetworkRequestBodies: Codable {
   let requestBody: String?
   let responseBody: String?
   let responseBodyBase64Encoded: Bool?
+  let responseBodyLoadError: NetworkResponseBodyLoadError?
+}
+
+enum NetworkResponseBodyLoadError: String, Codable {
+  case unavailable
+  case failed
+
+  static func resolve(_ response: NetworkCDPMessage?) -> Self? {
+    if response?.error == nil, response?.result?["body"]?.stringValue != nil { return nil }
+    if let error = response?.error,
+       error.code == -32000,
+       error.message.hasPrefix("No response body captured for ") {
+      return .unavailable
+    }
+    return .failed
+  }
 }
 
 struct NetworkStreamStarted: Codable {

--- a/snapo-app-mac/Snap-O/NetworkInspector/NetworkInspectorService.swift
+++ b/snapo-app-mac/Snap-O/NetworkInspector/NetworkInspectorService.swift
@@ -265,13 +265,16 @@ actor NetworkInspectorService {
 
   func loadBodies(_ input: NetworkLoadBodiesInput) async -> NetworkRequestBodies {
     let reference = NetworkServerReference(deviceId: input.deviceId, socketName: input.socketName)
+    let currentInstanceID = Self.instanceID(for: servers[reference.key]?.appInfo)
     if let requestedInstanceID = input.serverInstanceId,
-       requestedInstanceID != Self.instanceID(for: servers[reference.key]?.appInfo) {
+       requestedInstanceID != currentInstanceID {
       return NetworkRequestBodies(
         requestId: input.requestId,
         requestBody: nil,
         responseBody: nil,
-        responseBodyBase64Encoded: nil
+        responseBodyBase64Encoded: nil,
+        responseBodyLoadError: input.includeResponseBody == false ? nil :
+          (currentInstanceID == nil ? .failed : .unavailable)
       )
     }
 
@@ -293,7 +296,8 @@ actor NetworkInspectorService {
       requestId: input.requestId,
       requestBody: request?.result?["postData"]?.stringValue,
       responseBody: response?.result?["body"]?.stringValue,
-      responseBodyBase64Encoded: response?.result?["base64Encoded"]?.boolValue
+      responseBodyBase64Encoded: response?.result?["base64Encoded"]?.boolValue,
+      responseBodyLoadError: input.includeResponseBody == false ? nil : .resolve(response)
     )
   }
 

--- a/snapo-network-inspector-web/src/features/network-inspector/NetworkInspectorApp.tsx
+++ b/snapo-network-inspector-web/src/features/network-inspector/NetworkInspectorApp.tsx
@@ -87,6 +87,7 @@ export function NetworkInspectorApp({
           streamIsRetrying={model.streamIsRetrying}
           uiState={model.uiState}
           onOpenDocs={model.openDocs}
+          onRetryResponseBody={model.retryResponseBody}
         />
       </main>
     </div>

--- a/snapo-network-inspector-web/src/features/network-inspector/components/DetailPane.tsx
+++ b/snapo-network-inspector-web/src/features/network-inspector/components/DetailPane.tsx
@@ -16,7 +16,8 @@ export const DetailContent = memo(function DetailContent({
   serverScopedItems,
   streamIsRetrying,
   uiState,
-  onOpenDocs
+  onOpenDocs,
+  onRetryResponseBody
 }: {
   client: NetworkClient;
   record: InspectorRecord | null;
@@ -26,6 +27,7 @@ export const DetailContent = memo(function DetailContent({
   streamIsRetrying: boolean;
   uiState: InspectorUiState;
   onOpenDocs(): void;
+  onRetryResponseBody(): void;
 }): JSX.Element {
   if (record == null) {
     const empty = resolveDetailEmptyState({ servers, selectedServer, serverScopedItems, streamIsRetrying });
@@ -46,7 +48,7 @@ export const DetailContent = memo(function DetailContent({
   }
 
   if (record.kind === "websocket") return <WebSocketDetail client={client} record={record} uiState={uiState} />;
-  return <RequestDetail client={client} record={record} uiState={uiState} />;
+  return <RequestDetail client={client} record={record} uiState={uiState} onRetryResponseBody={onRetryResponseBody} />;
 });
 
 function EmptyState({

--- a/snapo-network-inspector-web/src/features/network-inspector/components/RequestDetail.test.tsx
+++ b/snapo-network-inspector-web/src/features/network-inspector/components/RequestDetail.test.tsx
@@ -12,6 +12,7 @@ describe("Response Body loading state", () => {
         client={{} as NetworkClient}
         record={request({ encodedDataLength: 7_340_032 })}
         uiState={expandedUiState}
+        onRetryResponseBody={() => {}}
       />
     );
 
@@ -29,6 +30,7 @@ describe("Response Body loading state", () => {
         client={{} as NetworkClient}
         record={request({ encodedDataLength: 9_437_184, responseBodyTruncatedBytes: 4_194_304 })}
         uiState={expandedUiState}
+        onRetryResponseBody={() => {}}
       />
     );
 
@@ -37,17 +39,53 @@ describe("Response Body loading state", () => {
     expect(markup).toContain("Loading...");
   });
 
-  it("does not leave a loading indicator behind when a body is unavailable", () => {
+  it("explains when a body is no longer available", () => {
     const markup = renderToStaticMarkup(
       <RequestDetail
         client={{} as NetworkClient}
-        record={request({ encodedDataLength: 7_340_032, responseBodyLoadCompleted: true })}
+        record={request({
+          encodedDataLength: 7_340_032,
+          responseBodyLoadCompleted: true,
+          responseBodyLoadError: "unavailable"
+        })}
         uiState={expandedUiState}
+        onRetryResponseBody={() => {}}
       />
     );
 
-    expect(markup).not.toContain("Response Body");
+    expect(markup).toContain("Response Body");
+    expect(markup).toContain("This response is no longer available. Try making the request again.");
+    expect(markup).not.toContain("Captured 7.3 MB");
+    expect(markup).not.toContain("Retry");
     expect(markup).not.toContain("Loading...");
+  });
+
+  it("offers a retry after a temporary failure", () => {
+    const markup = renderToStaticMarkup(
+      <RequestDetail
+        client={{} as NetworkClient}
+        record={request({ responseBodyLoadCompleted: true, responseBodyLoadError: "failed" })}
+        uiState={expandedUiState}
+        onRetryResponseBody={() => {}}
+      />
+    );
+    expect(markup).toContain("Couldn’t load the response. Try again.");
+    expect(markup).toContain('type="button">Retry</button>');
+    expect(markup).not.toContain("no longer available");
+    expect(markup).not.toContain("Loading...");
+  });
+
+  it("does not label a genuinely empty response as unavailable", () => {
+    const markup = renderToStaticMarkup(
+      <RequestDetail
+        client={{} as NetworkClient}
+        record={request({ status: { kind: "success", code: 204 }, encodedDataLength: 0 })}
+        uiState={expandedUiState}
+        onRetryResponseBody={() => {}}
+      />
+    );
+    expect(markup).not.toContain("Response Body");
+    expect(markup).not.toContain("no longer available");
   });
 });
 

--- a/snapo-network-inspector-web/src/features/network-inspector/components/RequestDetail.tsx
+++ b/snapo-network-inspector-web/src/features/network-inspector/components/RequestDetail.tsx
@@ -15,11 +15,13 @@ import { SseCopyAllButton, SseEventList } from "./StreamEvents";
 export const RequestDetail = memo(function RequestDetail({
   client,
   record,
-  uiState
+  uiState,
+  onRetryResponseBody
 }: {
   client: NetworkClient;
   record: RequestRecord;
   uiState: InspectorUiState;
+  onRetryResponseBody(): void;
 }): JSX.Element {
   const isSseResponse = isLikelyStreamingRequest(record);
   const requestBodyDisplayText = useRequestBodyDisplayText(record);
@@ -38,6 +40,7 @@ export const RequestDetail = memo(function RequestDetail({
         totalBytes: record.encodedDataLength
       });
   const isResponseBodyLoading = !isSseResponse && shouldRequestResponseBody(record);
+  const responseBodyLoadError = !isSseResponse && responseBody == null ? record.responseBodyLoadError : null;
   const prefix = `request:${recordId(record)}`;
   const timingText = useAdaptiveTimingText(record.startedAt, record.endedAt, record.status);
 
@@ -103,14 +106,33 @@ export const RequestDetail = memo(function RequestDetail({
           />
         </Section>
       ) : null}
-      {responseBody == null && !isResponseBodyLoading ? null : (
+      {responseBody == null && !isResponseBodyLoading && responseBodyLoadError == null ? null : (
         <Section
           title="Response Body"
-          meta={responseBody == null ? responseBodyCaptureMetadata(record) : payloadMetadata(responseBody)}
+          meta={
+            responseBodyLoadError != null
+              ? null
+              : responseBody == null
+                ? responseBodyCaptureMetadata(record)
+                : payloadMetadata(responseBody)
+          }
           storageKey={`${prefix}:responseBody`}
           uiState={uiState}
         >
-          {responseBody == null ? (
+          {responseBodyLoadError != null ? (
+            <div className="body-load-message" role="status">
+              <span>
+                {responseBodyLoadError === "unavailable"
+                  ? "This response is no longer available. Try making the request again."
+                  : "Couldn’t load the response. Try again."}
+              </span>
+              {responseBodyLoadError === "failed" ? (
+                <button className="text-button" type="button" onClick={onRetryResponseBody}>
+                  Retry
+                </button>
+              ) : null}
+            </div>
+          ) : responseBody == null ? (
             <div className="payload-card">
               <div className="body-loading" role="status">
                 <LoaderCircle className="body-loading-spinner" size={14} aria-hidden="true" />

--- a/snapo-network-inspector-web/src/features/network-inspector/hooks/useNetworkInspectorModel.ts
+++ b/snapo-network-inspector-web/src/features/network-inspector/hooks/useNetworkInspectorModel.ts
@@ -55,6 +55,7 @@ export interface NetworkInspectorModel {
   setSearchText(value: string): void;
   toggleSortOrder(): void;
   clearCompletedRecords(): void;
+  retryResponseBody(): void;
   openDocs(): void;
 }
 
@@ -213,6 +214,20 @@ export function useNetworkInspectorModel(): NetworkInspectorModel {
   }, [selectedRecordId, visibleRecords]);
   const selectedRequestKey = selectedRecord?.kind === "request" ? selectedRecordId : null;
 
+  const retryResponseBody = useCallback(() => {
+    if (selectedRecord?.kind !== "request" || selectedRecord.responseBodyLoadError !== "failed") return;
+    const recordKey = requestRecordKey(selectedRecord.server, selectedRecord.requestId);
+    bodyLoader.forgetJob(`${recordKey}\u0000response`);
+    bodyLoader.forgetRecords(
+      bodyCache.put(recordKey, {
+        requestId: selectedRecord.requestId,
+        responseBodyLoadCompleted: false,
+        responseBodyLoadError: null
+      })
+    );
+    setBodyCacheRevision((revision) => revision + 1);
+  }, [bodyCache, bodyLoader, selectedRecord]);
+
   useEffect(() => {
     bodyLoader.forgetRecords(bodyCache.select(selectedRequestKey));
   }, [bodyCache, bodyLoader, selectedRequestKey]);
@@ -358,6 +373,7 @@ export function useNetworkInspectorModel(): NetworkInspectorModel {
     setSearchText,
     toggleSortOrder,
     clearCompletedRecords,
+    retryResponseBody,
     openDocs
   };
 }

--- a/snapo-network-inspector-web/src/network/body-loader.test.ts
+++ b/snapo-network-inspector-web/src/network/body-loader.test.ts
@@ -108,7 +108,64 @@ describe("RequestBodyLoader", () => {
     loader.schedule([request]);
     await nextTask();
 
-    expect(loaded).toEqual([{ requestId: "request", responseBodyLoadCompleted: true }]);
+    expect(loaded).toEqual([
+      { requestId: "request", responseBodyLoadCompleted: true, responseBodyLoadError: "failed" }
+    ]);
+    loader.dispose();
+  });
+
+  it("preserves a confirmed unavailable response", async () => {
+    const loaded: RequestBodies[] = [];
+    const request = job("request", bodyLoadPriority.selected);
+    request.input.includeResponseBody = true;
+    const loader = new RequestBodyLoader(
+      async (input) => ({ requestId: input.requestId, responseBodyLoadError: "unavailable" }),
+      (_recordKey, bodies) => loaded.push(bodies)
+    );
+    loader.retainRecords(new Set([request.recordKey]));
+    loader.schedule([request]);
+    await nextTask();
+    expect(loaded).toEqual([
+      { requestId: "request", responseBodyLoadCompleted: true, responseBodyLoadError: "unavailable" }
+    ]);
+    loader.dispose();
+  });
+
+  it("retries only the failed response job and clears its error after success", async () => {
+    const loaded: RequestBodies[] = [];
+    const started: string[] = [];
+    const request = job("request", bodyLoadPriority.selected);
+    const response: BodyLoadJob = {
+      ...request,
+      key: "request:response",
+      input: { ...request.input, includeRequestBody: false, includeResponseBody: true }
+    };
+    let failResponse = true;
+    const loader = new RequestBodyLoader(
+      async (input) => {
+        started.push(input.includeResponseBody ? "response" : "request");
+        if (!input.includeResponseBody) return { requestId: input.requestId, requestBody: "input" };
+        if (failResponse) throw new Error("temporary failure");
+        return { requestId: input.requestId, responseBody: "output" };
+      },
+      (_recordKey, bodies) => loaded.push(bodies)
+    );
+    loader.retainRecords(new Set([request.recordKey]));
+    loader.schedule([request, response]);
+    await nextTask();
+    loader.schedule([response]);
+    expect(started).toEqual(["request", "response"]);
+    failResponse = false;
+    loader.forgetJob(response.key);
+    loader.schedule([request, response]);
+    await nextTask();
+    expect(started).toEqual(["request", "response", "response"]);
+    expect(loaded.at(-1)).toEqual({
+      requestId: "request",
+      responseBody: "output",
+      responseBodyLoadCompleted: true,
+      responseBodyLoadError: null
+    });
     loader.dispose();
   });
 });

--- a/snapo-network-inspector-web/src/network/body-loader.ts
+++ b/snapo-network-inspector-web/src/network/body-loader.ts
@@ -85,6 +85,13 @@ export class RequestBodyLoader {
     }
   }
 
+  forgetJob(key: string): void {
+    const entry = this.entries.get(key);
+    if (entry == null) return;
+    entry.cancelled = true;
+    this.entries.delete(key);
+  }
+
   dispose(): void {
     this.disposed = true;
     for (const entry of this.entries.values()) entry.cancelled = true;
@@ -103,7 +110,13 @@ export class RequestBodyLoader {
           if (!this.disposed && !entry.cancelled && this.retainedRecordKeys.has(entry.recordKey)) {
             this.didLoadBodies(entry.recordKey, {
               ...bodies,
-              ...(entry.input.includeResponseBody ? { responseBodyLoadCompleted: true } : {})
+              ...(entry.input.includeResponseBody
+                ? {
+                    responseBodyLoadCompleted: true,
+                    responseBodyLoadError:
+                      bodies.responseBody != null ? null : (bodies.responseBodyLoadError ?? "failed")
+                  }
+                : {})
             });
           }
         })
@@ -116,7 +129,8 @@ export class RequestBodyLoader {
           ) {
             this.didLoadBodies(entry.recordKey, {
               requestId: entry.input.requestId,
-              responseBodyLoadCompleted: true
+              responseBodyLoadCompleted: true,
+              responseBodyLoadError: "failed"
             });
           }
         })

--- a/snapo-network-inspector-web/src/network/body-retention.test.ts
+++ b/snapo-network-inspector-web/src/network/body-retention.test.ts
@@ -60,4 +60,26 @@ describe("RequestBodyCache", () => {
     expect(cache.peek("b")?.requestBody).toBe("b");
     expect(evicted).toEqual(["a"]);
   });
+
+  it("clears a response failure for retry without losing the request body", () => {
+    const cache = new RequestBodyCache(100);
+    cache.put("request", {
+      requestId: "request",
+      requestBody: "input",
+      responseBodyLoadCompleted: true,
+      responseBodyLoadError: "failed"
+    });
+    cache.put("request", { requestId: "request", requestBody: "input" });
+    expect(cache.peek("request")?.responseBodyLoadError).toBe("failed");
+    cache.put("request", {
+      requestId: "request",
+      responseBodyLoadCompleted: false,
+      responseBodyLoadError: null
+    });
+    expect(cache.peek("request")).toMatchObject({
+      requestBody: "input",
+      responseBodyLoadCompleted: false,
+      responseBodyLoadError: null
+    });
+  });
 });

--- a/snapo-network-inspector-web/src/network/body-retention.ts
+++ b/snapo-network-inspector-web/src/network/body-retention.ts
@@ -89,7 +89,9 @@ function mergeBodies(existing: RequestBodies | undefined, incoming: RequestBodie
     requestBody: incoming.requestBody ?? existing?.requestBody,
     responseBody: incoming.responseBody ?? existing?.responseBody,
     responseBodyBase64Encoded: incoming.responseBodyBase64Encoded ?? existing?.responseBodyBase64Encoded,
-    responseBodyLoadCompleted: incoming.responseBodyLoadCompleted ?? existing?.responseBodyLoadCompleted
+    responseBodyLoadCompleted: incoming.responseBodyLoadCompleted ?? existing?.responseBodyLoadCompleted,
+    responseBodyLoadError:
+      incoming.responseBodyLoadError !== undefined ? incoming.responseBodyLoadError : existing?.responseBodyLoadError
   };
 }
 

--- a/snapo-network-inspector-web/src/network/bridge-types.ts
+++ b/snapo-network-inspector-web/src/network/bridge-types.ts
@@ -131,12 +131,15 @@ export interface CdpMessage {
   };
 }
 
+export type ResponseBodyLoadError = "unavailable" | "failed";
+
 export interface RequestBodies {
   requestId: string;
   requestBody?: string | null;
   responseBody?: string | null;
   responseBodyBase64Encoded?: boolean | null;
   responseBodyLoadCompleted?: boolean;
+  responseBodyLoadError?: ResponseBodyLoadError | null;
 }
 
 export interface LoadBodiesInput {

--- a/snapo-network-inspector-web/src/network/cdp.ts
+++ b/snapo-network-inspector-web/src/network/cdp.ts
@@ -1,4 +1,4 @@
-import type { CdpMessage, RequestBodies, SnapOServer } from "./bridge-types";
+import type { CdpMessage, RequestBodies, ResponseBodyLoadError, SnapOServer } from "./bridge-types";
 import type { Protocol } from "devtools-protocol";
 import { isLikelyStreamingRequest } from "./request-classification";
 
@@ -48,6 +48,7 @@ export interface RequestRecord {
   responseBodyBase64Encoded?: boolean | null;
   responseBodyTruncatedBytes?: number | null;
   responseBodyLoadCompleted?: boolean;
+  responseBodyLoadError?: ResponseBodyLoadError | null;
   responseType?: string | null;
   hasReceivedResponse?: boolean;
   streamEvents: StreamEventRecord[];
@@ -489,7 +490,9 @@ export function applyRequestBodies(record: RequestRecord, bodies: RequestBodies)
     requestBody: bodies.requestBody ?? record.requestBody,
     responseBody: bodies.responseBody ?? record.responseBody,
     responseBodyBase64Encoded: bodies.responseBodyBase64Encoded ?? record.responseBodyBase64Encoded,
-    responseBodyLoadCompleted: bodies.responseBodyLoadCompleted ?? record.responseBodyLoadCompleted
+    responseBodyLoadCompleted: bodies.responseBodyLoadCompleted ?? record.responseBodyLoadCompleted,
+    responseBodyLoadError:
+      bodies.responseBodyLoadError !== undefined ? bodies.responseBodyLoadError : record.responseBodyLoadError
   };
 }
 

--- a/snapo-network-inspector-web/src/styles.css
+++ b/snapo-network-inspector-web/src/styles.css
@@ -728,7 +728,8 @@ body.split-pane-resizing {
 .header-value,
 .headers-empty,
 .pending-response,
-.messages-empty {
+.messages-empty,
+.body-load-message {
   font-size: 12px;
   line-height: 16px;
 }
@@ -771,6 +772,15 @@ body.split-pane-resizing {
 .body-loading-spinner {
   flex: 0 0 auto;
   animation: spin 1s linear infinite;
+}
+
+.body-load-message {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: baseline;
+  gap: 8px;
+  padding: 8px 0;
+  color: var(--on-surface-variant);
 }
 
 .messages-empty {


### PR DESCRIPTION
Snap-O hid the Response Body section when a saved response was missing or failed to load. Users could not tell what happened or try again. This PR explains the problem and offers Retry when the response may still be available. It does not change how long Snap-O keeps responses.

## Summary

- Show a clear message when a response is no longer available.
- Offer Retry when loading fails, without losing request data that is already loaded.
- Match the inspector's existing text style.
- Add a root `AGENTS.md` with public-repository safeguards and plain-English guidance for docs, comments, UI text, and PRs.

## Validation

- All 129 web tests passed, including missing, empty, and retried responses.
- Type, lint, and formatting checks passed.
- The macOS app built with code signing disabled.
- Retry passed a test with a simulated failure. Recovery has not been tested on a device.
