### PR TITLE
Center and share the inspector waiting state

### DIFF
--- a/snapo-network-inspector-web/src/App.test.tsx
+++ b/snapo-network-inspector-web/src/App.test.tsx
@@ -161,10 +161,10 @@ describe("app inspector restoration UI", () => {
     vi.useRealTimers();
   });
 
-  it("shows only an accessible spinner until the remembered inspector appears", async () => {
+  it("shows a spinner and status text until the remembered inspector appears", async () => {
     await act(async () => root.render(<App />));
     expect(container.querySelector('[role="status"] svg')).not.toBeNull();
-    expect(container.textContent).toBe("");
+    expect(container.querySelector('[role="status"]')?.textContent).toBe("Waiting for inspector");
     expect(container.querySelector("[data-inspector]")).toBeNull();
 
     discovered = [app(20, ["network", "tweaks"])];

--- a/snapo-network-inspector-web/src/App.tsx
+++ b/snapo-network-inspector-web/src/App.tsx
@@ -1,10 +1,10 @@
-import { LoaderCircle } from "lucide-react";
 import { useMemo } from "react";
 import { createNetworkClient } from "./network/client";
 import { NetworkInspectorApp } from "./features/network-inspector/NetworkInspectorApp";
 import { useNetworkInspectorModel } from "./features/network-inspector/hooks/useNetworkInspectorModel";
 import { TweaksInspectorApp } from "./features/tweaks-inspector/TweaksInspectorApp";
 import { AppInspectorPicker } from "./features/app-inspector/components/AppInspectorPicker";
+import { InspectorWaitingState } from "./features/app-inspector/components/InspectorWaitingState";
 import { isInspectorMetadataPending } from "./features/app-inspector/selection";
 import { useAppInspector } from "./features/app-inspector/useAppInspector";
 
@@ -45,9 +45,7 @@ export function App(): JSX.Element {
               onSelect={select}
             />
           ) : null}
-          <div className="inspector-loading" role="status" aria-label="Connecting to inspector">
-            <LoaderCircle className="body-loading-spinner" size={20} aria-hidden="true" />
-          </div>
+          <InspectorWaitingState />
         </main>
       ) : displayedTweaks ? (
         <TweaksInspectorApp

--- a/snapo-network-inspector-web/src/features/app-inspector/components/InspectorWaitingState.tsx
+++ b/snapo-network-inspector-web/src/features/app-inspector/components/InspectorWaitingState.tsx
@@ -1,0 +1,11 @@
+import { LoaderCircle } from "lucide-react";
+
+export function InspectorWaitingState(): JSX.Element {
+  const label = "Waiting for inspector";
+  return (
+    <div className="inspector-loading" role="status" aria-label={label}>
+      <span>{label}</span>
+      <LoaderCircle className="body-loading-spinner" size={20} aria-hidden="true" />
+    </div>
+  );
+}

--- a/snapo-network-inspector-web/src/features/tweaks-inspector/TweaksInspectorApp.recovery.test.tsx
+++ b/snapo-network-inspector-web/src/features/tweaks-inspector/TweaksInspectorApp.recovery.test.tsx
@@ -72,6 +72,26 @@ describe("Tweaks connection recovery", () => {
     );
   }
 
+  it.each([true, false])("shows status text while loading with native picker %s", async (usesNativeServerPicker) => {
+    Object.assign(client, { usesNativeServerPicker });
+    let finish!: (value: TweakList) => void;
+    vi.mocked(client.listTweaks).mockImplementationOnce(
+      () =>
+        new Promise((resolve) => {
+          finish = resolve;
+        })
+    );
+    await render();
+    const status = container.querySelector('[role="status"]');
+    expect(status?.textContent).toBe("Waiting for inspector");
+    expect(status?.querySelector('svg[aria-hidden="true"]')).not.toBeNull();
+    expect(container.querySelector(".tweaks-inspector-toolbar") != null).toBe(!usesNativeServerPicker);
+
+    await act(async () => finish(response));
+    expect(container.querySelector('[role="status"]')).toBeNull();
+    expect(container.querySelector<HTMLInputElement>('input[type="text"]')?.value).toBe("Recovered");
+  });
+
   it("retries a failed initial request without changing the selected inspector", async () => {
     vi.mocked(client.listTweaks).mockRejectedValueOnce(connectionError);
     await render();

--- a/snapo-network-inspector-web/src/features/tweaks-inspector/TweaksInspectorApp.tsx
+++ b/snapo-network-inspector-web/src/features/tweaks-inspector/TweaksInspectorApp.tsx
@@ -1,4 +1,4 @@
-import { ChevronDown, LoaderCircle, RotateCcw } from "lucide-react";
+import { ChevronDown, RotateCcw } from "lucide-react";
 import { useCallback, useEffect, useId, useMemo, useRef, useState, type CSSProperties } from "react";
 import type {
   AppInspectorOption,
@@ -13,6 +13,7 @@ import type {
 } from "../../network/bridge-types";
 import type { NativeColorPanelChange, NetworkClient } from "../../network/client";
 import { AppInspectorPicker } from "../app-inspector/components/AppInspectorPicker";
+import { InspectorWaitingState } from "../app-inspector/components/InspectorWaitingState";
 import { TweakUpdateQueue } from "./tweak-update-queue";
 
 interface TweakSection {
@@ -326,9 +327,7 @@ export function TweaksInspectorApp({
       ) : null}
 
       {!hasSnapshot && !connectionError ? (
-        <div className="inspector-loading" role="status" aria-label="Connecting to inspector">
-          <LoaderCircle className="body-loading-spinner" size={20} aria-hidden="true" />
-        </div>
+        <InspectorWaitingState />
       ) : hasSnapshot && !error && tweaks.length === 0 ? (
         <TweaksEmptyState onOpenDocs={() => void client.openExternal(docsUrl)} />
       ) : (

--- a/snapo-network-inspector-web/src/styles.css
+++ b/snapo-network-inspector-web/src/styles.css
@@ -777,9 +777,15 @@ body.split-pane-resizing {
 }
 
 .inspector-loading {
-  display: grid;
+  display: flex;
   flex: 1;
-  place-items: center;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 12px;
+  color: var(--on-surface-variant);
+  font-size: 13px;
+  text-align: center;
 }
 
 .body-loading-spinner {
@@ -1435,7 +1441,8 @@ pre {
   padding: 20px clamp(18px, 4vw, 36px) 48px;
 }
 
-.tweaks-inspector > .empty-detail {
+.tweaks-inspector > .empty-detail,
+.tweaks-inspector > .inspector-loading {
   grid-row: 2;
 }
 


### PR DESCRIPTION
The Tweaks waiting spinner appeared at the top of the pane when the native toolbar was used. It also lacked visible status text, leaving the blank pane unexplained.

## Summary

- Center “Waiting for inspector” above the spinner, with a 12 px gap.
- Share the waiting-state component between discovery and Tweaks.
- Place the Tweaks waiting state in the content row, below any web toolbar.
- Keep connection and retry behavior unchanged.

## Validation

- All 203 web tests pass, including waiting-state coverage with and without the native picker.
- TypeScript, ESLint, Stylelint, Prettier, and the web production build pass.
- Unsigned macOS app build passes.
- Browser checks confirm centered text and spinner with a 12 px gap.

No device connection behavior changed; this PR only updates the waiting UI.
