### PR TITLE
Make capture controls select the displayed mode

### DIFF
--- a/.github/workflows/mac.yml
+++ b/.github/workflows/mac.yml
@@ -81,6 +81,9 @@ jobs:
       - name: Test live preview frame export
         working-directory: snapo-app-mac
         run: sh scripts/test-live-preview-frame-export.sh
+      - name: Test capture mode transitions
+        working-directory: snapo-app-mac
+        run: sh scripts/test-capture-modes.sh
       - name: Build Snap-O
         working-directory: snapo-app-mac
         run: |

--- a/snapo-app-mac/Snap-O/App/SnapOCommands.swift
+++ b/snapo-app-mac/Snap-O/App/SnapOCommands.swift
@@ -53,20 +53,12 @@ struct SnapOCommands: Commands {
         .disabled(captureController?.canStartRecordingNow != true)
       }
 
-      if captureController?.isLivePreviewActive == true || captureController?.isStoppingLivePreview == true {
-        Button("Stop Live Preview") {
-          Task { await captureController?.stopLivePreview() }
-        }
-        .keyboardShortcut(.escape, modifiers: [])
-        .disabled(captureController?.isStoppingLivePreview == true)
-      } else {
-        Button("Start Live Preview") {
-          workspaceController?.revealCapture()
-          Task { await captureController?.startLivePreview() }
-        }
-        .keyboardShortcut("l", modifiers: [.command, .shift])
-        .disabled(captureController?.canStartLivePreviewNow != true)
+      Button("Live Preview") {
+        workspaceController?.revealCapture()
+        Task { await captureController?.startLivePreview() }
       }
+      .keyboardShortcut("l", modifiers: [.command, .shift])
+      .disabled(captureController?.canSelectLivePreview != true)
     }
 
     CommandGroup(before: .saveItem) {

--- a/snapo-app-mac/Snap-O/CaptureWindow/CaptureSelectionPill.swift
+++ b/snapo-app-mac/Snap-O/CaptureWindow/CaptureSelectionPill.swift
@@ -1,0 +1,15 @@
+import SwiftUI
+
+struct CaptureSelectionPill: View {
+  let position: String
+
+  var body: some View {
+    Text(position)
+      .font(.system(size: 12, weight: .semibold, design: .rounded))
+      .monospacedDigit()
+      .padding(.horizontal, 10)
+      .padding(.vertical, 5)
+      .fixedSize()
+      .background(.regularMaterial, in: Capsule())
+  }
+}

--- a/snapo-app-mac/Snap-O/CaptureWindow/CaptureToolbar.swift
+++ b/snapo-app-mac/Snap-O/CaptureWindow/CaptureToolbar.swift
@@ -204,16 +204,17 @@ struct CaptureToolbar: View {
   private func captureControls() -> some View {
     if controller.isRecording {
       recordingControls()
-    } else if controller.isLivePreviewActive || controller.isStoppingLivePreview {
-      livePreviewControls()
     } else {
-      IdleToolbarControls(
+      CaptureActionToolbarControls(
         screenshot: { Task { await controller.captureScreenshots() } },
         canCaptureNow: controller.canCaptureNow,
+        isShowingScreenshot: !controller.isLivePreviewActive && controller.currentCapture?.media.isImage == true,
         startRecording: { Task { await controller.startRecording() } },
         canStartRecordingNow: controller.canStartRecordingNow,
+        isShowingRecording: !controller.isLivePreviewActive && controller.currentCapture?.media.isVideo == true,
         startLivePreview: { Task { await controller.startLivePreview() } },
-        canStartLivePreviewNow: controller.canStartLivePreviewNow
+        canSelectLivePreview: controller.canSelectLivePreview,
+        isLivePreviewActive: controller.isLivePreviewActive
       )
     }
   }
@@ -243,21 +244,6 @@ struct CaptureToolbar: View {
       .help("Stop Recording (⎋)")
       .keyboardShortcut(.escape, modifiers: [])
     }
-  }
-
-  private func livePreviewControls() -> some View {
-    Button {
-      Task { await controller.stopLivePreview() }
-    } label: {
-      Label("Live", systemImage: "play.circle")
-        .labelStyle(.iconOnly)
-        .font(SnapOToolbarStyle.iconFont)
-        .symbolEffect(.pulse)
-        .foregroundStyle(.blue)
-    }
-    .help("Stop Live Preview (⎋)")
-    .keyboardShortcut(.escape, modifiers: [])
-    .disabled(controller.isStoppingLivePreview)
   }
 
   private func captureToggle() -> some View {
@@ -312,36 +298,35 @@ struct CaptureToolbar: View {
 
   private func captureProgress(_ progress: String) -> some View {
     let isCaptureInFlight = controller.isProcessing || controller.isRecording
+    let canBrowseCaptures = !isCaptureInFlight && controller.hasAlternativeMedia()
 
-    return Text(progress)
-      .font(.system(size: 12, weight: .semibold, design: .rounded))
-      .padding(.horizontal, 10)
-      .padding(.vertical, 5)
-      .fixedSize()
-      .background(.regularMaterial, in: Capsule())
+    return CaptureSelectionPill(position: progress)
       .opacity(isCaptureInFlight ? 0.45 : 1)
       .allowsHitTesting(!isCaptureInFlight)
       .onHover { hovering in
-        guard !isCaptureInFlight else {
+        guard canBrowseCaptures else {
           if !hovering { controller.setProgressHovering(false) }
           return
         }
         controller.setProgressHovering(hovering)
       }
-      .onChange(of: isCaptureInFlight) {
-        guard isCaptureInFlight else { return }
+      .onChange(of: canBrowseCaptures) {
+        guard !canBrowseCaptures else { return }
         controller.setProgressHovering(false)
       }
   }
 }
 
-struct IdleToolbarControls: View {
+struct CaptureActionToolbarControls: View {
   let screenshot: @MainActor () -> Void
   let canCaptureNow: Bool
+  let isShowingScreenshot: Bool
   let startRecording: @MainActor () -> Void
   let canStartRecordingNow: Bool
+  let isShowingRecording: Bool
   let startLivePreview: @MainActor () -> Void
-  let canStartLivePreviewNow: Bool
+  let canSelectLivePreview: Bool
+  let isLivePreviewActive: Bool
   @Environment(AppSettings.self)
   private var settings
 
@@ -354,6 +339,7 @@ struct IdleToolbarControls: View {
           .labelStyle(.iconOnly)
           .font(SnapOToolbarStyle.iconFont)
           .frame(width: 34, height: 32)
+          .modifier(CaptureSelectionHighlight(isSelected: isShowingScreenshot))
       }
       .help("New Screenshot (⌘R)")
       .disabled(!canCaptureNow)
@@ -367,6 +353,7 @@ struct IdleToolbarControls: View {
           Label("Record", systemImage: "ant.circle")
             .font(SnapOToolbarStyle.iconFont)
             .frame(width: 34, height: 32)
+            .modifier(CaptureSelectionHighlight(isSelected: isShowingRecording))
         } primaryAction: {
           startRecording()
         }
@@ -386,6 +373,7 @@ struct IdleToolbarControls: View {
           Label("Record", systemImage: "record.circle")
             .font(SnapOToolbarStyle.iconFont)
             .frame(width: 34, height: 32)
+            .modifier(CaptureSelectionHighlight(isSelected: isShowingRecording))
         }
         .help("Start Recording (⌘⇧R)")
         .disabled(!canStartRecordingNow)
@@ -394,15 +382,29 @@ struct IdleToolbarControls: View {
       Button {
         startLivePreview()
       } label: {
-        Label("Live", systemImage: "play.circle")
+        Label("Live Preview", systemImage: "play.circle")
           .font(SnapOToolbarStyle.iconFont)
           .frame(width: 34, height: 32)
+          .symbolEffect(.pulse, isActive: isLivePreviewActive)
+          .modifier(CaptureSelectionHighlight(isSelected: isLivePreviewActive))
       }
-      .help("Live Preview (⌘⇧L)")
-      .disabled(!canStartLivePreviewNow)
+      .help("Live Preview (⌘⇧L). Option-drag the preview to capture a frame.")
+      .disabled(!canSelectLivePreview)
     }
     .labelStyle(.iconOnly)
     .controlSize(.extraLarge)
     .snapOToolbarGroupStyle()
+  }
+}
+
+private struct CaptureSelectionHighlight: ViewModifier {
+  let isSelected: Bool
+
+  func body(content: Content) -> some View {
+    if isSelected {
+      content.foregroundStyle(.blue)
+    } else {
+      content
+    }
   }
 }

--- a/snapo-app-mac/Snap-O/CaptureWindow/CaptureWindow.swift
+++ b/snapo-app-mac/Snap-O/CaptureWindow/CaptureWindow.swift
@@ -106,7 +106,7 @@ struct CaptureWindow: View {
       )
       .background(
         WindowLevelController(
-          shouldFloat: controller.isRecording || controller.isLivePreviewActive
+          shouldFloat: controller.isRecording
         )
         .frame(width: 0, height: 0)
       )

--- a/snapo-app-mac/Snap-O/CaptureWindow/CaptureWindowController.swift
+++ b/snapo-app-mac/Snap-O/CaptureWindow/CaptureWindowController.swift
@@ -122,15 +122,19 @@ final class CaptureWindowController {
   }
 
   var canCaptureNow: Bool {
-    !isTornDown && !isProcessing && !isRecording && !isLivePreviewActive && hasDevices
+    !isTornDown && !isProcessing && !isRecording && !isStoppingLivePreview && hasDevices
   }
 
   var canStartRecordingNow: Bool {
-    !isTornDown && !isProcessing && !isRecording && !isLivePreviewActive && hasDevices
+    canCaptureNow
   }
 
   var canStartLivePreviewNow: Bool {
-    !isTornDown && !isProcessing && !isRecording && !isLivePreviewActive && hasDevices
+    canCaptureNow && !isLivePreviewActive
+  }
+
+  var canSelectLivePreview: Bool {
+    !isStoppingLivePreview && (isLivePreviewActive || canStartLivePreviewNow)
   }
 
   var mediaList: [CaptureMedia] {
@@ -198,6 +202,7 @@ final class CaptureWindowController {
     guard canCaptureNow else { return }
     cancelPreloadConsumptionIfNeeded()
     isProcessing = true
+    guard await stopLivePreviewForCapture() else { return }
     lastError = nil
     screenshotFailures = []
     if pendingPreferredDeviceID == nil {
@@ -223,11 +228,12 @@ final class CaptureWindowController {
   func startRecording() async {
     guard canStartRecordingNow else { return }
     cancelPreloadConsumptionIfNeeded()
-    let devices = knownDevices
     isProcessing = true
+    guard await stopLivePreviewForCapture() else { return }
+    let devices = knownDevices
     lastError = nil
     screenshotFailures = []
-    pendingPreferredDeviceID = currentCapture?.device.id
+    pendingPreferredDeviceID = pendingPreferredDeviceID ?? currentCapture?.device.id ?? lastViewedDeviceID
     mediaDisplayMode.updateMediaList(
       [],
       preserveDeviceID: nil,
@@ -283,13 +289,12 @@ final class CaptureWindowController {
     screenshotFailures = []
     let preferredDeviceID = currentCapture?.device.id ?? lastViewedDeviceID ?? knownDevices.first?.id
     pendingPreferredDeviceID = preferredDeviceID
+    let options = LivePreviewOptions(showsTouches: AppSettings.shared.showTouchesDuringCapture)
 
     let livePreviewMode = LivePreviewMode(
       livePreviewService: livePreviewService,
       adbService: adbService,
-      options: LivePreviewOptions(
-        showsTouches: AppSettings.shared.showTouchesDuringCapture
-      ),
+      options: options,
       mediaDisplayMode: mediaDisplayMode,
       preferredDeviceIDProvider: { [weak self] in
         guard let self else { return nil }
@@ -303,37 +308,33 @@ final class CaptureWindowController {
         return nil
       },
       onMediaApplied: { [weak self] in
-        guard let self, !isTornDown else { return }
+        guard let self, !isTornDown, !isStoppingLivePreview else { return }
         isProcessing = false
         pendingPreferredDeviceID = nil
-      },
-      errorHandler: { [weak self] error in
-        self?.lastError = error.localizedDescription
       }
     )
     mode = .livePreview(livePreviewMode)
     await livePreviewMode.start(with: knownDevices)
-    guard !isTornDown else { return }
+    guard !isTornDown, !livePreviewMode.isStopping,
+          case .livePreview(let currentMode) = mode, currentMode === livePreviewMode else { return }
     isProcessing = false
   }
 
-  func stopLivePreview() async {
-    guard case .livePreview(let livePreviewMode) = mode else { return }
-    guard !livePreviewMode.isStopping else { return }
+  private func stopLivePreviewForCapture() async -> Bool {
+    guard case .livePreview(let livePreviewMode) = mode else { return !isTornDown }
     let preferredDeviceID = currentCapture?.device.id ?? lastViewedDeviceID
     await livePreviewMode.stop()
-    guard !isTornDown else { return }
+    guard !isTornDown,
+          case .livePreview(let currentMode) = mode, currentMode === livePreviewMode else { return false }
     pendingPreferredDeviceID = preferredDeviceID
     if let preferredDeviceID { mediaDisplayMode.updateLastViewedDeviceID(preferredDeviceID) }
-    if !hasDevices {
+    mode = .idle
+    guard hasDevices else {
       isProcessing = false
       pendingPreferredDeviceID = nil
-      mode = .idle
-      return
+      return false
     }
-    if isProcessing { isProcessing = false }
-    mode = .idle
-    await captureScreenshots()
+    return true
   }
 
   func tearDown() async {
@@ -481,7 +482,7 @@ final class CaptureWindowController {
       guard case .livePreview(let currentMode) = mode,
             currentMode === livePreviewMode,
             !currentMode.isStopping else {
-        _ = await livePreviewService.stop(renderer.operation)
+        await livePreviewMode.stopRenderer(renderer)
         return nil
       }
       lastError = nil

--- a/snapo-app-mac/Snap-O/CaptureWindow/LivePreviewManager.swift
+++ b/snapo-app-mac/Snap-O/CaptureWindow/LivePreviewManager.swift
@@ -21,6 +21,8 @@ final class LivePreviewManager {
   private var lastDisplayInfo: [String: DisplayInfo] = [:]
   private var activeOperations: [UUID: LivePreviewOperationHandle] = [:]
   private var inFlightRendererRequestIDs: Set<UUID> = []
+  private var stoppingRendererIDs: Set<UUID> = []
+  private var deviceSyncID = UUID()
   private var isStopped = false
 
   init(
@@ -39,13 +41,13 @@ final class LivePreviewManager {
   func start(with devices: [Device]) async {
     guard !isStopped else { return }
     updateDeviceOrder(with: devices)
-    await syncDevices(with: devices, requireRefresh: true)
+    await syncDevices(with: devices)
   }
 
   func updateDevices(_ devices: [Device]) async {
     guard !isStopped else { return }
     updateDeviceOrder(with: devices)
-    await syncDevices(with: devices, requireRefresh: false)
+    await syncDevices(with: devices)
   }
 
   func makeRenderer(for deviceID: String) async throws -> LivePreviewRenderer {
@@ -70,10 +72,7 @@ final class LivePreviewManager {
       }
     }
 
-    let operation = try await livePreviewService.start(
-      for: deviceID,
-      options: options
-    )
+    let operation = try await livePreviewService.start(for: deviceID, options: options)
     guard !isStopped,
           !Task.isCancelled,
           deviceInfo[deviceID] != nil
@@ -99,17 +98,15 @@ final class LivePreviewManager {
     }
 
     let session = operation.session
-    Task.detached(priority: .userInitiated) { [weak self] in
-      guard let self else { return }
+    Task { [weak self] in
       do {
         let media = try await session.waitUntilReady()
-        await MainActor.run {
-          if !self.isStopped,
-             self.activeOperations[operation.id] != nil,
-             let latestDevice = self.deviceInfo[deviceID] {
-            self.storeMedia(media, for: latestDevice)
-          }
-        }
+        guard let self,
+              !isStopped,
+              activeOperations[operation.id] != nil,
+              let device = deviceInfo[deviceID]
+        else { return }
+        storeMedia(media, for: device)
       } catch {
         if !(error is CancellationError) {
           SnapOLog.ui.error(
@@ -123,7 +120,10 @@ final class LivePreviewManager {
   }
 
   func stopRenderer(_ renderer: LivePreviewRenderer) async {
-    activeOperations.removeValue(forKey: renderer.operation.id)
+    let operationID = renderer.operation.id
+    guard activeOperations.removeValue(forKey: operationID) != nil else { return }
+    stoppingRendererIDs.insert(operationID)
+    defer { stoppingRendererIDs.remove(operationID) }
     _ = await livePreviewService.stop(renderer.operation)
     if !activeOperations.values.contains(where: { $0.deviceID == renderer.deviceID }) {
       await pointerInjector.stopDevice(renderer.deviceID)
@@ -144,30 +144,24 @@ final class LivePreviewManager {
     for operation in operations {
       _ = await livePreviewService.stop(operation)
     }
-    while !inFlightRendererRequestIDs.isEmpty {
+    while !inFlightRendererRequestIDs.isEmpty || !stoppingRendererIDs.isEmpty {
       await Task.yield()
     }
   }
 
   // MARK: - Device + Media Management
 
-  private func syncDevices(with devices: [Device], requireRefresh: Bool) async {
+  private func syncDevices(with devices: [Device]) async {
+    let syncID = UUID()
+    deviceSyncID = syncID
     let currentIDs = Set(devices.map(\.id))
     let removedDeviceIDs = Set(deviceInfo.keys).subtracting(currentIDs)
     let removedOperations = activeOperations.values.filter { !currentIDs.contains($0.deviceID) }
     for operation in removedOperations {
       activeOperations.removeValue(forKey: operation.id)
-      _ = await livePreviewService.stop(operation)
+      stoppingRendererIDs.insert(operation.id)
     }
-    for deviceID in removedDeviceIDs {
-      await pointerInjector.stopDevice(deviceID)
-    }
-
-    guard !isStopped else { return }
-
-    for id in Array(deviceInfo.keys) where !currentIDs.contains(id) {
-      deviceInfo.removeValue(forKey: id)
-    }
+    deviceInfo = Dictionary(uniqueKeysWithValues: devices.map { ($0.id, $0) })
     for id in Array(lastDisplayInfo.keys) where !currentIDs.contains(id) {
       lastDisplayInfo.removeValue(forKey: id)
     }
@@ -175,20 +169,22 @@ final class LivePreviewManager {
       captureIDs.removeValue(forKey: id)
     }
 
-    for device in devices {
-      deviceInfo[device.id] = device
+    for operation in removedOperations {
+      _ = await livePreviewService.stop(operation)
+      stoppingRendererIDs.remove(operation.id)
+    }
+    for deviceID in removedDeviceIDs {
+      await pointerInjector.stopDevice(deviceID)
     }
 
-    let devicesToFetch: [Device] = if requireRefresh {
-      devices
-    } else {
-      devices.filter { lastDisplayInfo[$0.id] == nil }
-    }
+    guard !isStopped, deviceSyncID == syncID else { return }
+
+    let devicesToFetch = devices.filter { lastDisplayInfo[$0.id] == nil }
 
     if !devicesToFetch.isEmpty {
       let fetched = await fetchDisplayInfos(for: devicesToFetch)
-      guard !isStopped else { return }
-      for (id, info) in fetched {
+      guard !isStopped, deviceSyncID == syncID else { return }
+      for (id, info) in fetched where deviceInfo[id] != nil && lastDisplayInfo[id] == nil {
         lastDisplayInfo[id] = info
       }
     }

--- a/snapo-app-mac/Snap-O/CaptureWindow/LivePreviewMode.swift
+++ b/snapo-app-mac/Snap-O/CaptureWindow/LivePreviewMode.swift
@@ -11,7 +11,6 @@ final class LivePreviewMode {
   private let mediaDisplayMode: MediaDisplayMode
   private let preferredDeviceIDProvider: @MainActor () -> String?
   private let onMediaApplied: @MainActor () -> Void
-  private let errorHandler: @MainActor (Error) -> Void
   private var manager: LivePreviewManager?
   @ObservationIgnored private var stopTask: Task<Void, Never>?
   private(set) var isStopping: Bool = false
@@ -22,8 +21,7 @@ final class LivePreviewMode {
     options: LivePreviewOptions,
     mediaDisplayMode: MediaDisplayMode,
     preferredDeviceIDProvider: @escaping @MainActor () -> String?,
-    onMediaApplied: @escaping @MainActor () -> Void,
-    errorHandler: @escaping @MainActor (Error) -> Void
+    onMediaApplied: @escaping @MainActor () -> Void
   ) {
     self.livePreviewService = livePreviewService
     self.adbService = adbService
@@ -31,7 +29,6 @@ final class LivePreviewMode {
     self.mediaDisplayMode = mediaDisplayMode
     self.preferredDeviceIDProvider = preferredDeviceIDProvider
     self.onMediaApplied = onMediaApplied
-    self.errorHandler = errorHandler
   }
 
   func start(with devices: [Device]) async {
@@ -62,12 +59,7 @@ final class LivePreviewMode {
     guard let manager else {
       throw LivePreviewModeError.inactive
     }
-    do {
-      return try await manager.makeRenderer(for: deviceID)
-    } catch {
-      errorHandler(error)
-      throw error
-    }
+    return try await manager.makeRenderer(for: deviceID)
   }
 
   func stopRenderer(_ renderer: LivePreviewRenderer) async {

--- a/snapo-app-mac/Tests/CaptureMode/CaptureModeTests.swift
+++ b/snapo-app-mac/Tests/CaptureMode/CaptureModeTests.swift
@@ -1,0 +1,121 @@
+import Foundation
+
+@MainActor
+final class MediaDisplayMode {
+  func updateMediaList(_: [CaptureMedia], preserveDeviceID _: String?, shouldSort _: Bool) {}
+}
+
+@main
+@MainActor
+struct CaptureModeTests {
+  static let options = LivePreviewOptions(showsTouches: false)
+  static let first = testDevice("first")
+  static let second = testDevice("second")
+
+  static func main() async throws {
+    try await stopWaitsForRendererCleanup()
+    await stopDuringRendererStart()
+    await overlappingDeviceUpdates()
+    await modePropagatesCancellation()
+    print("Capture mode tests passed (4 cases)")
+  }
+
+  static func eventually(_ condition: () async -> Bool) async {
+    for _ in 0 ..< 10000 {
+      if await condition() { return }
+      await Task.yield()
+    }
+    fatalError("Condition did not become true")
+  }
+
+  static func makeManager(_ service: LivePreviewService) -> LivePreviewManager {
+    LivePreviewManager(livePreviewService: service, adbService: ADBService(), options: options) { _ in }
+  }
+
+  static func stopWaitsForRendererCleanup() async throws {
+    let gate = TestGate()
+    let service = LivePreviewService(stopGate: gate)
+    let manager = makeManager(service)
+    await manager.start(with: [first])
+    let renderer = try await manager.makeRenderer(for: first.id)
+    let stopRenderer = Task { await manager.stopRenderer(renderer) }
+    await eventually { await service.stops.count == 1 }
+    await manager.stopRenderer(renderer)
+    var stopped = false
+    let stop = Task { await manager.stop()
+      stopped = true
+    }
+    for _ in 0 ..< 20 {
+      await Task.yield()
+    }
+    precondition(!stopped)
+    await gate.open()
+    await stopRenderer.value
+    await stop.value
+    let stops = await service.stops
+    let active = await service.active
+    precondition(stops.count == 1 && active.isEmpty)
+  }
+
+  static func stopDuringRendererStart() async {
+    let gate = TestGate()
+    let service = LivePreviewService(startGate: gate)
+    let manager = makeManager(service)
+    await manager.start(with: [first])
+    let renderer = Task { try? await manager.makeRenderer(for: first.id) }
+    await eventually { await service.starts.count == 1 }
+    let stop = Task { await manager.stop() }
+    for _ in 0 ..< 20 {
+      await Task.yield()
+    }
+    await gate.open()
+    let result = await renderer.value
+    await stop.value
+    let active = await service.active
+    precondition(result == nil && active.isEmpty)
+  }
+
+  static func overlappingDeviceUpdates() async {
+    let gate = TestGate()
+    var displayed: [String] = []
+    let manager = LivePreviewManager(
+      livePreviewService: LivePreviewService(),
+      adbService: ADBService(displayGates: [first.id: gate]), options: options
+    ) { displayed = $0.map(\.device.id) }
+    let start = Task { await manager.start(with: [first]) }
+    for _ in 0 ..< 20 {
+      await Task.yield()
+    }
+    await manager.updateDevices([second])
+    await gate.open()
+    await start.value
+    precondition(displayed == [second.id])
+    await manager.stop()
+  }
+
+  static func modePropagatesCancellation() async {
+    let gate = TestGate()
+    let service = LivePreviewService(startGate: gate)
+    let mode = LivePreviewMode(
+      livePreviewService: service, adbService: ADBService(), options: options,
+      mediaDisplayMode: MediaDisplayMode(), preferredDeviceIDProvider: { first.id }, onMediaApplied: {}
+    )
+    await mode.start(with: [first])
+    let renderer = Task { try await mode.makeRenderer(for: first.id) }
+    await eventually { await service.starts.count == 1 }
+    let stop = Task { await mode.stop() }
+    await eventually { mode.isStopping }
+    await gate.open()
+    do {
+      _ = try await renderer.value
+      fatalError("Expected cancellation")
+    } catch is CancellationError {
+      // Expected during an intentional mode switch.
+    } catch {
+      fatalError("Unexpected error: \(error)")
+    }
+    await stop.value
+    let active = await service.active
+    precondition(active.isEmpty)
+  }
+}

--- a/snapo-app-mac/Tests/CaptureSupport/TestSupport.swift
+++ b/snapo-app-mac/Tests/CaptureSupport/TestSupport.swift
@@ -1,0 +1,171 @@
+import CoreGraphics
+import Foundation
+import OSLog
+import SnapODeviceClient
+
+enum StartupCaptureMode { case screenshot, livePreview }
+enum SnapOLog {
+  static let ui = Logger(subsystem: "Snap-O.StartupTests", category: "test")
+}
+
+actor TestGate {
+  private var isOpen = false
+  private var waiters: [CheckedContinuation<Void, Never>] = []
+
+  func wait() async {
+    guard !isOpen else { return }
+    await withCheckedContinuation { waiters.append($0) }
+  }
+
+  func open() {
+    isOpen = true
+    let pending = waiters
+    waiters.removeAll()
+    for waiter in pending {
+      waiter.resume()
+    }
+  }
+}
+
+let testDisplay = DisplayInfo(size: CGSize(width: 1080, height: 2400), densityScale: 3)
+
+func testDevice(_ id: String) -> Device {
+  Device(id: id, model: id, androidVersion: "16", vendorModel: nil, manufacturer: nil, avdName: nil)
+}
+
+func testCapture(_ device: Device, age: TimeInterval = 0) -> CaptureMedia {
+  CaptureMedia(device: device, media: .image(
+    url: URL(fileURLWithPath: "/tmp/\(device.id).png"),
+    capturedAt: Date().addingTimeInterval(-age),
+    display: testDisplay
+  ))
+}
+
+struct LivePreviewOptions: Equatable { let showsTouches: Bool }
+struct LivePreviewOperationHandle {
+  let id: UUID
+  let deviceID: String
+  let session: LivePreviewSession
+}
+
+@MainActor
+final class LivePreviewSession {
+  private let readyGate: TestGate?
+  private var isStopped = false
+
+  init(readyGate: TestGate?) {
+    self.readyGate = readyGate
+  }
+
+  func waitUntilReady() async throws -> Media {
+    await readyGate?.wait()
+    guard !isStopped else { throw CancellationError() }
+    return .livePreview(capturedAt: Date(), display: testDisplay)
+  }
+
+  func cancel() async {
+    isStopped = true
+    await readyGate?.open()
+  }
+}
+
+actor LivePreviewService {
+  private let startGate: TestGate?
+  private let stopGate: TestGate?
+  private let readyGate: TestGate?
+  private(set) var starts: [String] = []
+  private(set) var stops: [UUID] = []
+  private(set) var active: Set<UUID> = []
+
+  init(startGate: TestGate? = nil, stopGate: TestGate? = nil, readyGate: TestGate? = nil) {
+    self.startGate = startGate
+    self.stopGate = stopGate
+    self.readyGate = readyGate
+  }
+
+  func start(for deviceID: String, options _: LivePreviewOptions) async throws -> LivePreviewOperationHandle {
+    starts.append(deviceID)
+    await startGate?.wait()
+    let handle = await LivePreviewOperationHandle(
+      id: UUID(), deviceID: deviceID, session: LivePreviewSession(readyGate: readyGate)
+    )
+    active.insert(handle.id)
+    return handle
+  }
+
+  func stop(_ handle: LivePreviewOperationHandle) async -> Error? {
+    stops.append(handle.id)
+    await stopGate?.wait()
+    await handle.session.cancel()
+    active.remove(handle.id)
+    return nil
+  }
+}
+
+actor ScreenshotService {
+  private let gate: TestGate?
+  private(set) var requests: [[String]] = []
+
+  init(gate: TestGate? = nil) {
+    self.gate = gate
+  }
+
+  func capture(for devices: [Device]) async -> ScreenshotCaptureResult {
+    requests.append(devices.map(\.id))
+    await gate?.wait()
+    return ScreenshotCaptureResult(media: devices.map { testCapture($0) }, failures: [])
+  }
+}
+
+actor ADBService {
+  private let displayGates: [String: TestGate]
+  init(displayGates: [String: TestGate] = [:]) {
+    self.displayGates = displayGates
+  }
+
+  func exec() -> ADBService {
+    self
+  }
+
+  func displayDensity(deviceID _: String) throws -> Int {
+    3
+  }
+
+  func displaySize(deviceID: String) async throws -> String {
+    await displayGates[deviceID]?.wait()
+    return "1080x2400"
+  }
+}
+
+enum LivePreviewPointerAction { case down }
+enum LivePreviewPointerSource { case mouse }
+struct LivePreviewPointerEvent {
+  let deviceID: String
+  let action: LivePreviewPointerAction
+  let source: LivePreviewPointerSource
+  let location: CGPoint
+  let displaySize: CGSize
+}
+
+actor LivePreviewPointerInjector {
+  init(adb _: ADBService) {}
+  func prepare(deviceID _: String) {}
+  func stopDevice(_: String) {}
+  func stopAll() {}
+  func enqueue(_: LivePreviewPointerEvent) {}
+}
+
+@MainActor
+final class LivePreviewRenderer {
+  let operation: LivePreviewOperationHandle
+  var deviceID: String {
+    operation.deviceID
+  }
+
+  init(
+    operation: LivePreviewOperationHandle,
+    pointerHandler _: @escaping (LivePreviewPointerAction, LivePreviewPointerSource, CGPoint, CGSize) -> Void
+  ) {
+    self.operation = operation
+  }
+}

--- a/snapo-app-mac/scripts/test-capture-modes.sh
+++ b/snapo-app-mac/scripts/test-capture-modes.sh
@@ -1,0 +1,17 @@
+#!/bin/sh
+set -eu
+
+APP_DIR=$(CDPATH= cd -- "$(dirname -- "$0")/.." && pwd)
+TEST_DIR=$(mktemp -d "${TMPDIR:-/tmp}/snap-o-capture-mode-tests.XXXXXX")
+cd "$APP_DIR"
+
+xcrun swiftc -swift-version 6 -parse-as-library -module-name SnapODeviceClient \
+  -emit-module -emit-object SnapODeviceClient/Sources/SnapODeviceClient/Device.swift \
+  -emit-module-path "$TEST_DIR/SnapODeviceClient.swiftmodule" -o "$TEST_DIR/Device.o"
+xcrun swiftc -swift-version 6 -parse-as-library -I "$TEST_DIR" \
+  "$TEST_DIR/Device.o" Snap-O/Models/Media.swift Snap-O/Models/Device+Formatting.swift \
+  Snap-O/Capture/CaptureMedia.swift Snap-O/Utilities/Perf.swift \
+  Snap-O/CaptureWindow/LivePreviewManager.swift Snap-O/CaptureWindow/LivePreviewMode.swift \
+  Tests/CaptureSupport/TestSupport.swift Tests/CaptureMode/CaptureModeTests.swift \
+  -o "$TEST_DIR/capture-mode-tests"
+"$TEST_DIR/capture-mode-tests"


### PR DESCRIPTION
Live Preview hid the screenshot and recording controls, and clicking its button stopped the preview. This made switching modes less direct. The toolbar now keeps all three choices visible and highlights the media being viewed.

## Summary

- Let Screenshot and Recording stop Live Preview before starting their capture.
- Make clicking the active Live Preview button do nothing.
- Keep the single red stop button while recording.
- Stop keeping Live Preview windows on top.
- Remove duplicate error reporting and add mode-transition tests to CI.
- Keep screenshot-first startup in this PR.

## Validation

- `sh scripts/test-capture-modes.sh` passed all four cases, including cancellation and cleanup during mode changes.
- The pinned formatting and lint checks passed.
- The macOS app built with code signing disabled. GitHub build, web, and style checks passed.
- The lifecycle tests use simulated device services. No new real-device smoke test was run after splitting the stack.

## Stack

Merge in this order:

1. #243 — Option-drag screenshots.
2. #244 — Capture mode controls.
3. #245 — Live Preview startup.