### PR TITLE
Make Live Preview drags smoother with acknowledged input

### DIFF
--- a/.github/workflows/mac.yml
+++ b/.github/workflows/mac.yml
@@ -81,6 +81,9 @@ jobs:
       - name: Test live preview frame export
         working-directory: snapo-app-mac
         run: sh scripts/test-live-preview-frame-export.sh
+      - name: Test live preview pointer delivery
+        working-directory: snapo-app-mac
+        run: sh scripts/test-live-preview-pointer.sh
       - name: Test capture mode transitions
         working-directory: snapo-app-mac
         run: sh scripts/test-capture-modes.sh

--- a/snapo-app-mac/Snap-O/LivePreview/LivePreviewPointerBackend.swift
+++ b/snapo-app-mac/Snap-O/LivePreview/LivePreviewPointerBackend.swift
@@ -1,4 +1,5 @@
 import CoreGraphics
+import Foundation
 
 /// Input source reported by the live-preview surface.
 enum LivePreviewPointerSource: String {
@@ -22,10 +23,15 @@ struct LivePreviewPointerEvent {
 }
 
 protocol LivePreviewPointerBackend: Sendable {
+  var minimumMoveInterval: Duration { get }
   func send(_ event: LivePreviewPointerEvent) async throws
   func stop() async
 }
 
 extension LivePreviewPointerBackend {
+  var minimumMoveInterval: Duration {
+    .nanoseconds(16_666_667)
+  }
+
   func stop() async {}
 }

--- a/snapo-app-mac/Snap-O/LivePreview/LivePreviewPointerInjector.swift
+++ b/snapo-app-mac/Snap-O/LivePreview/LivePreviewPointerInjector.swift
@@ -2,7 +2,7 @@ import Foundation
 
 /// Serializes pointer events per source, selects a backend, and keeps each gesture on one backend.
 actor LivePreviewPointerInjector {
-  private typealias PreferredBackendFactory = @Sendable (String) async throws -> any LivePreviewPointerBackend
+  typealias PreferredBackendFactory = @Sendable (String) async throws -> any LivePreviewPointerBackend
 
   private enum DeviceState {
     case preparing(generation: UUID, task: Task<Void, Never>)
@@ -36,6 +36,9 @@ actor LivePreviewPointerInjector {
 
   private let makePreferredBackend: PreferredBackendFactory
   private let fallbackBackend: any LivePreviewPointerBackend
+  private let now: @Sendable () -> ContinuousClock.Instant
+  private let sleepUntil: @Sendable (ContinuousClock.Instant) async throws -> Void
+  private var nextTouchSend: [String: ContinuousClock.Instant] = [:]
   private var deviceStates: [String: DeviceState] = [:]
   private var touchRoutes: [String: TouchRoute] = [:]
   private var pendingTouchEvents: [LivePreviewPointerEvent] = []
@@ -44,13 +47,26 @@ actor LivePreviewPointerInjector {
   private var isFlushingMouseEvents = false
 
   init(adb: ADBService) {
-    makePreferredBackend = { deviceID in
-      try await UInputLivePreviewPointerBackend.start(
-        adb: adb,
-        deviceID: deviceID
-      )
+    self.init(
+      makePreferredBackend: { deviceID in
+        try await UInputLivePreviewPointerBackend.start(adb: adb, deviceID: deviceID)
+      },
+      fallbackBackend: ShellLivePreviewPointerBackend(adb: adb)
+    )
+  }
+
+  init(
+    makePreferredBackend: @escaping PreferredBackendFactory,
+    fallbackBackend: any LivePreviewPointerBackend,
+    now: @escaping @Sendable () -> ContinuousClock.Instant = { .now },
+    sleepUntil: @escaping @Sendable (ContinuousClock.Instant) async throws -> Void = {
+      try await Task.sleep(until: $0, clock: .continuous)
     }
-    fallbackBackend = ShellLivePreviewPointerBackend(adb: adb)
+  ) {
+    self.makePreferredBackend = makePreferredBackend
+    self.fallbackBackend = fallbackBackend
+    self.now = now
+    self.sleepUntil = sleepUntil
   }
 
   func prepare(deviceID: String) {
@@ -121,6 +137,7 @@ actor LivePreviewPointerInjector {
   }
 
   func stopDevice(_ deviceID: String) async {
+    nextTouchSend.removeValue(forKey: deviceID)
     pendingTouchEvents.removeAll { $0.deviceID == deviceID }
     pendingMouseEvents.removeAll { $0.deviceID == deviceID }
     touchRoutes.removeValue(forKey: deviceID)
@@ -129,6 +146,7 @@ actor LivePreviewPointerInjector {
   }
 
   func stopAll() async {
+    nextTouchSend.removeAll()
     pendingTouchEvents.removeAll()
     pendingMouseEvents.removeAll()
     touchRoutes.removeAll()
@@ -151,6 +169,12 @@ actor LivePreviewPointerInjector {
       return
     }
     deviceStates[deviceID] = .ready(generation: generation, backend: backend)
+    SnapOLog.ui.info(
+      """
+      Live Preview drag backend ready: uinput (\(deviceID, privacy: .private)) \
+      moveInterval=\(String(describing: backend.minimumMoveInterval), privacy: .public)
+      """
+    )
   }
 
   private func failPreparation(
@@ -178,10 +202,21 @@ actor LivePreviewPointerInjector {
   }
 
   private func flushTouchQueue() async {
-    while !pendingTouchEvents.isEmpty {
+    while let pending = pendingTouchEvents.first {
+      if pending.action == .move,
+         let deadline = nextTouchSend[pending.deviceID], now() < deadline {
+        do {
+          try await sleepUntil(deadline)
+        } catch {
+          break
+        }
+        // Keep the move replaceable until delivery, including while the timer waits.
+        continue
+      }
       let event = pendingTouchEvents.removeFirst()
+      nextTouchSend[event.deviceID] = now().advanced(by: minimumMoveInterval(for: event.deviceID))
       do {
-        try await send(event)
+        try await sendTouchEvent(event)
       } catch is CancellationError {
         // Teardown can cancel an in-flight backend operation.
       } catch {
@@ -192,10 +227,15 @@ actor LivePreviewPointerInjector {
     }
 
     isFlushingTouchEvents = false
+  }
 
-    if !pendingTouchEvents.isEmpty {
-      isFlushingTouchEvents = true
-      await flushTouchQueue()
+  private func minimumMoveInterval(for deviceID: String) -> Duration {
+    switch touchRoutes[deviceID] {
+    case .preferred(_, let backend): return backend.minimumMoveInterval
+    case .fallback, .discarded: return fallbackBackend.minimumMoveInterval
+    case nil:
+      if case .ready(_, let backend) = deviceStates[deviceID] { return backend.minimumMoveInterval }
+      return fallbackBackend.minimumMoveInterval
     }
   }
 
@@ -214,19 +254,9 @@ actor LivePreviewPointerInjector {
     }
 
     isFlushingMouseEvents = false
-
-    if !pendingMouseEvents.isEmpty {
-      isFlushingMouseEvents = true
-      await flushMouseQueue()
-    }
   }
 
-  private func send(_ event: LivePreviewPointerEvent) async throws {
-    if event.source == .mouse {
-      try await fallbackBackend.send(event)
-      return
-    }
-
+  private func sendTouchEvent(_ event: LivePreviewPointerEvent) async throws {
     switch event.action {
     case .down:
       try await sendTouchDown(event)

--- a/snapo-app-mac/Snap-O/LivePreview/LivePreviewPointerInjector.swift
+++ b/snapo-app-mac/Snap-O/LivePreview/LivePreviewPointerInjector.swift
@@ -260,10 +260,8 @@ actor LivePreviewPointerInjector {
     switch event.action {
     case .down:
       try await sendTouchDown(event)
-    case .move:
-      try await sendTouchMove(event)
-    case .up, .cancel:
-      try await sendTouchEnd(event)
+    case .move, .up, .cancel:
+      try await sendRoutedTouchEvent(event)
     }
   }
 
@@ -304,32 +302,11 @@ actor LivePreviewPointerInjector {
     }
   }
 
-  private func sendTouchMove(_ event: LivePreviewPointerEvent) async throws {
-    switch touchRoutes[event.deviceID] {
-    case .preferred(let generation, let backend):
-      do {
-        try await backend.send(event)
-      } catch {
-        let isCurrent = deviceStates[event.deviceID]?.generation == generation &&
-          touchRoutes[event.deviceID]?.generation == generation
-        if isCurrent {
-          deviceStates[event.deviceID] = .fallback(generation: generation)
-          touchRoutes[event.deviceID] = .discarded(generation: generation)
-        }
-        await backend.stop()
-        if isCurrent { throw error }
-      }
-    case .fallback:
-      try await fallbackBackend.send(event)
-    case .discarded, nil:
-      break
-    }
-  }
-
-  private func sendTouchEnd(_ event: LivePreviewPointerEvent) async throws {
+  private func sendRoutedTouchEvent(_ event: LivePreviewPointerEvent) async throws {
     guard let route = touchRoutes[event.deviceID] else { return }
+    let endsGesture = event.action == .up || event.action == .cancel
     defer {
-      if touchRoutes[event.deviceID]?.generation == route.generation {
+      if endsGesture, touchRoutes[event.deviceID]?.generation == route.generation {
         touchRoutes.removeValue(forKey: event.deviceID)
       }
     }
@@ -339,9 +316,13 @@ actor LivePreviewPointerInjector {
       do {
         try await backend.send(event)
       } catch {
-        let isCurrent = deviceStates[event.deviceID]?.generation == generation
+        let isCurrent = deviceStates[event.deviceID]?.generation == generation &&
+          touchRoutes[event.deviceID]?.generation == generation
         if isCurrent {
           deviceStates[event.deviceID] = .fallback(generation: generation)
+          if !endsGesture {
+            touchRoutes[event.deviceID] = .discarded(generation: generation)
+          }
         }
         await backend.stop()
         if isCurrent { throw error }

--- a/snapo-app-mac/Snap-O/LivePreview/LivePreviewView.swift
+++ b/snapo-app-mac/Snap-O/LivePreview/LivePreviewView.swift
@@ -46,7 +46,6 @@ final class LivePreviewDisplayView: NSView, NSDraggingSource {
 
   private var pointerState = PointerState()
   private let hoverThrottleInterval: TimeInterval = 1.0 / 45.0
-  private let dragThrottleInterval: TimeInterval = 1.0 / 60.0
   private var frameDragOrigin: CGPoint?
   private var isDraggingFrame = false
 
@@ -252,12 +251,10 @@ final class LivePreviewDisplayView: NSView, NSDraggingSource {
       guard let devicePoint else { return }
       pointerState.isPointerDown = true
       pointerState.lastDeviceLocation = devicePoint
-      pointerState.lastDragTimestamp = event.timestamp
       sendPointer(.down, .touchscreen, devicePoint)
 
     case .drag:
-      guard pointerState.isPointerDown, let devicePoint,
-            shouldSendDragEvent(at: event.timestamp) else { return }
+      guard pointerState.isPointerDown, let devicePoint else { return }
       pointerState.lastDeviceLocation = devicePoint
       sendPointer(.move, .touchscreen, devicePoint)
 
@@ -273,12 +270,6 @@ final class LivePreviewDisplayView: NSView, NSDraggingSource {
   private func shouldSendHoverEvent(at timestamp: TimeInterval) -> Bool {
     guard timestamp - pointerState.lastHoverTimestamp >= hoverThrottleInterval else { return false }
     pointerState.lastHoverTimestamp = timestamp
-    return true
-  }
-
-  private func shouldSendDragEvent(at timestamp: TimeInterval) -> Bool {
-    guard timestamp - pointerState.lastDragTimestamp >= dragThrottleInterval else { return false }
-    pointerState.lastDragTimestamp = timestamp
     return true
   }
 
@@ -312,7 +303,6 @@ final class LivePreviewDisplayView: NSView, NSDraggingSource {
   private struct PointerState {
     var isPointerDown = false
     var lastHoverTimestamp: TimeInterval = 0
-    var lastDragTimestamp: TimeInterval = 0
     var lastDeviceLocation: CGPoint?
   }
 }

--- a/snapo-app-mac/Snap-O/LivePreview/UInputLivePreviewPointerBackend.swift
+++ b/snapo-app-mac/Snap-O/LivePreview/UInputLivePreviewPointerBackend.swift
@@ -4,10 +4,18 @@ import SnapODeviceClient
 
 /// Owns one persistent virtual touchscreen for one Android device.
 actor UInputLivePreviewPointerBackend: LivePreviewPointerBackend {
+  nonisolated var minimumMoveInterval: Duration {
+    touchscreen.supportsSynchronization ? .nanoseconds(8_333_334) : .nanoseconds(16_666_667)
+  }
+
   private let adb: ADBService
   private let deviceID: String
   private let touchscreen: ADBVirtualTouchscreen
-  private var displayRotation: ADBDisplayRotation
+  private var displayViewport: ADBDisplayViewport?
+  private var viewportUpdatedAt = ContinuousClock.now
+  private var viewportRefresh: Task<ADBDisplayViewport, Error>?
+  private var idleRefresh: Task<Void, Never>?
+  private var isPointerDown = false
   private var isStopped = false
 
   static func start(
@@ -16,11 +24,13 @@ actor UInputLivePreviewPointerBackend: LivePreviewPointerBackend {
   ) async throws -> UInputLivePreviewPointerBackend {
     let exec = await adb.exec()
     let touchscreen = try await exec.startVirtualTouchscreen(deviceID: deviceID)
-    return UInputLivePreviewPointerBackend(
+    let backend = UInputLivePreviewPointerBackend(
       adb: adb,
       deviceID: deviceID,
       touchscreen: touchscreen
     )
+    await backend.startIdleRefresh()
+    return backend
   }
 
   private init(
@@ -31,7 +41,7 @@ actor UInputLivePreviewPointerBackend: LivePreviewPointerBackend {
     self.adb = adb
     self.deviceID = deviceID
     self.touchscreen = touchscreen
-    displayRotation = touchscreen.initialDisplayRotation
+    displayViewport = touchscreen.initialDisplayViewport
   }
 
   func send(_ event: LivePreviewPointerEvent) async throws {
@@ -41,11 +51,14 @@ actor UInputLivePreviewPointerBackend: LivePreviewPointerBackend {
     }
 
     if event.action == .down {
-      let exec = await adb.exec()
-      let refreshedRotation = try await exec.displayRotation(deviceID: deviceID)
-      guard !isStopped else { throw CancellationError() }
-      displayRotation = refreshedRotation
+      isPointerDown = true
+      let sizeChanged = displayViewport?.width != Int(event.displaySize.width.rounded()) ||
+        displayViewport?.height != Int(event.displaySize.height.rounded())
+      if viewportRefresh != nil || sizeChanged || viewportUpdatedAt.duration(to: .now) >= .seconds(1) {
+        displayViewport = try await refreshViewport()
+      }
     }
+    guard !isStopped, let displayViewport else { throw CancellationError() }
 
     try touchscreen.send(
       action: event.virtualTouchAction,
@@ -53,13 +66,64 @@ actor UInputLivePreviewPointerBackend: LivePreviewPointerBackend {
       y: event.location.y,
       displayWidth: event.displaySize.width,
       displayHeight: event.displaySize.height,
-      rotation: displayRotation
+      rotation: displayViewport.rotation
     )
+    if event.action == .up || event.action == .cancel {
+      isPointerDown = false
+    }
   }
 
-  func stop() {
+  private func startIdleRefresh() {
+    idleRefresh = Task { [weak self] in
+      while !Task.isCancelled {
+        do {
+          try await Task.sleep(for: .milliseconds(250))
+        } catch {
+          return
+        }
+        guard let self else { return }
+        await refreshIfIdle()
+      }
+    }
+  }
+
+  private func refreshIfIdle() async {
+    guard !isStopped, !isPointerDown else { return }
+    do {
+      _ = try await refreshViewport()
+    } catch is CancellationError {
+      // Stopping the preview cancels its refresh request.
+    } catch {
+      SnapOLog.ui.debug("Unable to refresh drag rotation: \(error.localizedDescription, privacy: .public)")
+    }
+  }
+
+  private func refreshViewport() async throws -> ADBDisplayViewport {
+    if let viewportRefresh { return try await viewportRefresh.value }
+    let task = Task { [adb, deviceID] in
+      let exec = await adb.exec()
+      return try await exec.displayViewport(deviceID: deviceID)
+    }
+    viewportRefresh = task
+    defer { viewportRefresh = nil }
+    do {
+      let viewport = try await task.value
+      guard !isStopped else { throw CancellationError() }
+      displayViewport = viewport
+      viewportUpdatedAt = .now
+      return viewport
+    } catch {
+      displayViewport = nil
+      throw error
+    }
+  }
+
+  func stop() async {
     guard !isStopped else { return }
     isStopped = true
+    idleRefresh?.cancel()
+    idleRefresh = nil
+    viewportRefresh?.cancel()
     touchscreen.close()
   }
 }

--- a/snapo-app-mac/Snap-O/LivePreview/UInputLivePreviewPointerBackend.swift
+++ b/snapo-app-mac/Snap-O/LivePreview/UInputLivePreviewPointerBackend.swift
@@ -11,11 +11,7 @@ actor UInputLivePreviewPointerBackend: LivePreviewPointerBackend {
   private let adb: ADBService
   private let deviceID: String
   private let touchscreen: ADBVirtualTouchscreen
-  private var displayViewport: ADBDisplayViewport?
-  private var viewportUpdatedAt = ContinuousClock.now
-  private var viewportRefresh: Task<ADBDisplayViewport, Error>?
-  private var idleRefresh: Task<Void, Never>?
-  private var isPointerDown = false
+  private var displayRotation: ADBDisplayRotation
   private var isStopped = false
 
   static func start(
@@ -24,13 +20,11 @@ actor UInputLivePreviewPointerBackend: LivePreviewPointerBackend {
   ) async throws -> UInputLivePreviewPointerBackend {
     let exec = await adb.exec()
     let touchscreen = try await exec.startVirtualTouchscreen(deviceID: deviceID)
-    let backend = UInputLivePreviewPointerBackend(
+    return UInputLivePreviewPointerBackend(
       adb: adb,
       deviceID: deviceID,
       touchscreen: touchscreen
     )
-    await backend.startIdleRefresh()
-    return backend
   }
 
   private init(
@@ -41,7 +35,7 @@ actor UInputLivePreviewPointerBackend: LivePreviewPointerBackend {
     self.adb = adb
     self.deviceID = deviceID
     self.touchscreen = touchscreen
-    displayViewport = touchscreen.initialDisplayViewport
+    displayRotation = touchscreen.initialDisplayRotation
   }
 
   func send(_ event: LivePreviewPointerEvent) async throws {
@@ -51,14 +45,11 @@ actor UInputLivePreviewPointerBackend: LivePreviewPointerBackend {
     }
 
     if event.action == .down {
-      isPointerDown = true
-      let sizeChanged = displayViewport?.width != Int(event.displaySize.width.rounded()) ||
-        displayViewport?.height != Int(event.displaySize.height.rounded())
-      if viewportRefresh != nil || sizeChanged || viewportUpdatedAt.duration(to: .now) >= .seconds(1) {
-        displayViewport = try await refreshViewport()
-      }
+      let exec = await adb.exec()
+      let refreshedRotation = try await exec.displayRotation(deviceID: deviceID)
+      guard !isStopped else { throw CancellationError() }
+      displayRotation = refreshedRotation
     }
-    guard !isStopped, let displayViewport else { throw CancellationError() }
 
     try touchscreen.send(
       action: event.virtualTouchAction,
@@ -66,64 +57,13 @@ actor UInputLivePreviewPointerBackend: LivePreviewPointerBackend {
       y: event.location.y,
       displayWidth: event.displaySize.width,
       displayHeight: event.displaySize.height,
-      rotation: displayViewport.rotation
+      rotation: displayRotation
     )
-    if event.action == .up || event.action == .cancel {
-      isPointerDown = false
-    }
-  }
-
-  private func startIdleRefresh() {
-    idleRefresh = Task { [weak self] in
-      while !Task.isCancelled {
-        do {
-          try await Task.sleep(for: .milliseconds(250))
-        } catch {
-          return
-        }
-        guard let self else { return }
-        await refreshIfIdle()
-      }
-    }
-  }
-
-  private func refreshIfIdle() async {
-    guard !isStopped, !isPointerDown else { return }
-    do {
-      _ = try await refreshViewport()
-    } catch is CancellationError {
-      // Stopping the preview cancels its refresh request.
-    } catch {
-      SnapOLog.ui.debug("Unable to refresh drag rotation: \(error.localizedDescription, privacy: .public)")
-    }
-  }
-
-  private func refreshViewport() async throws -> ADBDisplayViewport {
-    if let viewportRefresh { return try await viewportRefresh.value }
-    let task = Task { [adb, deviceID] in
-      let exec = await adb.exec()
-      return try await exec.displayViewport(deviceID: deviceID)
-    }
-    viewportRefresh = task
-    defer { viewportRefresh = nil }
-    do {
-      let viewport = try await task.value
-      guard !isStopped else { throw CancellationError() }
-      displayViewport = viewport
-      viewportUpdatedAt = .now
-      return viewport
-    } catch {
-      displayViewport = nil
-      throw error
-    }
   }
 
   func stop() async {
     guard !isStopped else { return }
     isStopped = true
-    idleRefresh?.cancel()
-    idleRefresh = nil
-    viewportRefresh?.cancel()
     touchscreen.close()
   }
 }

--- a/snapo-app-mac/SnapODeviceClient/Sources/SnapODeviceClient/ADB/ADBSocketConnection.swift
+++ b/snapo-app-mac/SnapODeviceClient/Sources/SnapODeviceClient/ADB/ADBSocketConnection.swift
@@ -47,6 +47,10 @@ public final class ADBSocketConnection {
     socketDescriptor = try Self.openSocket()
   }
 
+  init(connectedSocket: Int32) {
+    socketDescriptor = connectedSocket
+  }
+
   deinit {
     close()
   }
@@ -159,6 +163,21 @@ public final class ADBSocketConnection {
     let size = try readOnce(into: &scratch)
     if size == 0 { return nil }
     return Data(scratch.prefix(size))
+  }
+
+  func readChunk(maxLength: Int, deadline: ContinuousClock.Instant) throws -> Data? {
+    while true {
+      try Task.checkCancellation()
+      let remaining = ContinuousClock.now.duration(to: deadline)
+      guard remaining > .zero else { throw ADBError.requestTimedOut("Waiting for uinput acknowledgment") }
+      let parts = remaining.components
+      let milliseconds = parts.seconds * 1000 + parts.attoseconds / 1_000_000_000_000_000 + 1
+      var descriptor = pollfd(fd: socketDescriptor, events: Int16(POLLIN), revents: 0)
+      let result = Darwin.poll(&descriptor, 1, Int32(clamping: milliseconds))
+      if result > 0 { return try readChunk(maxLength: maxLength) }
+      if result == 0 { throw ADBError.requestTimedOut("Waiting for uinput acknowledgment") }
+      if errno != EINTR { throw Self.makeSocketError(errno, context: "poll") }
+    }
   }
 
   public func readLengthPrefixedPayload() throws -> Data? {

--- a/snapo-app-mac/SnapODeviceClient/Sources/SnapODeviceClient/ADB/ADBVirtualTouchscreen.swift
+++ b/snapo-app-mac/SnapODeviceClient/Sources/SnapODeviceClient/ADB/ADBVirtualTouchscreen.swift
@@ -14,21 +14,34 @@ public enum ADBVirtualTouchAction: Sendable {
   case cancel
 }
 
+public struct ADBDisplayViewport: Equatable, Sendable {
+  public let rotation: ADBDisplayRotation
+  public let width: Int
+  public let height: Int
+}
+
 /// A virtual direct-touch device backed by a persistent Android `uinput` process.
 public final class ADBVirtualTouchscreen: @unchecked Sendable {
-  public let initialDisplayRotation: ADBDisplayRotation
+  public let initialDisplayViewport: ADBDisplayViewport
+  public let supportsSynchronization: Bool
+  public var initialDisplayRotation: ADBDisplayRotation {
+    initialDisplayViewport.rotation
+  }
 
   private let connection: ADBSocketConnection
   private var activeGeometry: UInputTouchscreenProtocol.Geometry?
   private var nextTrackingID = 1
+  private var synchronizationSequence: UInt64 = 0
   private var isClosed = false
 
   fileprivate init(
     connection: ADBSocketConnection,
-    initialDisplayRotation: ADBDisplayRotation
+    initialDisplayViewport: ADBDisplayViewport,
+    supportsSynchronization: Bool
   ) {
     self.connection = connection
-    self.initialDisplayRotation = initialDisplayRotation
+    self.initialDisplayViewport = initialDisplayViewport
+    self.supportsSynchronization = supportsSynchronization
   }
 
   public func send(
@@ -57,7 +70,7 @@ public final class ADBVirtualTouchscreen: @unchecked Sendable {
       let point = geometry.rawPoint(x: x, y: y)
       let trackingID = nextTrackingID
       nextTrackingID = trackingID == UInputTouchscreenProtocol.maximumTrackingID ? 1 : trackingID + 1
-      try connection.writeLine(
+      try sendCommand(
         UInputTouchscreenProtocol.injectCommand(
           action: .down,
           point: point,
@@ -69,7 +82,7 @@ public final class ADBVirtualTouchscreen: @unchecked Sendable {
     case .move:
       guard let activeGeometry else { return }
       let point = activeGeometry.rawPoint(x: x, y: y)
-      try connection.writeLine(
+      try sendCommand(
         UInputTouchscreenProtocol.injectCommand(
           action: .move,
           point: point,
@@ -78,15 +91,30 @@ public final class ADBVirtualTouchscreen: @unchecked Sendable {
       )
 
     case .up, .cancel:
-      guard activeGeometry != nil else { return }
-      try connection.writeLine(
+      guard let activeGeometry else { return }
+      let finalPoint = action == .up ? activeGeometry.rawPoint(x: x, y: y) : nil
+      try sendCommand(
         UInputTouchscreenProtocol.injectCommand(
           action: action,
-          point: nil,
+          point: finalPoint,
           trackingID: nil
         )
       )
-      activeGeometry = nil
+      self.activeGeometry = nil
+    }
+  }
+
+  private func sendCommand(_ command: String) throws {
+    guard supportsSynchronization else {
+      try connection.writeLine(command)
+      return
+    }
+    synchronizationSequence &+= 1
+    let sync = UInputTouchscreenProtocol.synchronizationCommand(sequence: synchronizationSequence)
+    try connection.writeLine(command + "\n" + sync)
+    // The barrier confirms kernel injection, not handling or drawing by the Android app.
+    try UInputTouchscreenProtocol.waitForSynchronization(sequence: synchronizationSequence) {
+      try connection.readChunk(maxLength: $0, deadline: $1)
     }
   }
 
@@ -110,6 +138,8 @@ public final class ADBVirtualTouchscreen: @unchecked Sendable {
 public extension ADBClient {
   /// Starts a virtual touchscreen when the device's Android build exposes a usable `uinput` tool.
   func startVirtualTouchscreen(deviceID: String) async throws -> ADBVirtualTouchscreen {
+    let sdk = try await runShellString(deviceID: deviceID, command: "getprop ro.build.version.sdk")
+    let supportsSynchronization = UInputTouchscreenProtocol.supportsSynchronization(sdk: sdk)
     let identifier = UUID().uuidString
     let name = "Snap-O Live Preview \(identifier)"
     let port = "snapo:live-preview:\(identifier)"
@@ -120,10 +150,11 @@ public extension ADBClient {
       try connection.sendTransport(to: deviceID)
       try connection.sendShell("exec /system/bin/uinput -")
       try connection.writeLine(registerCommand)
-      let rotation = try await waitForVirtualTouchscreen(deviceID: deviceID, name: name)
+      let viewport = try await waitForVirtualTouchscreen(deviceID: deviceID, name: name)
       return ADBVirtualTouchscreen(
         connection: connection,
-        initialDisplayRotation: rotation
+        initialDisplayViewport: viewport,
+        supportsSynchronization: supportsSynchronization
       )
     } catch {
       connection.close()
@@ -132,20 +163,24 @@ public extension ADBClient {
   }
 
   func displayRotation(deviceID: String) async throws -> ADBDisplayRotation {
+    try await displayViewport(deviceID: deviceID).rotation
+  }
+
+  func displayViewport(deviceID: String) async throws -> ADBDisplayViewport {
     let output = try await runShellString(
       deviceID: deviceID,
       command: "dumpsys input | grep -m 1 'Viewport INTERNAL: displayId=0'"
     )
-    guard let rotation = UInputTouchscreenProtocol.displayRotation(from: output) else {
-      throw ADBError.parseFailure("Unable to determine display rotation")
+    guard let viewport = UInputTouchscreenProtocol.displayViewport(from: output) else {
+      throw ADBError.parseFailure("Unable to determine display viewport")
     }
-    return rotation
+    return viewport
   }
 
   private func waitForVirtualTouchscreen(
     deviceID: String,
     name: String
-  ) async throws -> ADBDisplayRotation {
+  ) async throws -> ADBDisplayViewport {
     let clock = ContinuousClock()
     let deadline = clock.now.advanced(by: .seconds(2))
 
@@ -153,8 +188,8 @@ public extension ADBClient {
       try Task.checkCancellation()
       let output = try await runShellString(deviceID: deviceID, command: "dumpsys input")
       if UInputTouchscreenProtocol.isRegisteredTouchscreen(named: name, in: output),
-         let rotation = UInputTouchscreenProtocol.displayRotation(from: output) {
-        return rotation
+         let viewport = UInputTouchscreenProtocol.displayViewport(from: output) {
+        return viewport
       }
       guard clock.now < deadline else { break }
       try await Task.sleep(for: .milliseconds(50))
@@ -167,6 +202,49 @@ public extension ADBClient {
 enum UInputTouchscreenProtocol {
   static let maximumAxisValue = 32767
   static let maximumTrackingID = 65535
+
+  static func supportsSynchronization(sdk: String) -> Bool {
+    // The JSON sync command is available from Android 15. Older tools retain paced writes.
+    (Int(sdk.trimmingCharacters(in: .whitespacesAndNewlines)) ?? 0) >= 35
+  }
+
+  static func synchronizationCommand(sequence: UInt64) -> String {
+    #"{"id":1,"command":"sync","syncToken":""# + String(sequence) + #""}"#
+  }
+
+  static func waitForSynchronization(
+    sequence: UInt64,
+    readChunk: (Int, ContinuousClock.Instant) throws -> Data?
+  ) throws {
+    struct Response: Decodable {
+      let reason: String
+      let id: Int
+      let syncToken: String
+    }
+
+    let deadline = ContinuousClock.now.advanced(by: .milliseconds(500))
+    let maximumResponseBytes = 1024
+    let decoder = JSONDecoder()
+    var response = Data()
+    while response.count < maximumResponseBytes {
+      try Task.checkCancellation()
+      guard ContinuousClock.now < deadline else {
+        throw ADBError.requestTimedOut("Waiting for uinput acknowledgment")
+      }
+      guard let chunk = try readChunk(maximumResponseBytes - response.count, deadline), !chunk.isEmpty else {
+        throw ADBError.protocolFailure("uinput closed before acknowledging injection")
+      }
+      response.append(chunk)
+      // uinput writes JSON objects without newline delimiters.
+      if let decoded = try? decoder.decode(Response.self, from: response) {
+        guard decoded.reason == "sync", decoded.id == 1, decoded.syncToken == String(sequence) else {
+          throw ADBError.protocolFailure("Unexpected uinput acknowledgment")
+        }
+        return
+      }
+    }
+    throw ADBError.protocolFailure("Invalid or oversized uinput acknowledgment")
+  }
 
   struct Point: Equatable {
     let x: Int
@@ -236,6 +314,13 @@ enum UInputTouchscreenProtocol {
     point: Point?,
     trackingID: Int?
   ) -> String {
+    let liftEvents = [
+      3, 47, 0,
+      3, 57, -1,
+      1, 330, 0,
+      1, 325, 0,
+      0, 0, 0
+    ]
     let events: [Int] = switch action {
     case .down:
       if let point, let trackingID {
@@ -263,13 +348,12 @@ enum UInputTouchscreenProtocol {
         []
       }
     case .up, .cancel:
-      [
-        3, 47, 0,
-        3, 57, -1,
-        1, 330, 0,
-        1, 325, 0,
-        0, 0, 0
-      ]
+      if action == .up, let point {
+        // InputReader must see the final position while the contact is still active.
+        [3, 47, 0, 3, 53, point.x, 3, 54, point.y, 0, 0, 0] + liftEvents
+      } else {
+        liftEvents
+      }
     }
     let values = events.map(String.init).joined(separator: ",")
     return #"{"id":1,"command":"inject","events":["# + values + "]}"
@@ -283,6 +367,18 @@ enum UInputTouchscreenProtocol {
     let suffix = viewport[marker.upperBound...]
     guard let value = suffix.first?.wholeNumberValue else { return nil }
     return ADBDisplayRotation(rawValue: value)
+  }
+
+  static func displayViewport(from output: String) -> ADBDisplayViewport? {
+    guard let line = output.split(separator: "\n").first(where: {
+      $0.contains("Viewport INTERNAL: displayId=0")
+    }),
+      let rotation = displayRotation(from: String(line)),
+      let frame = line.firstMatch(of: /logicalFrame=\[\s*(\d+),\s*(\d+),\s*(\d+),\s*(\d+)\]/),
+      let left = Int(frame.1), let top = Int(frame.2),
+      let right = Int(frame.3), let bottom = Int(frame.4),
+      right > left, bottom > top else { return nil }
+    return ADBDisplayViewport(rotation: rotation, width: right - left, height: bottom - top)
   }
 
   static func isRegisteredTouchscreen(named name: String, in output: String) -> Bool {

--- a/snapo-app-mac/SnapODeviceClient/Sources/SnapODeviceClient/ADB/ADBVirtualTouchscreen.swift
+++ b/snapo-app-mac/SnapODeviceClient/Sources/SnapODeviceClient/ADB/ADBVirtualTouchscreen.swift
@@ -14,19 +14,10 @@ public enum ADBVirtualTouchAction: Sendable {
   case cancel
 }
 
-public struct ADBDisplayViewport: Equatable, Sendable {
-  public let rotation: ADBDisplayRotation
-  public let width: Int
-  public let height: Int
-}
-
 /// A virtual direct-touch device backed by a persistent Android `uinput` process.
 public final class ADBVirtualTouchscreen: @unchecked Sendable {
-  public let initialDisplayViewport: ADBDisplayViewport
+  public let initialDisplayRotation: ADBDisplayRotation
   public let supportsSynchronization: Bool
-  public var initialDisplayRotation: ADBDisplayRotation {
-    initialDisplayViewport.rotation
-  }
 
   private let connection: ADBSocketConnection
   private var activeGeometry: UInputTouchscreenProtocol.Geometry?
@@ -36,11 +27,11 @@ public final class ADBVirtualTouchscreen: @unchecked Sendable {
 
   fileprivate init(
     connection: ADBSocketConnection,
-    initialDisplayViewport: ADBDisplayViewport,
+    initialDisplayRotation: ADBDisplayRotation,
     supportsSynchronization: Bool
   ) {
     self.connection = connection
-    self.initialDisplayViewport = initialDisplayViewport
+    self.initialDisplayRotation = initialDisplayRotation
     self.supportsSynchronization = supportsSynchronization
   }
 
@@ -150,10 +141,10 @@ public extension ADBClient {
       try connection.sendTransport(to: deviceID)
       try connection.sendShell("exec /system/bin/uinput -")
       try connection.writeLine(registerCommand)
-      let viewport = try await waitForVirtualTouchscreen(deviceID: deviceID, name: name)
+      let rotation = try await waitForVirtualTouchscreen(deviceID: deviceID, name: name)
       return ADBVirtualTouchscreen(
         connection: connection,
-        initialDisplayViewport: viewport,
+        initialDisplayRotation: rotation,
         supportsSynchronization: supportsSynchronization
       )
     } catch {
@@ -163,24 +154,20 @@ public extension ADBClient {
   }
 
   func displayRotation(deviceID: String) async throws -> ADBDisplayRotation {
-    try await displayViewport(deviceID: deviceID).rotation
-  }
-
-  func displayViewport(deviceID: String) async throws -> ADBDisplayViewport {
     let output = try await runShellString(
       deviceID: deviceID,
       command: "dumpsys input | grep -m 1 'Viewport INTERNAL: displayId=0'"
     )
-    guard let viewport = UInputTouchscreenProtocol.displayViewport(from: output) else {
-      throw ADBError.parseFailure("Unable to determine display viewport")
+    guard let rotation = UInputTouchscreenProtocol.displayRotation(from: output) else {
+      throw ADBError.parseFailure("Unable to determine display rotation")
     }
-    return viewport
+    return rotation
   }
 
   private func waitForVirtualTouchscreen(
     deviceID: String,
     name: String
-  ) async throws -> ADBDisplayViewport {
+  ) async throws -> ADBDisplayRotation {
     let clock = ContinuousClock()
     let deadline = clock.now.advanced(by: .seconds(2))
 
@@ -188,8 +175,8 @@ public extension ADBClient {
       try Task.checkCancellation()
       let output = try await runShellString(deviceID: deviceID, command: "dumpsys input")
       if UInputTouchscreenProtocol.isRegisteredTouchscreen(named: name, in: output),
-         let viewport = UInputTouchscreenProtocol.displayViewport(from: output) {
-        return viewport
+         let rotation = UInputTouchscreenProtocol.displayRotation(from: output) {
+        return rotation
       }
       guard clock.now < deadline else { break }
       try await Task.sleep(for: .milliseconds(50))
@@ -367,18 +354,6 @@ enum UInputTouchscreenProtocol {
     let suffix = viewport[marker.upperBound...]
     guard let value = suffix.first?.wholeNumberValue else { return nil }
     return ADBDisplayRotation(rawValue: value)
-  }
-
-  static func displayViewport(from output: String) -> ADBDisplayViewport? {
-    guard let line = output.split(separator: "\n").first(where: {
-      $0.contains("Viewport INTERNAL: displayId=0")
-    }),
-      let rotation = displayRotation(from: String(line)),
-      let frame = line.firstMatch(of: /logicalFrame=\[\s*(\d+),\s*(\d+),\s*(\d+),\s*(\d+)\]/),
-      let left = Int(frame.1), let top = Int(frame.2),
-      let right = Int(frame.3), let bottom = Int(frame.4),
-      right > left, bottom > top else { return nil }
-    return ADBDisplayViewport(rotation: rotation, width: right - left, height: bottom - top)
   }
 
   static func isRegisteredTouchscreen(named name: String, in output: String) -> Bool {

--- a/snapo-app-mac/SnapODeviceClient/Tests/SnapODeviceClientTests/ADBVirtualTouchscreenTests.swift
+++ b/snapo-app-mac/SnapODeviceClient/Tests/SnapODeviceClientTests/ADBVirtualTouchscreenTests.swift
@@ -1,3 +1,4 @@
+import Darwin
 import Foundation
 @testable import SnapODeviceClient
 import Testing
@@ -33,6 +34,85 @@ struct ADBVirtualTouchscreenTests {
 
     #expect(command.contains(#""type":100,"data":[1,3]"#))
     #expect(command.contains(#""type":101,"data":[330,325]"#))
+  }
+
+  @Test("only enables acknowledgments on supported Android versions")
+  func synchronizationSupport() {
+    #expect(!UInputTouchscreenProtocol.supportsSynchronization(sdk: "34"))
+    #expect(!UInputTouchscreenProtocol.supportsSynchronization(sdk: "unknown"))
+    #expect(UInputTouchscreenProtocol.supportsSynchronization(sdk: "35\n"))
+    #expect(UInputTouchscreenProtocol.supportsSynchronization(sdk: "37"))
+  }
+
+  @Test("matches a fragmented acknowledgment without a newline")
+  func synchronizationResponse() throws {
+    let command = try JSONSerialization.jsonObject(
+      with: Data(UInputTouchscreenProtocol.synchronizationCommand(sequence: 42).utf8)
+    ) as? [String: Any]
+    #expect(command?["command"] as? String == "sync")
+    #expect(command?["syncToken"] as? String == "42")
+
+    var chunks = [Data(#"{"reason":"syn"#.utf8), Data(#"c","id":1,"syncToken":"42"}"#.utf8)]
+    var deadlines: [ContinuousClock.Instant] = []
+    try UInputTouchscreenProtocol.waitForSynchronization(sequence: 42) { limit, deadline in
+      deadlines.append(deadline)
+      #expect(limit <= 1024)
+      return chunks.removeFirst()
+    }
+    #expect(chunks.isEmpty)
+    #expect(deadlines.count == 2 && deadlines[0] == deadlines[1])
+  }
+
+  @Test("rejects wrong tokens and bounds invalid acknowledgment data")
+  func invalidSynchronizationResponse() {
+    #expect(throws: (any Error).self) {
+      try UInputTouchscreenProtocol.waitForSynchronization(sequence: 42) { _, _ in
+        Data(#"{"reason":"sync","id":1,"syncToken":"41"}"#.utf8)
+      }
+    }
+    var bytesRead = 0
+    #expect(throws: (any Error).self) {
+      try UInputTouchscreenProtocol.waitForSynchronization(sequence: 42) { limit, _ in
+        let count = min(128, limit)
+        bytesRead += count
+        return Data(repeating: UInt8(ascii: "x"), count: count)
+      }
+    }
+    #expect(bytesRead == 1024)
+  }
+
+  @Test("does not accept a closed or timed-out acknowledgment stream")
+  func missingSynchronizationResponse() {
+    #expect(throws: (any Error).self) {
+      try UInputTouchscreenProtocol.waitForSynchronization(sequence: 1) { _, _ in nil }
+    }
+    #expect(throws: (any Error).self) {
+      try UInputTouchscreenProtocol.waitForSynchronization(sequence: 1) { _, _ in
+        throw ADBError.requestTimedOut("Test timeout")
+      }
+    }
+  }
+
+  @Test("socket acknowledgments time out and accept data when readable")
+  func synchronizationSocketDeadline() throws {
+    var descriptors: [Int32] = [-1, -1]
+    try #require(socketpair(AF_UNIX, SOCK_STREAM, 0, &descriptors) == 0)
+    let connection = ADBSocketConnection(connectedSocket: descriptors[0])
+    defer {
+      connection.close()
+      Darwin.close(descriptors[1])
+    }
+    #expect(throws: (any Error).self) {
+      try connection.readChunk(maxLength: 1024, deadline: .now.advanced(by: .milliseconds(5)))
+    }
+    let response = Data(#"{"reason":"sync","id":1,"syncToken":"7"}"#.utf8)
+    let written = response.withUnsafeBytes {
+      Darwin.write(descriptors[1], $0.baseAddress, $0.count)
+    }
+    #expect(written == response.count)
+    try UInputTouchscreenProtocol.waitForSynchronization(sequence: 7) {
+      try connection.readChunk(maxLength: $0, deadline: $1)
+    }
   }
 
   @Test("maps logical coordinates through display rotation")
@@ -150,6 +230,34 @@ struct ADBVirtualTouchscreenTests {
     let viewport = "Viewport INTERNAL: displayId=0, port=0, orientation=3, logicalFrame=[0, 0, 2400, 1080]"
     #expect(UInputTouchscreenProtocol.displayRotation(from: viewport) == .rotation270)
     #expect(UInputTouchscreenProtocol.displayRotation(from: "orientation=unknown") == nil)
+  }
+
+  @Test("sends the final position before lifting but does not move on cancel")
+  func releasePosition() throws {
+    let point = UInputTouchscreenProtocol.Point(x: 321, y: 654)
+    let up = try decodeInject(UInputTouchscreenProtocol.injectCommand(action: .up, point: point, trackingID: nil))
+    let cancel = try decodeInject(UInputTouchscreenProtocol.injectCommand(action: .cancel, point: point, trackingID: nil))
+    #expect(up.events == [
+      3, 47, 0, 3, 53, 321, 3, 54, 654, 0, 0, 0,
+      3, 47, 0, 3, 57, -1, 1, 330, 0, 1, 325, 0, 0, 0, 0
+    ])
+    #expect(cancel.events == Array(up.events.suffix(15)))
+  }
+
+  @Test("parses viewport size and rotation from the same internal display")
+  func displayViewport() throws {
+    let output = """
+    Viewport EXTERNAL: displayId=1, orientation=1, logicalFrame=[0, 0, 900, 600]
+    Viewport INTERNAL: displayId=0, orientation=3, logicalFrame=[10, 20, 2410, 1100]
+    """
+    let viewport = try #require(UInputTouchscreenProtocol.displayViewport(from: output))
+    #expect(viewport.rotation == .rotation270)
+    #expect(viewport.width == 2400)
+    #expect(viewport.height == 1080)
+    #expect(UInputTouchscreenProtocol.displayViewport(from: "Viewport INTERNAL: displayId=0, orientation=0") == nil)
+    #expect(UInputTouchscreenProtocol.displayViewport(
+      from: "Viewport INTERNAL: displayId=0, orientation=0, logicalFrame=[0, 0, 0, 1080]"
+    ) == nil)
   }
 
   private func decodeInject(_ value: String) throws -> InjectCommand {

--- a/snapo-app-mac/SnapODeviceClient/Tests/SnapODeviceClientTests/ADBVirtualTouchscreenTests.swift
+++ b/snapo-app-mac/SnapODeviceClient/Tests/SnapODeviceClientTests/ADBVirtualTouchscreenTests.swift
@@ -227,8 +227,14 @@ struct ADBVirtualTouchscreenTests {
 
   @Test("parses the active display rotation")
   func displayRotation() {
-    let viewport = "Viewport INTERNAL: displayId=0, port=0, orientation=3, logicalFrame=[0, 0, 2400, 1080]"
+    let viewport = """
+    Viewport EXTERNAL: displayId=1, orientation=1, logicalFrame=[0, 0, 900, 600]
+    Viewport INTERNAL: displayId=0, port=0, orientation=3, logicalFrame=[0, 0, 2400, 1080]
+    """
     #expect(UInputTouchscreenProtocol.displayRotation(from: viewport) == .rotation270)
+    #expect(UInputTouchscreenProtocol.displayRotation(
+      from: "Viewport INTERNAL: displayId=0, orientation=2"
+    ) == .rotation180)
     #expect(UInputTouchscreenProtocol.displayRotation(from: "orientation=unknown") == nil)
   }
 
@@ -242,22 +248,6 @@ struct ADBVirtualTouchscreenTests {
       3, 47, 0, 3, 57, -1, 1, 330, 0, 1, 325, 0, 0, 0, 0
     ])
     #expect(cancel.events == Array(up.events.suffix(15)))
-  }
-
-  @Test("parses viewport size and rotation from the same internal display")
-  func displayViewport() throws {
-    let output = """
-    Viewport EXTERNAL: displayId=1, orientation=1, logicalFrame=[0, 0, 900, 600]
-    Viewport INTERNAL: displayId=0, orientation=3, logicalFrame=[10, 20, 2410, 1100]
-    """
-    let viewport = try #require(UInputTouchscreenProtocol.displayViewport(from: output))
-    #expect(viewport.rotation == .rotation270)
-    #expect(viewport.width == 2400)
-    #expect(viewport.height == 1080)
-    #expect(UInputTouchscreenProtocol.displayViewport(from: "Viewport INTERNAL: displayId=0, orientation=0") == nil)
-    #expect(UInputTouchscreenProtocol.displayViewport(
-      from: "Viewport INTERNAL: displayId=0, orientation=0, logicalFrame=[0, 0, 0, 1080]"
-    ) == nil)
   }
 
   private func decodeInject(_ value: String) throws -> InjectCommand {

--- a/snapo-app-mac/Tests/LivePreviewPointer/DeviceClientDouble.swift
+++ b/snapo-app-mac/Tests/LivePreviewPointer/DeviceClientDouble.swift
@@ -1,0 +1,98 @@
+import Foundation
+
+public enum ADBDisplayRotation: Sendable { case rotation0, rotation90, rotation180, rotation270 }
+public enum ADBVirtualTouchAction: Sendable { case down, move, up, cancel }
+public enum ADBError: Error { case protocolFailure(String) }
+
+public struct ADBDisplayViewport: Sendable {
+  public let rotation: ADBDisplayRotation
+  public let width: Int
+  public let height: Int
+
+  public init(rotation: ADBDisplayRotation = .rotation0, width: Int = 100, height: Int = 200) {
+    self.rotation = rotation
+    self.width = width
+    self.height = height
+  }
+}
+
+public final class ADBVirtualTouchscreen: @unchecked Sendable {
+  public let supportsSynchronization = true
+  public let initialDisplayViewport = ADBDisplayViewport()
+  private let lock = NSLock()
+  private var recordedActions: [ADBVirtualTouchAction] = []
+  private var recordedRotations: [ADBDisplayRotation] = []
+  private var closed = false
+
+  public init() {}
+
+  public var actions: [ADBVirtualTouchAction] {
+    lock.withLock { recordedActions }
+  }
+
+  public var rotations: [ADBDisplayRotation] {
+    lock.withLock { recordedRotations }
+  }
+
+  public var isClosed: Bool {
+    lock.withLock { closed }
+  }
+
+  public func send(
+    action: ADBVirtualTouchAction, x: Double, y: Double,
+    displayWidth: Double, displayHeight: Double, rotation: ADBDisplayRotation
+  ) throws {
+    try lock.withLock {
+      guard !closed else { throw CancellationError() }
+      recordedActions.append(action)
+      recordedRotations.append(rotation)
+    }
+  }
+
+  public func close() {
+    lock.withLock { closed = true }
+  }
+}
+
+public actor ADBClient {
+  public let touchscreen = ADBVirtualTouchscreen()
+  public private(set) var queryCount = 0
+  private var viewport = ADBDisplayViewport()
+  private var queryGate: CheckedContinuation<Void, Never>?
+  private var shouldHoldQuery = false
+  private var shouldFail = false
+
+  public init() {}
+
+  public func startVirtualTouchscreen(deviceID: String) throws -> ADBVirtualTouchscreen {
+    touchscreen
+  }
+
+  public func setViewport(_ viewport: ADBDisplayViewport) {
+    self.viewport = viewport
+  }
+
+  public func holdQuery() {
+    shouldHoldQuery = true
+  }
+
+  public func failQueries() {
+    shouldFail = true
+  }
+
+  public func releaseQuery() {
+    shouldHoldQuery = false
+    queryGate?.resume()
+    queryGate = nil
+  }
+
+  public func displayViewport(deviceID: String) async throws -> ADBDisplayViewport {
+    queryCount += 1
+    if shouldHoldQuery {
+      await withCheckedContinuation { queryGate = $0 }
+    }
+    try Task.checkCancellation()
+    if shouldFail { throw ADBError.protocolFailure("Test viewport unavailable") }
+    return viewport
+  }
+}

--- a/snapo-app-mac/Tests/LivePreviewPointer/DeviceClientDouble.swift
+++ b/snapo-app-mac/Tests/LivePreviewPointer/DeviceClientDouble.swift
@@ -4,21 +4,9 @@ public enum ADBDisplayRotation: Sendable { case rotation0, rotation90, rotation1
 public enum ADBVirtualTouchAction: Sendable { case down, move, up, cancel }
 public enum ADBError: Error { case protocolFailure(String) }
 
-public struct ADBDisplayViewport: Sendable {
-  public let rotation: ADBDisplayRotation
-  public let width: Int
-  public let height: Int
-
-  public init(rotation: ADBDisplayRotation = .rotation0, width: Int = 100, height: Int = 200) {
-    self.rotation = rotation
-    self.width = width
-    self.height = height
-  }
-}
-
 public final class ADBVirtualTouchscreen: @unchecked Sendable {
   public let supportsSynchronization = true
-  public let initialDisplayViewport = ADBDisplayViewport()
+  public let initialDisplayRotation = ADBDisplayRotation.rotation0
   private let lock = NSLock()
   private var recordedActions: [ADBVirtualTouchAction] = []
   private var recordedRotations: [ADBDisplayRotation] = []
@@ -57,7 +45,7 @@ public final class ADBVirtualTouchscreen: @unchecked Sendable {
 public actor ADBClient {
   public let touchscreen = ADBVirtualTouchscreen()
   public private(set) var queryCount = 0
-  private var viewport = ADBDisplayViewport()
+  private var rotation = ADBDisplayRotation.rotation0
   private var queryGate: CheckedContinuation<Void, Never>?
   private var shouldHoldQuery = false
   private var shouldFail = false
@@ -68,8 +56,8 @@ public actor ADBClient {
     touchscreen
   }
 
-  public func setViewport(_ viewport: ADBDisplayViewport) {
-    self.viewport = viewport
+  public func setRotation(_ rotation: ADBDisplayRotation) {
+    self.rotation = rotation
   }
 
   public func holdQuery() {
@@ -86,13 +74,13 @@ public actor ADBClient {
     queryGate = nil
   }
 
-  public func displayViewport(deviceID: String) async throws -> ADBDisplayViewport {
+  public func displayRotation(deviceID: String) async throws -> ADBDisplayRotation {
     queryCount += 1
     if shouldHoldQuery {
       await withCheckedContinuation { queryGate = $0 }
     }
     try Task.checkCancellation()
-    if shouldFail { throw ADBError.protocolFailure("Test viewport unavailable") }
-    return viewport
+    if shouldFail { throw ADBError.protocolFailure("Test rotation unavailable") }
+    return rotation
   }
 }

--- a/snapo-app-mac/Tests/LivePreviewPointer/LivePreviewPointerTests.swift
+++ b/snapo-app-mac/Tests/LivePreviewPointer/LivePreviewPointerTests.swift
@@ -127,12 +127,12 @@ struct LivePreviewPointerTests {
         await reconnectIgnoresOldSend(action, failing: failing)
       }
     }
-    try await freshRotationDoesNotQueryOnDown()
-    try await activeDragPausesRefreshAndNextDragChecksStaleRotation()
+    try await rotationIsQueriedOncePerGesture()
+    try await rotationStaysFixedUntilNextGesture()
     try await changedSizeRefreshesBeforeDown()
-    try await idleRefreshFindsHalfTurn()
-    try await stopDuringRefreshDoesNotSend()
-    try await failedRefreshDoesNotReuseOldRotation()
+    try await immediateHalfTurnRefreshesBeforeDown()
+    try await stopDuringRotationQueryDoesNotSend()
+    try await failedRotationQueryDoesNotReuseOldRotation()
     print("Live preview pointer tests passed (23 cases)")
   }
 
@@ -371,7 +371,7 @@ struct LivePreviewPointerTests {
     await sender.stopAll()
   }
 
-  private static func freshRotationDoesNotQueryOnDown() async throws {
+  private static func rotationIsQueriedOncePerGesture() async throws {
     let client = ADBClient()
     let backend = try await UInputLivePreviewPointerBackend.start(adb: ADBService(client: client), deviceID: "test-device")
     precondition(backend.minimumMoveInterval == .nanoseconds(8_333_334))
@@ -379,7 +379,7 @@ struct LivePreviewPointerTests {
     try await backend.send(event(.move, x: 20))
     try await backend.send(event(.up, x: 30))
     let count = await client.queryCount
-    precondition(count == 0)
+    precondition(count == 1)
     let touchscreen = await client.touchscreen
     precondition(touchscreen.actions == [.down, .move, .up])
     await backend.stop()
@@ -387,7 +387,7 @@ struct LivePreviewPointerTests {
 
   private static func changedSizeRefreshesBeforeDown() async throws {
     let client = ADBClient()
-    await client.setViewport(ADBDisplayViewport(rotation: .rotation90, width: 200, height: 100))
+    await client.setRotation(.rotation90)
     let backend = try await UInputLivePreviewPointerBackend.start(adb: ADBService(client: client), deviceID: "test-device")
     try await backend.send(event(.down, size: CGSize(width: 200, height: 100)))
     let count = await client.queryCount
@@ -396,41 +396,45 @@ struct LivePreviewPointerTests {
     await backend.stop()
   }
 
-  private static func activeDragPausesRefreshAndNextDragChecksStaleRotation() async throws {
+  private static func rotationStaysFixedUntilNextGesture() async throws {
     let client = ADBClient()
     let backend = try await UInputLivePreviewPointerBackend.start(adb: ADBService(client: client), deviceID: "test-device")
     try await backend.send(event(.down))
-    await client.setViewport(ADBDisplayViewport(rotation: .rotation180))
-    try await Task.sleep(for: .milliseconds(1050))
+    await client.setRotation(.rotation180)
     try await backend.send(event(.move, x: 20))
-    let idleQueries = await client.queryCount
-    precondition(idleQueries == 0)
+    let activeQueries = await client.queryCount
+    precondition(activeQueries == 1)
     try await backend.send(event(.up))
     try await backend.send(event(.down))
     let count = await client.queryCount
     let touchscreen = await client.touchscreen
-    precondition(count == 1)
+    precondition(count == 2)
     precondition(touchscreen.rotations == [.rotation0, .rotation0, .rotation0, .rotation180])
     await backend.stop()
   }
 
-  private static func idleRefreshFindsHalfTurn() async throws {
+  private static func immediateHalfTurnRefreshesBeforeDown() async throws {
     let client = ADBClient()
     let backend = try await UInputLivePreviewPointerBackend.start(adb: ADBService(client: client), deviceID: "test-device")
-    await client.setViewport(ADBDisplayViewport(rotation: .rotation180))
-    await waitUntil { await client.queryCount > 0 }
     try await backend.send(event(.down))
+    try await backend.send(event(.up))
+    await client.setRotation(.rotation180)
+    try await backend.send(event(.down))
+    try await backend.send(event(.move, x: 20))
+    try await backend.send(event(.up, x: 30))
+    let count = await client.queryCount
     let touchscreen = await client.touchscreen
-    precondition(touchscreen.rotations == [.rotation180])
+    precondition(count == 2)
+    precondition(touchscreen.rotations == [.rotation0, .rotation0, .rotation180, .rotation180, .rotation180])
     await backend.stop()
   }
 
-  private static func stopDuringRefreshDoesNotSend() async throws {
+  private static func stopDuringRotationQueryDoesNotSend() async throws {
     let client = ADBClient()
     await client.holdQuery()
     let backend = try await UInputLivePreviewPointerBackend.start(adb: ADBService(client: client), deviceID: "test-device")
-    await waitUntil { await client.queryCount > 0 }
     let send = Task { try await backend.send(event(.down)) }
+    await waitUntil { await client.queryCount == 1 }
     await backend.stop()
     await client.releaseQuery()
     do {
@@ -441,17 +445,20 @@ struct LivePreviewPointerTests {
     precondition(touchscreen.actions.isEmpty && touchscreen.isClosed)
   }
 
-  private static func failedRefreshDoesNotReuseOldRotation() async throws {
+  private static func failedRotationQueryDoesNotReuseOldRotation() async throws {
     let client = ADBClient()
     let backend = try await UInputLivePreviewPointerBackend.start(adb: ADBService(client: client), deviceID: "test-device")
+    try await backend.send(event(.down))
+    try await backend.send(event(.up))
+    await client.setRotation(.rotation180)
     await client.failQueries()
-    await waitUntil { await client.queryCount > 0 }
     do {
       try await backend.send(event(.down))
-      preconditionFailure("Failed refresh reused an old rotation")
+      preconditionFailure("Failed query reused an old rotation")
     } catch ADBError.protocolFailure {}
     let touchscreen = await client.touchscreen
-    precondition(touchscreen.actions.isEmpty)
+    let count = await client.queryCount
+    precondition(count == 2 && touchscreen.actions == [.down, .up])
     await backend.stop()
   }
 }

--- a/snapo-app-mac/Tests/LivePreviewPointer/LivePreviewPointerTests.swift
+++ b/snapo-app-mac/Tests/LivePreviewPointer/LivePreviewPointerTests.swift
@@ -20,8 +20,10 @@ struct ShellLivePreviewPointerBackend: LivePreviewPointerBackend {
 private actor RecordingBackend: LivePreviewPointerBackend {
   let minimumMoveInterval: Duration
   private(set) var events: [LivePreviewPointerEvent] = []
+  private(set) var isStopped = false
   private var gate: CheckedContinuation<Void, Never>?
   private var holdFirstSend: Bool
+  private var failNextSend = false
 
   init(holdFirstSend: Bool = false, minimumMoveInterval: Duration = .nanoseconds(16_666_667)) {
     self.holdFirstSend = holdFirstSend
@@ -29,16 +31,44 @@ private actor RecordingBackend: LivePreviewPointerBackend {
   }
 
   func send(_ event: LivePreviewPointerEvent) async throws {
+    let shouldFail = failNextSend
+    failNextSend = false
     events.append(event)
     if holdFirstSend {
       holdFirstSend = false
       await withCheckedContinuation { gate = $0 }
     }
+    if shouldFail { throw ADBError.protocolFailure("Test send failed") }
+  }
+
+  func holdNextSend(failing: Bool) {
+    holdFirstSend = true
+    failNextSend = failing
+  }
+
+  func resetEvents() {
+    events.removeAll()
+  }
+
+  func stop() async {
+    isStopped = true
   }
 
   func release() {
     gate?.resume()
     gate = nil
+  }
+}
+
+private actor BackendSequence {
+  private var backends: [RecordingBackend]
+
+  init(_ backends: [RecordingBackend]) {
+    self.backends = backends
+  }
+
+  func next() -> RecordingBackend {
+    backends.removeFirst()
   }
 }
 
@@ -88,13 +118,22 @@ struct LivePreviewPointerTests {
     await gestureBoundariesStayOrdered()
     await stopDiscardsWaitingMove()
     await hoverIsNotPaced()
+    for endAction in [LivePreviewPointerAction.up, .cancel] {
+      await preferredGestureEnds(endAction)
+    }
+    for action in [LivePreviewPointerAction.move, .up, .cancel] {
+      await preferredFailureWaitsForNextGesture(action)
+      for failing in [false, true] {
+        await reconnectIgnoresOldSend(action, failing: failing)
+      }
+    }
     try await freshRotationDoesNotQueryOnDown()
     try await activeDragPausesRefreshAndNextDragChecksStaleRotation()
     try await changedSizeRefreshesBeforeDown()
     try await idleRefreshFindsHalfTurn()
     try await stopDuringRefreshDoesNotSend()
     try await failedRefreshDoesNotReuseOldRotation()
-    print("Live preview pointer tests passed (12 cases)")
+    print("Live preview pointer tests passed (23 cases)")
   }
 
   private static func event(
@@ -233,6 +272,102 @@ struct LivePreviewPointerTests {
     await sender.enqueue(event(.move, x: 2, source: .mouse))
     await waitUntil { await backend.events.count == 2 }
     precondition(!clock.isSleeping)
+    await sender.stopAll()
+  }
+
+  private static func preparePreferredBackend(
+    _ sender: LivePreviewPointerInjector, preferred: RecordingBackend, fallback: RecordingBackend
+  ) async {
+    await sender.prepare(deviceID: "test-device")
+    let deadline = ContinuousClock.now.advanced(by: .seconds(5))
+    // Preparation is asynchronous; complete taps until the preferred backend accepts one.
+    while await preferred.events.isEmpty {
+      precondition(ContinuousClock.now < deadline, "Preferred backend never became ready")
+      let fallbackCount = await fallback.events.count
+      await sender.enqueue(event(.down))
+      await sender.enqueue(event(.up))
+      await waitUntil {
+        let preferredCount = await preferred.events.count
+        let count = await fallback.events.count
+        return preferredCount == 2 || count == fallbackCount + 2
+      }
+    }
+    await preferred.resetEvents()
+    await fallback.resetEvents()
+  }
+
+  private static func preferredGestureEnds(_ endAction: LivePreviewPointerAction) async {
+    let preferred = RecordingBackend(minimumMoveInterval: .zero)
+    let fallback = RecordingBackend(minimumMoveInterval: .zero)
+    let sender = LivePreviewPointerInjector(makePreferredBackend: { _ in preferred }, fallbackBackend: fallback)
+    await preparePreferredBackend(sender, preferred: preferred, fallback: fallback)
+    let actions: [LivePreviewPointerAction] = [.down, .move, endAction, .down, .up]
+    for action in actions {
+      await sender.enqueue(event(action))
+    }
+    await waitUntil { await preferred.events.count == actions.count }
+    let sent = await preferred.events
+    let fallbackEvents = await fallback.events
+    precondition(sent.map(\.action) == actions && fallbackEvents.isEmpty)
+    await sender.stopAll()
+  }
+
+  private static func preferredFailureWaitsForNextGesture(_ action: LivePreviewPointerAction) async {
+    let preferred = RecordingBackend(minimumMoveInterval: .zero)
+    let fallback = RecordingBackend(minimumMoveInterval: .zero)
+    let sender = LivePreviewPointerInjector(makePreferredBackend: { _ in preferred }, fallbackBackend: fallback)
+    await preparePreferredBackend(sender, preferred: preferred, fallback: fallback)
+    await sender.enqueue(event(.down))
+    await waitUntil { await preferred.events.count == 1 }
+    await preferred.holdNextSend(failing: true)
+    await sender.enqueue(event(action))
+    await waitUntil { await preferred.events.count == 2 }
+    if action == .move {
+      await sender.enqueue(event(.move, x: 1))
+      await sender.enqueue(event(.up))
+    }
+    for nextAction in [LivePreviewPointerAction.down, .move, .up] {
+      await sender.enqueue(event(nextAction))
+    }
+    await preferred.release()
+    await waitUntil { await fallback.events.count == 3 }
+    let preferredEvents = await preferred.events
+    let fallbackEvents = await fallback.events
+    let stopped = await preferred.isStopped
+    precondition(preferredEvents.map(\.action) == [.down, action] && stopped)
+    precondition(fallbackEvents.map(\.action) == [.down, .move, .up])
+    await sender.stopAll()
+  }
+
+  private static func reconnectIgnoresOldSend(_ action: LivePreviewPointerAction, failing: Bool) async {
+    let old = RecordingBackend(minimumMoveInterval: .zero)
+    let replacement = RecordingBackend(minimumMoveInterval: .zero)
+    let fallback = RecordingBackend(minimumMoveInterval: .zero)
+    let backends = BackendSequence([old, replacement])
+    let sender = LivePreviewPointerInjector(makePreferredBackend: { _ in await backends.next() }, fallbackBackend: fallback)
+    await preparePreferredBackend(sender, preferred: old, fallback: fallback)
+    await sender.enqueue(event(.down))
+    await waitUntil { await old.events.count == 1 }
+    await old.holdNextSend(failing: failing)
+    await sender.enqueue(event(action))
+    await waitUntil { await old.events.count == 2 }
+    await sender.enqueue(event(.move, x: 99))
+    await sender.enqueue(event(.up))
+    await sender.stopDevice("test-device")
+    await sender.prepare(deviceID: "test-device")
+    await old.release()
+    await preparePreferredBackend(sender, preferred: replacement, fallback: fallback)
+    for nextAction in [LivePreviewPointerAction.down, .move, .up] {
+      await sender.enqueue(event(nextAction))
+    }
+    await waitUntil { await replacement.events.count == 3 }
+    let oldEvents = await old.events
+    let replacementEvents = await replacement.events
+    let fallbackEvents = await fallback.events
+    let stopped = await replacement.isStopped
+    precondition(oldEvents.map(\.action) == [.down, action])
+    precondition(replacementEvents.map(\.action) == [.down, .move, .up])
+    precondition(fallbackEvents.isEmpty && !stopped)
     await sender.stopAll()
   }
 

--- a/snapo-app-mac/Tests/LivePreviewPointer/LivePreviewPointerTests.swift
+++ b/snapo-app-mac/Tests/LivePreviewPointer/LivePreviewPointerTests.swift
@@ -1,0 +1,322 @@
+import Foundation
+import SnapODeviceClient
+
+actor ADBService {
+  let client: ADBClient
+  init(client: ADBClient) {
+    self.client = client
+  }
+
+  func exec() -> ADBClient {
+    client
+  }
+}
+
+struct ShellLivePreviewPointerBackend: LivePreviewPointerBackend {
+  init(adb: ADBService) {}
+  func send(_ event: LivePreviewPointerEvent) async throws {}
+}
+
+private actor RecordingBackend: LivePreviewPointerBackend {
+  let minimumMoveInterval: Duration
+  private(set) var events: [LivePreviewPointerEvent] = []
+  private var gate: CheckedContinuation<Void, Never>?
+  private var holdFirstSend: Bool
+
+  init(holdFirstSend: Bool = false, minimumMoveInterval: Duration = .nanoseconds(16_666_667)) {
+    self.holdFirstSend = holdFirstSend
+    self.minimumMoveInterval = minimumMoveInterval
+  }
+
+  func send(_ event: LivePreviewPointerEvent) async throws {
+    events.append(event)
+    if holdFirstSend {
+      holdFirstSend = false
+      await withCheckedContinuation { gate = $0 }
+    }
+  }
+
+  func release() {
+    gate?.resume()
+    gate = nil
+  }
+}
+
+private final class TestClock: @unchecked Sendable {
+  private let lock = NSLock()
+  private var instant = ContinuousClock.now
+  private var waiters: [(ContinuousClock.Instant, CheckedContinuation<Void, Never>)] = []
+
+  var now: ContinuousClock.Instant {
+    lock.withLock { instant }
+  }
+
+  var isSleeping: Bool {
+    lock.withLock { !waiters.isEmpty }
+  }
+
+  func sleep(until deadline: ContinuousClock.Instant) async {
+    await withCheckedContinuation { continuation in
+      lock.withLock {
+        if instant >= deadline {
+          continuation.resume()
+        } else {
+          waiters.append((deadline, continuation))
+        }
+      }
+    }
+  }
+
+  func advance(by duration: Duration = .milliseconds(17)) {
+    lock.withLock {
+      instant = instant.advanced(by: duration)
+      let ready = waiters.filter { $0.0 <= instant }
+      waiters.removeAll { $0.0 <= instant }
+      for (_, continuation) in ready {
+        continuation.resume()
+      }
+    }
+  }
+}
+
+@main
+struct LivePreviewPointerTests {
+  static func main() async throws {
+    await latestMoveSurvivesSlowSend()
+    await pacedMoveUsesLatestPosition()
+    await fasterBackendKeepsMovesBounded()
+    await gestureBoundariesStayOrdered()
+    await stopDiscardsWaitingMove()
+    await hoverIsNotPaced()
+    try await freshRotationDoesNotQueryOnDown()
+    try await activeDragPausesRefreshAndNextDragChecksStaleRotation()
+    try await changedSizeRefreshesBeforeDown()
+    try await idleRefreshFindsHalfTurn()
+    try await stopDuringRefreshDoesNotSend()
+    try await failedRefreshDoesNotReuseOldRotation()
+    print("Live preview pointer tests passed (12 cases)")
+  }
+
+  private static func event(
+    _ action: LivePreviewPointerAction, x: Double = 0,
+    source: LivePreviewPointerSource = .touchscreen,
+    size: CGSize = CGSize(width: 100, height: 200)
+  ) -> LivePreviewPointerEvent {
+    LivePreviewPointerEvent(
+      deviceID: "test-device",
+      action: action,
+      source: source,
+      location: CGPoint(x: x, y: 10),
+      displaySize: size
+    )
+  }
+
+  private static func injector(_ backend: RecordingBackend, clock: TestClock) -> LivePreviewPointerInjector {
+    LivePreviewPointerInjector(
+      makePreferredBackend: { _ in throw CancellationError() }, fallbackBackend: backend,
+      now: { clock.now }, sleepUntil: { await clock.sleep(until: $0) }
+    )
+  }
+
+  private static func waitUntil(_ condition: () async -> Bool) async {
+    let deadline = ContinuousClock.now.advanced(by: .seconds(5))
+    while await !condition() {
+      precondition(ContinuousClock.now < deadline, "Timed out waiting for test state")
+      try? await Task.sleep(for: .milliseconds(1))
+    }
+  }
+
+  private static func latestMoveSurvivesSlowSend() async {
+    let clock = TestClock()
+    let backend = RecordingBackend(holdFirstSend: true)
+    let sender = injector(backend, clock: clock)
+    await sender.enqueue(event(.down))
+    await waitUntil { await backend.events.count == 1 }
+    for x in 1 ... 100 {
+      await sender.enqueue(event(.move, x: Double(x)))
+    }
+    clock.advance(by: .seconds(1))
+    await backend.release()
+    await waitUntil { await backend.events.count == 2 }
+    let sent = await backend.events
+    precondition(sent.map(\.action) == [.down, .move])
+    precondition(sent.last?.location.x == 100)
+    await sender.stopAll()
+  }
+
+  private static func pacedMoveUsesLatestPosition() async {
+    let clock = TestClock()
+    let backend = RecordingBackend()
+    let sender = injector(backend, clock: clock)
+    await sender.enqueue(event(.down))
+    await waitUntil { await backend.events.count == 1 }
+    await sender.enqueue(event(.move, x: 1))
+    await waitUntil { clock.isSleeping }
+    await sender.enqueue(event(.move, x: 2))
+    clock.advance()
+    await waitUntil { await backend.events.count == 2 }
+    let sent = await backend.events
+    precondition(sent.last?.location.x == 2)
+    // No later input is needed to deliver a move that arrived inside the pacing interval.
+    await sender.enqueue(event(.up, x: 3))
+    await waitUntil { await backend.events.count == 3 }
+    let lastAction = await backend.events.last?.action
+    precondition(lastAction == .up)
+    await sender.stopAll()
+  }
+
+  private static func gestureBoundariesStayOrdered() async {
+    let clock = TestClock()
+    let backend = RecordingBackend(holdFirstSend: true)
+    let sender = injector(backend, clock: clock)
+    await sender.enqueue(event(.down))
+    await waitUntil { await backend.events.count == 1 }
+    for (action, x) in [(LivePreviewPointerAction.move, 1.0), (.up, 2), (.down, 3), (.move, 4), (.cancel, 5)] {
+      await sender.enqueue(event(action, x: x))
+    }
+    clock.advance()
+    await backend.release()
+    await waitUntil { await backend.events.count == 4 }
+    await waitUntil { clock.isSleeping }
+    clock.advance()
+    await waitUntil { await backend.events.count == 6 }
+    let sent = await backend.events
+    precondition(sent.map(\.action) == [.down, .move, .up, .down, .move, .cancel])
+    precondition(sent.map(\.location.x) == [0, 1, 2, 3, 4, 5])
+    await sender.stopAll()
+  }
+
+  private static func fasterBackendKeepsMovesBounded() async {
+    let clock = TestClock()
+    let backend = RecordingBackend(holdFirstSend: true, minimumMoveInterval: .nanoseconds(8_333_334))
+    let sender = injector(backend, clock: clock)
+    await sender.enqueue(event(.down))
+    await waitUntil { await backend.events.count == 1 }
+    for x in 1 ... 100 {
+      await sender.enqueue(event(.move, x: Double(x)))
+    }
+    clock.advance(by: .milliseconds(9))
+    await backend.release()
+    await waitUntil { await backend.events.count == 2 }
+    let sent = await backend.events
+    precondition(sent.last?.location.x == 100)
+    await sender.enqueue(event(.move, x: 101))
+    await waitUntil { clock.isSleeping }
+    clock.advance(by: .milliseconds(9))
+    await waitUntil { await backend.events.count == 3 }
+    await sender.stopAll()
+  }
+
+  private static func stopDiscardsWaitingMove() async {
+    let clock = TestClock()
+    let backend = RecordingBackend()
+    let sender = injector(backend, clock: clock)
+    await sender.enqueue(event(.down))
+    await waitUntil { await backend.events.count == 1 }
+    await sender.enqueue(event(.move, x: 1))
+    await waitUntil { clock.isSleeping }
+    await sender.stopDevice("test-device")
+    clock.advance()
+    await sender.enqueue(event(.move, source: .mouse))
+    await waitUntil { await backend.events.count == 2 }
+    let sent = await backend.events
+    precondition(sent.last?.source == .mouse)
+    await sender.stopAll()
+  }
+
+  private static func hoverIsNotPaced() async {
+    let clock = TestClock()
+    let backend = RecordingBackend()
+    let sender = injector(backend, clock: clock)
+    await sender.enqueue(event(.move, source: .mouse))
+    await waitUntil { await backend.events.count == 1 }
+    await sender.enqueue(event(.move, x: 2, source: .mouse))
+    await waitUntil { await backend.events.count == 2 }
+    precondition(!clock.isSleeping)
+    await sender.stopAll()
+  }
+
+  private static func freshRotationDoesNotQueryOnDown() async throws {
+    let client = ADBClient()
+    let backend = try await UInputLivePreviewPointerBackend.start(adb: ADBService(client: client), deviceID: "test-device")
+    precondition(backend.minimumMoveInterval == .nanoseconds(8_333_334))
+    try await backend.send(event(.down))
+    try await backend.send(event(.move, x: 20))
+    try await backend.send(event(.up, x: 30))
+    let count = await client.queryCount
+    precondition(count == 0)
+    let touchscreen = await client.touchscreen
+    precondition(touchscreen.actions == [.down, .move, .up])
+    await backend.stop()
+  }
+
+  private static func changedSizeRefreshesBeforeDown() async throws {
+    let client = ADBClient()
+    await client.setViewport(ADBDisplayViewport(rotation: .rotation90, width: 200, height: 100))
+    let backend = try await UInputLivePreviewPointerBackend.start(adb: ADBService(client: client), deviceID: "test-device")
+    try await backend.send(event(.down, size: CGSize(width: 200, height: 100)))
+    let count = await client.queryCount
+    let touchscreen = await client.touchscreen
+    precondition(count == 1 && touchscreen.rotations == [.rotation90])
+    await backend.stop()
+  }
+
+  private static func activeDragPausesRefreshAndNextDragChecksStaleRotation() async throws {
+    let client = ADBClient()
+    let backend = try await UInputLivePreviewPointerBackend.start(adb: ADBService(client: client), deviceID: "test-device")
+    try await backend.send(event(.down))
+    await client.setViewport(ADBDisplayViewport(rotation: .rotation180))
+    try await Task.sleep(for: .milliseconds(1050))
+    try await backend.send(event(.move, x: 20))
+    let idleQueries = await client.queryCount
+    precondition(idleQueries == 0)
+    try await backend.send(event(.up))
+    try await backend.send(event(.down))
+    let count = await client.queryCount
+    let touchscreen = await client.touchscreen
+    precondition(count == 1)
+    precondition(touchscreen.rotations == [.rotation0, .rotation0, .rotation0, .rotation180])
+    await backend.stop()
+  }
+
+  private static func idleRefreshFindsHalfTurn() async throws {
+    let client = ADBClient()
+    let backend = try await UInputLivePreviewPointerBackend.start(adb: ADBService(client: client), deviceID: "test-device")
+    await client.setViewport(ADBDisplayViewport(rotation: .rotation180))
+    await waitUntil { await client.queryCount > 0 }
+    try await backend.send(event(.down))
+    let touchscreen = await client.touchscreen
+    precondition(touchscreen.rotations == [.rotation180])
+    await backend.stop()
+  }
+
+  private static func stopDuringRefreshDoesNotSend() async throws {
+    let client = ADBClient()
+    await client.holdQuery()
+    let backend = try await UInputLivePreviewPointerBackend.start(adb: ADBService(client: client), deviceID: "test-device")
+    await waitUntil { await client.queryCount > 0 }
+    let send = Task { try await backend.send(event(.down)) }
+    await backend.stop()
+    await client.releaseQuery()
+    do {
+      try await send.value
+      preconditionFailure("Stopped backend accepted a pointer")
+    } catch is CancellationError {}
+    let touchscreen = await client.touchscreen
+    precondition(touchscreen.actions.isEmpty && touchscreen.isClosed)
+  }
+
+  private static func failedRefreshDoesNotReuseOldRotation() async throws {
+    let client = ADBClient()
+    let backend = try await UInputLivePreviewPointerBackend.start(adb: ADBService(client: client), deviceID: "test-device")
+    await client.failQueries()
+    await waitUntil { await client.queryCount > 0 }
+    do {
+      try await backend.send(event(.down))
+      preconditionFailure("Failed refresh reused an old rotation")
+    } catch ADBError.protocolFailure {}
+    let touchscreen = await client.touchscreen
+    precondition(touchscreen.actions.isEmpty)
+    await backend.stop()
+  }
+}

--- a/snapo-app-mac/scripts/test-live-preview-pointer.sh
+++ b/snapo-app-mac/scripts/test-live-preview-pointer.sh
@@ -1,0 +1,18 @@
+#!/bin/sh
+set -eu
+
+APP_DIR=$(CDPATH= cd -- "$(dirname -- "$0")/.." && pwd)
+TEST_DIR=$(mktemp -d "${TMPDIR:-/tmp}/snap-o-pointer-tests.XXXXXX")
+cd "$APP_DIR"
+
+# Exercise the production sender and rotation lifecycle without injecting device input.
+xcrun swiftc -swift-version 6 -parse-as-library -module-name SnapODeviceClient \
+  -emit-module -emit-object Tests/LivePreviewPointer/DeviceClientDouble.swift \
+  -emit-module-path "$TEST_DIR/SnapODeviceClient.swiftmodule" -o "$TEST_DIR/DeviceClient.o"
+xcrun swiftc -swift-version 6 -parse-as-library -I "$TEST_DIR" \
+  "$TEST_DIR/DeviceClient.o" Snap-O/Utilities/Logging.swift \
+  Snap-O/LivePreview/LivePreviewPointerBackend.swift \
+  Snap-O/LivePreview/LivePreviewPointerInjector.swift \
+  Snap-O/LivePreview/UInputLivePreviewPointerBackend.swift \
+  Tests/LivePreviewPointer/LivePreviewPointerTests.swift -o "$TEST_DIR/pointer-tests"
+"$TEST_DIR/pointer-tests"


### PR DESCRIPTION
Live Preview dropped drag positions before delivery and limited input to 60 Hz. Remote drags looked less smooth than direct touch. This change raises the supported input rate while keeping pending moves replaceable.

## Summary

- Send the latest pending drag position at up to 120 Hz when Android uinput supports acknowledgments. Keep one injection outstanding and retain a 60 Hz ceiling for older uinput and shell input.
- Bound acknowledgment reads by size and timeout. An acknowledgment confirms kernel injection, not app handling or rendering.
- Deliver the final position before lifting. Query rotation before each gesture and keep it fixed until release; remove idle polling and the viewport cache.
- Share move, release, and cancel delivery, while keeping pointer-down and gesture cleanup explicit.
- Remove investigation-only counters and logs, add pointer tests to CI, and leave hover and video delivery unchanged.

## Validation

- macOS app build with code signing disabled.
- 23 pointer delivery, failure, reconnect, and rotation tests, including immediate 180-degree rotation; 33 device-client tests.
- Existing startup capture, preview session, visibility, capture mode, and frame export tests.
- Full SwiftFormat and strict SwiftLint checks.
- Manual Android drag testing confirmed smoother input before the rotation fix. The rotation fix and older Android behavior have automated coverage, not a separate device test.
