### PR TITLE
Capture screenshots by Option-dragging Live Preview

### DIFF
--- a/.github/workflows/mac.yml
+++ b/.github/workflows/mac.yml
@@ -13,9 +13,6 @@ on:
       - '.github/workflows/mac.yml'
       - 'VERSION'
   pull_request:
-    branches:
-      - main
-      - master
     paths:
       - 'snapo-app-mac/**'
       - 'snapo-network-inspector-web/**'
@@ -81,6 +78,9 @@ jobs:
       - name: Test shared device client
         working-directory: snapo-app-mac/SnapODeviceClient
         run: swift test
+      - name: Test live preview frame export
+        working-directory: snapo-app-mac
+        run: sh scripts/test-live-preview-frame-export.sh
       - name: Build Snap-O
         working-directory: snapo-app-mac
         run: |

--- a/snapo-app-mac/Snap-O/CaptureWindow/CaptureMediaView.swift
+++ b/snapo-app-mac/Snap-O/CaptureWindow/CaptureMediaView.swift
@@ -20,7 +20,7 @@ struct CaptureMediaView<Host: LivePreviewHosting>: View {
           ) { makeTempDragFile() }
 
         case .livePreview:
-          LiveCaptureView(host: livePreviewHost, capture: capture)
+          LiveCaptureView(host: livePreviewHost, capture: capture, fileStore: fileStore)
         }
       }
       .frame(width: proxy.size.width, height: proxy.size.height)

