### PR TITLE
Keep the app picker stable when switching inspectors

### DIFF
--- a/snapo-app-mac/Snap-O/CaptureWindow/CaptureToolbar.swift
+++ b/snapo-app-mac/Snap-O/CaptureWindow/CaptureToolbar.swift
@@ -138,14 +138,19 @@ struct CaptureToolbar: View {
 
         if let networkModel {
           HStack(spacing: 8) {
-            if networkModel.preferredInspectorKind == .tweaks {
-              tweaksInspectorControls(model: networkModel)
-            } else {
-              NetworkInspectorToolbarControls(
-                model: networkModel,
-                isSearchPresented: $isNetworkSearchPresented
-              )
+            Group {
+              if networkModel.preferredInspectorKind == .tweaks {
+                tweaksInspectorControls(model: networkModel)
+              } else {
+                NetworkInspectorToolbarControls(
+                  model: networkModel,
+                  isSearchPresented: $isNetworkSearchPresented
+                )
+              }
             }
+            // Reserve the three-button network group's width without stretching its background.
+            .frame(minWidth: 110, alignment: .leading)
+
             AppInspectorPicker(model: networkModel)
               .padding(.leading, 4)
             AppInspectorViewPicker(model: networkModel)


### PR DESCRIPTION
Switching between Network and Tweaks moved the app picker because their action groups have different widths. Reserve space for the three-button group so the picker stays in place during normal inspector switching.

## Summary

- Give inspector actions a shared 110 pt minimum-width slot.
- Keep actions start-aligned and preserve their natural button backgrounds.
- Retain the left-aligned toolbar layout and allow the search field to expand as before.

## Validation

- Unsigned macOS app build passes.
- SwiftFormat and SwiftLint pass for the changed file.
- `git diff --check` passes.

The expanded search field can still move the picker; this change fixes the one-button versus three-button layout shift.
