### PR TITLE
Fix inspector discovery and stream startup races

### DIFF
--- a/snapo-network-inspector-web/src/App.test.tsx
+++ b/snapo-network-inspector-web/src/App.test.tsx
@@ -189,6 +189,24 @@ describe("app inspector restoration UI", () => {
     expect(container.querySelector('[data-inspector="tweaks"]')).not.toBeNull();
   });
 
+  it("waits without selecting a placeholder, then opens its identified replacement", async () => {
+    vi.mocked(mocks.client.loadInspectorPreferences).mockResolvedValue(null);
+    discovered = [{ ...app(10, ["network"]), processName: null, name: "snapo_network_10" }];
+    await act(async () => root.render(<App />));
+    expect(container.querySelector('[role="status"]')).not.toBeNull();
+    expect(container.querySelector("[data-inspector]")).toBeNull();
+    expect(mocks.client.startStream).not.toHaveBeenCalled();
+    expect(mocks.client.appInspectorStateChanged).toHaveBeenLastCalledWith(
+      expect.objectContaining({ selectedApp: null, selection: null, isRestoring: true })
+    );
+
+    discovered = [app(20, ["network"])];
+    await act(async () => vi.advanceTimersByTimeAsync(2_500));
+    expect(container.querySelector('[role="status"]')).toBeNull();
+    expect(container.querySelector('[data-inspector="network"]')?.getAttribute("data-socket")).toBe("snapo_network_20");
+    expect(mocks.client.startStream).toHaveBeenCalledWith({ deviceId: "phone", socketName: "snapo_network_20" });
+  });
+
   it("keeps a browser picker available during restoration", async () => {
     Object.assign(mocks.client, { usesNativeServerPicker: false });
     await act(async () => root.render(<App />));

--- a/snapo-network-inspector-web/src/features/app-inspector/restoration.test.ts
+++ b/snapo-network-inspector-web/src/features/app-inspector/restoration.test.ts
@@ -194,10 +194,33 @@ describe("inspector restoration", () => {
     const owner = new InspectorRestoration();
     expect(owner.reconcile([{ ...app(), processName: null }])).toMatchObject({
       selection: null,
+      selectedApp: null,
       isRestoring: true
     });
     expect(JSON.parse(owner.serialize()).last).toBeNull();
     expect(owner.reconcile([app()]).selection?.kind).toBe("network");
+  });
+
+  it("selects an identified replacement when an unidentified process exits", () => {
+    const owner = new InspectorRestoration();
+    owner.reconcile([{ ...app(), processName: null }]);
+    expect(owner.reconcile([])).toMatchObject({ selection: null, selectedApp: null, isRestoring: false });
+    expect(owner.reconcile([app(20)])).toMatchObject({
+      selection: { appId: "phone:pid:20", kind: "network" },
+      isRestoring: false
+    });
+  });
+
+  it("does not let an unidentified process delay another identified app", () => {
+    const owner = new InspectorRestoration();
+    const ready = app(20);
+    expect(owner.reconcile([{ ...app(), processName: null }, ready]).selection?.appId).toBe(ready.id);
+  });
+
+  it("ignores identified apps without an available inspector", () => {
+    const owner = new InspectorRestoration();
+    expect(owner.reconcile([app(10, [])])).toMatchObject({ selection: null, isRestoring: false });
+    expect(owner.reconcile([app(10, []), app(20)]).selection?.appId).toBe("phone:pid:20");
   });
 
   it("does not restore by an unverified display name", () => {

--- a/snapo-network-inspector-web/src/features/app-inspector/restoration.ts
+++ b/snapo-network-inspector-web/src/features/app-inspector/restoration.ts
@@ -91,7 +91,9 @@ export class InspectorRestoration {
       displayedTweaks: this.kind === "tweaks" ? (this.retained.tweaks ?? null) : null,
       selectedApp: this.target,
       preferredKind: this.kind,
-      isRestoring: this.awaitingAppIdentity || (this.kind != null && this.current == null)
+      isRestoring:
+        this.awaitingAppIdentity ||
+        (this.current == null && (this.kind != null || this.apps.some((app) => app.inspectors.length > 0)))
     };
   }
 
@@ -116,7 +118,7 @@ export class InspectorRestoration {
       const option = app.inspectors.find((candidate) => candidate.kind === this.kind);
       this.setCurrent(app, option);
     } else if (this.kind == null) {
-      const first = apps.find((candidate) => candidate.inspectors.length > 0);
+      const first = apps.find((candidate) => identity(candidate) && candidate.inspectors.length > 0);
       if (first) this.selectApp(first);
     } else {
       this.current = null;

--- a/snapo-network-inspector-web/src/features/tweaks-inspector/TweaksInspectorApp.recovery.test.tsx
+++ b/snapo-network-inspector-web/src/features/tweaks-inspector/TweaksInspectorApp.recovery.test.tsx
@@ -232,4 +232,96 @@ describe("Tweaks connection recovery", () => {
     expect(client.stopTweakStream).toHaveBeenCalledWith("old-stream");
     expect(client.startTweakStream).toHaveBeenLastCalledWith(other.server);
   });
+
+  it("ignores a late old-stream event while reconnecting the same endpoint", async () => {
+    await render();
+    await render(selection, false);
+    let finish!: (value: TweakList) => void;
+    vi.mocked(client.listTweaks).mockImplementationOnce(
+      () =>
+        new Promise((resolve) => {
+          finish = resolve;
+        })
+    );
+    await render();
+    expect(container.querySelector("fieldset")?.disabled).toBe(true);
+    await act(async () => receive({ streamId: "stream-1", server: selection.server, tweaks: modifiedResponse.tweaks }));
+    expect(container.querySelector("fieldset")?.disabled).toBe(true);
+    expect(container.querySelector<HTMLInputElement>('input[type="text"]')?.value).toBe("Recovered");
+    await act(async () => finish(response));
+  });
+
+  it("preserves an initial snapshot that arrives before stream startup resolves", async () => {
+    let finish!: (value: { streamId: string }) => void;
+    vi.mocked(client.startTweakStream).mockImplementationOnce(
+      () =>
+        new Promise((resolve) => {
+          finish = resolve;
+        })
+    );
+    await render();
+    await act(async () =>
+      receive({ streamId: "new-stream", server: selection.server, tweaks: modifiedResponse.tweaks })
+    );
+    expect(container.querySelector("fieldset")?.disabled).toBe(true);
+    expect(container.querySelector<HTMLInputElement>('input[type="text"]')?.value).toBe("Recovered");
+    await act(async () => finish({ streamId: "new-stream" }));
+    expect(container.querySelector("fieldset")?.disabled).toBe(false);
+    expect(container.querySelector<HTMLInputElement>('input[type="text"]')?.value).toBe("Changed");
+  });
+
+  it("ignores an old stream while the new stream start is pending", async () => {
+    let finish!: (value: { streamId: string }) => void;
+    vi.mocked(client.startTweakStream).mockImplementationOnce(
+      () =>
+        new Promise((resolve) => {
+          finish = resolve;
+        })
+    );
+    await render();
+    await act(async () =>
+      receive({ streamId: "old-stream", server: selection.server, tweaks: modifiedResponse.tweaks })
+    );
+    await act(async () => finish({ streamId: "new-stream" }));
+    expect(container.querySelector<HTMLInputElement>('input[type="text"]')?.value).toBe("Recovered");
+  });
+
+  it("ignores early events when stream startup fails", async () => {
+    let reject!: (cause: Error) => void;
+    vi.mocked(client.startTweakStream).mockImplementationOnce(
+      () =>
+        new Promise((_, fail) => {
+          reject = fail;
+        })
+    );
+    await render();
+    await act(async () =>
+      receive({ streamId: "new-stream", server: selection.server, tweaks: modifiedResponse.tweaks })
+    );
+    await act(async () => reject(connectionError));
+    expect(container.querySelector("fieldset")?.disabled).toBe(true);
+    expect(container.querySelector<HTMLInputElement>('input[type="text"]')?.value).toBe("Recovered");
+    await act(async () => vi.advanceTimersByTimeAsync(250));
+    expect(client.startTweakStream).toHaveBeenCalledTimes(2);
+    expect(container.querySelector("fieldset")?.disabled).toBe(false);
+    expect(container.querySelector<HTMLInputElement>('input[type="text"]')?.value).toBe("Recovered");
+  });
+
+  it("discards early events and stops a late stream exactly once after unmount", async () => {
+    let finish!: (value: { streamId: string }) => void;
+    vi.mocked(client.startTweakStream).mockImplementationOnce(
+      () =>
+        new Promise((resolve) => {
+          finish = resolve;
+        })
+    );
+    await render();
+    await act(async () =>
+      receive({ streamId: "new-stream", server: selection.server, tweaks: modifiedResponse.tweaks })
+    );
+    await act(async () => root.render(null));
+    await act(async () => finish({ streamId: "new-stream" }));
+    expect(client.stopTweakStream).toHaveBeenCalledExactlyOnceWith("new-stream");
+    expect(container.textContent).toBe("");
+  });
 });

--- a/snapo-network-inspector-web/src/features/tweaks-inspector/TweaksInspectorApp.tsx
+++ b/snapo-network-inspector-web/src/features/tweaks-inspector/TweaksInspectorApp.tsx
@@ -4,6 +4,7 @@ import type {
   AppInspectorOption,
   InspectableApp,
   SelectedAppInspector,
+  StreamStarted,
   TweakActionDescriptor,
   TweakDescriptor,
   TweakUpdate,
@@ -98,7 +99,7 @@ export function TweaksInspectorApp({
   useEffect(() => {
     if (!isConnected) return;
     let disposed = false;
-    let streamId: string | undefined;
+    let streamStart: Promise<StreamStarted> | undefined;
     let retryTimer: ReturnType<typeof setTimeout> | undefined;
     let retryDelay = 250;
 
@@ -109,17 +110,19 @@ export function TweaksInspectorApp({
     };
 
     const unsubscribe = client.onTweaksChanged((event) => {
-      if (
-        disposed ||
-        event.server.deviceId !== server.deviceId ||
-        event.server.socketName !== server.socketName ||
-        (streamId !== undefined && event.streamId !== streamId)
-      ) {
+      if (disposed || event.server.deviceId !== server.deviceId || event.server.socketName !== server.socketName) {
         return;
       }
 
-      applySnapshot(event.tweaks);
-      setConnectionState({ connection, error: null });
+      // The initial event can arrive before the start reply identifies its stream.
+      void streamStart?.then(
+        ({ streamId }) => {
+          if (disposed || event.streamId !== streamId) return;
+          applySnapshot(event.tweaks);
+          setConnectionState({ connection, error: null });
+        },
+        () => {}
+      );
     });
 
     const connect = async () => {
@@ -130,12 +133,9 @@ export function TweaksInspectorApp({
         setConnectionState(null);
         setSaving(false);
 
-        const started = await client.startTweakStream(server);
-        if (disposed) {
-          void client.stopTweakStream(started.streamId).catch(() => {});
-          return;
-        }
-        streamId = started.streamId;
+        streamStart = client.startTweakStream(server);
+        await streamStart;
+        if (disposed) return;
         setConnectionState({ connection, error: null });
       } catch (cause) {
         if (disposed) return;
@@ -154,7 +154,7 @@ export function TweaksInspectorApp({
       clearTimeout(retryTimer);
       queue.cancel();
       unsubscribe();
-      if (streamId !== undefined) void client.stopTweakStream(streamId).catch(() => {});
+      void streamStart?.then(({ streamId }) => client.stopTweakStream(streamId)).catch(() => {});
     };
   }, [client, connection, isConnected, queue, server]);
 


### PR DESCRIPTION
Initial discovery could stay stuck on an exited process before its identity arrived. During Tweaks reconnection, stale stream events could also replace cached values and enable editing too early. These fixes make selection and event handling wait for the identity they need.

## Summary

- Auto-select only identified apps with an available inspector, while preserving loading feedback and explicit choices.
- Match Tweaks events after the existing stream-start promise resolves, preserving valid early snapshots and rejecting stale events.
- Use the same promise to clean up streams that finish starting after unmount. No macOS or Android API changes.
- Add regression tests for replacement processes, delayed snapshots, failed startup, and cleanup.

## Validation

- All 201 web tests passed, including 14 Tweaks recovery tests.
- Web typecheck, JavaScript/CSS lint, formatting, and production build passed.
- Unsigned macOS app build passed.
- Diff whitespace checks passed.
- No physical-device or interactive GUI validation performed.
