### PR TITLE
Reduce Live Preview CPU use and pause hidden streams

### DIFF
--- a/snapo-app-mac/Snap-O/CaptureWindow/CaptureToolbar.swift
+++ b/snapo-app-mac/Snap-O/CaptureWindow/CaptureToolbar.swift
@@ -390,7 +390,6 @@ struct CaptureActionToolbarControls: View {
         Label("Live Preview", systemImage: "play.circle")
           .font(SnapOToolbarStyle.iconFont)
           .frame(width: 34, height: 32)
-          .symbolEffect(.pulse, isActive: isLivePreviewActive)
           .modifier(CaptureSelectionHighlight(isSelected: isLivePreviewActive))
       }
       .help("Live Preview (⌘⇧L). Option-drag the preview to capture a frame.")

--- a/snapo-app-mac/Snap-O/CaptureWindow/LiveCaptureView.swift
+++ b/snapo-app-mac/Snap-O/CaptureWindow/LiveCaptureView.swift
@@ -15,6 +15,7 @@ struct LiveCaptureView<Host: LivePreviewHosting>: View {
 
   @State private var renderer: LivePreviewRenderer?
   @State private var streamTask: Task<Void, Never>?
+  @State private var cleanupTask: Task<Void, Never>?
   @State private var streamLifecycleID: UUID?
   @State private var isViewVisible = false
   @State private var isWindowVisible = false
@@ -55,30 +56,36 @@ struct LiveCaptureView<Host: LivePreviewHosting>: View {
 
   private func startStreamIfNeeded() {
     guard streamTask == nil else { return }
-    restartStream()
-  }
-
-  private func restartStream() {
-    stopStream()
 
     let deviceID = capture.device.id
     let lifecycleID = UUID()
+    let previousCleanup = cleanupTask
     streamLifecycleID = lifecycleID
     streamTask = Task(priority: .userInitiated) { @MainActor in
+      await previousCleanup?.value
+      guard isLifecycleActive(lifecycleID) else { return }
+      cleanupTask = nil
       await runRendererLifecycle(deviceID: deviceID, lifecycleID: lifecycleID)
     }
   }
 
   private func stopStream() {
     streamLifecycleID = nil
-    streamTask?.cancel()
+    let taskToStop = streamTask
+    taskToStop?.cancel()
     streamTask = nil
     let rendererToStop = renderer
     renderer = nil
-    if let rendererToStop {
-      Task {
+    guard taskToStop != nil || rendererToStop != nil else { return }
+
+    let previousCleanup = cleanupTask
+    cleanupTask = Task {
+      await previousCleanup?.value
+      if let rendererToStop {
         await host.stopLivePreviewStream(rendererToStop)
       }
+      // Startup or a spontaneous stop may still own the device after the renderer is cleared.
+      await taskToStop?.value
     }
   }
 

--- a/snapo-app-mac/Snap-O/CaptureWindow/LiveCaptureView.swift
+++ b/snapo-app-mac/Snap-O/CaptureWindow/LiveCaptureView.swift
@@ -16,6 +16,8 @@ struct LiveCaptureView<Host: LivePreviewHosting>: View {
   @State private var renderer: LivePreviewRenderer?
   @State private var streamTask: Task<Void, Never>?
   @State private var streamLifecycleID: UUID?
+  @State private var isViewVisible = false
+  @State private var isWindowVisible = false
 
   var body: some View {
     ZStack {
@@ -26,8 +28,29 @@ struct LiveCaptureView<Host: LivePreviewHosting>: View {
       }
     }
     .frame(maxWidth: .infinity, maxHeight: .infinity)
-    .onAppear { startStreamIfNeeded() }
-    .onDisappear { stopStream() }
+    .background {
+      WindowVisibilityReader { isVisible in
+        isWindowVisible = isVisible
+        updateStreamVisibility()
+      }
+      .frame(width: 0, height: 0)
+    }
+    .onAppear {
+      isViewVisible = true
+      updateStreamVisibility()
+    }
+    .onDisappear {
+      isViewVisible = false
+      stopStream()
+    }
+  }
+
+  private func updateStreamVisibility() {
+    if isViewVisible, isWindowVisible {
+      startStreamIfNeeded()
+    } else {
+      stopStream()
+    }
   }
 
   private func startStreamIfNeeded() {

--- a/snapo-app-mac/Snap-O/LivePreview/LivePreviewView.swift
+++ b/snapo-app-mac/Snap-O/LivePreview/LivePreviewView.swift
@@ -120,9 +120,7 @@ final class LivePreviewDisplayView: NSView, NSDraggingSource {
     isDraggingFrame = false
     pointerState = PointerState()
     renderer?.session.sampleBufferHandler = nil
-    displayLayer.sampleBufferRenderer.stopRequestingMediaData()
     displayLayer.sampleBufferRenderer.flush(removingDisplayedImage: true, completionHandler: nil)
-    displayLayer.sampleBufferRenderer.requestMediaDataWhenReady(on: .main) {}
     endedLivePreviewTrace = false
   }
 

--- a/snapo-app-mac/Tests/StartupCapture/LivePreviewVisibilityTests.swift
+++ b/snapo-app-mac/Tests/StartupCapture/LivePreviewVisibilityTests.swift
@@ -70,20 +70,30 @@ final class TestHost: LivePreviewHosting {
   var starts = 0
   var stops: [UUID] = []
   var active: Set<UUID> = []
+  var busyStarts = 0
   var delayStart = false
   var startContinuation: CheckedContinuation<Void, Never>?
+  var delayStop = false
+  var stopContinuation: CheckedContinuation<Void, Never>?
+  var latestSession: LivePreviewSession?
   func startLivePreviewStream(for _: String) async -> LivePreviewRenderer? {
     starts += 1
+    guard active.isEmpty else {
+      busyStarts += 1
+      return nil
+    }
     if delayStart { await withCheckedContinuation { startContinuation = $0 } }
     let renderer = LivePreviewRenderer(session: LivePreviewSession())
+    latestSession = renderer.session
     active.insert(renderer.operation.id)
     return renderer
   }
 
   func stopLivePreviewStream(_ renderer: LivePreviewRenderer) async {
     stops.append(renderer.operation.id)
-    active.remove(renderer.operation.id)
     renderer.session.stop()
+    if delayStop { await withCheckedContinuation { stopContinuation = $0 } }
+    active.remove(renderer.operation.id)
   }
 }
 
@@ -119,31 +129,72 @@ struct LivePreviewVisibilityTests {
     Visibility.shared.isVisible = true
     eventually("Visible preview starts once") { host.starts == 1 && host.active.count == 1 }
     precondition(!NSApplication.shared.isActive, "Test must leave the app inactive")
+    host.delayStop = true
     Visibility.shared.isVisible = false
-    eventually("Hidden preview must stop") { host.active.isEmpty && host.stops.count == 1 }
-    pump()
-    precondition(host.starts == 1, "Hidden preview must not retry")
+    eventually("Cleanup should be pending") { host.stopContinuation != nil }
     Visibility.shared.isVisible = true
-    eventually("Visible preview restarts") { host.starts == 2 && host.active.count == 1 }
+    eventually("Uncover during pending cleanup") { Visibility.shared.reportedVisibility == true }
+    pump()
+    precondition(host.starts == 1, "Replacement must wait for cleanup")
     Visibility.shared.isVisible = false
-    eventually("Hidden preview must stop again") { host.active.isEmpty && host.stops.count == 2 }
+    eventually("Hide while waiting for cleanup") { Visibility.shared.reportedVisibility == false }
+    Visibility.shared.isVisible = true
+    eventually("Uncover again while waiting for cleanup") { Visibility.shared.reportedVisibility == true }
+    pump()
+    precondition(host.starts == 1, "Repeated visibility changes must not bypass cleanup")
+    host.delayStop = false
+    host.stopContinuation?.resume()
+    host.stopContinuation = nil
+    eventually("Restart once after cleanup") { host.starts == 2 && host.active.count == 1 }
+    Visibility.shared.isVisible = false
+    eventually("Hidden preview must stop") { host.active.isEmpty && host.stops.count == 2 }
+    pump()
+    precondition(host.starts == 2, "Hidden preview must not retry")
+    Visibility.shared.isVisible = true
+    eventually("Visible preview restarts") { host.starts == 3 && host.active.count == 1 }
+    Visibility.shared.isVisible = false
+    eventually("Hidden preview must stop again") { host.active.isEmpty && host.stops.count == 3 }
     host.delayStart = true
     Visibility.shared.isVisible = true
     eventually("Startup should be pending") { host.startContinuation != nil }
     Visibility.shared.isVisible = false
     eventually("Hide during pending startup") { Visibility.shared.reportedVisibility == false }
+    Visibility.shared.isVisible = true
+    eventually("Uncover during pending startup") { Visibility.shared.reportedVisibility == true }
+    pump()
+    precondition(host.starts == 4, "Replacement must wait for cancelled startup")
+    host.delayStart = false
+    host.delayStop = true
     host.startContinuation?.resume()
     host.startContinuation = nil
-    eventually("Late startup must be cleaned up") { host.active.isEmpty && host.stops.count == 3 }
-    host.delayStart = false
-    Visibility.shared.isVisible = true
+    eventually("Late startup cleanup should be pending") { host.stopContinuation != nil }
+    pump()
+    precondition(host.starts == 4, "Replacement must wait for late startup cleanup")
+    host.delayStop = false
+    host.stopContinuation?.resume()
+    host.stopContinuation = nil
     eventually("Preview should recover after cancelled startup") { host.active.count == 1 }
+    eventually("Restart after late startup cleanup") { host.starts == 5 && host.stops.count == 4 }
     NotificationCenter.default.post(name: NSApplication.didResignActiveNotification, object: NSApplication.shared)
     pump()
-    precondition(host.active.count == 1 && host.stops.count == 3, "Visible preview must keep running while inactive")
+    precondition(host.active.count == 1 && host.stops.count == 4, "Visible preview must keep running while inactive")
+    host.delayStop = true
+    host.latestSession?.stop()
+    eventually("Spontaneous stop cleanup should be pending") { host.stopContinuation != nil }
+    Visibility.shared.isVisible = false
+    eventually("Hide during spontaneous cleanup") { Visibility.shared.reportedVisibility == false }
+    Visibility.shared.isVisible = true
+    eventually("Uncover during spontaneous cleanup") { Visibility.shared.reportedVisibility == true }
+    pump()
+    precondition(host.starts == 5, "Replacement must wait for spontaneous stop cleanup")
+    host.delayStop = false
+    host.stopContinuation?.resume()
+    host.stopContinuation = nil
+    eventually("Restart after spontaneous cleanup") { host.starts == 6 && host.active.count == 1 }
     window.contentView = nil
-    eventually("Removing the view must stop its renderer") { host.active.isEmpty && host.stops.count == 4 }
+    eventually("Removing the view must stop its renderer") { host.active.isEmpty && host.stops.count == 6 }
     precondition(Set(host.stops).count == host.stops.count, "Stop each renderer once")
+    precondition(host.busyStarts == 0, "Never restart while the previous operation owns the device")
     print("Live Preview visibility tests passed")
   }
 }

--- a/snapo-app-mac/Tests/StartupCapture/LivePreviewVisibilityTests.swift
+++ b/snapo-app-mac/Tests/StartupCapture/LivePreviewVisibilityTests.swift
@@ -1,0 +1,149 @@
+import AppKit
+import Observation
+import OSLog
+import SwiftUI
+
+struct CaptureMedia {
+  struct Device { let id: String }
+  let device = Device(id: "test-device")
+}
+
+struct FileStore {}
+enum SnapOLog { static let ui = Logger(subsystem: "Snap-O.VisibilityTests", category: "test") }
+
+@MainActor
+final class LivePreviewSession {
+  private var stopped = false
+  private var continuation: CheckedContinuation<Error?, Never>?
+  func waitUntilStop() async -> Error? {
+    if stopped { return nil }
+    return await withCheckedContinuation { continuation = $0 }
+  }
+
+  func stop() {
+    stopped = true
+    continuation?.resume(returning: nil)
+    continuation = nil
+  }
+}
+
+struct LivePreviewRenderer {
+  struct Operation { let id = UUID() }
+  let operation = Operation()
+  let session: LivePreviewSession
+}
+
+struct LivePreviewRendererView: View {
+  let renderer: LivePreviewRenderer
+  let fileStore: FileStore
+  var body: some View {
+    Color.green
+  }
+}
+
+/// Drives the production view lifecycle without a device or an on-screen window.
+@Observable
+@MainActor
+final class Visibility {
+  static let shared = Visibility()
+  var isVisible = false
+  var reportedVisibility: Bool?
+}
+
+struct WindowVisibilityReader: View {
+  let visibilityDidChange: (Bool) -> Void
+  var body: some View {
+    Color.clear
+      .onAppear { reportVisibility() }
+      .onChange(of: Visibility.shared.isVisible) { reportVisibility() }
+  }
+
+  private func reportVisibility() {
+    let isVisible = Visibility.shared.isVisible
+    visibilityDidChange(isVisible)
+    Visibility.shared.reportedVisibility = isVisible
+  }
+}
+
+@MainActor
+final class TestHost: LivePreviewHosting {
+  var starts = 0
+  var stops: [UUID] = []
+  var active: Set<UUID> = []
+  var delayStart = false
+  var startContinuation: CheckedContinuation<Void, Never>?
+  func startLivePreviewStream(for _: String) async -> LivePreviewRenderer? {
+    starts += 1
+    if delayStart { await withCheckedContinuation { startContinuation = $0 } }
+    let renderer = LivePreviewRenderer(session: LivePreviewSession())
+    active.insert(renderer.operation.id)
+    return renderer
+  }
+
+  func stopLivePreviewStream(_ renderer: LivePreviewRenderer) async {
+    stops.append(renderer.operation.id)
+    active.remove(renderer.operation.id)
+    renderer.session.stop()
+  }
+}
+
+@main
+@MainActor
+struct LivePreviewVisibilityTests {
+  static func eventually(_ message: String, _ condition: () -> Bool) {
+    let deadline = Date().addingTimeInterval(5)
+    while !condition(), Date() < deadline {
+      RunLoop.main.run(until: Date().addingTimeInterval(0.01))
+    }
+    precondition(condition(), message)
+  }
+
+  static func pump() {
+    RunLoop.main.run(until: Date().addingTimeInterval(0.3))
+  }
+
+  static func main() {
+    _ = NSApplication.shared
+    let host = TestHost()
+    let view = NSHostingView(rootView: LiveCaptureView(host: host, capture: CaptureMedia(), fileStore: FileStore()))
+    let window = NSWindow(
+      contentRect: NSRect(x: 0, y: 0, width: 120, height: 120),
+      styleMask: [.borderless],
+      backing: .buffered,
+      defer: false
+    )
+    window.contentView = view
+    view.layoutSubtreeIfNeeded()
+    eventually("Visibility reader must attach") { Visibility.shared.reportedVisibility == false }
+    precondition(host.starts == 0, "Hidden preview must not start")
+    Visibility.shared.isVisible = true
+    eventually("Visible preview starts once") { host.starts == 1 && host.active.count == 1 }
+    precondition(!NSApplication.shared.isActive, "Test must leave the app inactive")
+    Visibility.shared.isVisible = false
+    eventually("Hidden preview must stop") { host.active.isEmpty && host.stops.count == 1 }
+    pump()
+    precondition(host.starts == 1, "Hidden preview must not retry")
+    Visibility.shared.isVisible = true
+    eventually("Visible preview restarts") { host.starts == 2 && host.active.count == 1 }
+    Visibility.shared.isVisible = false
+    eventually("Hidden preview must stop again") { host.active.isEmpty && host.stops.count == 2 }
+    host.delayStart = true
+    Visibility.shared.isVisible = true
+    eventually("Startup should be pending") { host.startContinuation != nil }
+    Visibility.shared.isVisible = false
+    eventually("Hide during pending startup") { Visibility.shared.reportedVisibility == false }
+    host.startContinuation?.resume()
+    host.startContinuation = nil
+    eventually("Late startup must be cleaned up") { host.active.isEmpty && host.stops.count == 3 }
+    host.delayStart = false
+    Visibility.shared.isVisible = true
+    eventually("Preview should recover after cancelled startup") { host.active.count == 1 }
+    NotificationCenter.default.post(name: NSApplication.didResignActiveNotification, object: NSApplication.shared)
+    pump()
+    precondition(host.active.count == 1 && host.stops.count == 3, "Visible preview must keep running while inactive")
+    window.contentView = nil
+    eventually("Removing the view must stop its renderer") { host.active.isEmpty && host.stops.count == 4 }
+    precondition(Set(host.stops).count == host.stops.count, "Stop each renderer once")
+    print("Live Preview visibility tests passed")
+  }
+}

--- a/snapo-app-mac/scripts/test-startup-capture.sh
+++ b/snapo-app-mac/scripts/test-startup-capture.sh
@@ -22,3 +22,7 @@ xcrun swiftc -swift-version 6 -parse-as-library -I "$TEST_DIR" \
   "$TEST_DIR/Device.o" Snap-O/Models/Media.swift Snap-O/LivePreview/LivePreviewSession.swift \
   Tests/StartupCapture/LivePreviewSessionTests.swift -o "$TEST_DIR/session-tests"
 "$TEST_DIR/session-tests"
+xcrun swiftc -swift-version 6 -parse-as-library \
+  Snap-O/CaptureWindow/LiveCaptureView.swift \
+  Tests/StartupCapture/LivePreviewVisibilityTests.swift -o "$TEST_DIR/visibility-tests"
+"$TEST_DIR/visibility-tests"


### PR DESCRIPTION
Live Preview registered an empty media-readiness callback that AVFoundation repeatedly scheduled on the main thread. It also kept streaming while its window was fully covered. These behaviors wasted CPU while previewing or leaving the app open.

## Summary

- Remove the unused pull callback; incoming frames already drive rendering.
- Reuse recorded-video playback's window-visibility check to stop hidden previews and restart them when uncovered, even if another app is foreground.
- Wait for prior stream cleanup before restarting, including cancelled startup and spontaneous-stop cleanup.
- Remove the continuous toolbar pulse while retaining the blue selected state.
- Test hidden startup, pause/resume, inactive-but-visible playback, late startup cleanup, and teardown through the production SwiftUI view.

## Validation

- macOS app build, SwiftFormat, and SwiftLint pass.
- Startup capture, live-preview session/visibility, capture-mode, and frame-export tests pass.
- The visibility regression test fails against the previous implementation.
- A gated slow-cleanup test reproduces the review finding before the fix and passes afterward, with no overlapping device ownership.
- CPU samples confirmed the repeated AVFoundation callback disappeared after the fix. Resolution and frame rate are unchanged.

Visibility is injected in the lifecycle tests; they do not automate desktop window occlusion. Visible previews intentionally continue running when Snap-O is not the foreground app.
