### PR TITLE
Preserve inspector selection and content across reconnects

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -46,6 +46,10 @@ Delivery is bounded at every host hop, including the Swift-to-WebKit bridge. If 
 
 Swift owns ADB and network transport. React owns inspector UI state. Native controls send intents to React; React sends an immutable state projection back for native toolbar rendering.
 
+Network and Tweaks connections use one socket-discovery snapshot per refresh. The React app owns inspector selection and remembers each device/process preference separately from its live socket. The Mac host stores these preferences in UserDefaults; the browser uses local storage. Partial discovery never replaces that preference. During reconnect, the last network request view stays browsable and the toolbar keeps its known inspector types. Selecting a cached type waits for a live endpoint; it never reconnects through a stale socket. A full-pane spinner is used only when there is no previous inspector to show.
+
+The network model outlives the visible inspector. Restoration pauses its connection without discarding captured records or cached bodies. A previously loaded Tweaks view stays visible but disabled until fresh data arrives. Selecting an app waits for its process identity before resolving its saved inspector; selecting an inspector icon overrides that preference explicitly.
+
 ## Testing seams
 
 - Swift Testing covers discovery, wire compatibility, ordered sessions, cancellation, timeouts, and backpressure.

--- a/snapo-app-mac/Snap-O/CaptureWindow/CaptureToolbar.swift
+++ b/snapo-app-mac/Snap-O/CaptureWindow/CaptureToolbar.swift
@@ -138,7 +138,7 @@ struct CaptureToolbar: View {
 
         if let networkModel {
           HStack(spacing: 8) {
-            if networkModel.selectedInspector?.kind == .tweaks {
+            if networkModel.preferredInspectorKind == .tweaks {
               tweaksInspectorControls(model: networkModel)
             } else {
               NetworkInspectorToolbarControls(
@@ -154,7 +154,7 @@ struct CaptureToolbar: View {
 
         Spacer()
 
-        if let networkModel, networkModel.selectedInspector?.kind != .tweaks {
+        if let networkModel, networkModel.preferredInspectorKind != .tweaks {
           NetworkInspectorExportMenu(model: networkModel)
         }
 

--- a/snapo-app-mac/Snap-O/NetworkInspector/NetworkInspectorBridgeModels.swift
+++ b/snapo-app-mac/Snap-O/NetworkInspector/NetworkInspectorBridgeModels.swift
@@ -18,6 +18,7 @@ struct InspectableApp: Codable, Identifiable {
   let id: String
   let name: String
   let packageName: String
+  let processName: String?
   let deviceId: String
   let deviceDisplayTitle: String
   let appIconBase64: String?
@@ -29,6 +30,16 @@ struct SelectedAppInspector: Codable {
   let kind: AppInspectorKind
   let server: InspectorServerReference
   let protocolVersion: Int?
+}
+
+struct AppInspectorState: Codable {
+  let apps: [InspectableApp]
+  let selection: SelectedAppInspector?
+  let displayedNetwork: SelectedAppInspector?
+  let displayedTweaks: SelectedAppInspector?
+  let selectedApp: InspectableApp?
+  let preferredKind: AppInspectorKind?
+  let isRestoring: Bool
 }
 
 enum TweakValue: Codable {

--- a/snapo-app-mac/Snap-O/NetworkInspector/NetworkInspectorHostModel.swift
+++ b/snapo-app-mac/Snap-O/NetworkInspector/NetworkInspectorHostModel.swift
@@ -8,6 +8,10 @@ final class NetworkInspectorHostModel {
   private(set) var selectedServer: NetworkInspectorServer?
   private(set) var inspectorApps: [InspectableApp] = []
   private(set) var selectedInspector: SelectedAppInspector?
+  private(set) var displayedNetwork: SelectedAppInspector?
+  private(set) var selectedInspectorApp: InspectableApp?
+  private(set) var preferredInspectorKind: AppInspectorKind?
+  private(set) var isRestoringInspector = false
   private(set) var searchText = ""
   private(set) var sortNewestFirst = false
   private(set) var hasClearableItems = false
@@ -26,8 +30,8 @@ final class NetworkInspectorHostModel {
     bridge.inspectorStateChangedHandler = { [weak self] state in
       self?.apply(state)
     }
-    bridge.inspectorAppsChangedHandler = { [weak self] apps in
-      self?.applyInspectorApps(apps)
+    bridge.appInspectorStateChangedHandler = { [weak self] state in
+      self?.apply(state)
     }
     bridge.tweaksStateChangedHandler = { [weak self] state in
       self?.apply(state)
@@ -48,53 +52,17 @@ final class NetworkInspectorHostModel {
     webContainer.stop()
   }
 
-  func selectServer(_ server: NetworkInspectorServer) {
-    sendPageEvent(
-      name: "network:selected-server",
-      payload: NetworkServerReference(deviceId: server.deviceId, socketName: server.socketName)
-    )
-  }
-
   func selectApp(_ app: InspectableApp) {
-    let currentOption = app.inspectors.first {
-      app.id == selectedInspector?.appId
-        && $0.kind == selectedInspector?.kind
-        && $0.server == selectedInspector?.server
-    }
-    let matchingKind = app.inspectors.first { $0.kind == selectedInspector?.kind }
-    guard let option = currentOption ?? matchingKind ?? app.inspectors.first else { return }
-    selectInspector(app, option: option)
+    sendPageEvent(name: "inspector:app-selected", payload: app.id)
   }
 
   func selectInspector(_ app: InspectableApp, option: AppInspectorOption) {
-    let selection = SelectedAppInspector(
-      appId: app.id,
-      kind: option.kind,
-      server: option.server,
-      protocolVersion: option.protocolVersion
+    sendPageEvent(
+      name: "inspector:selected",
+      payload: SelectedAppInspector(
+        appId: app.id, kind: option.kind, server: option.server, protocolVersion: option.protocolVersion
+      )
     )
-    if selectedInspector?.appId != selection.appId
-      || selectedInspector?.kind != selection.kind
-      || selectedInspector?.server != selection.server {
-      webContainer.closeNativeColorPanel()
-    }
-    if selectedInspector?.kind != selection.kind || selectedInspector?.server != selection.server {
-      hasResettableTweaks = false
-    }
-    selectedInspector = selection
-    sendPageEvent(name: "inspector:selected", payload: selection)
-
-    if option.kind == .network,
-       let server = servers.first(where: {
-         $0.deviceId == option.server.deviceId && $0.socketName == option.server.socketName
-       }) {
-      selectServer(server)
-    }
-  }
-
-  var selectedInspectorApp: InspectableApp? {
-    guard let selectedInspector else { return nil }
-    return inspectorApps.first { $0.id == selectedInspector.appId }
   }
 
   func setSearchText(_ searchText: String) {
@@ -127,6 +95,7 @@ final class NetworkInspectorHostModel {
 
   private func apply(_ state: NetworkInspectorNativeState) {
     servers = state.servers
+    guard let displayedNetwork, displayedNetwork.server == state.selectedServer else { return }
     selectedServer = state.selectedServer.flatMap { selection in
       state.servers.first {
         $0.deviceId == selection.deviceId && $0.socketName == selection.socketName
@@ -149,47 +118,23 @@ final class NetworkInspectorHostModel {
     hasResettableTweaks = state.hasResettableTweaks
   }
 
-  private func applyInspectorApps(_ apps: [InspectableApp]) {
-    inspectorApps = apps
-
-    if let selection = selectedInspector,
-       let app = apps.first(where: { app in
-         app.inspectors.contains { $0.kind == selection.kind && $0.server == selection.server }
-       }),
-       let option = app.inspectors.first(where: {
-         $0.kind == selection.kind && $0.server == selection.server
-       }) {
-      if selection.appId != app.id || selection.protocolVersion != option.protocolVersion {
-        selectInspector(app, option: option)
-      }
-      return
-    }
-
-    if let selection = selectedInspector,
-       let app = apps.first(where: { $0.id == selection.appId }),
-       !app.inspectors.isEmpty {
-      selectApp(app)
-      return
-    }
-
-    if let selectedServer,
-       let app = apps.first(where: {
-         $0.deviceId == selectedServer.deviceId && $0.inspectors.contains {
-           $0.kind == .network && $0.server.socketName == selectedServer.socketName
-         }
-       }),
-       let network = app.inspectors.first(where: { $0.kind == .network }) {
-      selectInspector(app, option: network)
-      return
-    }
-
-    guard let app = apps.first, let option = app.inspectors.first else {
+  private func apply(_ state: AppInspectorState) {
+    if selectedInspector?.kind != state.selection?.kind || selectedInspector?.server != state.selection?.server {
       webContainer.closeNativeColorPanel()
-      selectedInspector = nil
       hasResettableTweaks = false
-      return
     }
-    selectInspector(app, option: option)
+    if state.displayedNetwork == nil || displayedNetwork?.server != state.displayedNetwork?.server {
+      selectedServer = nil
+      hasClearableItems = false
+      hasVisibleRecords = false
+      selectedRecordKind = nil
+    }
+    inspectorApps = state.apps
+    selectedInspector = state.selection
+    displayedNetwork = state.displayedNetwork
+    selectedInspectorApp = state.selectedApp
+    preferredInspectorKind = state.preferredKind
+    isRestoringInspector = state.isRestoring
   }
 
   private func dispatch(_ output: NetworkInspectorOutput) {

--- a/snapo-app-mac/Snap-O/NetworkInspector/NetworkInspectorServerPicker.swift
+++ b/snapo-app-mac/Snap-O/NetworkInspector/NetworkInspectorServerPicker.swift
@@ -20,7 +20,7 @@ struct AppInspectorPicker: View {
         AppInspectorIcon(
           app: model.selectedInspectorApp,
           size: Metrics.iconSize,
-          statusSize: Metrics.statusSize
+          statusSize: model.isRestoringInspector ? 0 : Metrics.statusSize
         )
 
         HStack(spacing: 6) {
@@ -71,7 +71,8 @@ struct AppInspectorViewPicker: View {
   @Bindable var model: NetworkInspectorHostModel
 
   var body: some View {
-    if let app = model.selectedInspectorApp, app.inspectors.count > 1 {
+    if let app = model.selectedInspectorApp,
+       app.inspectors.count > 1 || (model.selectedInspector == nil && !app.inspectors.isEmpty) {
       HStack(spacing: 0) {
         ForEach(app.inspectors) { option in
           Button {
@@ -80,7 +81,7 @@ struct AppInspectorViewPicker: View {
             Label(option.kind.title, systemImage: option.kind.systemImage)
               .labelStyle(.iconOnly)
               .font(.system(size: 15, weight: .medium))
-              .foregroundStyle(model.selectedInspector?.kind == option.kind ? Color.accentColor : Color.primary)
+              .foregroundStyle(model.preferredInspectorKind == option.kind ? Color.accentColor : Color.primary)
               .frame(width: 34, height: 32)
           }
           .help(option.kind.title)

--- a/snapo-app-mac/Snap-O/NetworkInspector/NetworkInspectorService.swift
+++ b/snapo-app-mac/Snap-O/NetworkInspector/NetworkInspectorService.swift
@@ -43,10 +43,7 @@ actor NetworkInspectorService {
   init(adbService: ADBService, deviceTracker: DeviceTracker) {
     self.adbService = adbService
     self.deviceTracker = deviceTracker
-    tweaksService = TweaksInspectorService(
-      adbService: adbService,
-      deviceTracker: deviceTracker
-    )
+    tweaksService = TweaksInspectorService(adbService: adbService)
   }
 
   func outputStream() -> AsyncStream<NetworkInspectorOutput> {
@@ -70,9 +67,9 @@ actor NetworkInspectorService {
   }
 
   func listInspectorApps() async -> [InspectableApp] {
-    async let networkServers = listServers()
-    async let tweakApps = tweaksService.listApps()
-    let networkEndpoints = await networkServers.map { server in
+    await refresh()
+    let tweakApps = await tweaksService.currentApps()
+    let networkEndpoints = currentServers().map { server in
       InspectorEndpoint(
         kind: .network,
         reference: NetworkServerReference(
@@ -82,14 +79,14 @@ actor NetworkInspectorService {
         deviceDisplayTitle: server.deviceDisplayTitle,
         protocolVersion: server.protocolVersion,
         metadata: InspectorAppMetadata(
-          processName: server.appName,
+          processName: server.appName ?? server.packageName,
           packageName: server.hasAppInfo ? server.packageName : nil,
           packageNameHint: server.packageName,
           appIconBase64: server.appIconBase64
         )
       )
     }
-    let tweakEndpoints = await tweakApps.map { app in
+    let tweakEndpoints = tweakApps.map { app in
       InspectorEndpoint(
         kind: .tweaks,
         reference: NetworkServerReference(
@@ -100,6 +97,7 @@ actor NetworkInspectorService {
         protocolVersion: app.protocolVersion,
         metadata: InspectorAppMetadata(
           appName: app.name,
+          processName: app.processName,
           packageName: app.packageName,
           appIconBase64: app.appIconBase64
         )
@@ -110,6 +108,7 @@ actor NetworkInspectorService {
         id: process.id,
         name: process.name,
         packageName: process.metadata.packageName ?? process.metadata.packageNameHint ?? process.name,
+        processName: process.metadata.processName ?? process.metadata.packageNameHint,
         deviceId: process.deviceId,
         deviceDisplayTitle: process.deviceDisplayTitle,
         appIconBase64: process.metadata.appIconBase64,
@@ -409,12 +408,16 @@ actor NetworkInspectorService {
   private func refreshNow() async {
     let devices = await deviceTracker.latestDevices
     let adb = await adbService.exec()
-    let references = await NetworkServerDiscovery.discover(
+    let sockets = await InspectorDiscovery.discover(
       on: devices.map(\.id),
       using: adb
     )
     guard !Task.isCancelled, !isStopped else { return }
 
+    let references = sockets.filter { $0.kind == .network }.map(\.reference)
+    async let refreshedTweaks: Void = tweaksService.refresh(
+      devices: devices, references: sockets.filter { $0.kind == .tweaks }.map(\.reference), using: adb
+    )
     let devicesByID = Dictionary(uniqueKeysWithValues: devices.map { ($0.id, $0) })
     let seenKeys = Set(references.map(\.key))
     for reference in references {
@@ -433,6 +436,7 @@ actor NetworkInspectorService {
     for key in removedKeys {
       await removeServer(key, message: nil)
     }
+    await refreshedTweaks
   }
 
   private func connect(
@@ -473,7 +477,7 @@ actor NetworkInspectorService {
         appInfo: nil,
         packageNameHint: nil
       )
-      populatePackageNameHint(reference: reference, connectionID: connectionID, using: adb)
+      await populatePackageNameHint(reference: reference, connectionID: connectionID, using: adb)
     } catch {
       return
     }
@@ -483,21 +487,9 @@ actor NetworkInspectorService {
     reference: NetworkServerReference,
     connectionID: UUID,
     using adb: ADBClient
-  ) {
-    Task { [weak self] in
-      guard let packageName = await NetworkServerDiscovery.packageNameHint(
-        for: reference,
-        using: adb
-      )
-      else {
-        return
-      }
-      await self?.setPackageNameHint(
-        packageName,
-        reference: reference,
-        connectionID: connectionID
-      )
-    }
+  ) async {
+    guard let packageName = await NetworkServerDiscovery.packageNameHint(for: reference, using: adb) else { return }
+    setPackageNameHint(packageName, reference: reference, connectionID: connectionID)
   }
 
   private func setPackageNameHint(

--- a/snapo-app-mac/Snap-O/NetworkInspector/NetworkInspectorWebBridge.swift
+++ b/snapo-app-mac/Snap-O/NetworkInspector/NetworkInspectorWebBridge.swift
@@ -14,7 +14,7 @@ final class NetworkInspectorWebBridge: NSObject, WKScriptMessageHandlerWithReply
   private weak static var colorPanelOwner: NetworkInspectorWebBridge?
 
   var inspectorStateChangedHandler: ((NetworkInspectorNativeState) -> Void)?
-  var inspectorAppsChangedHandler: (([InspectableApp]) -> Void)?
+  var appInspectorStateChangedHandler: ((AppInspectorState) -> Void)?
   var tweaksStateChangedHandler: ((TweaksInspectorNativeState) -> Void)?
   var colorPanelChangedHandler: ((NativeColorPanelChange) -> Void)?
 
@@ -72,9 +72,16 @@ final class NetworkInspectorWebBridge: NSObject, WKScriptMessageHandlerWithReply
     case "listServers":
       return try await Self.jsonObject(service.listServers())
     case "listInspectorApps":
-      let apps = await service.listInspectorApps()
-      inspectorAppsChangedHandler?(apps)
-      return try Self.jsonObject(apps)
+      return try await Self.jsonObject(service.listInspectorApps())
+    case "loadInspectorPreferences":
+      return UserDefaults.standard.string(forKey: "inspectorPreferences")
+    case "saveInspectorPreferences":
+      let input = try Self.decode(InspectorPreferencesInput.self, from: payload)
+      UserDefaults.standard.set(input.value, forKey: "inspectorPreferences")
+      return nil
+    case "appInspectorStateChanged":
+      try appInspectorStateChangedHandler?(Self.decode(AppInspectorState.self, from: payload))
+      return nil
     case "listTweaks":
       let reference = try Self.decode(InspectorServerReference.self, from: payload)
       return try await Self.jsonObject(service.listTweaks(for: reference))
@@ -269,6 +276,10 @@ final class NetworkInspectorWebBridge: NSObject, WKScriptMessageHandlerWithReply
     }
     let data = try JSONSerialization.data(withJSONObject: payload)
     return try JSONDecoder().decode(type, from: data)
+  }
+
+  private struct InspectorPreferencesInput: Decodable {
+    let value: String
   }
 
   private struct StreamIdentifier: Decodable {

--- a/snapo-app-mac/Snap-O/NetworkInspector/TweaksInspectorService.swift
+++ b/snapo-app-mac/Snap-O/NetworkInspector/TweaksInspectorService.swift
@@ -8,6 +8,7 @@ actor TweaksInspectorService {
     let socketName: String
     var name: String?
     var packageName: String?
+    var processName: String?
     var protocolVersion: Int?
     var appIconBase64: String?
   }
@@ -29,83 +30,57 @@ actor TweaksInspectorService {
     let baseURL: URL
     var hasLoadedIcon = false
     var metadataTask: Task<Void, Never>?
+
+    var reference: NetworkServerReference {
+      NetworkServerReference(deviceId: app.deviceID, socketName: app.socketName)
+    }
   }
 
-  private static let socketPrefix = "snapo_tweaks_"
   private static let discoveryRequestTimeout: TimeInterval = 2
 
   private let adbService: ADBService
-  private let deviceTracker: DeviceTracker
   private var connections: [String: Connection] = [:]
-  private var refreshTask: Task<Void, Never>?
   private var isStopped = false
 
-  init(adbService: ADBService, deviceTracker: DeviceTracker) {
+  init(adbService: ADBService) {
     self.adbService = adbService
-    self.deviceTracker = deviceTracker
   }
 
-  func listApps() async -> [App] {
-    guard !isStopped else { return [] }
-    if let refreshTask {
-      await refreshTask.value
-    } else {
-      let task = Task<Void, Never> { [weak self] in
-        await self?.refreshNow()
-      }
-      refreshTask = task
-      await task.value
-      refreshTask = nil
-    }
-
-    return connections.values.map(\.app).sorted {
-      if $0.deviceID != $1.deviceID {
-        return $0.deviceID < $1.deviceID
-      }
+  func currentApps() -> [App] {
+    connections.values.map(\.app).sorted {
+      if $0.deviceID != $1.deviceID { return $0.deviceID < $1.deviceID }
       return $0.socketName < $1.socketName
     }
   }
 
-  private func refreshNow() async {
-    let devices = await deviceTracker.latestDevices
-    let adb = await adbService.exec()
-    var activeKeys = Set<String>()
+  func refresh(devices: [Device], references: [NetworkServerReference], using adb: ADBClient) async {
+    guard !isStopped else { return }
+    let devicesByID = Dictionary(uniqueKeysWithValues: devices.map { ($0.id, $0) })
+    let activeKeys = Set(references.map(\.key))
 
     await withTaskGroup(of: Void.self) { group in
-      for device in devices {
-        guard !Task.isCancelled, !isStopped,
-              let output = try? await adb.listUnixSockets(deviceID: device.id) else {
-          continue
-        }
-
-        for socketName in Self.socketNames(in: output) {
-          let key = Self.connectionKey(deviceID: device.id, socketName: socketName)
-          activeKeys.insert(key)
-
-          if var connection = connections[key] {
-            connection.app.deviceDisplayTitle = device.displayTitle
-            connections[key] = connection
-            populateMetadata(for: key)
-          } else {
-            group.addTask {
-              await self.connect(
-                deviceID: device.id,
-                deviceDisplayTitle: device.displayTitle,
-                socketName: socketName,
-                using: adb
-              )
-            }
+      for reference in references {
+        guard let device = devicesByID[reference.deviceId], !Task.isCancelled, !isStopped else { continue }
+        let key = reference.key
+        if var connection = connections[key] {
+          connection.app.deviceDisplayTitle = device.displayTitle
+          connections[key] = connection
+          populateMetadata(for: key)
+        } else {
+          group.addTask {
+            await self.connect(
+              reference: reference,
+              deviceDisplayTitle: device.displayTitle,
+              using: adb
+            )
           }
         }
       }
     }
 
     guard !Task.isCancelled, !isStopped else { return }
-    let removedKeys = connections.keys.filter { !activeKeys.contains($0) }
-    for key in removedKeys {
-      guard let connection = connections.removeValue(forKey: key) else {
-        continue
-      }
+    for key in connections.keys.filter({ !activeKeys.contains($0) }) {
+      guard let connection = connections.removeValue(forKey: key) else { continue }
       connection.metadataTask?.cancel()
       await adb.removeForward(connection.forward)
     }
@@ -113,7 +88,7 @@ actor TweaksInspectorService {
 
   func listTweaks(for reference: InspectorServerReference) async throws -> TweakList {
     let connection = try connection(for: reference)
-    return try await load(TweakList.self, path: "tweaks", baseURL: connection.baseURL)
+    return try await load(TweakList.self, path: "tweaks", connection: connection)
   }
 
   func updateTweaks(_ input: UpdateTweaksInput) async throws -> TweakUpdates {
@@ -123,7 +98,7 @@ actor TweaksInspectorService {
     request.setValue("application/json", forHTTPHeaderField: "Content-Type")
     request.httpBody = try JSONEncoder().encode(TweakPatch(values: input.values))
 
-    let (data, response) = try await URLSession.shared.data(for: request)
+    let (data, response) = try await data(for: request, connection: connection)
     try Self.validate(response, data: data)
     return try JSONDecoder().decode(TweakUpdates.self, from: data)
   }
@@ -135,7 +110,7 @@ actor TweaksInspectorService {
     request.setValue("application/json", forHTTPHeaderField: "Content-Type")
     request.httpBody = try JSONEncoder().encode(TweakAction(name: input.name))
 
-    let (data, response) = try await URLSession.shared.data(for: request)
+    let (data, response) = try await data(for: request, connection: connection)
     try Self.validate(response, data: data)
   }
 
@@ -147,26 +122,29 @@ actor TweaksInspectorService {
     var request = URLRequest(url: connection.baseURL.appending(path: "tweaks/events"))
     request.setValue("text/event-stream", forHTTPHeaderField: "Accept")
 
-    let (bytes, response) = try await URLSession.shared.bytes(for: request)
-    try Self.validate(response)
+    do {
+      let (bytes, response) = try await URLSession.shared.bytes(for: request)
+      try Self.validate(response)
 
-    // SSE frames end with an empty line, which AsyncBytes.lines omits.
-    var decoder = TweakEventStreamDecoder()
+      // SSE frames end with an empty line, which AsyncBytes.lines omits.
+      var decoder = TweakEventStreamDecoder()
 
-    for try await byte in bytes {
-      try Task.checkCancellation()
+      for try await byte in bytes {
+        try Task.checkCancellation()
 
-      guard let data = decoder.consume(byte) else { continue }
-      let tweaks = try JSONDecoder().decode(TweakList.self, from: data)
-      await onChange(tweaks)
+        guard let data = decoder.consume(byte) else { continue }
+        let tweaks = try JSONDecoder().decode(TweakList.self, from: data)
+        await onChange(tweaks)
+      }
+    } catch {
+      await invalidateConnection(connection, after: error)
+      throw error
     }
   }
 
   func stop() async {
     guard !isStopped else { return }
     isStopped = true
-    refreshTask?.cancel()
-    refreshTask = nil
     for connection in connections.values {
       connection.metadataTask?.cancel()
     }
@@ -180,12 +158,11 @@ actor TweaksInspectorService {
   }
 
   private func connect(
-    deviceID: String,
+    reference: NetworkServerReference,
     deviceDisplayTitle: String,
-    socketName: String,
     using adb: ADBClient
   ) async {
-    let key = Self.connectionKey(deviceID: deviceID, socketName: socketName)
+    let key = reference.key
     guard !Task.isCancelled, !isStopped, connections[key] == nil else {
       return
     }
@@ -194,8 +171,8 @@ actor TweaksInspectorService {
 
     do {
       let handle = try await adb.forwardLocalAbstract(
-        deviceID: deviceID,
-        abstractSocket: socketName
+        deviceID: reference.deviceId,
+        abstractSocket: reference.socketName
       )
       forward = handle
 
@@ -208,10 +185,16 @@ actor TweaksInspectorService {
         throw NetworkInspectorError.invalidBridgeMessage
       }
 
+      let processName = await NetworkServerDiscovery.packageNameHint(for: reference, using: adb)
+      guard !Task.isCancelled, !isStopped else {
+        await adb.removeForward(handle)
+        return
+      }
       let app = App(
-        deviceID: deviceID,
+        deviceID: reference.deviceId,
         deviceDisplayTitle: deviceDisplayTitle,
-        socketName: socketName
+        socketName: reference.socketName,
+        processName: processName
       )
       connections[key] = Connection(id: UUID(), app: app, forward: handle, baseURL: baseURL)
       populateMetadata(for: key)
@@ -224,7 +207,7 @@ actor TweaksInspectorService {
 
   private func populateMetadata(for key: String) {
     guard let connection = connections[key],
-          connection.app.protocolVersion == nil || !connection.hasLoadedIcon,
+          connection.app.protocolVersion == nil || connection.app.processName == nil || !connection.hasLoadedIcon,
           connection.metadataTask == nil else { return }
     connections[key]?.metadataTask = Task { [weak self] in
       await self?.loadMetadata(for: key, connectionID: connection.id)
@@ -239,11 +222,18 @@ actor TweaksInspectorService {
     }
     guard let connection = connections[key], connection.id == connectionID else { return }
 
+    if connection.app.processName == nil {
+      let adb = await adbService.exec()
+      let processName = await NetworkServerDiscovery.packageNameHint(for: connection.reference, using: adb)
+      guard !Task.isCancelled, connections[key]?.id == connectionID else { return }
+      connections[key]?.app.processName = processName
+    }
+
     if connection.app.protocolVersion == nil,
        let info = try? await load(
          AppInfo.self,
          path: "app",
-         baseURL: connection.baseURL,
+         connection: connection,
          timeoutInterval: Self.discoveryRequestTimeout
        ),
        !Task.isCancelled,
@@ -254,9 +244,9 @@ actor TweaksInspectorService {
       connections[key] = current
     }
 
-    guard !Task.isCancelled, !connection.hasLoadedIcon else { return }
+    guard !Task.isCancelled, connections[key]?.id == connectionID, !connection.hasLoadedIcon else { return }
     do {
-      let icon = try await loadIcon(baseURL: connection.baseURL)
+      let icon = try await loadIcon(connection: connection)
       guard !Task.isCancelled,
             var current = connections[key], current.id == connectionID else { return }
       current.app.appIconBase64 = icon?.base64EncodedString()
@@ -267,21 +257,20 @@ actor TweaksInspectorService {
     }
   }
 
-  private func loadIcon(baseURL: URL) async throws -> Data? {
+  private func loadIcon(connection: Connection) async throws -> Data? {
     let request = URLRequest(
-      url: baseURL.appending(path: "app/icon"),
+      url: connection.baseURL.appending(path: "app/icon"),
       timeoutInterval: Self.discoveryRequestTimeout
     )
-    let (data, response) = try await URLSession.shared.data(for: request)
+    let (data, response) = try await data(for: request, connection: connection)
     if (response as? HTTPURLResponse)?.statusCode == 404 { return nil }
     try Self.validate(response, data: data)
     return data
   }
 
   private func connection(for reference: InspectorServerReference) throws -> Connection {
-    let key = Self.connectionKey(deviceID: reference.deviceId, socketName: reference.socketName)
-    guard let connection = connections[key] else {
-      throw NetworkInspectorError.invalidBridgeMessage
+    guard let connection = connections[reference.key] else {
+      throw NetworkInspectorError.serverNotConnected(reference)
     }
     return connection
   }
@@ -289,17 +278,39 @@ actor TweaksInspectorService {
   private func load<T: Decodable>(
     _ type: T.Type,
     path: String,
-    baseURL: URL,
+    connection: Connection,
     timeoutInterval: TimeInterval? = nil
   ) async throws -> T {
-    var request = URLRequest(url: baseURL.appending(path: path))
+    var request = URLRequest(url: connection.baseURL.appending(path: path))
     if let timeoutInterval {
       request.timeoutInterval = timeoutInterval
     }
 
-    let (data, response) = try await URLSession.shared.data(for: request)
+    let (data, response) = try await data(for: request, connection: connection)
     try Self.validate(response, data: data)
     return try JSONDecoder().decode(type, from: data)
+  }
+
+  private func data(for request: URLRequest, connection: Connection) async throws -> (Data, URLResponse) {
+    do {
+      return try await URLSession.shared.data(for: request)
+    } catch {
+      await invalidateConnection(connection, after: error)
+      throw error
+    }
+  }
+
+  private func invalidateConnection(_ connection: Connection, after error: Error) async {
+    guard let error = error as? URLError,
+          [.cannotConnectToHost, .networkConnectionLost, .notConnectedToInternet, .timedOut].contains(error.code)
+    else { return }
+    let key = connection.reference.key
+    guard connections[key]?.id == connection.id else { return }
+
+    // A brief device disconnect can remove the forward without changing the Android socket.
+    connections.removeValue(forKey: key)?.metadataTask?.cancel()
+    let adb = await adbService.exec()
+    await adb.removeForward(connection.forward)
   }
 
   private static func validate(_ response: URLResponse, data: Data? = nil) throws {
@@ -314,26 +325,5 @@ actor TweaksInspectorService {
         message: message
       )
     }
-  }
-
-  private static func socketNames(in output: String) -> [String] {
-    Array(Set(output.split(separator: "\n").compactMap { line in
-      guard let token = line.split(whereSeparator: \.isWhitespace).last else {
-        return nil
-      }
-      let socket = String(token)
-      guard socket.hasPrefix("@\(socketPrefix)") else {
-        return nil
-      }
-      let name = String(socket.dropFirst())
-      guard InspectorKind.tweaks.pid(inSocketName: name) != nil else {
-        return nil
-      }
-      return name
-    })).sorted()
-  }
-
-  private static func connectionKey(deviceID: String, socketName: String) -> String {
-    "\(deviceID):\(socketName)"
   }
 }

--- a/snapo-app-mac/SnapODeviceClient/Sources/SnapODeviceClient/InspectorDiscovery.swift
+++ b/snapo-app-mac/SnapODeviceClient/Sources/SnapODeviceClient/InspectorDiscovery.swift
@@ -1,6 +1,6 @@
 import Foundation
 
-public enum InspectorKind: String, Codable, Sendable {
+public enum InspectorKind: String, Codable, Sendable, CaseIterable {
   case network
   case tweaks
 
@@ -99,7 +99,43 @@ public struct InspectableProcess: Sendable {
   }
 }
 
+public struct DiscoveredInspectorSocket: Sendable, Equatable {
+  public let kind: InspectorKind
+  public let reference: NetworkServerReference
+}
+
 public enum InspectorDiscovery {
+  public static func sockets(inProcNetUnix output: String, deviceID: String) -> [DiscoveredInspectorSocket] {
+    Set(output.split(separator: "\n").compactMap { $0.split(whereSeparator: \.isWhitespace).last })
+      .sorted().compactMap { token in
+        guard token.first == "@" else { return nil }
+        let name = String(token.dropFirst())
+        guard let kind = InspectorKind.allCases.first(where: { $0.pid(inSocketName: name) != nil }) else {
+          return nil
+        }
+        return DiscoveredInspectorSocket(
+          kind: kind,
+          reference: NetworkServerReference(deviceId: deviceID, socketName: name)
+        )
+      }
+  }
+
+  public static func discover(on deviceIDs: [String], using adb: ADBClient) async -> [DiscoveredInspectorSocket] {
+    await withTaskGroup(of: [DiscoveredInspectorSocket].self) { group in
+      for deviceID in deviceIDs {
+        group.addTask {
+          guard let output = try? await adb.listUnixSockets(deviceID: deviceID) else { return [] }
+          return Self.sockets(inProcNetUnix: output, deviceID: deviceID)
+        }
+      }
+      var sockets: [DiscoveredInspectorSocket] = []
+      for await result in group {
+        sockets.append(contentsOf: result)
+      }
+      return sockets.sorted { $0.reference.identifier < $1.reference.identifier }
+    }
+  }
+
   public static func processes(from endpoints: [InspectorEndpoint]) -> [InspectableProcess] {
     Dictionary(grouping: endpoints, by: \.processID).map { id, endpoints in
       let ordered = endpoints.sorted {

--- a/snapo-app-mac/SnapODeviceClient/Sources/SnapODeviceClient/NetworkServerDiscovery.swift
+++ b/snapo-app-mac/SnapODeviceClient/Sources/SnapODeviceClient/NetworkServerDiscovery.swift
@@ -72,7 +72,7 @@ public enum NetworkServerDiscovery {
     for reference: NetworkServerReference,
     using adb: ADBClient
   ) async -> String? {
-    guard let pid = pid(inSocketName: reference.socketName),
+    guard let pid = InspectorKind.allCases.compactMap({ $0.pid(inSocketName: reference.socketName) }).first,
           let output = try? await adb.runShellString(
             deviceID: reference.deviceId,
             command: "cat /proc/\(pid)/cmdline 2>/dev/null"

--- a/snapo-app-mac/SnapODeviceClient/Tests/SnapODeviceClientTests/InspectorDiscoveryTests.swift
+++ b/snapo-app-mac/SnapODeviceClient/Tests/SnapODeviceClientTests/InspectorDiscoveryTests.swift
@@ -4,13 +4,29 @@ import Testing
 
 @Suite("Inspector process discovery")
 struct InspectorDiscoveryTests {
+  @Test("discovers both inspector kinds from one socket snapshot")
+  func parsesSharedSnapshot() {
+    let output = """
+    1: 0 @snapo_tweaks_42
+    2: 0 @snapo_network_42
+    3: 0 @snapo_tweaks_42
+    4: 0 @snapo_network_invalid
+    5: 0 @snapo_unknown_42
+    6: 0 @snapo_tweaks_0
+    """
+    let sockets = InspectorDiscovery.sockets(inProcNetUnix: output, deviceID: "phone")
+    #expect(sockets.map(\.kind) == [.network, .tweaks])
+    #expect(sockets.map(\.reference.deviceId) == ["phone", "phone"])
+    #expect(sockets.map(\.reference.socketName) == ["snapo_network_42", "snapo_tweaks_42"])
+  }
+
   @Test("shared inspector types preserve the web bridge wire format")
   func preservesBridgeEncoding() throws {
     let encoder = JSONEncoder()
     encoder.outputFormatting = .sortedKeys
-    #expect(try String(decoding: encoder.encode(InspectorKind.tweaks), as: UTF8.self) == "\"tweaks\"")
+    #expect(try String(bytes: encoder.encode(InspectorKind.tweaks), encoding: .utf8) == "\"tweaks\"")
     let server = NetworkServerReference(deviceId: "device", socketName: "snapo_tweaks_42")
-    #expect(try String(decoding: encoder.encode(server), as: UTF8.self)
+    #expect(try String(bytes: encoder.encode(server), encoding: .utf8)
       == "{\"deviceId\":\"device\",\"socketName\":\"snapo_tweaks_42\"}")
   }
 

--- a/snapo-network-inspector-web/src/App.test.tsx
+++ b/snapo-network-inspector-web/src/App.test.tsx
@@ -1,0 +1,318 @@
+// @vitest-environment jsdom
+import { act } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type {
+  AppInspectorKind,
+  CdpMessage,
+  InspectableApp,
+  SelectedAppInspector,
+  SnapOServer,
+  StreamEvent
+} from "./network/bridge-types";
+import type { NetworkClient } from "./network/client";
+import { recordId } from "./network/cdp";
+import type { NetworkInspectorModel } from "./features/network-inspector/hooks/useNetworkInspectorModel";
+import { InspectorRestoration } from "./features/app-inspector/restoration";
+import { App } from "./App";
+
+const mocks = vi.hoisted(() => ({
+  client: null as unknown as NetworkClient,
+  model: null as NetworkInspectorModel | null
+}));
+const replayMessages: CdpMessage[] = [
+  {
+    method: "Network.requestWillBeSent",
+    snapoSequence: 1,
+    params: {
+      requestId: "request-1",
+      wallTime: 1_710_000_000,
+      timestamp: 100,
+      request: { url: "https://example.test/items", method: "GET", headers: {}, hasPostData: false }
+    }
+  },
+  {
+    method: "Network.responseReceived",
+    snapoSequence: 2,
+    params: {
+      requestId: "request-1",
+      timestamp: 100.1,
+      type: "XHR",
+      response: { url: "https://example.test/items", status: 200, headers: {}, mimeType: "application/json" }
+    }
+  },
+  {
+    method: "Network.loadingFinished",
+    snapoSequence: 3,
+    params: {
+      requestId: "request-1",
+      timestamp: 100.25,
+      encodedDataLength: 12
+    }
+  }
+];
+vi.mock("./network/client", () => ({ createNetworkClient: () => mocks.client }));
+vi.mock("./features/network-inspector/NetworkInspectorApp", () => ({
+  NetworkInspectorApp: ({
+    model,
+    inspectorSelection
+  }: {
+    model: NetworkInspectorModel;
+    inspectorSelection: SelectedAppInspector | null;
+  }) => {
+    mocks.model = model;
+    return <div data-inspector="network" data-socket={inspectorSelection?.server.socketName} />;
+  }
+}));
+vi.mock("./features/tweaks-inspector/TweaksInspectorApp", () => ({
+  TweaksInspectorApp: () => <div data-inspector="tweaks" />
+}));
+
+function app(pid: number, kinds: AppInspectorKind[]): InspectableApp {
+  return {
+    id: `phone:pid:${pid}`,
+    name: "Demo",
+    packageName: "com.example.demo",
+    processName: "com.example.demo",
+    deviceId: "phone",
+    deviceDisplayTitle: "Phone",
+    inspectors: kinds.map((kind) => ({
+      kind,
+      protocolVersion: 4,
+      server: { deviceId: "phone", socketName: `snapo_${kind}_${pid}` }
+    }))
+  };
+}
+
+describe("app inspector restoration UI", () => {
+  let root: Root;
+  let container: HTMLDivElement;
+  let discovered: InspectableApp[];
+  let nativeSelect: (selection: SelectedAppInspector) => void;
+  let events: Set<(event: StreamEvent) => void>;
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+    Object.assign(globalThis, { IS_REACT_ACT_ENVIRONMENT: true });
+    discovered = [app(20, ["tweaks"])];
+    events = new Set();
+    mocks.model = null;
+    const saved = new InspectorRestoration();
+    saved.reconcile([app(10, ["network", "tweaks"])]);
+    mocks.client = {
+      usesNativeServerPicker: true,
+      loadInspectorPreferences: vi.fn(async () => saved.serialize()),
+      saveInspectorPreferences: vi.fn(async () => {}),
+      listInspectorApps: vi.fn(async () => discovered),
+      listServers: vi.fn(async () =>
+        discovered.flatMap((app) =>
+          app.inspectors
+            .filter((option) => option.kind === "network")
+            .map(
+              (option): SnapOServer => ({
+                ...option.server,
+                server: app.id,
+                deviceDisplayTitle: app.deviceDisplayTitle,
+                displayName: app.name,
+                isConnected: true,
+                hasAppInfo: true,
+                instanceId: app.id,
+                isProtocolNewerThanSupported: false,
+                isProtocolOlderThanSupported: false
+              })
+            )
+        )
+      ),
+      startStream: vi.fn(async () => ({ streamId: "network-stream" })),
+      stopStream: vi.fn(async () => {}),
+      loadBodies: vi.fn(async ({ requestId }) => ({ requestId, responseBody: "cached response" })),
+      onEvent: vi.fn((callback) => {
+        events.add(callback);
+        return () => events.delete(callback);
+      }),
+      onStatus: vi.fn(() => () => {}),
+      debugInspectorPreset: vi.fn(async () => "live"),
+      onDebugInspectorPreset: vi.fn(() => () => {}),
+      selectedDeviceChanged: vi.fn(),
+      onPreferredDevice: vi.fn(() => () => {}),
+      nativeInspectorStateChanged: vi.fn(),
+      onNativeSelectedServer: vi.fn(() => () => {}),
+      onNativeSearchText: vi.fn(() => () => {}),
+      onNativeSortOrder: vi.fn(() => () => {}),
+      onNativeClearCompleted: vi.fn(() => () => {}),
+      onNativeCopySelectedUrl: vi.fn(() => () => {}),
+      onNativeCopySelectedCurl: vi.fn(() => () => {}),
+      onNativeExportVisibleHar: vi.fn(() => () => {}),
+      appInspectorStateChanged: vi.fn(),
+      onNativeSelectedInspector: vi.fn((callback) => {
+        nativeSelect = callback;
+        return () => {};
+      }),
+      onNativeSelectedApp: vi.fn(() => () => {})
+    } as unknown as NetworkClient;
+    container = document.createElement("div");
+    document.body.append(container);
+    root = createRoot(container);
+  });
+
+  afterEach(async () => {
+    await act(async () => root.unmount());
+    container.remove();
+    vi.useRealTimers();
+  });
+
+  it("shows only an accessible spinner until the remembered inspector appears", async () => {
+    await act(async () => root.render(<App />));
+    expect(container.querySelector('[role="status"] svg')).not.toBeNull();
+    expect(container.textContent).toBe("");
+    expect(container.querySelector("[data-inspector]")).toBeNull();
+
+    discovered = [app(20, ["network", "tweaks"])];
+    await act(async () => vi.advanceTimersByTimeAsync(2_500));
+    expect(container.querySelector('[data-inspector="network"]')?.getAttribute("data-socket")).toBe("snapo_network_20");
+    expect(container.querySelector('[role="status"]')).toBeNull();
+  });
+
+  it("honors a native explicit choice while discovery is in flight", async () => {
+    await act(async () => root.render(<App />));
+    let finish!: (apps: InspectableApp[]) => void;
+    vi.mocked(mocks.client.listInspectorApps).mockImplementationOnce(
+      () =>
+        new Promise((resolve) => {
+          finish = resolve;
+        })
+    );
+    await act(async () => vi.advanceTimersByTimeAsync(2_500));
+    await act(async () => nativeSelect({ appId: discovered[0].id, ...discovered[0].inspectors[0] }));
+    expect(container.querySelector('[data-inspector="tweaks"]')).not.toBeNull();
+    await act(async () => finish([app(20, ["network", "tweaks"])]));
+    expect(container.querySelector('[data-inspector="tweaks"]')).not.toBeNull();
+  });
+
+  it("keeps a browser picker available during restoration", async () => {
+    Object.assign(mocks.client, { usesNativeServerPicker: false });
+    await act(async () => root.render(<App />));
+    expect(container.querySelector('button[aria-label="Select an app"]')).not.toBeNull();
+    const tweaks = container.querySelector('button[aria-label="Tweaks"]') as HTMLButtonElement;
+    await act(async () => tweaks.click());
+    expect(container.querySelector('[data-inspector="tweaks"]')).not.toBeNull();
+  });
+
+  async function captureTraffic() {
+    discovered = [app(20, ["network", "tweaks"])];
+    await act(async () => root.render(<App />));
+    const server = discovered[0].inspectors[0].server;
+    await act(async () => {
+      for (const message of replayMessages) {
+        for (const receive of events)
+          receive({ streamId: "network-stream", server, serverInstanceId: discovered[0].id, message });
+      }
+    });
+    expect(mocks.model?.allRecords).toHaveLength(1);
+    expect(mocks.model?.selectedRecord).toMatchObject({ requestId: "request-1", responseBody: "cached response" });
+  }
+
+  it("retains actual records, bodies, and selection while reconnecting", async () => {
+    await captureTraffic();
+    const selectedRecordId = mocks.model?.selectedRecordId;
+    const bodyLoads = vi.mocked(mocks.client.loadBodies).mock.calls.length;
+    discovered = [];
+    await act(async () => vi.advanceTimersByTimeAsync(2_500));
+    expect(container.querySelector(".inspector-loading-shell")).toBeNull();
+    expect(container.querySelector('[data-inspector="network"]')).not.toBeNull();
+    expect(mocks.model?.selectedServer?.isConnected).toBe(false);
+    expect(mocks.model?.visibleRecords).toHaveLength(1);
+    expect(mocks.model?.selectedRecord).toMatchObject({ responseBody: "cached response" });
+    expect(mocks.client.nativeInspectorStateChanged).toHaveBeenLastCalledWith(
+      expect.objectContaining({
+        selectedServer: { deviceId: "phone", socketName: "snapo_network_20" },
+        hasVisibleRecords: true
+      })
+    );
+    expect(mocks.client.stopStream).toHaveBeenCalled();
+    const starts = vi.mocked(mocks.client.startStream).mock.calls.length;
+    await act(async () => vi.advanceTimersByTimeAsync(5_000));
+    expect(mocks.client.startStream).toHaveBeenCalledTimes(starts);
+    expect(mocks.client.loadBodies).toHaveBeenCalledTimes(bodyLoads);
+
+    await act(async () => mocks.model?.setSearchText("no-match"));
+    expect(mocks.model?.visibleRecords).toHaveLength(0);
+    await act(async () => mocks.model?.setSearchText(""));
+    expect(mocks.model?.visibleRecords).toHaveLength(1);
+
+    discovered = [app(20, ["network", "tweaks"])];
+    await act(async () => vi.advanceTimersByTimeAsync(2_500));
+    expect(mocks.model?.allRecords).toHaveLength(1);
+    expect(mocks.model?.selectedRecordId).toBe(selectedRecordId);
+    expect(mocks.model?.selectedRecord).toMatchObject({ responseBody: "cached response" });
+    expect(mocks.client.loadBodies).toHaveBeenCalledTimes(bodyLoads);
+  });
+
+  it("honors cached native toolbar choices offline without starting stale streams", async () => {
+    await captureTraffic();
+    const initial = discovered[0];
+    discovered = [];
+    await act(async () => vi.advanceTimersByTimeAsync(2_500));
+    const starts = vi.mocked(mocks.client.startStream).mock.calls.length;
+    await act(async () => nativeSelect({ appId: initial.id, ...initial.inspectors[1] }));
+    expect(container.querySelector(".inspector-loading-shell")).not.toBeNull();
+    expect(mocks.client.appInspectorStateChanged).toHaveBeenLastCalledWith(
+      expect.objectContaining({ selection: null, preferredKind: "tweaks", isRestoring: true })
+    );
+    await act(async () => nativeSelect({ appId: initial.id, ...initial.inspectors[0] }));
+    expect(container.querySelector('[data-inspector="network"]')).not.toBeNull();
+    expect(mocks.model?.selectedRecord).toMatchObject({ responseBody: "cached response" });
+    expect(mocks.client.startStream).toHaveBeenCalledTimes(starts);
+  });
+
+  it("retains old-process traffic when a new PID has nothing to replay", async () => {
+    await captureTraffic();
+    discovered = [];
+    await act(async () => vi.advanceTimersByTimeAsync(2_500));
+    discovered = [app(30, ["network", "tweaks"])];
+    await act(async () => vi.advanceTimersByTimeAsync(2_500));
+    expect(mocks.model?.selectedServer?.socketName).toBe("snapo_network_30");
+    expect(mocks.model?.visibleRecords).toHaveLength(0);
+    expect(mocks.model?.allRecords).toMatchObject([
+      { server: { socketName: "snapo_network_20" }, responseBody: "cached response" }
+    ]);
+  });
+
+  it("allows browsing another captured request without loading bodies offline", async () => {
+    await captureTraffic();
+    const server = discovered[0].inspectors[0].server;
+    await act(async () => {
+      for (const original of replayMessages) {
+        const message = {
+          ...original,
+          snapoSequence: (original.snapoSequence ?? 0) + 10,
+          params: { ...original.params, requestId: "request-2" }
+        };
+        for (const receive of events)
+          receive({ streamId: "network-stream", server, serverInstanceId: discovered[0].id, message });
+      }
+    });
+    const firstId = mocks.model!.selectedRecordId!;
+    const second = mocks.model!.allRecords.find(
+      (record) => record.kind === "request" && record.requestId === "request-2"
+    )!;
+    const bodyLoads = vi.mocked(mocks.client.loadBodies).mock.calls.length;
+    discovered = [];
+    await act(async () => vi.advanceTimersByTimeAsync(2_500));
+    await act(async () => mocks.model!.selectRecord(recordId(second)));
+    expect(mocks.model?.selectedRecord).toMatchObject({ requestId: "request-2" });
+    expect(mocks.client.loadBodies).toHaveBeenCalledTimes(bodyLoads);
+    await act(async () => mocks.model!.selectRecord(firstId));
+    expect(mocks.model?.selectedRecord).toMatchObject({ requestId: "request-1", responseBody: "cached response" });
+  });
+
+  it("retains network traffic while viewing Tweaks", async () => {
+    await captureTraffic();
+    await act(async () => nativeSelect({ appId: discovered[0].id, ...discovered[0].inspectors[1] }));
+    expect(container.querySelector('[data-inspector="tweaks"]')).not.toBeNull();
+    expect(mocks.client.stopStream).toHaveBeenCalled();
+    await act(async () => nativeSelect({ appId: discovered[0].id, ...discovered[0].inspectors[0] }));
+    expect(mocks.model?.allRecords).toHaveLength(1);
+    expect(mocks.model?.selectedRecord).toMatchObject({ responseBody: "cached response" });
+  });
+});

--- a/snapo-network-inspector-web/src/App.tsx
+++ b/snapo-network-inspector-web/src/App.tsx
@@ -1,59 +1,75 @@
-import { useCallback, useEffect, useMemo, useState } from "react";
-import type { AppInspectorOption, InspectableApp, SelectedAppInspector } from "./network/bridge-types";
+import { LoaderCircle } from "lucide-react";
+import { useMemo } from "react";
 import { createNetworkClient } from "./network/client";
 import { NetworkInspectorApp } from "./features/network-inspector/NetworkInspectorApp";
+import { useNetworkInspectorModel } from "./features/network-inspector/hooks/useNetworkInspectorModel";
 import { TweaksInspectorApp } from "./features/tweaks-inspector/TweaksInspectorApp";
-import { isInspectorMetadataPending, reconcileInspectorSelection } from "./features/app-inspector/selection";
+import { AppInspectorPicker } from "./features/app-inspector/components/AppInspectorPicker";
+import { isInspectorMetadataPending } from "./features/app-inspector/selection";
+import { useAppInspector } from "./features/app-inspector/useAppInspector";
 
 export function App(): JSX.Element {
   const client = useMemo(() => createNetworkClient(), []);
-  const [apps, setApps] = useState<InspectableApp[]>([]);
-  const [selection, setSelection] = useState<SelectedAppInspector | null>(null);
-
-  const selectInspector = useCallback((app: InspectableApp, option: AppInspectorOption) => {
-    setSelection({ appId: app.id, kind: option.kind, server: option.server, protocolVersion: option.protocolVersion });
-  }, []);
-
-  useEffect(() => {
-    let disposed = false;
-
-    const refresh = async () => {
-      try {
-        const discovered = await client.listInspectorApps();
-        if (disposed) return;
-
-        setApps(discovered);
-        setSelection((current) => reconcileInspectorSelection(discovered, current));
-      } catch {
-        if (!disposed) setApps([]);
-      }
-    };
-
-    void refresh();
-    const interval = window.setInterval(() => {
-      if (!document.hidden) void refresh();
-    }, 2_500);
-    const unsubscribe = client.onNativeSelectedInspector(setSelection);
-
-    return () => {
-      disposed = true;
-      window.clearInterval(interval);
-      unsubscribe();
-    };
-  }, [client]);
+  const {
+    apps,
+    selection,
+    displayedNetwork,
+    displayedTweaks,
+    selectedApp,
+    preferredKind,
+    isRestoring,
+    loading,
+    select
+  } = useAppInspector(client);
+  const pending =
+    loading ||
+    isRestoring ||
+    (selection != null && isInspectorMetadataPending(selection, client.usesNativeServerPicker));
+  const showsNetwork = displayedNetwork != null || (!pending && selection?.kind !== "tweaks");
+  const networkModel = useNetworkInspectorModel(
+    displayedNetwork?.server ?? null,
+    showsNetwork,
+    selection?.kind === "network"
+  );
 
   return (
     <div className="window-frame">
-      {selection && isInspectorMetadataPending(selection, client.usesNativeServerPicker) ? (
-        <main className="tweaks-inspector">
-          <div className="tweaks-inspector-content" role="status">
-            Loading inspector…
+      {pending && !displayedNetwork && !displayedTweaks ? (
+        <main className="inspector-loading-shell">
+          {!client.usesNativeServerPicker ? (
+            <AppInspectorPicker
+              apps={apps}
+              selection={selection}
+              selectedApp={selectedApp}
+              preferredKind={preferredKind}
+              onSelect={select}
+            />
+          ) : null}
+          <div className="inspector-loading" role="status" aria-label="Connecting to inspector">
+            <LoaderCircle className="body-loading-spinner" size={20} aria-hidden="true" />
           </div>
         </main>
-      ) : selection?.kind === "tweaks" ? (
-        <TweaksInspectorApp client={client} apps={apps} selection={selection} onSelect={selectInspector} />
+      ) : displayedTweaks ? (
+        <TweaksInspectorApp
+          key={
+            selectedApp ? `${selectedApp.deviceId}:${selectedApp.processName ?? selectedApp.id}` : displayedTweaks.appId
+          }
+          client={client}
+          apps={apps}
+          selection={displayedTweaks}
+          isConnected={selection?.kind === "tweaks" && !pending}
+          selectedApp={selectedApp}
+          onSelect={select}
+        />
       ) : (
-        <NetworkInspectorApp inspectorApps={apps} inspectorSelection={selection} onInspectorSelect={selectInspector} />
+        <NetworkInspectorApp
+          model={networkModel}
+          inspectorApps={apps}
+          inspectorSelection={displayedNetwork}
+          selectedApp={selectedApp}
+          preferredKind={preferredKind}
+          onInspectorSelect={select}
+        />
       )}
     </div>
   );

--- a/snapo-network-inspector-web/src/App.tweaks.test.tsx
+++ b/snapo-network-inspector-web/src/App.tweaks.test.tsx
@@ -1,0 +1,133 @@
+// @vitest-environment jsdom
+import { act } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { InspectableApp, TweakList } from "./network/bridge-types";
+import type { NetworkClient } from "./network/client";
+import { InspectorRestoration } from "./features/app-inspector/restoration";
+import { App } from "./App";
+
+const mocks = vi.hoisted(() => ({ client: null as unknown as NetworkClient }));
+vi.mock("./network/client", () => ({ createNetworkClient: () => mocks.client }));
+vi.mock("./features/network-inspector/hooks/useNetworkInspectorModel", () => ({
+  useNetworkInspectorModel: () => ({})
+}));
+vi.mock("./features/network-inspector/NetworkInspectorApp", () => ({ NetworkInspectorApp: () => null }));
+
+function app(pid: number): InspectableApp {
+  return {
+    id: `phone:pid:${pid}`,
+    name: "Demo",
+    packageName: "com.example.demo",
+    processName: "com.example.demo",
+    deviceId: "phone",
+    deviceDisplayTitle: "Phone",
+    inspectors: [
+      { kind: "tweaks", protocolVersion: 4, server: { deviceId: "phone", socketName: `snapo_tweaks_${pid}` } }
+    ]
+  };
+}
+
+describe("retained Tweaks view", () => {
+  let root: Root;
+  let container: HTMLDivElement;
+  let discovered: InspectableApp[];
+  let selectApp: (id: string) => void;
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+    Object.assign(globalThis, { IS_REACT_ACT_ENVIRONMENT: true });
+    discovered = [app(10)];
+    const saved = new InspectorRestoration();
+    saved.reconcile(discovered);
+    mocks.client = {
+      usesNativeServerPicker: true,
+      loadInspectorPreferences: vi.fn(async () => saved.serialize()),
+      saveInspectorPreferences: vi.fn(async () => {}),
+      listInspectorApps: vi.fn(async () => discovered),
+      appInspectorStateChanged: vi.fn(),
+      onNativeSelectedInspector: vi.fn(() => () => {}),
+      onNativeSelectedApp: vi.fn((callback) => {
+        selectApp = callback;
+        return () => {};
+      }),
+      listTweaks: vi.fn(
+        async (): Promise<TweakList> => ({
+          tweaks: [{ name: "Demo title", type: "string", value: "Cached value", default: "Default" }]
+        })
+      ),
+      startTweakStream: vi.fn(async () => ({ streamId: "stream" })),
+      stopTweakStream: vi.fn(async () => {}),
+      onTweaksChanged: vi.fn(() => () => {}),
+      onNativeTweaksReset: vi.fn(() => () => {}),
+      nativeTweaksStateChanged: vi.fn()
+    } as unknown as NetworkClient;
+    container = document.createElement("div");
+    document.body.append(container);
+    root = createRoot(container);
+  });
+
+  afterEach(async () => {
+    await act(async () => root.unmount());
+    container.remove();
+    vi.useRealTimers();
+  });
+
+  it("preserves the real Tweaks view through disconnect and PID replacement", async () => {
+    await act(async () => root.render(<App />));
+    const input = container.querySelector<HTMLInputElement>('input[type="text"]')!;
+    expect(input.value).toBe("Cached value");
+    discovered = [];
+    await act(async () => vi.advanceTimersByTimeAsync(2_500));
+    expect(container.querySelector('input[type="text"]')).toBe(input);
+    expect(container.querySelector("fieldset")?.disabled).toBe(true);
+    expect(container.querySelector('[role="status"]')).toBeNull();
+
+    let finish!: (value: TweakList) => void;
+    vi.mocked(mocks.client.listTweaks).mockImplementationOnce(
+      () =>
+        new Promise((resolve) => {
+          finish = resolve;
+        })
+    );
+    discovered = [app(20)];
+    await act(async () => vi.advanceTimersByTimeAsync(2_500));
+    expect(container.querySelector('input[type="text"]')).toBe(input);
+    expect(input.value).toBe("Cached value");
+    expect(container.querySelector("fieldset")?.disabled).toBe(true);
+    await act(async () =>
+      finish({ tweaks: [{ name: "Demo title", type: "string", value: "Fresh value", default: "Default" }] })
+    );
+    expect(input.value).toBe("Fresh value");
+    expect(container.querySelector("fieldset")?.disabled).toBe(false);
+  });
+
+  it("keeps a successfully loaded empty view through disconnect", async () => {
+    vi.mocked(mocks.client.listTweaks).mockResolvedValue({ tweaks: [] });
+    await act(async () => root.render(<App />));
+    expect(container.textContent).toContain("No tweaks on screen");
+    discovered = [];
+    await act(async () => vi.advanceTimersByTimeAsync(2_500));
+    expect(container.textContent).toContain("No tweaks on screen");
+    expect(container.querySelector('[role="status"]')).toBeNull();
+  });
+
+  it("does not show another app's cached values while loading", async () => {
+    await act(async () => root.render(<App />));
+    const other = { ...app(20), packageName: "com.example.other", processName: "com.example.other" };
+    discovered = [app(10), other];
+    await act(async () => vi.advanceTimersByTimeAsync(2_500));
+    let finish!: (value: TweakList) => void;
+    vi.mocked(mocks.client.listTweaks).mockImplementationOnce(
+      () =>
+        new Promise((resolve) => {
+          finish = resolve;
+        })
+    );
+    await act(async () => selectApp(other.id));
+    expect(container.querySelector('input[type="text"]')).toBeNull();
+    expect(container.querySelector('[role="status"]')).not.toBeNull();
+    await act(async () => finish({ tweaks: [] }));
+    expect(container.textContent).toContain("No tweaks on screen");
+  });
+});

--- a/snapo-network-inspector-web/src/features/app-inspector/components/AppInspectorPicker.test.tsx
+++ b/snapo-network-inspector-web/src/features/app-inspector/components/AppInspectorPicker.test.tsx
@@ -5,6 +5,24 @@ import type { InspectableApp, SelectedAppInspector } from "../../../network/brid
 import { AppInspectorMenu, AppInspectorPicker, AppInspectorViewPicker } from "./AppInspectorPicker";
 
 describe("app-first inspector menu", () => {
+  it("keeps the remembered inspector controls visible offline without a spinner", () => {
+    const markup = renderToStaticMarkup(
+      <AppInspectorPicker apps={[]} selection={null} selectedApp={apps[0]} preferredKind="tweaks" onSelect={vi.fn()} />
+    );
+    expect(markup).not.toContain("body-loading-spinner");
+    expect(markup).toContain('aria-label="Network" aria-checked="false"');
+    expect(markup).toContain('aria-label="Tweaks" aria-checked="true"');
+    expect(markup).toContain(apps[0].name);
+  });
+
+  it("uses cached types instead of a partial live app in the toolbar", () => {
+    const partial = { ...apps[0], inspectors: [apps[0].inspectors[1]] };
+    const markup = renderToStaticMarkup(
+      <AppInspectorPicker apps={[partial]} selection={selection} selectedApp={apps[0]} onSelect={vi.fn()} />
+    );
+    expect(markup).toContain('aria-label="Network"');
+    expect(markup).toContain('aria-label="Tweaks"');
+  });
   it("shows one selectable row per app without separate inspector rows", () => {
     const markup = renderToStaticMarkup(<AppInspectorMenu apps={apps} selection={selection} onSelect={vi.fn()} />);
 
@@ -56,24 +74,24 @@ describe("app-first inspector menu", () => {
     }
   });
 
-  it("keeps the inspector kind when the app row is clicked", () => {
+  it("delegates an app-row choice to the selection owner", () => {
     const onSelect = vi.fn();
     const otherAppSelection = { appId: apps[1].id, ...apps[1].inspectors[0] };
     const buttons = menuButtons(AppInspectorMenu({ apps, selection: otherAppSelection, onSelect }));
 
     buttons.get("ChatGPT, Pixel 9 Pro XL")!();
 
-    expect(onSelect).toHaveBeenCalledExactlyOnceWith(apps[0], apps[0].inspectors[1]);
+    expect(onSelect).toHaveBeenCalledExactlyOnceWith(apps[0]);
   });
 
-  it("falls back to the first available inspector when the app row is clicked", () => {
+  it("delegates a single-inspector app choice to the selection owner", () => {
     const onSelect = vi.fn();
     const networkSelection = { appId: apps[0].id, ...apps[0].inspectors[0] };
     const buttons = menuButtons(AppInspectorMenu({ apps, selection: networkSelection, onSelect }));
 
     buttons.get("Snap-O Tweaks Demo, Android Emulator")!();
 
-    expect(onSelect).toHaveBeenCalledExactlyOnceWith(apps[1], apps[1].inspectors[0]);
+    expect(onSelect).toHaveBeenCalledExactlyOnceWith(apps[1]);
   });
 
   it("checks only the selected app", () => {

--- a/snapo-network-inspector-web/src/features/app-inspector/components/AppInspectorPicker.tsx
+++ b/snapo-network-inspector-web/src/features/app-inspector/components/AppInspectorPicker.tsx
@@ -1,21 +1,29 @@
 import { Check, ChevronDown, Network, SlidersHorizontal } from "lucide-react";
 import { useEffect, useId, useRef, useState } from "react";
-import type { AppInspectorOption, InspectableApp, SelectedAppInspector } from "../../../network/bridge-types";
-import { preferredInspector } from "../selection";
+import type {
+  AppInspectorKind,
+  AppInspectorOption,
+  InspectableApp,
+  SelectedAppInspector
+} from "../../../network/bridge-types";
 
 export function AppInspectorPicker({
   apps,
   selection,
+  selectedApp: rememberedApp,
+  preferredKind,
   onSelect
 }: {
   apps: InspectableApp[];
   selection: SelectedAppInspector | null;
-  onSelect(app: InspectableApp, option: AppInspectorOption): void;
+  selectedApp?: InspectableApp | null;
+  preferredKind?: AppInspectorKind | null;
+  onSelect(app: InspectableApp, option?: AppInspectorOption): void;
 }): JSX.Element {
   const [expanded, setExpanded] = useState(false);
   const rootRef = useRef<HTMLDivElement>(null);
   const menuId = useId();
-  const selectedApp = apps.find((app) => app.id === selection?.appId);
+  const selectedApp = rememberedApp ?? apps.find((app) => app.id === selection?.appId);
 
   useEffect(() => {
     if (!expanded) return;
@@ -71,7 +79,14 @@ export function AppInspectorPicker({
         ) : null}
       </div>
 
-      {selectedApp ? <AppInspectorViewPicker app={selectedApp} selection={selection} onSelect={onSelect} /> : null}
+      {selectedApp ? (
+        <AppInspectorViewPicker
+          app={selectedApp}
+          selection={selection}
+          preferredKind={preferredKind}
+          onSelect={onSelect}
+        />
+      ) : null}
     </div>
   );
 }
@@ -79,25 +94,27 @@ export function AppInspectorPicker({
 export function AppInspectorViewPicker({
   app,
   selection,
+  preferredKind,
   onSelect
 }: {
   app: InspectableApp;
   selection: SelectedAppInspector | null;
-  onSelect(app: InspectableApp, option: AppInspectorOption): void;
+  preferredKind?: AppInspectorKind | null;
+  onSelect(app: InspectableApp, option?: AppInspectorOption): void;
 }): JSX.Element | null {
-  if (app.inspectors.length < 2) return null;
+  if (app.inspectors.length === 0 || (app.inspectors.length < 2 && selection != null)) return null;
 
   return (
     <div className="inspector-app-segments" role="radiogroup" aria-label="Inspector">
       {app.inspectors.map((option) => {
-        const selected = selection?.appId === app.id && selection.kind === option.kind;
+        const selected = (preferredKind ?? (selection?.appId === app.id ? selection.kind : null)) === option.kind;
         const title = option.kind === "network" ? "Network" : "Tweaks";
         const Icon = option.kind === "network" ? Network : SlidersHorizontal;
 
         return (
           <button
             className="inspector-app-segment"
-            key={`${option.kind}:${option.server.socketName}`}
+            key={option.kind}
             type="button"
             role="radio"
             aria-label={title}
@@ -122,12 +139,12 @@ export function AppInspectorMenu({
   id?: string;
   apps: InspectableApp[];
   selection: SelectedAppInspector | null;
-  onSelect(app: InspectableApp, option: AppInspectorOption): void;
+  onSelect(app: InspectableApp, option?: AppInspectorOption): void;
 }): JSX.Element {
   return (
     <div className="inspector-app-menu" id={id} role="menu" aria-label="Apps">
       {apps.map((app) => {
-        const option = preferredInspector(app, selection);
+        const option = app.inspectors[0];
         const selected = selection?.appId === app.id;
 
         return (
@@ -142,7 +159,7 @@ export function AppInspectorMenu({
               title={app.packageName}
               disabled={!option}
               onClick={() => {
-                if (option) onSelect(app, option);
+                if (option) onSelect(app);
               }}
             >
               <Check className="inspector-app-option-check" size={15} aria-hidden="true" />

--- a/snapo-network-inspector-web/src/features/app-inspector/restoration.test.ts
+++ b/snapo-network-inspector-web/src/features/app-inspector/restoration.test.ts
@@ -1,0 +1,213 @@
+import { describe, expect, it } from "vitest";
+import type { AppInspectorKind, InspectableApp } from "../../network/bridge-types";
+import { InspectorRestoration } from "./restoration";
+
+function app(
+  pid = 10,
+  kinds: AppInspectorKind[] = ["network", "tweaks"],
+  processName = "com.example.demo",
+  deviceId = "phone"
+): InspectableApp {
+  return {
+    id: `${deviceId}:pid:${pid}`,
+    name: "Demo",
+    packageName: processName.split(":")[0],
+    processName,
+    deviceId,
+    deviceDisplayTitle: "Phone",
+    inspectors: kinds.map((kind) => ({ kind, server: { deviceId, socketName: `snapo_${kind}_${pid}` } }))
+  };
+}
+
+function selected(kind: AppInspectorKind = "network") {
+  const owner = new InspectorRestoration();
+  const initial = app();
+  owner.reconcile([initial]);
+  owner.selectInspector(initial, initial.inspectors.find((option) => option.kind === kind)!);
+  return owner;
+}
+
+describe("inspector restoration", () => {
+  it("keeps the live selection object stable across unchanged scans", () => {
+    const owner = selected();
+    const current = owner.snapshot().selection;
+    expect(owner.reconcile([app()]).selection).toBe(current);
+  });
+
+  it("waits through an empty scan and Tweaks-first discovery, then restores Network", () => {
+    const owner = selected();
+    const displayedNetwork = owner.snapshot().selection;
+    const saved = owner.serialize();
+    expect(owner.reconcile([])).toMatchObject({ selection: null, displayedNetwork, isRestoring: true });
+    expect(owner.reconcile([app(20, ["tweaks"])])).toMatchObject({
+      selection: null,
+      preferredKind: "network",
+      isRestoring: true
+    });
+    expect(owner.serialize()).toBe(saved);
+    expect(owner.snapshot().displayedNetwork).toBe(displayedNetwork);
+    expect(owner.reconcile([app(20)])).toMatchObject({
+      selection: { kind: "network", server: { socketName: "snapo_network_20" } },
+      isRestoring: false
+    });
+  });
+
+  it("does not show the previous app's history after an explicit app change", () => {
+    const owner = selected();
+    const other = app(20, ["network", "tweaks"], "com.example.other");
+    expect(owner.selectApp({ ...other, processName: null }).displayedNetwork).toBeNull();
+    expect(owner.reconcile([other]).displayedNetwork?.appId).toBe(other.id);
+    expect(owner.selectInspector(other, other.inspectors[1]).displayedNetwork).toBeNull();
+  });
+
+  it("keeps known inspector types through empty and partial scans", () => {
+    const owner = selected();
+    const kinds = () => owner.snapshot().selectedApp?.inspectors.map((option) => option.kind);
+    owner.reconcile([]);
+    expect(kinds()).toEqual(["network", "tweaks"]);
+    owner.reconcile([app(20, ["tweaks"])]);
+    expect(kinds()).toEqual(["network", "tweaks"]);
+    expect(owner.snapshot().selection).toBeNull();
+    owner.reconcile([app(20)]);
+    expect(owner.snapshot().selectedApp?.inspectors).toEqual(app(20).inspectors);
+  });
+
+  it("treats cached inspector choices as intent without reconnecting stale sockets", () => {
+    const owner = selected();
+    const network = owner.snapshot().displayedNetwork;
+    owner.reconcile([]);
+    const cached = owner.snapshot().selectedApp!;
+    expect(owner.selectInspector(cached, cached.inspectors[1])).toMatchObject({
+      selection: null,
+      displayedNetwork: null,
+      preferredKind: "tweaks",
+      isRestoring: true
+    });
+    expect(owner.selectInspector(cached, cached.inspectors[0])).toMatchObject({
+      selection: null,
+      displayedNetwork: network,
+      preferredKind: "network",
+      isRestoring: true
+    });
+    owner.reconcile([app(20, ["tweaks"])]);
+    const partial = owner.snapshot().selectedApp!;
+    expect(owner.selectInspector(partial, partial.inspectors[0]).selection).toBeNull();
+    expect(owner.selectInspector(partial, partial.inspectors[1]).selection?.server.socketName).toBe("snapo_tweaks_20");
+    expect(owner.reconcile([app(20)]).selection?.kind).toBe("tweaks");
+  });
+
+  it("does not carry cached types to another app", () => {
+    const owner = selected();
+    const other = app(20, ["network"], "com.example.other");
+    owner.reconcile([other]);
+    expect(owner.selectApp(other).selectedApp?.inspectors).toEqual(other.inspectors);
+  });
+
+  it("retains the displayed Tweaks endpoint through disconnect and a new PID", () => {
+    const owner = selected("tweaks");
+    const displayedTweaks = owner.snapshot().selection;
+    expect(owner.reconcile([])).toMatchObject({ selection: null, displayedTweaks, isRestoring: true });
+    expect(owner.reconcile([app(20, ["network"])])).toMatchObject({ selection: null, displayedTweaks });
+    expect(owner.reconcile([app(20)]).displayedTweaks?.server.socketName).toBe("snapo_tweaks_20");
+    const other = app(30, ["network"], "com.example.other");
+    owner.reconcile([app(20), other]);
+    expect(owner.selectApp(other).displayedTweaks).toBeNull();
+  });
+
+  it("restores after restarting the host, without saving a PID or socket", () => {
+    const saved = selected("tweaks").serialize();
+    expect(saved).not.toContain("snapo_");
+    expect(saved).not.toContain("pid:");
+    const owner = new InspectorRestoration(saved);
+    expect(owner.reconcile([app(30, ["network"])]).isRestoring).toBe(true);
+    expect(owner.reconcile([app(30)]).selection?.kind).toBe("tweaks");
+  });
+
+  it("does not switch to another process, device, or app while restoring", () => {
+    const owner = selected();
+    const others = [
+      app(10, ["network"], "com.example.other"),
+      app(20, ["network"], "com.example.demo:worker"),
+      app(10, ["network"], "com.example.demo", "tablet")
+    ];
+    expect(owner.reconcile(others).selection).toBeNull();
+    expect(owner.reconcile([...others, app(40)]).selection?.server.socketName).toBe("snapo_network_40");
+  });
+
+  it("lets an explicit inspector choice cancel pending restoration", () => {
+    const owner = selected();
+    const partial = app(20, ["tweaks"]);
+    owner.reconcile([partial]);
+    owner.selectInspector(partial, partial.inspectors[0]);
+    expect(owner.reconcile([app(20)]).selection?.kind).toBe("tweaks");
+    expect(new InspectorRestoration(owner.serialize()).reconcile([app(30)]).selection?.kind).toBe("tweaks");
+  });
+
+  it("remembers a different inspector for each app", () => {
+    const owner = selected();
+    const other = app(20, ["network", "tweaks"], "com.example.other");
+    owner.reconcile([app(), other]);
+    owner.selectInspector(other, other.inspectors[1]);
+    const partial = app(30, ["tweaks"]);
+    expect(owner.selectApp(partial)).toMatchObject({ selection: null, preferredKind: "network", isRestoring: true });
+    expect(owner.reconcile([app(30), other]).selection?.kind).toBe("network");
+    expect(owner.selectApp(other).selection?.kind).toBe("tweaks");
+  });
+
+  it("learns identity when metadata arrives without changing inspector kind", () => {
+    const owner = new InspectorRestoration();
+    const pending = { ...app(), processName: null };
+    owner.reconcile([pending]);
+    owner.selectInspector(pending, pending.inspectors[1]);
+    expect(JSON.parse(owner.serialize()).last).toBeNull();
+    expect(owner.reconcile([app()]).selection?.kind).toBe("tweaks");
+    expect(new InspectorRestoration(owner.serialize()).reconcile([app(30)]).selection?.kind).toBe("tweaks");
+  });
+
+  it("waits for identity before resolving an app-row choice", () => {
+    const owner = selected("tweaks");
+    const first = app();
+    const other = app(20, ["network", "tweaks"], "com.example.other");
+    owner.selectInspector(other, other.inspectors[0]);
+    const saved = owner.serialize();
+    const pending = { ...first, processName: null };
+
+    owner.reconcile([pending, other]);
+    expect(owner.selectApp(pending)).toMatchObject({ selection: null, isRestoring: true });
+    expect(owner.reconcile([]).isRestoring).toBe(true);
+    expect(owner.reconcile([pending, other]).selection).toBeNull();
+    expect(owner.serialize()).toBe(saved);
+    expect(owner.reconcile([first, other]).selection?.kind).toBe("tweaks");
+    expect(JSON.parse(owner.serialize()).last.kind).toBe("tweaks");
+  });
+
+  it("lets an inspector icon override a pending app-row preference", () => {
+    const owner = selected("tweaks");
+    const pending = { ...app(), processName: null };
+    owner.selectApp(pending);
+    expect(owner.selectInspector(pending, pending.inspectors[0]).selection?.kind).toBe("network");
+    expect(owner.reconcile([app()]).selection?.kind).toBe("network");
+    expect(JSON.parse(owner.serialize()).last.kind).toBe("network");
+  });
+
+  it("uses a spinner for an unidentified first app", () => {
+    const owner = new InspectorRestoration();
+    expect(owner.reconcile([{ ...app(), processName: null }])).toMatchObject({
+      selection: null,
+      isRestoring: true
+    });
+    expect(JSON.parse(owner.serialize()).last).toBeNull();
+    expect(owner.reconcile([app()]).selection?.kind).toBe("network");
+  });
+
+  it("does not restore by an unverified display name", () => {
+    const owner = new InspectorRestoration(selected().serialize());
+    expect(owner.reconcile([{ ...app(20), processName: null }]).selection).toBeNull();
+    expect(owner.reconcile([app(20)]).selection?.kind).toBe("network");
+  });
+
+  it("selects an available inspector when there is no saved choice", () => {
+    const owner = new InspectorRestoration("invalid JSON");
+    expect(owner.reconcile([app(20, ["tweaks"])]).selection?.kind).toBe("tweaks");
+  });
+});

--- a/snapo-network-inspector-web/src/features/app-inspector/restoration.ts
+++ b/snapo-network-inspector-web/src/features/app-inspector/restoration.ts
@@ -1,0 +1,195 @@
+import type {
+  AppInspectorKind,
+  AppInspectorOption,
+  AppInspectorState,
+  InspectableApp,
+  SelectedAppInspector
+} from "../../network/bridge-types";
+
+interface InspectorPreference {
+  deviceId: string;
+  processName: string;
+  kind: AppInspectorKind;
+}
+
+interface SavedPreferences {
+  last: InspectorPreference | null;
+  apps: InspectorPreference[];
+}
+
+function identity(app: InspectableApp): string | null {
+  // Native discovery supplies the real process name, never a temporary display label.
+  return app.processName || null;
+}
+
+function matches(app: InspectableApp, preference: InspectorPreference): boolean {
+  return app.deviceId === preference.deviceId && identity(app) === preference.processName;
+}
+
+function sameApp(a: InspectableApp | null, b: InspectableApp): boolean {
+  if (!a || a.deviceId !== b.deviceId) return false;
+  const first = identity(a);
+  const second = identity(b);
+  return first && second ? first === second : a.id === b.id;
+}
+
+function samePreference(a: InspectorPreference, b: InspectorPreference): boolean {
+  return a.deviceId === b.deviceId && a.processName === b.processName;
+}
+
+function isPreference(value: unknown): value is InspectorPreference {
+  if (value == null || typeof value !== "object") return false;
+  const p = value as Partial<InspectorPreference>;
+  return (
+    typeof p.deviceId === "string" &&
+    typeof p.processName === "string" &&
+    p.processName.length > 0 &&
+    (p.kind === "network" || p.kind === "tweaks")
+  );
+}
+
+export class InspectorRestoration {
+  private saved: SavedPreferences = { last: null, apps: [] };
+  private target: InspectableApp | null = null;
+  private kind: AppInspectorKind | null = null;
+  private current: SelectedAppInspector | null = null;
+  private retained: Partial<Record<AppInspectorKind, SelectedAppInspector>> = {};
+  private apps: InspectableApp[] = [];
+  private awaitingAppIdentity = false;
+
+  constructor(raw: string | null = null) {
+    try {
+      const parsed: unknown = raw == null ? null : JSON.parse(raw);
+      if (parsed && typeof parsed === "object" && "apps" in parsed && Array.isArray(parsed.apps)) {
+        this.saved.apps = parsed.apps.filter(isPreference);
+        if ("last" in parsed && isPreference(parsed.last)) {
+          this.saved.last = parsed.last;
+          this.kind = parsed.last.kind;
+        }
+      }
+    } catch {
+      /* Ignore stale or invalid saved preferences. */
+    }
+  }
+
+  serialize(): string {
+    return JSON.stringify(this.saved);
+  }
+
+  hydrate(raw: string | null): void {
+    if (this.kind != null || this.awaitingAppIdentity) return;
+    const restored = new InspectorRestoration(raw);
+    this.saved = restored.saved;
+    this.kind = restored.kind;
+  }
+
+  snapshot(): AppInspectorState {
+    return {
+      apps: this.apps,
+      selection: this.current,
+      displayedNetwork: this.kind === "network" ? (this.retained.network ?? null) : null,
+      displayedTweaks: this.kind === "tweaks" ? (this.retained.tweaks ?? null) : null,
+      selectedApp: this.target,
+      preferredKind: this.kind,
+      isRestoring: this.awaitingAppIdentity || (this.kind != null && this.current == null)
+    };
+  }
+
+  reconcile(apps: InspectableApp[]): AppInspectorState {
+    this.apps = apps;
+    if (this.awaitingAppIdentity) {
+      const app = apps.find((candidate) => candidate.id === this.target?.id);
+      if (app) {
+        this.updateTarget(app);
+        if (identity(app)) return this.selectApp(app);
+      }
+      return this.snapshot();
+    }
+    const preference = this.saved.last;
+    const exact =
+      this.target && apps.find((app) => app.id === this.target?.id && (!preference || matches(app, preference)));
+    const app = exact || (preference && apps.find((candidate) => matches(candidate, preference)));
+
+    if (app && this.kind) {
+      this.updateTarget(app);
+      this.remember(app, this.kind);
+      const option = app.inspectors.find((candidate) => candidate.kind === this.kind);
+      this.setCurrent(app, option);
+    } else if (this.kind == null) {
+      const first = apps.find((candidate) => candidate.inspectors.length > 0);
+      if (first) this.selectApp(first);
+    } else {
+      this.current = null;
+    }
+    return this.snapshot();
+  }
+
+  selectApp(app: InspectableApp): AppInspectorState {
+    if (!identity(app)) {
+      this.updateTarget(app);
+      this.current = null;
+      this.retained = {};
+      this.awaitingAppIdentity = true;
+      return this.snapshot();
+    }
+    const preference = this.saved.apps.find((candidate) => matches(app, candidate));
+    const kind =
+      preference?.kind ?? app.inspectors.find((option) => option.kind === this.kind)?.kind ?? app.inspectors[0]?.kind;
+    if (kind) this.selectKind(app, kind);
+    return this.snapshot();
+  }
+
+  selectInspector(app: InspectableApp, option: AppInspectorOption): AppInspectorState {
+    this.selectKind(app, option.kind);
+    return this.snapshot();
+  }
+
+  private selectKind(app: InspectableApp, kind: AppInspectorKind): void {
+    if (!sameApp(this.target, app)) this.retained = {};
+    this.awaitingAppIdentity = false;
+    this.updateTarget(app);
+    this.kind = kind;
+    // An explicit choice supersedes pending restoration, even before metadata arrives.
+    this.saved.last = null;
+    this.remember(app, kind);
+    // Cached toolbar options express intent, never permission to reuse an old socket.
+    const liveApp = this.apps.find((candidate) => candidate.id === app.id && sameApp(candidate, app));
+    const option = liveApp?.inspectors.find((candidate) => candidate.kind === kind);
+    this.setCurrent(liveApp ?? app, option);
+  }
+
+  private updateTarget(app: InspectableApp): void {
+    const options = new Map<AppInspectorKind, AppInspectorOption>();
+    const previous = this.target;
+    if (previous && sameApp(previous, app)) {
+      for (const option of previous.inspectors) options.set(option.kind, option);
+    }
+    for (const option of app.inspectors) options.set(option.kind, option);
+    this.target = { ...app, inspectors: [...options.values()].sort((a, b) => a.kind.localeCompare(b.kind)) };
+  }
+
+  private setCurrent(app: InspectableApp, option: AppInspectorOption | undefined): void {
+    if (!option) {
+      this.current = null;
+      return;
+    }
+    if (
+      this.current?.appId === app.id &&
+      this.current.kind === option.kind &&
+      this.current.server.deviceId === option.server.deviceId &&
+      this.current.server.socketName === option.server.socketName &&
+      this.current.protocolVersion === option.protocolVersion
+    )
+      return;
+    this.current = { appId: app.id, ...option };
+    this.retained[option.kind] = this.current;
+  }
+
+  private remember(app: InspectableApp, kind: AppInspectorKind): void {
+    const processName = identity(app);
+    if (!processName) return;
+    const preference = { deviceId: app.deviceId, processName, kind };
+    this.saved.last = preference;
+    this.saved.apps = [...this.saved.apps.filter((entry) => !samePreference(entry, preference)), preference];
+  }
+}

--- a/snapo-network-inspector-web/src/features/app-inspector/selection.test.ts
+++ b/snapo-network-inspector-web/src/features/app-inspector/selection.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest";
 import type { AppInspectorOption, InspectableApp, SelectedAppInspector } from "../../network/bridge-types";
-import { isInspectorMetadataPending, preferredInspector, reconcileInspectorSelection } from "./selection";
+import { isInspectorMetadataPending } from "./selection";
 
 const network: AppInspectorOption = {
   kind: "network",
@@ -20,81 +20,9 @@ const app: InspectableApp = {
   inspectors: [network, tweaks]
 };
 
-describe("preferred app inspector", () => {
-  it("preserves the exact endpoint when reselecting the current app", () => {
-    const anotherTweaks: AppInspectorOption = {
-      ...tweaks,
-      server: { ...tweaks.server, socketName: "snapo_tweaks_20" }
-    };
-    const selection: SelectedAppInspector = { appId: app.id, ...anotherTweaks };
-
-    expect(preferredInspector({ ...app, inspectors: [network, tweaks, anotherTweaks] }, selection)).toBe(anotherTweaks);
-  });
-
-  it("preserves the inspector kind when switching apps", () => {
-    const selection: SelectedAppInspector = {
-      appId: "emulator:other.app",
-      kind: "tweaks",
-      server: { deviceId: "emulator", socketName: "other_tweaks" }
-    };
-
-    expect(preferredInspector(app, selection)).toBe(tweaks);
-  });
-
-  it("falls back to an available inspector when the kind is unsupported", () => {
-    expect(preferredInspector({ ...app, inspectors: [network] }, { appId: app.id, ...tweaks })).toBe(network);
-    expect(preferredInspector({ ...app, inspectors: [tweaks] }, { appId: app.id, ...network })).toBe(tweaks);
-  });
-
-  it("uses the first inspector when there is no current selection", () => {
-    expect(preferredInspector(app, null)).toBe(network);
-  });
-
-  it("uses the refreshed endpoint when the selected endpoint disappears", () => {
-    const selection: SelectedAppInspector = {
-      appId: app.id,
-      kind: "tweaks",
-      server: { ...tweaks.server, socketName: "old_tweaks" }
-    };
-
-    expect(preferredInspector(app, selection)).toBe(tweaks);
-  });
-
-  it("returns no option when an app has no inspectors", () => {
-    expect(preferredInspector({ ...app, inspectors: [] }, null)).toBeUndefined();
-  });
-});
-
-describe("discovered inspector selection", () => {
+describe("inspector metadata", () => {
   const processApp = { ...app, id: "pixel:pid:10" };
   const current: SelectedAppInspector = { appId: processApp.id, ...tweaks };
-
-  it("preserves selection while app names, icons, and other inspectors load", () => {
-    const discovered = { ...processApp, name: "Loaded app", appIconBase64: "icon" };
-    expect(reconcileInspectorSelection([discovered], current)).toBe(current);
-  });
-
-  it("updates the selected protocol version after metadata loads", () => {
-    const pending = { ...current, protocolVersion: undefined };
-    expect(reconcileInspectorSelection([processApp], pending)).toEqual(current);
-  });
-
-  it("finds the same endpoint when replacing an old package-based ID", () => {
-    const legacy = { ...current, appId: app.id };
-    expect(reconcileInspectorSelection([processApp], legacy)).toEqual(current);
-  });
-
-  it("keeps the process selected if one inspector disappears", () => {
-    const remaining = { ...processApp, inspectors: [network] };
-    expect(reconcileInspectorSelection([remaining], current)).toEqual({ appId: processApp.id, ...network });
-  });
-
-  it("falls back when the process exits", () => {
-    const next = { ...app, id: "pixel:pid:20", inspectors: [network] };
-    expect(reconcileInspectorSelection([next], current)).toEqual({ appId: next.id, ...network });
-    expect(reconcileInspectorSelection([], current)).toBeNull();
-  });
-
   it("waits for the native Tweaks protocol version before enabling controls", () => {
     const pending = { ...current, protocolVersion: undefined };
     expect(isInspectorMetadataPending(pending, true)).toBe(true);

--- a/snapo-network-inspector-web/src/features/app-inspector/selection.ts
+++ b/snapo-network-inspector-web/src/features/app-inspector/selection.ts
@@ -1,45 +1,4 @@
-import type { AppInspectorOption, InspectableApp, SelectedAppInspector } from "../../network/bridge-types";
-
-export function preferredInspector(
-  app: InspectableApp,
-  selection: SelectedAppInspector | null
-): AppInspectorOption | undefined {
-  const currentOption = app.inspectors.find(
-    (option) =>
-      app.id === selection?.appId &&
-      option.kind === selection.kind &&
-      option.server.deviceId === selection.server.deviceId &&
-      option.server.socketName === selection.server.socketName
-  );
-  return currentOption ?? app.inspectors.find((option) => option.kind === selection?.kind) ?? app.inspectors[0];
-}
-
-export function reconcileInspectorSelection(
-  apps: InspectableApp[],
-  current: SelectedAppInspector | null
-): SelectedAppInspector | null {
-  if (current) {
-    for (const app of apps) {
-      const option = app.inspectors.find(
-        (candidate) =>
-          candidate.kind === current.kind &&
-          candidate.server.deviceId === current.server.deviceId &&
-          candidate.server.socketName === current.server.socketName
-      );
-      if (option) {
-        return app.id === current.appId && option.protocolVersion === current.protocolVersion
-          ? current
-          : { ...current, appId: app.id, protocolVersion: option.protocolVersion };
-      }
-    }
-    const app = apps.find((candidate) => candidate.id === current.appId);
-    const option = app && preferredInspector(app, current);
-    if (app && option) return { appId: app.id, ...option };
-  }
-
-  const app = apps.find((candidate) => candidate.inspectors.length > 0);
-  return app ? { appId: app.id, ...app.inspectors[0] } : null;
-}
+import type { SelectedAppInspector } from "../../network/bridge-types";
 
 export function isInspectorMetadataPending(selection: SelectedAppInspector, usesNativeServerPicker: boolean): boolean {
   return usesNativeServerPicker && selection.kind === "tweaks" && selection.protocolVersion == null;

--- a/snapo-network-inspector-web/src/features/app-inspector/useAppInspector.ts
+++ b/snapo-network-inspector-web/src/features/app-inspector/useAppInspector.ts
@@ -1,0 +1,95 @@
+import { useCallback, useEffect, useRef, useState } from "react";
+import type { AppInspectorOption, InspectableApp } from "../../network/bridge-types";
+import type { NetworkClient } from "../../network/client";
+import { InspectorRestoration } from "./restoration";
+
+export function useAppInspector(client: NetworkClient) {
+  const [owner] = useState(() => new InspectorRestoration());
+  const [state, setState] = useState(() => owner.snapshot());
+  const [loading, setLoading] = useState(true);
+  const lastSaved = useRef<string | null>(null);
+  const saveQueue = useRef(Promise.resolve());
+
+  const publish = useCallback(() => {
+    const snapshot = owner.snapshot();
+    setState(snapshot);
+    client.appInspectorStateChanged(snapshot);
+    const saved = owner.serialize();
+    if (saved !== lastSaved.current) {
+      lastSaved.current = saved;
+      saveQueue.current = saveQueue.current
+        .then(() => client.saveInspectorPreferences(saved))
+        .catch(() => {
+          if (lastSaved.current === saved) lastSaved.current = null;
+        });
+    }
+  }, [client, owner]);
+
+  const select = useCallback(
+    (app: InspectableApp, option?: AppInspectorOption) => {
+      if (option) owner.selectInspector(app, option);
+      else owner.selectApp(app);
+      publish();
+    },
+    [owner, publish]
+  );
+
+  useEffect(() => {
+    let disposed = false;
+    let refreshing = false;
+    let initialized = false;
+
+    const refresh = async () => {
+      if (!initialized || refreshing) return;
+      refreshing = true;
+      try {
+        const apps = await client.listInspectorApps();
+        if (disposed) return;
+        owner.reconcile(apps);
+        publish();
+        setLoading(false);
+      } catch {
+        // A failed scan is not evidence that the user's chosen app has gone away.
+      } finally {
+        refreshing = false;
+      }
+    };
+
+    const unsubscribeInspector = client.onNativeSelectedInspector((selection) => {
+      const state = owner.snapshot();
+      const app =
+        state.selectedApp?.id === selection.appId
+          ? state.selectedApp
+          : state.apps.find((candidate) => candidate.id === selection.appId);
+      const option = app?.inspectors.find((candidate) => candidate.kind === selection.kind);
+      if (app && option) select(app, option);
+    });
+    const unsubscribeApp = client.onNativeSelectedApp((id) => {
+      const app = owner.snapshot().apps.find((candidate) => candidate.id === id);
+      if (app) select(app);
+    });
+
+    void client
+      .loadInspectorPreferences()
+      .catch(() => null)
+      .then((saved) => {
+        if (disposed) return;
+        owner.hydrate(saved);
+        lastSaved.current = saved;
+        initialized = true;
+        publish();
+        void refresh();
+      });
+    const interval = window.setInterval(() => {
+      if (!document.hidden) void refresh();
+    }, 2_500);
+    return () => {
+      disposed = true;
+      window.clearInterval(interval);
+      unsubscribeInspector();
+      unsubscribeApp();
+    };
+  }, [client, owner, publish, select]);
+
+  return { ...state, loading, select };
+}

--- a/snapo-network-inspector-web/src/features/network-inspector/NetworkInspectorApp.tsx
+++ b/snapo-network-inspector-web/src/features/network-inspector/NetworkInspectorApp.tsx
@@ -1,22 +1,31 @@
-import { useEffect, type CSSProperties } from "react";
-import type { AppInspectorOption, InspectableApp, SelectedAppInspector } from "../../network/bridge-types";
+import { type CSSProperties } from "react";
+import type {
+  AppInspectorKind,
+  AppInspectorOption,
+  InspectableApp,
+  SelectedAppInspector
+} from "../../network/bridge-types";
 import { DetailContent } from "./components/DetailPane";
 import { Sidebar } from "./components/Sidebar";
-import { useNetworkInspectorModel } from "./hooks/useNetworkInspectorModel";
+import type { NetworkInspectorModel } from "./hooks/useNetworkInspectorModel";
 import { usePersistentSplitPane } from "./hooks/usePersistentSplitPane";
 import { useSearchHighlights } from "./hooks/useSearchHighlights";
 
 export function NetworkInspectorApp({
+  model,
   inspectorApps = [],
   inspectorSelection = null,
+  selectedApp = null,
+  preferredKind,
   onInspectorSelect
 }: {
+  model: NetworkInspectorModel;
   inspectorApps?: InspectableApp[];
   inspectorSelection?: SelectedAppInspector | null;
-  onInspectorSelect?(app: InspectableApp, option: AppInspectorOption): void;
+  selectedApp?: InspectableApp | null;
+  preferredKind?: AppInspectorKind | null;
+  onInspectorSelect?(app: InspectableApp, option?: AppInspectorOption): void;
 }): JSX.Element {
-  const model = useNetworkInspectorModel();
-  const { selectServer } = model;
   const {
     containerRef,
     sidebarWidth,
@@ -28,11 +37,6 @@ export function NetworkInspectorApp({
     resizeWithKeyboard
   } = usePersistentSplitPane();
   useSearchHighlights(containerRef, model.searchText);
-
-  useEffect(() => {
-    if (inspectorSelection?.kind !== "network") return;
-    selectServer(inspectorSelection.server);
-  }, [inspectorSelection, selectServer]);
 
   return (
     <div className="app-shell" ref={containerRef} style={{ "--sidebar-width": `${sidebarWidth}px` } as CSSProperties}>
@@ -53,8 +57,22 @@ export function NetworkInspectorApp({
         onServerChange={model.selectServer}
         inspectorApps={inspectorApps}
         inspectorSelection={inspectorSelection}
+        selectedApp={selectedApp}
+        preferredKind={preferredKind}
         onInspectorSelect={onInspectorSelect}
-        onReplacementServerClick={model.selectReplacementServer}
+        onReplacementServerClick={(server) => {
+          const app = inspectorApps.find((candidate) =>
+            candidate.inspectors.some(
+              (option) =>
+                option.kind === "network" &&
+                option.server.deviceId === server.deviceId &&
+                option.server.socketName === server.socketName
+            )
+          );
+          const option = app?.inspectors.find((candidate) => candidate.kind === "network");
+          if (app && option && onInspectorSelect) onInspectorSelect(app, option);
+          else model.selectReplacementServer(server);
+        }}
         onSearchTextChange={model.setSearchText}
         onToggleSortOrder={model.toggleSortOrder}
         onClearCompleted={model.clearCompletedRecords}

--- a/snapo-network-inspector-web/src/features/network-inspector/components/DetailPane.tsx
+++ b/snapo-network-inspector-web/src/features/network-inspector/components/DetailPane.tsx
@@ -48,7 +48,15 @@ export const DetailContent = memo(function DetailContent({
   }
 
   if (record.kind === "websocket") return <WebSocketDetail client={client} record={record} uiState={uiState} />;
-  return <RequestDetail client={client} record={record} uiState={uiState} onRetryResponseBody={onRetryResponseBody} />;
+  return (
+    <RequestDetail
+      client={client}
+      record={record}
+      uiState={uiState}
+      isConnected={selectedServer?.isConnected === true}
+      onRetryResponseBody={onRetryResponseBody}
+    />
+  );
 });
 
 function EmptyState({

--- a/snapo-network-inspector-web/src/features/network-inspector/components/RecordList.tsx
+++ b/snapo-network-inspector-web/src/features/network-inspector/components/RecordList.tsx
@@ -22,7 +22,8 @@ export const RecordList = memo(function RecordList({
   placeholder,
   selectedRecordId,
   onSelect,
-  client
+  client,
+  isConnected = true
 }: {
   records: InspectorRecord[];
   allRecords: InspectorRecord[];
@@ -30,6 +31,7 @@ export const RecordList = memo(function RecordList({
   selectedRecordId: string | null;
   onSelect(id: string): void;
   client: NetworkClient;
+  isConnected?: boolean;
 }): JSX.Element {
   const listId = useId();
   const listRef = useRef<HTMLDivElement>(null);
@@ -51,10 +53,10 @@ export const RecordList = memo(function RecordList({
         x,
         y,
         keyboard,
-        items: sidebarContextMenuItems(record, selectedRecordId, allRecords, client)
+        items: sidebarContextMenuItems(record, selectedRecordId, allRecords, client, isConnected)
       });
     },
-    [allRecords, client, selectRecord, selectedRecordId]
+    [allRecords, client, isConnected, selectRecord, selectedRecordId]
   );
   const openActiveContextMenu = () => {
     const record = records[selectedIndex];
@@ -211,13 +213,17 @@ function sidebarContextMenuItems(
   clicked: InspectorRecord,
   selectedRecordId: string | null,
   allRecords: InspectorRecord[],
-  client: NetworkClient
+  client: NetworkClient,
+  isConnected: boolean
 ): ContextMenuItem[] {
   const exportRecords = contextMenuExportSelection(clicked, selectedRecordId, allRecords);
   const items: ContextMenuItem[] = [{ label: "Copy URL", action: () => void client.copyText(clicked.url) }];
   if (clicked.kind === "request") {
-    items.push({ label: "Copy as cURL", action: () => void copyCurl(client, clicked) });
+    items.push({ label: "Copy as cURL", action: () => void copyCurl(client, clicked, isConnected) });
   }
-  items.push({ label: "Export HAR (sanitized)...", action: () => void exportAsHar(client, exportRecords) });
+  items.push({
+    label: "Export HAR (sanitized)...",
+    action: () => void exportAsHar(client, exportRecords, undefined, isConnected)
+  });
   return items;
 }

--- a/snapo-network-inspector-web/src/features/network-inspector/components/RequestDetail.test.tsx
+++ b/snapo-network-inspector-web/src/features/network-inspector/components/RequestDetail.test.tsx
@@ -6,6 +6,34 @@ import type { InspectorUiState } from "../hooks/useInspectorUiState";
 import { RequestDetail } from "./RequestDetail";
 
 describe("Response Body loading state", () => {
+  it("shows an uncached body as offline instead of loading forever", () => {
+    const markup = renderToStaticMarkup(
+      <RequestDetail
+        client={{} as NetworkClient}
+        record={request({ encodedDataLength: 12 })}
+        uiState={expandedUiState}
+        isConnected={false}
+        onRetryResponseBody={() => {}}
+      />
+    );
+    expect(markup).toContain("Response body isn’t cached on this Mac.");
+    expect(markup).not.toContain("body-loading-spinner");
+    expect(markup).not.toContain(">Retry</button>");
+  });
+
+  it("keeps a cached body readable offline", () => {
+    const markup = renderToStaticMarkup(
+      <RequestDetail
+        client={{} as NetworkClient}
+        record={request({ responseBody: "cached-response" })}
+        uiState={expandedUiState}
+        isConnected={false}
+        onRetryResponseBody={() => {}}
+      />
+    );
+    expect(markup).toContain("cached-response");
+    expect(markup).not.toContain("isn’t cached");
+  });
   it("shows the captured size and an accessible loading indicator before hydration completes", () => {
     const markup = renderToStaticMarkup(
       <RequestDetail

--- a/snapo-network-inspector-web/src/features/network-inspector/components/RequestDetail.tsx
+++ b/snapo-network-inspector-web/src/features/network-inspector/components/RequestDetail.tsx
@@ -16,11 +16,13 @@ export const RequestDetail = memo(function RequestDetail({
   client,
   record,
   uiState,
+  isConnected = true,
   onRetryResponseBody
 }: {
   client: NetworkClient;
   record: RequestRecord;
   uiState: InspectorUiState;
+  isConnected?: boolean;
   onRetryResponseBody(): void;
 }): JSX.Element {
   const isSseResponse = isLikelyStreamingRequest(record);
@@ -41,6 +43,8 @@ export const RequestDetail = memo(function RequestDetail({
       });
   const isResponseBodyLoading = !isSseResponse && shouldRequestResponseBody(record);
   const responseBodyLoadError = !isSseResponse && responseBody == null ? record.responseBodyLoadError : null;
+  const responseBodyIsOffline =
+    !isConnected && responseBody == null && (isResponseBodyLoading || responseBodyLoadError === "failed");
   const prefix = `request:${recordId(record)}`;
   const timingText = useAdaptiveTimingText(record.startedAt, record.endedAt, record.status);
 
@@ -119,7 +123,11 @@ export const RequestDetail = memo(function RequestDetail({
           storageKey={`${prefix}:responseBody`}
           uiState={uiState}
         >
-          {responseBodyLoadError != null ? (
+          {responseBodyIsOffline ? (
+            <div className="body-load-message" role="status">
+              Response body isn’t cached on this Mac.
+            </div>
+          ) : responseBodyLoadError != null ? (
             <div className="body-load-message" role="status">
               <span>
                 {responseBodyLoadError === "unavailable"

--- a/snapo-network-inspector-web/src/features/network-inspector/components/Sidebar.tsx
+++ b/snapo-network-inspector-web/src/features/network-inspector/components/Sidebar.tsx
@@ -3,6 +3,7 @@ import { memo } from "react";
 import type { NetworkClient } from "../../../network/client";
 import type { InspectorRecord, ServerId } from "../../../network/cdp";
 import type {
+  AppInspectorKind,
   AppInspectorOption,
   InspectableApp,
   SelectedAppInspector,
@@ -27,6 +28,8 @@ export const Sidebar = memo(function Sidebar({
   client,
   inspectorApps,
   inspectorSelection,
+  selectedApp,
+  preferredKind,
   showsServerPicker,
   showsInlineToolbar,
   onServerChange,
@@ -50,10 +53,12 @@ export const Sidebar = memo(function Sidebar({
   client: NetworkClient;
   inspectorApps?: InspectableApp[];
   inspectorSelection?: SelectedAppInspector | null;
+  selectedApp?: InspectableApp | null;
+  preferredKind?: AppInspectorKind | null;
   showsServerPicker: boolean;
   showsInlineToolbar: boolean;
   onServerChange(server: ServerId | null): void;
-  onInspectorSelect?(app: InspectableApp, option: AppInspectorOption): void;
+  onInspectorSelect?(app: InspectableApp, option?: AppInspectorOption): void;
   onReplacementServerClick(server: SnapOServer): void;
   onSearchTextChange(value: string): void;
   onToggleSortOrder(): void;
@@ -72,6 +77,8 @@ export const Sidebar = memo(function Sidebar({
               <AppInspectorPicker
                 apps={inspectorApps}
                 selection={inspectorSelection ?? null}
+                selectedApp={selectedApp}
+                preferredKind={preferredKind}
                 onSelect={onInspectorSelect}
               />
             ) : (
@@ -140,6 +147,7 @@ export const Sidebar = memo(function Sidebar({
         selectedRecordId={selectedRecordId}
         onSelect={onRecordSelect}
         client={client}
+        isConnected={selectedServer?.isConnected === true}
       />
     </aside>
   );

--- a/snapo-network-inspector-web/src/features/network-inspector/hooks/useNetworkInspectorModel.ts
+++ b/snapo-network-inspector-web/src/features/network-inspector/hooks/useNetworkInspectorModel.ts
@@ -59,7 +59,11 @@ export interface NetworkInspectorModel {
   openDocs(): void;
 }
 
-export function useNetworkInspectorModel(): NetworkInspectorModel {
+export function useNetworkInspectorModel(
+  controlledServer?: ServerId | null,
+  isActive = true,
+  allowsConnection = true
+): NetworkInspectorModel {
   const client = useMemo(() => createNetworkClient(), []);
   const [state, setState] = useState<InspectorDataState>(() => createEmptyInspectorState());
   const [preferredServer, setPreferredServer] = useState<ServerId | null>(null);
@@ -88,8 +92,8 @@ export function useNetworkInspectorModel(): NetworkInspectorModel {
   }, [bodyLoader]);
 
   const selectedServer = useMemo(
-    () => pickSelectedServer(preferredServer, state.servers),
-    [preferredServer, state.servers]
+    () => (controlledServer === undefined ? pickSelectedServer(preferredServer, state.servers) : controlledServer),
+    [controlledServer, preferredServer, state.servers]
   );
   const selectServer = useCallback((server: ServerId | null) => {
     setPreferredServer(server);
@@ -98,8 +102,8 @@ export function useNetworkInspectorModel(): NetworkInspectorModel {
 
   useEffect(() => {
     selectedServerRef.current = selectedServer;
-    if (selectedServer != null) client.selectedDeviceChanged(selectedServer.deviceId);
-  }, [client, selectedServer]);
+    if (isActive && selectedServer != null) client.selectedDeviceChanged(selectedServer.deviceId);
+  }, [client, isActive, selectedServer]);
 
   useEffect(
     () =>
@@ -113,7 +117,9 @@ export function useNetworkInspectorModel(): NetworkInspectorModel {
   useEffect(() => client.onNativeSelectedServer(selectServer), [client, selectServer]);
   useEffect(() => client.onNativeSearchText(setSearchText), [client]);
   useEffect(() => client.onNativeSortOrder(setSortNewestFirst), [client]);
-  useEffect(() => client.onNativeClearCompleted(clearCompletedRecords), [clearCompletedRecords, client]);
+  useEffect(() => {
+    if (isActive) return client.onNativeClearCompleted(clearCompletedRecords);
+  }, [clearCompletedRecords, client, isActive]);
 
   useEffect(() => {
     const unsubscribeEvent = client.onEvent((event) => {
@@ -137,6 +143,7 @@ export function useNetworkInspectorModel(): NetworkInspectorModel {
   }, [client]);
 
   useEffect(() => {
+    if (!isActive) return;
     let disposed = false;
     const refresh = async () => {
       const activeServers = await client.listServers();
@@ -158,12 +165,19 @@ export function useNetworkInspectorModel(): NetworkInspectorModel {
       disposed = true;
       window.clearInterval(timer);
     };
-  }, [client]);
+  }, [client, isActive]);
 
   const selectedServerKey = serverKey(selectedServer);
   const displayServers = useMemo(
-    () => applyDebugInspectorPreset(state.servers, selectedServer, debugPreset),
-    [debugPreset, selectedServer, state.servers]
+    () =>
+      applyDebugInspectorPreset(state.servers, selectedServer, debugPreset).map((server) =>
+        !allowsConnection &&
+        server.deviceId === selectedServer?.deviceId &&
+        server.socketName === selectedServer.socketName
+          ? { ...server, isConnected: false }
+          : server
+      ),
+    [allowsConnection, debugPreset, selectedServer, state.servers]
   );
   const selectedServerModel = useMemo(
     () => serverModelFor(displayServers, selectedServer),
@@ -179,14 +193,14 @@ export function useNetworkInspectorModel(): NetworkInspectorModel {
     streamLifecycle?.connectionKey === selectedServerConnectionKey && streamLifecycle.state === "retrying";
 
   useEffect(() => {
-    if (selectedServer == null || !selectedServerIsConnected) return;
+    if (!isActive || selectedServer == null || !selectedServerIsConnected) return;
     const connectionKey = selectedServerConnectionKey;
     const controller = new NetworkStreamController(client, selectedServer, (state) => {
       setStreamLifecycle({ connectionKey, state });
     });
     controller.start();
     return () => controller.dispose();
-  }, [client, selectedServer, selectedServerConnectionKey, selectedServerIsConnected]);
+  }, [client, isActive, selectedServer, selectedServerConnectionKey, selectedServerIsConnected]);
 
   const allRecords = hydrateCachedBodies([...state.requests.values(), ...state.webSockets.values()], bodyCache);
 
@@ -229,15 +243,16 @@ export function useNetworkInspectorModel(): NetworkInspectorModel {
   }, [bodyCache, bodyLoader, selectedRecord]);
 
   useEffect(() => {
+    if (!isActive) return;
     bodyLoader.forgetRecords(bodyCache.select(selectedRequestKey));
-  }, [bodyCache, bodyLoader, selectedRequestKey]);
+  }, [bodyCache, bodyLoader, isActive, selectedRequestKey]);
 
   useEffect(() => {
     const jobs: BodyLoadJob[] = [];
     const retainedRecordKeys = new Set(state.requests.keys());
     bodyLoader.forgetRecords(bodyCache.retainRecords(retainedRecordKeys));
 
-    if (selectedRecord?.kind === "request") {
+    if (isActive && selectedServerIsConnected && selectedRecord?.kind === "request") {
       const recordKey = requestRecordKey(selectedRecord.server, selectedRecord.requestId);
       const requestAttemptKey = `${recordKey}\u0000request`;
       const responseAttemptKey = `${recordKey}\u0000response`;
@@ -277,7 +292,7 @@ export function useNetworkInspectorModel(): NetworkInspectorModel {
 
     bodyLoader.retainRecords(retainedRecordKeys);
     bodyLoader.schedule(jobs);
-  }, [bodyCache, bodyLoader, selectedRecord, state.requests]);
+  }, [bodyCache, bodyLoader, isActive, selectedRecord, selectedServerIsConnected, state.requests]);
 
   const replacementServer = useMemo(
     () => replacementCandidate(displayServers, selectedServerModel),
@@ -301,26 +316,28 @@ export function useNetworkInspectorModel(): NetworkInspectorModel {
   useEffect(
     () =>
       client.onNativeCopySelectedUrl(() => {
-        if (selectedRecord != null) void client.copyText(selectedRecord.url);
+        if (isActive && selectedRecord != null) void client.copyText(selectedRecord.url);
       }),
-    [client, selectedRecord]
+    [client, isActive, selectedRecord]
   );
   useEffect(
     () =>
       client.onNativeCopySelectedCurl(() => {
-        if (selectedRecord?.kind === "request") void copyCurl(client, selectedRecord);
+        if (isActive && selectedRecord?.kind === "request")
+          void copyCurl(client, selectedRecord, selectedServerIsConnected);
       }),
-    [client, selectedRecord]
+    [client, isActive, selectedRecord, selectedServerIsConnected]
   );
   useEffect(
     () =>
       client.onNativeExportVisibleHar(() => {
-        void exportAsHar(client, visibleRecords);
+        if (isActive) void exportAsHar(client, visibleRecords, undefined, selectedServerIsConnected);
       }),
-    [client, visibleRecords]
+    [client, isActive, selectedServerIsConnected, visibleRecords]
   );
 
   useEffect(() => {
+    if (!isActive) return;
     client.nativeInspectorStateChanged({
       servers: displayServers,
       selectedServer:
@@ -335,6 +352,7 @@ export function useNetworkInspectorModel(): NetworkInspectorModel {
     });
   }, [
     client,
+    isActive,
     displayServers,
     hasClearableItems,
     hasVisibleRecords,

--- a/snapo-network-inspector-web/src/features/network-inspector/lib/exportActions.test.ts
+++ b/snapo-network-inspector-web/src/features/network-inspector/lib/exportActions.test.ts
@@ -5,6 +5,28 @@ import type { InspectorRecord, RequestRecord, StreamEventRecord } from "../../..
 import { copyCurl, exportAsHar, hydrateRecordsForHar } from "./exportActions";
 
 describe("export body readiness", () => {
+  it("copies and exports cached data without querying an offline server", async () => {
+    const client = {
+      loadBodies: vi.fn(),
+      copyText: vi.fn(async () => {}),
+      appVersion: vi.fn(async () => "test"),
+      saveFile: vi.fn(async () => ({ saved: true }))
+    } as unknown as NetworkClient;
+    const complete = request("offline", {
+      method: "POST",
+      requestHasPostData: true,
+      requestBodySize: 4,
+      hasReceivedResponse: true,
+      responseBody: "cached-response"
+    });
+    await copyCurl(client, complete, false);
+    await exportAsHar(client, [complete], undefined, false);
+    expect(client.loadBodies).not.toHaveBeenCalled();
+    expect(client.copyText).toHaveBeenCalledOnce();
+    expect(client.saveFile).toHaveBeenCalledWith(
+      expect.objectContaining({ data: expect.stringContaining("cached-response") })
+    );
+  });
   it("does not query a request body before its upload is known to be complete", async () => {
     const client = {
       loadBodies: vi.fn(),

--- a/snapo-network-inspector-web/src/features/network-inspector/lib/exportActions.ts
+++ b/snapo-network-inspector-web/src/features/network-inspector/lib/exportActions.ts
@@ -7,9 +7,9 @@ import { shouldRequestRequestBody, shouldRequestResponseBody } from "./records";
 
 const exportBodyLoadConcurrency = 3;
 
-export async function copyCurl(client: NetworkClient, request: RequestRecord): Promise<void> {
+export async function copyCurl(client: NetworkClient, request: RequestRecord, loadMissingBodies = true): Promise<void> {
   let hydrated = request;
-  if (shouldRequestRequestBody(request)) {
+  if (loadMissingBodies && shouldRequestRequestBody(request)) {
     try {
       hydrated = applyRequestBodies(
         request,
@@ -32,10 +32,11 @@ export async function copyCurl(client: NetworkClient, request: RequestRecord): P
 export async function exportAsHar(
   client: NetworkClient,
   records: InspectorRecord[],
-  maximumBodyBytes = hydratedBodyRetentionLimitBytes
+  maximumBodyBytes = hydratedBodyRetentionLimitBytes,
+  loadMissingBodies = true
 ): Promise<void> {
   if (records.length === 0) return;
-  const hydrated = await hydrateRecordsForHar(client, records, maximumBodyBytes);
+  const hydrated = await hydrateRecordsForHar(client, records, maximumBodyBytes, loadMissingBodies);
   const appVersion = await client.appVersion();
   await client.saveFile({
     defaultPath: harFileName(hydrated.length),
@@ -48,7 +49,8 @@ export async function exportAsHar(
 export async function hydrateRecordsForHar(
   client: Pick<NetworkClient, "loadBodies">,
   records: InspectorRecord[],
-  maximumBodyBytes = hydratedBodyRetentionLimitBytes
+  maximumBodyBytes = hydratedBodyRetentionLimitBytes,
+  loadMissingBodies = true
 ): Promise<InspectorRecord[]> {
   if (!Number.isSafeInteger(maximumBodyBytes) || maximumBodyBytes < 0) {
     throw new Error("HAR body budget must be a non-negative integer");
@@ -77,7 +79,7 @@ export async function hydrateRecordsForHar(
     return [index];
   });
 
-  let canHydrateMissingBodies = retainedBodyBytes < maximumBodyBytes;
+  let canHydrateMissingBodies = loadMissingBodies && retainedBodyBytes < maximumBodyBytes;
   for (
     let offset = 0;
     offset < hydrationIndexes.length && canHydrateMissingBodies;

--- a/snapo-network-inspector-web/src/features/tweaks-inspector/TweaksInspectorApp.recovery.test.tsx
+++ b/snapo-network-inspector-web/src/features/tweaks-inspector/TweaksInspectorApp.recovery.test.tsx
@@ -1,0 +1,185 @@
+// @vitest-environment jsdom
+import { act } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { SelectedAppInspector, TweakList, TweakStreamEvent } from "../../network/bridge-types";
+import type { NetworkClient } from "../../network/client";
+import { TweaksInspectorApp } from "./TweaksInspectorApp";
+
+const selection: SelectedAppInspector = {
+  appId: "phone:pid:10",
+  kind: "tweaks",
+  protocolVersion: 4,
+  server: { deviceId: "phone", socketName: "snapo_tweaks_10" }
+};
+const response: TweakList = {
+  tweaks: [{ name: "Demo title", type: "string", value: "Recovered", default: "Default" }]
+};
+const connectionError = new Error("Could not connect to the server.");
+
+describe("Tweaks connection recovery", () => {
+  let root: Root;
+  let container: HTMLDivElement;
+  let client: NetworkClient;
+  let receive: (event: TweakStreamEvent) => void;
+  let reset: () => void;
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+    Object.assign(globalThis, { IS_REACT_ACT_ENVIRONMENT: true });
+    client = {
+      usesNativeServerPicker: true,
+      listTweaks: vi.fn(async () => response),
+      startTweakStream: vi.fn(async () => ({ streamId: "stream-1" })),
+      stopTweakStream: vi.fn(async () => {}),
+      onTweaksChanged: vi.fn((callback) => {
+        receive = callback;
+        return () => {};
+      }),
+      updateTweaks: vi.fn(async () => ({ tweaks: [] })),
+      invokeTweakAction: vi.fn(async () => {}),
+      onNativeTweaksReset: vi.fn((callback) => {
+        reset = callback;
+        return () => {};
+      }),
+      nativeTweaksStateChanged: vi.fn()
+    } as unknown as NetworkClient;
+    container = document.createElement("div");
+    document.body.append(container);
+    root = createRoot(container);
+  });
+
+  afterEach(async () => {
+    await act(async () => root.unmount());
+    container.remove();
+    vi.useRealTimers();
+  });
+
+  async function render(selected = selection, isConnected = true) {
+    await act(async () =>
+      root.render(
+        <TweaksInspectorApp
+          client={client}
+          apps={[]}
+          selection={selected}
+          isConnected={isConnected}
+          onSelect={() => {}}
+        />
+      )
+    );
+  }
+
+  it("retries a failed initial request without changing the selected inspector", async () => {
+    vi.mocked(client.listTweaks).mockRejectedValueOnce(connectionError);
+    await render();
+    expect(container.querySelector('[role="alert"]')?.textContent).toContain(connectionError.message);
+    expect(client.startTweakStream).not.toHaveBeenCalled();
+
+    await act(async () => vi.advanceTimersByTimeAsync(250));
+    expect(client.listTweaks).toHaveBeenCalledTimes(2);
+    expect(client.startTweakStream).toHaveBeenCalledExactlyOnceWith(selection.server);
+    expect(container.querySelector('[role="alert"]')).toBeNull();
+    expect(container.querySelector<HTMLInputElement>('input[type="text"]')?.value).toBe("Recovered");
+    await act(async () => vi.advanceTimersByTimeAsync(10_000));
+    expect(client.startTweakStream).toHaveBeenCalledTimes(1);
+  });
+
+  it("retries a failed stream start while preserving loaded tweaks", async () => {
+    vi.mocked(client.startTweakStream).mockRejectedValueOnce(connectionError);
+    await render();
+    expect(container.textContent).toContain("Demo title");
+    expect(container.querySelector('[role="alert"]')).toBeNull();
+    expect(container.querySelector("fieldset")?.disabled).toBe(true);
+    await act(async () => vi.advanceTimersByTimeAsync(250));
+    expect(client.startTweakStream).toHaveBeenCalledTimes(2);
+    expect(container.querySelector('[role="alert"]')).toBeNull();
+    expect(container.querySelector("fieldset")?.disabled).toBe(false);
+    await act(async () => receive({ streamId: "stream-1", server: selection.server, tweaks: [] }));
+    expect(container.textContent).toContain("No tweaks on screen");
+  });
+
+  it("keeps loaded values visible and blocks edits and native reset while offline", async () => {
+    await render();
+    const input = container.querySelector<HTMLInputElement>('input[type="text"]')!;
+    expect(input.value).toBe("Recovered");
+    await render(selection, false);
+    expect(container.querySelector('input[type="text"]')).toBe(input);
+    expect(container.querySelector("fieldset")?.disabled).toBe(true);
+    expect(container.querySelector("fieldset")?.hasAttribute("inert")).toBe(true);
+    expect(container.querySelector('[role="status"]')).toBeNull();
+    expect(client.stopTweakStream).toHaveBeenCalledWith("stream-1");
+    await act(async () => reset());
+    expect(client.updateTweaks).not.toHaveBeenCalled();
+    expect(client.nativeTweaksStateChanged).toHaveBeenLastCalledWith({
+      server: selection.server,
+      hasResettableTweaks: false
+    });
+    const loads = vi.mocked(client.listTweaks).mock.calls.length;
+    await act(async () => vi.advanceTimersByTimeAsync(10_000));
+    expect(client.listTweaks).toHaveBeenCalledTimes(loads);
+    await render();
+    expect(container.querySelector("fieldset")?.disabled).toBe(false);
+  });
+
+  it("keeps the old values disabled until the replacement process has loaded", async () => {
+    await render();
+    await render(selection, false);
+    let finish!: (value: TweakList) => void;
+    vi.mocked(client.listTweaks).mockImplementationOnce(
+      () =>
+        new Promise((resolve) => {
+          finish = resolve;
+        })
+    );
+    const replacement = {
+      ...selection,
+      appId: "phone:pid:20",
+      server: { ...selection.server, socketName: "snapo_tweaks_20" }
+    };
+    await render(replacement);
+    expect(container.querySelector<HTMLInputElement>('input[type="text"]')?.value).toBe("Recovered");
+    expect(container.querySelector("fieldset")?.disabled).toBe(true);
+    expect(container.querySelector('[role="status"]')).toBeNull();
+    await act(async () =>
+      finish({ tweaks: [{ ...response.tweaks[0], value: "New process" } as TweakList["tweaks"][number]] })
+    );
+    expect(container.querySelector<HTMLInputElement>('input[type="text"]')?.value).toBe("New process");
+    expect(container.querySelector("fieldset")?.disabled).toBe(false);
+  });
+
+  it("backs off repeated failures and cancels retries when leaving the inspector", async () => {
+    vi.mocked(client.listTweaks).mockRejectedValue(connectionError);
+    await render();
+    for (const delay of [250, 500, 1_000, 2_000, 4_000, 4_000]) {
+      const count = vi.mocked(client.listTweaks).mock.calls.length;
+      await act(async () => vi.advanceTimersByTimeAsync(delay - 1));
+      expect(client.listTweaks).toHaveBeenCalledTimes(count);
+      await act(async () => vi.advanceTimersByTimeAsync(1));
+      expect(client.listTweaks).toHaveBeenCalledTimes(count + 1);
+    }
+    await act(async () => root.render(null));
+    const count = vi.mocked(client.listTweaks).mock.calls.length;
+    await act(async () => vi.advanceTimersByTimeAsync(20_000));
+    expect(client.listTweaks).toHaveBeenCalledTimes(count);
+  });
+
+  it("stops a late stream from an inspector that is no longer selected", async () => {
+    let finish!: (value: { streamId: string }) => void;
+    vi.mocked(client.startTweakStream).mockImplementationOnce(
+      () =>
+        new Promise((resolve) => {
+          finish = resolve;
+        })
+    );
+    await render();
+    const other = {
+      ...selection,
+      appId: "phone:pid:20",
+      server: { ...selection.server, socketName: "snapo_tweaks_20" }
+    };
+    await render(other);
+    await act(async () => finish({ streamId: "old-stream" }));
+    expect(client.stopTweakStream).toHaveBeenCalledWith("old-stream");
+    expect(client.startTweakStream).toHaveBeenLastCalledWith(other.server);
+  });
+});

--- a/snapo-network-inspector-web/src/features/tweaks-inspector/TweaksInspectorApp.recovery.test.tsx
+++ b/snapo-network-inspector-web/src/features/tweaks-inspector/TweaksInspectorApp.recovery.test.tsx
@@ -15,6 +15,9 @@ const selection: SelectedAppInspector = {
 const response: TweakList = {
   tweaks: [{ name: "Demo title", type: "string", value: "Recovered", default: "Default" }]
 };
+const modifiedResponse: TweakList = {
+  tweaks: [{ name: "Demo title", type: "string", value: "Changed", default: "Default", modified: true }]
+};
 const connectionError = new Error("Could not connect to the server.");
 
 describe("Tweaks connection recovery", () => {
@@ -95,6 +98,53 @@ describe("Tweaks connection recovery", () => {
     expect(container.querySelector('[role="alert"]')).toBeNull();
     expect(container.querySelector("fieldset")?.disabled).toBe(false);
     await act(async () => receive({ streamId: "stream-1", server: selection.server, tweaks: [] }));
+    expect(container.textContent).toContain("No tweaks on screen");
+  });
+
+  it("clears an update error only after accepting a fresh stream snapshot", async () => {
+    vi.mocked(client.listTweaks).mockResolvedValue(modifiedResponse);
+    vi.mocked(client.updateTweaks).mockRejectedValueOnce(new Error("Update failed"));
+    await render();
+    await act(async () => reset());
+    expect(container.querySelector('[role="alert"]')?.textContent).toBe("Update failed");
+    await act(async () => receive({ streamId: "other-stream", server: selection.server, tweaks: [] }));
+    expect(container.querySelector('[role="alert"]')?.textContent).toBe("Update failed");
+    await act(async () => receive({ streamId: "stream-1", server: selection.server, tweaks: [] }));
+    expect(container.querySelector('[role="alert"]')).toBeNull();
+    expect(container.textContent).toContain("No tweaks on screen");
+  });
+
+  it("clears an action error when the inspector reconnects", async () => {
+    vi.mocked(client.listTweaks).mockResolvedValue({ tweaks: [{ name: "Refresh preview", type: "action" }] });
+    vi.mocked(client.invokeTweakAction).mockRejectedValueOnce(new Error("Action failed"));
+    await render();
+    await act(async () => container.querySelector<HTMLButtonElement>('[aria-label="Run Refresh preview"]')!.click());
+    expect(container.querySelector('[role="alert"]')?.textContent).toBe("Action failed");
+    await render(selection, false);
+    vi.mocked(client.listTweaks).mockResolvedValue({ tweaks: [] });
+    await render();
+    expect(container.querySelector('[role="alert"]')).toBeNull();
+    expect(container.textContent).toContain("No tweaks on screen");
+  });
+
+  it("clears a rejected-update error after its reload succeeds", async () => {
+    vi.mocked(client.listTweaks).mockResolvedValue(modifiedResponse);
+    vi.mocked(client.updateTweaks).mockResolvedValueOnce({
+      tweaks: [],
+      errors: [{ name: "Demo title", error: "Rejected" }]
+    });
+    await render();
+    let finish!: (value: TweakList) => void;
+    vi.mocked(client.listTweaks).mockImplementationOnce(
+      () =>
+        new Promise((resolve) => {
+          finish = resolve;
+        })
+    );
+    await act(async () => reset());
+    expect(container.querySelector('[role="alert"]')?.textContent).toBe("Demo title: Rejected");
+    await act(async () => finish({ tweaks: [] }));
+    expect(container.querySelector('[role="alert"]')).toBeNull();
     expect(container.textContent).toContain("No tweaks on screen");
   });
 

--- a/snapo-network-inspector-web/src/features/tweaks-inspector/TweaksInspectorApp.test.ts
+++ b/snapo-network-inspector-web/src/features/tweaks-inspector/TweaksInspectorApp.test.ts
@@ -12,7 +12,6 @@ import {
   applyTweakUpdates,
   canResetTweaks,
   groupTweaks,
-  hasLoadedTweaksForServer,
   nativePanelTweakColor,
   parseTweakColor,
   reconcileStreamedTweaks,
@@ -52,21 +51,6 @@ describe("empty tweaks inspector", () => {
     expect(markup).toContain('class="text-button"');
     expect(markup).toContain("Read the developer guide");
     expect(markup).not.toContain('class="tweaks-columns"');
-  });
-
-  it("does not treat an incomplete request as loaded", () => {
-    expect(hasLoadedTweaksForServer(null, selection.server)).toBe(false);
-  });
-
-  it("recognizes when the selected server has finished loading", () => {
-    expect(hasLoadedTweaksForServer({ ...selection.server }, selection.server)).toBe(true);
-  });
-
-  it("waits again when switching to another app or device", () => {
-    expect(hasLoadedTweaksForServer(selection.server, { ...selection.server, deviceId: "emulator" })).toBe(false);
-    expect(hasLoadedTweaksForServer(selection.server, { ...selection.server, socketName: "snapo_tweaks_20" })).toBe(
-      false
-    );
   });
 });
 

--- a/snapo-network-inspector-web/src/features/tweaks-inspector/TweaksInspectorApp.tsx
+++ b/snapo-network-inspector-web/src/features/tweaks-inspector/TweaksInspectorApp.tsx
@@ -1,9 +1,8 @@
-import { ChevronDown, RotateCcw } from "lucide-react";
+import { ChevronDown, LoaderCircle, RotateCcw } from "lucide-react";
 import { useCallback, useEffect, useId, useMemo, useRef, useState, type CSSProperties } from "react";
 import type {
   AppInspectorOption,
   InspectableApp,
-  InspectorServerReference,
   SelectedAppInspector,
   TweakActionDescriptor,
   TweakDescriptor,
@@ -39,21 +38,33 @@ export function TweaksInspectorApp({
   client,
   apps,
   selection,
+  selectedApp,
+  isConnected = true,
   onSelect
 }: {
   client: NetworkClient;
   apps: InspectableApp[];
   selection: SelectedAppInspector;
-  onSelect(app: InspectableApp, option: AppInspectorOption): void;
+  selectedApp?: InspectableApp | null;
+  isConnected?: boolean;
+  onSelect(app: InspectableApp, option?: AppInspectorOption): void;
 }): JSX.Element {
+  const server = selection.server;
+  const connection = useMemo(() => ({ server, isConnected }), [isConnected, server]);
   const [tweaks, setTweaks] = useState<TweakDescriptor[]>([]);
-  const [loadedServer, setLoadedServer] = useState<InspectorServerReference | null>(null);
+  const [hasSnapshot, setHasSnapshot] = useState(false);
+  const [connectionState, setConnectionState] = useState<{
+    connection: typeof connection;
+    error: string | null;
+  } | null>(null);
   const [error, setError] = useState<string | null>(null);
   const [saving, setSaving] = useState(false);
   const [invokingActions, setInvokingActions] = useState(() => new Set<string>());
   const [orderByApp] = useState(() => new Map<string, TweakOrdering>());
   const activeColorPanel = useRef<ActiveColorPanelSession | null>(null);
-  const server = selection.server;
+  const currentConnection = connectionState?.connection === connection ? connectionState : null;
+  const canEdit = isConnected && currentConnection?.error === null;
+  const connectionError = currentConnection?.error ?? null;
   const protocolVersion = selection.protocolVersion ?? 1;
   const hasNativeColorPanel =
     client.usesNativeServerPicker &&
@@ -84,8 +95,16 @@ export function TweaksInspectorApp({
   );
 
   useEffect(() => {
+    if (!isConnected) return;
     let disposed = false;
     let streamId: string | undefined;
+    let retryTimer: ReturnType<typeof setTimeout> | undefined;
+    let retryDelay = 250;
+
+    const applySnapshot = (incoming: TweakDescriptor[]) => {
+      setTweaks((current) => reconcileStreamedTweaks(current, incoming, queue.pending, queue.inFlight));
+      setHasSnapshot(true);
+    };
 
     const unsubscribe = client.onTweaksChanged((event) => {
       if (
@@ -97,48 +116,59 @@ export function TweaksInspectorApp({
         return;
       }
 
-      setTweaks((current) => reconcileStreamedTweaks(current, event.tweaks, queue.pending, queue.inFlight));
-      setError(null);
+      applySnapshot(event.tweaks);
+      setConnectionState({ connection, error: null });
     });
 
-    void client
-      .listTweaks(server)
-      .then((response) => {
+    const connect = async () => {
+      try {
+        const response = await client.listTweaks(server);
         if (disposed) return;
-        setTweaks((current) => reconcileStreamedTweaks(current, response.tweaks, queue.pending, queue.inFlight));
-        setLoadedServer(server);
-        setError(null);
-      })
-      .catch((cause: unknown) => {
-        if (disposed) return;
-        setError(cause instanceof Error ? cause.message : "Unable to load tweaks.");
-      });
+        applySnapshot(response.tweaks);
+        setConnectionState(null);
+        setSaving(false);
 
-    void client
-      .startTweakStream(server)
-      .then((started) => {
+        const started = await client.startTweakStream(server);
         if (disposed) {
-          void client.stopTweakStream(started.streamId);
+          void client.stopTweakStream(started.streamId).catch(() => {});
           return;
         }
         streamId = started.streamId;
-      })
-      .catch((cause: unknown) => {
+        setConnectionState({ connection, error: null });
+      } catch (cause) {
         if (disposed) return;
-        setError(cause instanceof Error ? cause.message : "Unable to stream tweaks.");
-      });
+        setConnectionState({
+          connection,
+          error: cause instanceof Error ? cause.message : "Unable to connect to tweaks."
+        });
+        retryTimer = setTimeout(() => void connect(), retryDelay);
+        retryDelay = Math.min(retryDelay * 2, 4_000);
+      }
+    };
+    void connect();
 
     return () => {
       disposed = true;
+      clearTimeout(retryTimer);
       queue.cancel();
       unsubscribe();
-      if (streamId !== undefined) void client.stopTweakStream(streamId);
+      if (streamId !== undefined) void client.stopTweakStream(streamId).catch(() => {});
     };
-  }, [client, queue, server]);
+  }, [client, connection, isConnected, queue, server]);
+
+  const closeActiveColorPanel = useCallback(async () => {
+    const active = activeColorPanel.current;
+    activeColorPanel.current = null;
+    if (active) await client.closeNativeColorPanel?.(active.sessionId);
+  }, [client]);
+
+  useEffect(() => {
+    if (!canEdit) void closeActiveColorPanel().catch(() => {});
+  }, [canEdit, closeActiveColorPanel]);
 
   const openNativeColorPanel = useCallback(
     (tweak: TweakValueDescriptor, present = true) => {
-      if (!hasNativeColorPanel || client.openNativeColorPanel === undefined) {
+      if (!canEdit || !hasNativeColorPanel || client.openNativeColorPanel === undefined) {
         activeColorPanel.current = null;
         return;
       }
@@ -152,11 +182,12 @@ export function TweaksInspectorApp({
         setError(cause instanceof Error ? cause.message : "Unable to open the color picker.");
       });
     },
-    [client, hasNativeColorPanel]
+    [canEdit, client, hasNativeColorPanel]
   );
 
   const updateTweak = useCallback(
     (tweak: TweakValueDescriptor, value: TweakValue) => {
+      if (!canEdit) return;
       const active = activeColorPanel.current;
       if (active?.tweak.name === tweak.name && active.tweak.value !== value) {
         openNativeColorPanel({ ...tweak, value }, false);
@@ -170,7 +201,7 @@ export function TweaksInspectorApp({
       queue.enqueue(tweak.name, value);
       void queue.flush();
     },
-    [openNativeColorPanel, queue]
+    [canEdit, openNativeColorPanel, queue]
   );
 
   useEffect(() => {
@@ -179,8 +210,7 @@ export function TweaksInspectorApp({
 
     const tweak = tweaks.find((candidate) => candidate.name === active.tweak.name && candidate.type === "color");
     if (tweak === undefined || tweak.type === "action") {
-      activeColorPanel.current = null;
-      void client.closeNativeColorPanel?.(active.sessionId).catch((cause: unknown) => {
+      void closeActiveColorPanel().catch((cause: unknown) => {
         if (activeColorPanel.current !== null) return;
 
         setError(cause instanceof Error ? cause.message : "Unable to close the color picker.");
@@ -194,7 +224,7 @@ export function TweaksInspectorApp({
     }
 
     openNativeColorPanel(tweak, false);
-  }, [client, openNativeColorPanel, tweaks]);
+  }, [closeActiveColorPanel, openNativeColorPanel, tweaks]);
 
   useEffect(() => {
     if (!hasNativeColorPanel || client.onNativeColorPanelChange === undefined) return;
@@ -211,14 +241,14 @@ export function TweaksInspectorApp({
     });
 
     return () => {
-      activeColorPanel.current = null;
+      void closeActiveColorPanel().catch(() => {});
       unsubscribe();
     };
-  }, [client, hasNativeColorPanel, updateTweak]);
+  }, [client, closeActiveColorPanel, hasNativeColorPanel, updateTweak]);
 
   const invokeAction = useCallback(
     (action: TweakActionDescriptor) => {
-      if (action.conflicted) return;
+      if (!canEdit || action.conflicted) return;
 
       setInvokingActions((current) => new Set(current).add(action.name));
       setError(null);
@@ -236,25 +266,27 @@ export function TweaksInspectorApp({
           });
         });
     },
-    [client, server]
+    [canEdit, client, server]
   );
 
   const resetTweak = useCallback(
     (tweak: TweakValueDescriptor) => {
+      if (!canEdit) return;
       queue.enqueue(tweak.name, tweakResetValue(tweak, protocolVersion));
       void queue.flush();
     },
-    [protocolVersion, queue]
+    [canEdit, protocolVersion, queue]
   );
 
   const resetAll = useCallback(() => {
+    if (!canEdit) return;
     for (const tweak of tweaks) {
       if (tweak.type !== "action" && isModified(tweak, protocolVersion)) {
         queue.enqueue(tweak.name, tweakResetValue(tweak, protocolVersion));
       }
     }
     void queue.flush();
-  }, [protocolVersion, queue, tweaks]);
+  }, [canEdit, protocolVersion, queue, tweaks]);
 
   useEffect(() => client.onNativeTweaksReset(resetAll), [client, resetAll]);
 
@@ -267,9 +299,9 @@ export function TweaksInspectorApp({
   useEffect(() => {
     client.nativeTweaksStateChanged({
       server,
-      hasResettableTweaks: hasChanges && !saving
+      hasResettableTweaks: canEdit && hasChanges && !saving
     });
-  }, [client, hasChanges, saving, server]);
+  }, [canEdit, client, hasChanges, saving, server]);
 
   return (
     <main className="tweaks-inspector">
@@ -281,50 +313,62 @@ export function TweaksInspectorApp({
               type="button"
               title="Reset all tweaks"
               aria-label="Reset all tweaks"
-              disabled={!hasChanges || saving}
+              disabled={!canEdit || !hasChanges || saving}
               onClick={resetAll}
             >
               <RotateCcw size={16} aria-hidden="true" />
             </button>
           </div>
-          <AppInspectorPicker apps={apps} selection={selection} onSelect={onSelect} />
+          <AppInspectorPicker apps={apps} selection={selection} selectedApp={selectedApp} onSelect={onSelect} />
         </header>
       ) : null}
 
-      {hasLoadedTweaksForServer(loadedServer, server) && !error && tweaks.length === 0 ? (
+      {!hasSnapshot && !connectionError ? (
+        <div className="inspector-loading" role="status" aria-label="Connecting to inspector">
+          <LoaderCircle className="body-loading-spinner" size={20} aria-hidden="true" />
+        </div>
+      ) : hasSnapshot && !error && tweaks.length === 0 ? (
         <TweaksEmptyState onOpenDocs={() => void client.openExternal(docsUrl)} />
       ) : (
         <div className="tweaks-inspector-content">
-          {error ? (
+          {error || (!hasSnapshot && connectionError) ? (
             <p className="tweaks-error" role="alert">
-              {error}
+              {error ?? connectionError}
             </p>
           ) : null}
-          <div className="tweaks-columns">
-            {sections.map((column, index) => (
-              <div className="tweaks-column" key={index}>
-                {column.map((section) => (
-                  <section className="tweaks-section" key={section.name}>
-                    {section.name ? <h2>{section.name}</h2> : null}
-                    <div className="tweaks-section-list">
-                      {section.tweaks.map((tweak) => (
-                        <TweakControl
-                          key={tweak.name}
-                          tweak={tweak}
-                          protocolVersion={protocolVersion}
-                          onChange={updateTweak}
-                          onInvoke={invokeAction}
-                          invoking={invokingActions.has(tweak.name)}
-                          onReset={resetTweak}
-                          onOpenColorPanel={hasNativeColorPanel ? openNativeColorPanel : undefined}
-                        />
-                      ))}
-                    </div>
-                  </section>
-                ))}
-              </div>
-            ))}
-          </div>
+          <fieldset
+            className="tweaks-fields"
+            disabled={!canEdit}
+            aria-label="Tweaks"
+            aria-disabled={!canEdit}
+            {...(!canEdit ? { inert: "" } : {})}
+          >
+            <div className="tweaks-columns">
+              {sections.map((column, index) => (
+                <div className="tweaks-column" key={index}>
+                  {column.map((section) => (
+                    <section className="tweaks-section" key={section.name}>
+                      {section.name ? <h2>{section.name}</h2> : null}
+                      <div className="tweaks-section-list">
+                        {section.tweaks.map((tweak) => (
+                          <TweakControl
+                            key={tweak.name}
+                            tweak={tweak}
+                            protocolVersion={protocolVersion}
+                            onChange={updateTweak}
+                            onInvoke={invokeAction}
+                            invoking={invokingActions.has(tweak.name)}
+                            onReset={resetTweak}
+                            onOpenColorPanel={hasNativeColorPanel ? openNativeColorPanel : undefined}
+                          />
+                        ))}
+                      </div>
+                    </section>
+                  ))}
+                </div>
+              ))}
+            </div>
+          </fieldset>
         </div>
       )}
     </main>
@@ -341,13 +385,6 @@ export function TweaksEmptyState({ onOpenDocs }: { onOpenDocs(): void }): JSX.El
       </button>
     </section>
   );
-}
-
-export function hasLoadedTweaksForServer(
-  loadedServer: InspectorServerReference | null,
-  server: InspectorServerReference
-): boolean {
-  return loadedServer?.deviceId === server.deviceId && loadedServer.socketName === server.socketName;
 }
 
 export function canResetTweaks(tweaks: TweakDescriptor[], protocolVersion = modifiedTweakProtocolVersion): boolean {

--- a/snapo-network-inspector-web/src/features/tweaks-inspector/TweaksInspectorApp.tsx
+++ b/snapo-network-inspector-web/src/features/tweaks-inspector/TweaksInspectorApp.tsx
@@ -82,6 +82,7 @@ export function TweaksInspectorApp({
             .then((response) => {
               if (!isCurrent()) return;
               setTweaks((current) => reconcileStreamedTweaks(current, response.tweaks, pending, inFlight));
+              setError(null);
             })
             .catch((cause: unknown) => {
               if (!isCurrent()) return;
@@ -104,6 +105,7 @@ export function TweaksInspectorApp({
     const applySnapshot = (incoming: TweakDescriptor[]) => {
       setTweaks((current) => reconcileStreamedTweaks(current, incoming, queue.pending, queue.inFlight));
       setHasSnapshot(true);
+      setError(null);
     };
 
     const unsubscribe = client.onTweaksChanged((event) => {

--- a/snapo-network-inspector-web/src/network/bridge-types.ts
+++ b/snapo-network-inspector-web/src/network/bridge-types.ts
@@ -33,6 +33,7 @@ export interface InspectableApp {
   id: string;
   name: string;
   packageName: string;
+  processName?: string | null;
   deviceId: string;
   deviceDisplayTitle: string;
   appIconBase64?: string | null;
@@ -44,6 +45,16 @@ export interface SelectedAppInspector {
   kind: AppInspectorKind;
   server: InspectorServerReference;
   protocolVersion?: number | null;
+}
+
+export interface AppInspectorState {
+  apps: InspectableApp[];
+  selection: SelectedAppInspector | null;
+  displayedNetwork: SelectedAppInspector | null;
+  displayedTweaks: SelectedAppInspector | null;
+  selectedApp: InspectableApp | null;
+  preferredKind: AppInspectorKind | null;
+  isRestoring: boolean;
 }
 
 export type TweakValue = boolean | number | string;

--- a/snapo-network-inspector-web/src/network/client.ts
+++ b/snapo-network-inspector-web/src/network/client.ts
@@ -1,4 +1,5 @@
 import type {
+  AppInspectorState,
   DebugInspectorPreset,
   InspectableApp,
   InspectorServerReference,
@@ -31,6 +32,10 @@ export interface NetworkClient {
   readonly usesNativeServerPicker: boolean;
   appVersion(): Promise<string>;
   listInspectorApps(): Promise<InspectableApp[]>;
+  loadInspectorPreferences(): Promise<string | null>;
+  saveInspectorPreferences(value: string): Promise<void>;
+  appInspectorStateChanged(state: AppInspectorState): void;
+  onNativeSelectedApp(callback: (appId: string) => void): () => void;
   listServers(): Promise<SnapOServer[]>;
   listTweaks(server: InspectorServerReference): Promise<TweakList>;
   updateTweaks(input: UpdateTweaksInput): Promise<TweakUpdates>;
@@ -91,6 +96,22 @@ class WebKitNetworkClient implements NetworkClient {
 
   listInspectorApps(): Promise<InspectableApp[]> {
     return this.invoke<InspectableApp[]>("listInspectorApps");
+  }
+
+  loadInspectorPreferences(): Promise<string | null> {
+    return this.invoke<string | null>("loadInspectorPreferences");
+  }
+
+  saveInspectorPreferences(value: string): Promise<void> {
+    return this.invoke<void>("saveInspectorPreferences", { value });
+  }
+
+  appInspectorStateChanged(state: AppInspectorState): void {
+    void this.invoke<void>("appInspectorStateChanged", state);
+  }
+
+  onNativeSelectedApp(callback: (appId: string) => void): () => void {
+    return listenWebKitEvent<string>("inspector:app-selected", callback);
   }
 
   listServers(): Promise<SnapOServer[]> {
@@ -260,6 +281,7 @@ class HttpNetworkClient implements NetworkClient {
         id: inspectorProcessId("network", server),
         name: server.appName || server.displayName,
         packageName: server.packageName ?? server.displayName,
+        processName: server.appName ?? server.packageName,
         deviceId: server.deviceId,
         deviceDisplayTitle: server.deviceDisplayTitle,
         appIconBase64: server.appIconBase64,
@@ -272,6 +294,31 @@ class HttpNetworkClient implements NetworkClient {
         ]
       }));
     }
+  }
+
+  async loadInspectorPreferences(): Promise<string | null> {
+    try {
+      return window.localStorage.getItem("snapo.inspectorPreferences");
+    } catch {
+      return null;
+    }
+  }
+
+  async saveInspectorPreferences(value: string): Promise<void> {
+    try {
+      window.localStorage.setItem("snapo.inspectorPreferences", value);
+    } catch {
+      /* Storage may be disabled. */
+    }
+  }
+
+  appInspectorStateChanged(state: AppInspectorState): void {
+    void state;
+  }
+
+  onNativeSelectedApp(callback: (appId: string) => void): () => void {
+    void callback;
+    return () => {};
   }
 
   async listServers(): Promise<SnapOServer[]> {

--- a/snapo-network-inspector-web/src/styles.css
+++ b/snapo-network-inspector-web/src/styles.css
@@ -769,6 +769,19 @@ body.split-pane-resizing {
   line-height: 16px;
 }
 
+.inspector-loading-shell {
+  display: flex;
+  flex: 1;
+  flex-direction: column;
+  min-height: 0;
+}
+
+.inspector-loading {
+  display: grid;
+  flex: 1;
+  place-items: center;
+}
+
 .body-loading-spinner {
   flex: 0 0 auto;
   animation: spin 1s linear infinite;
@@ -1424,6 +1437,17 @@ pre {
 
 .tweaks-inspector > .empty-detail {
   grid-row: 2;
+}
+
+.tweaks-fields {
+  min-width: 0;
+  margin: 0;
+  border: 0;
+  padding: 0;
+}
+
+.tweaks-fields:disabled {
+  opacity: 0.5;
 }
 
 .tweaks-error {


### PR DESCRIPTION
Reconnecting a device or restarting an Android app could select whichever inspector appeared first, discard the visible inspection state, or leave Tweaks stuck after a failed connection. This keeps the user's inspector choice separate from live discovery and preserves useful content while the connection recovers.

## Summary

- Discover Network and Tweaks sockets together and persist the selected inspector by device and process identity.
- Keep known inspector icons and captured network requests available while disconnected, including cached-body browsing and local copy/export.
- Retain loaded Tweaks values in a disabled view until reconnection, retry startup failures, recreate broken ADB forwards, and clear stale errors after recovery.
- Add regression coverage for partial discovery, process restarts, explicit selections, offline content, and connection recovery.

## Validation

- 192 web tests and 27 Swift tests passed.
- TypeScript, ESLint/Stylelint, SwiftFormat, and SwiftLint passed.
- Unsigned macOS app build passed.
- Browser checks with synthetic data covered offline browsing, retained inspector controls, disabled Tweaks, and reconnection.
- Reviewed the complete change set and publication text for private data. No captures, diagnostic logs, screenshots, credentials, or private tracker references are included.
- Physical-device unplug/replug with the final build remains a manual check.