--- a/snapo-app-mac/Snap-O/CaptureWindow/LiveCaptureView.swift
+++ b/snapo-app-mac/Snap-O/CaptureWindow/LiveCaptureView.swift
@@ -11,6 +11,7 @@ protocol LivePreviewHosting: AnyObject {
 struct LiveCaptureView<Host: LivePreviewHosting>: View {
   let host: Host
   let capture: CaptureMedia
+  let fileStore: FileStore
 
   @State private var renderer: LivePreviewRenderer?
   @State private var streamTask: Task<Void, Never>?
@@ -19,7 +20,7 @@ struct LiveCaptureView<Host: LivePreviewHosting>: View {
   var body: some View {
     ZStack {
       if let renderer {
-        LivePreviewRendererView(renderer: renderer)
+        LivePreviewRendererView(renderer: renderer, fileStore: fileStore)
       } else {
         Color(nsColor: .unemphasizedSelectedContentBackgroundColor)
       }

--- a/snapo-app-mac/Snap-O/LivePreview/LivePreviewFrameExporter.swift
+++ b/snapo-app-mac/Snap-O/LivePreview/LivePreviewFrameExporter.swift
@@ -8,8 +8,15 @@ final class LivePreviewFrameExporter {
     let image: NSImage
   }
 
-  private enum ExportError: Error {
+  private enum ExportError: LocalizedError {
     case imageUnavailable
+
+    var errorDescription: String? {
+      switch self {
+      case .imageUnavailable:
+        "Could not create a PNG from the current live preview frame."
+      }
+    }
   }
 
   private let imageContext = CIContext()

--- a/snapo-app-mac/Snap-O/LivePreview/LivePreviewFrameExporter.swift
+++ b/snapo-app-mac/Snap-O/LivePreview/LivePreviewFrameExporter.swift
@@ -1,0 +1,28 @@
+import AppKit
+import CoreImage
+
+@MainActor
+final class LivePreviewFrameExporter {
+  struct Frame {
+    let url: URL
+    let image: NSImage
+  }
+
+  private enum ExportError: Error {
+    case imageUnavailable
+  }
+
+  private let imageContext = CIContext()
+
+  func export(_ pixelBuffer: CVPixelBuffer, to fileStore: FileStore) throws -> Frame {
+    let capturedAt = Date()
+    let source = CIImage(cvPixelBuffer: pixelBuffer)
+    guard let image = imageContext.createCGImage(source, from: source.extent),
+          let data = NSBitmapImageRep(cgImage: image).representation(using: .png, properties: [:]) else {
+      throw ExportError.imageUnavailable
+    }
+    let url = try fileStore.makeUniqueDragDestination(capturedAt: capturedAt, kind: .image)
+    try data.write(to: url, options: .atomic)
+    return Frame(url: url, image: NSImage(cgImage: image, size: .zero))
+  }
+}

--- a/snapo-app-mac/Snap-O/LivePreview/LivePreviewView.swift
+++ b/snapo-app-mac/Snap-O/LivePreview/LivePreviewView.swift
@@ -18,9 +18,10 @@ struct LivePreviewRenderer {
 
 struct LivePreviewRendererView: NSViewRepresentable {
   let renderer: LivePreviewRenderer
+  let fileStore: FileStore
 
   func makeNSView(context: Context) -> LivePreviewDisplayView {
-    let view = LivePreviewDisplayView()
+    let view = LivePreviewDisplayView(fileStore: fileStore)
     view.wantsLayer = true
     if view.layer == nil { view.layer = CALayer() }
     return view
@@ -35,7 +36,9 @@ struct LivePreviewRendererView: NSViewRepresentable {
   }
 }
 
-final class LivePreviewDisplayView: NSView {
+final class LivePreviewDisplayView: NSView, NSDraggingSource {
+  private let fileStore: FileStore
+  private let frameExporter = LivePreviewFrameExporter()
   private var renderer: LivePreviewRenderer?
   private var trackingArea: NSTrackingArea?
   private let displayLayer = AVSampleBufferDisplayLayer()
@@ -44,15 +47,19 @@ final class LivePreviewDisplayView: NSView {
   private var pointerState = PointerState()
   private let hoverThrottleInterval: TimeInterval = 1.0 / 45.0
   private let dragThrottleInterval: TimeInterval = 1.0 / 60.0
+  private var frameDragOrigin: CGPoint?
+  private var isDraggingFrame = false
 
-  override init(frame frameRect: NSRect) {
-    super.init(frame: frameRect)
+  init(fileStore: FileStore) {
+    self.fileStore = fileStore
+    super.init(frame: .zero)
     configureLayerIfNeeded()
+    toolTip = "Option-drag to capture the current frame"
   }
 
+  @available(*, unavailable)
   required init?(coder: NSCoder) {
-    super.init(coder: coder)
-    configureLayerIfNeeded()
+    nil
   }
 
   override var acceptsFirstResponder: Bool {
@@ -109,6 +116,9 @@ final class LivePreviewDisplayView: NSView {
   }
 
   private func detachSession() {
+    frameDragOrigin = nil
+    isDraggingFrame = false
+    pointerState = PointerState()
     renderer?.session.sampleBufferHandler = nil
     displayLayer.sampleBufferRenderer.stopRequestingMediaData()
     displayLayer.sampleBufferRenderer.flush(removingDisplayedImage: true, completionHandler: nil)
@@ -152,21 +162,71 @@ final class LivePreviewDisplayView: NSView {
   }
 
   override func mouseDown(with event: NSEvent) {
+    if event.modifierFlags.contains(.option) {
+      isDraggingFrame = true
+      if convertToDevicePoint(event: event) != nil {
+        frameDragOrigin = convert(event.locationInWindow, from: nil)
+      }
+      return
+    }
     handlePointer(.down, event: event)
   }
 
   override func mouseDragged(with event: NSEvent) {
+    if isDraggingFrame {
+      startFrameDragIfNeeded(with: event)
+      return
+    }
     handlePointer(.drag, event: event)
   }
 
   override func mouseUp(with event: NSEvent) {
+    if isDraggingFrame {
+      frameDragOrigin = nil
+      isDraggingFrame = false
+      return
+    }
     handlePointer(.up, event: event)
+  }
+
+  private func startFrameDragIfNeeded(with event: NSEvent) {
+    guard let origin = frameDragOrigin else { return }
+    let point = convert(event.locationInWindow, from: nil)
+    guard hypot(point.x - origin.x, point.y - origin.y) >= 3 else { return }
+    frameDragOrigin = nil
+
+    guard let pixelBuffer = displayLayer.sampleBufferRenderer.displayedPixelBuffer() else {
+      NSSound.beep()
+      return
+    }
+    do {
+      let frame = try frameExporter.export(pixelBuffer, to: fileStore)
+      let item = NSDraggingItem(pasteboardWriter: frame.url as NSURL)
+      item.setDraggingFrame(fittedMediaRect(contentSize: frame.image.size, in: bounds), contents: frame.image)
+      beginDraggingSession(with: [item], event: event, source: self)
+    } catch {
+      SnapOLog.ui.error("Unable to export live frame: \(error.localizedDescription, privacy: .public)")
+      NSSound.beep()
+    }
+  }
+
+  func draggingSession(_ session: NSDraggingSession, sourceOperationMaskFor context: NSDraggingContext) -> NSDragOperation {
+    .copy
+  }
+
+  func ignoreModifierKeys(for session: NSDraggingSession) -> Bool {
+    true
+  }
+
+  func draggingSession(_ session: NSDraggingSession, endedAt screenPoint: NSPoint, operation: NSDragOperation) {
+    frameDragOrigin = nil
+    isDraggingFrame = false
   }
 
   private enum PointerPhase { case hoverEnter, hoverMove, hoverExit, down, drag, up }
 
   private func handlePointer(_ phase: PointerPhase, event: NSEvent) {
-    guard renderer != nil else { return }
+    guard renderer != nil, !isDraggingFrame else { return }
     let devicePoint = convertToDevicePoint(event: event)
 
     switch phase {

--- a/snapo-app-mac/Snap-O/Storage/FileStore.swift
+++ b/snapo-app-mac/Snap-O/Storage/FileStore.swift
@@ -5,8 +5,8 @@ private let log = SnapOLog.storage
 final class FileStore: Sendable {
   private let baseDir: URL
 
-  init() {
-    baseDir = FileManager.default.temporaryDirectory.appendingPathComponent("Snap-O", isDirectory: true)
+  init(baseDir: URL = FileManager.default.temporaryDirectory.appendingPathComponent("Snap-O", isDirectory: true)) {
+    self.baseDir = baseDir
     purgeExistingFiles()
   }
 
@@ -30,6 +30,13 @@ final class FileStore: Sendable {
 
   func makeDragDestination(capturedAt: Date, kind: MediaSaveKind) -> URL {
     makeDestination(prefix: "Snap-O", date: capturedAt, kind: kind)
+  }
+
+  func makeUniqueDragDestination(capturedAt: Date, kind: MediaSaveKind) throws -> URL {
+    let filename = makeDragDestination(capturedAt: capturedAt, kind: kind).lastPathComponent
+    let directory = baseDir.appendingPathComponent(UUID().uuidString, isDirectory: true)
+    try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+    return directory.appendingPathComponent(filename)
   }
 
   private func makeDestination(prefix: String, date: Date, kind: MediaSaveKind) -> URL {

--- a/snapo-app-mac/Tests/LivePreviewFrameExport/LivePreviewFrameExportTests.swift
+++ b/snapo-app-mac/Tests/LivePreviewFrameExport/LivePreviewFrameExportTests.swift
@@ -1,0 +1,75 @@
+import AppKit
+import CoreVideo
+import Foundation
+import OSLog
+
+enum MediaSaveKind {
+  case image
+  var fileExtension: String {
+    "png"
+  }
+}
+
+enum SnapOLog {
+  static let storage = Logger(subsystem: "Snap-O.FrameExportTests", category: "storage")
+}
+
+@main
+@MainActor
+struct LivePreviewFrameExportTests {
+  static func main() throws {
+    let directory = FileManager.default.temporaryDirectory
+      .appendingPathComponent("Snap-O-FrameExport-\(UUID().uuidString)", isDirectory: true)
+    let store = FileStore(baseDir: directory)
+    defer { store.purgeExistingFiles() }
+    let exporter = LivePreviewFrameExporter()
+    let buffer = makeBuffer()
+    fill(buffer, red: 255, blue: 0)
+    let first = try exporter.export(buffer, to: store)
+    let original = try Data(contentsOf: first.url)
+
+    fill(buffer, red: 0, blue: 255)
+    let second = try exporter.export(buffer, to: store)
+    precondition(first.url != second.url)
+    let unchanged = try Data(contentsOf: first.url)
+    precondition(unchanged == original)
+    guard let png = NSBitmapImageRep(data: original),
+          let color = png.colorAt(x: 0, y: 0)?.usingColorSpace(.deviceRGB)
+    else { fatalError("Could not read exported PNG") }
+    precondition(png.pixelsWide == 16 && png.pixelsHigh == 24)
+    precondition(color.redComponent > 0.9 && color.blueComponent < 0.1)
+
+    let timestamp = Date()
+    let pathA = try store.makeUniqueDragDestination(capturedAt: timestamp, kind: .image)
+    let pathB = try store.makeUniqueDragDestination(capturedAt: timestamp, kind: .image)
+    precondition(pathA != pathB && pathA.lastPathComponent == pathB.lastPathComponent)
+    print("Live preview frame export tests passed")
+  }
+
+  private static func makeBuffer() -> CVPixelBuffer {
+    var result: CVPixelBuffer?
+    let status = CVPixelBufferCreate(
+      kCFAllocatorDefault, 16, 24, kCVPixelFormatType_32BGRA,
+      [kCVPixelBufferIOSurfacePropertiesKey: [:]] as CFDictionary, &result
+    )
+    guard status == kCVReturnSuccess, let result else { fatalError("Could not create pixel buffer") }
+    return result
+  }
+
+  private static func fill(_ buffer: CVPixelBuffer, red: UInt8, blue: UInt8) {
+    CVPixelBufferLockBaseAddress(buffer, [])
+    defer { CVPixelBufferUnlockBaseAddress(buffer, []) }
+    guard let base = CVPixelBufferGetBaseAddress(buffer)?.assumingMemoryBound(to: UInt8.self) else {
+      fatalError("Pixel buffer has no storage")
+    }
+    for y in 0 ..< CVPixelBufferGetHeight(buffer) {
+      for x in 0 ..< CVPixelBufferGetWidth(buffer) {
+        let offset = y * CVPixelBufferGetBytesPerRow(buffer) + x * 4
+        base[offset] = blue
+        base[offset + 1] = 0
+        base[offset + 2] = red
+        base[offset + 3] = 255
+      }
+    }
+  }
+}

--- a/snapo-app-mac/scripts/test-live-preview-frame-export.sh
+++ b/snapo-app-mac/scripts/test-live-preview-frame-export.sh
@@ -1,0 +1,12 @@
+#!/bin/sh
+set -eu
+
+APP_DIR=$(CDPATH= cd -- "$(dirname -- "$0")/.." && pwd)
+TEST_DIR=$(mktemp -d "${TMPDIR:-/tmp}/snap-o-frame-export-tests.XXXXXX")
+cd "$APP_DIR"
+
+xcrun swiftc -swift-version 6 -parse-as-library \
+  Snap-O/Storage/FileStore.swift Snap-O/LivePreview/LivePreviewFrameExporter.swift \
+  Tests/LivePreviewFrameExport/LivePreviewFrameExportTests.swift \
+  -o "$TEST_DIR/frame-export-tests"
+"$TEST_DIR/frame-export-tests"


### PR DESCRIPTION
Taking a screenshot while using Live Preview required leaving the preview. This PR lets users Option-drag the visible frame as a PNG while the preview keeps running.

## Summary

- Capture the displayed frame when the drag starts.
- Keep ordinary dragging available for device control.
- Save each dragged image separately so later captures cannot overwrite it.
- Run Mac CI for stacked PRs and add the frame-export test.

## Validation

- `sh scripts/test-live-preview-frame-export.sh` passed with synthetic frames. It checks image pixels, dimensions, and separate files.
- The pinned formatting and lint checks passed.
- The macOS app built with code signing disabled. GitHub build, web, and style checks passed.
- Dragging into another app has not been rechecked on a device for this revision.

## Stack

Merge in this order:

1. #243 — Option-drag screenshots.
2. #244 — Capture mode controls.
3. #245 — Live Preview startup.