### PR TITLE
Refine network request details and SSE layout

### DIFF
--- a/snapo-network-inspector-web/README.md
+++ b/snapo-network-inspector-web/README.md
@@ -18,6 +18,12 @@ npm run dev
 
 Running the renderer by itself uses the HTTP endpoints under `/api/network/...` and `/api/inspector/...`. To use the native WebKit bridge and inspect a connected device, build and run the Swift app in `snapo-app-mac`.
 
+### Request detail preview
+
+With the development server running, open `/preview.html` to review the request detail layout with synthetic data. The selector includes JSON, HTTP error, server-sent event, and connection failure examples. Sections, JSON expansion, and copy controls use the real detail component. No device or API server is needed.
+
+The preview uses a separate HTML entry point and is not included in the production build. Changes to the shared detail components and styles appear through hot reload.
+
 ## Validation
 
 ```bash

--- a/snapo-network-inspector-web/preview.html
+++ b/snapo-network-inspector-web/preview.html
@@ -1,0 +1,12 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Snap-O Request Detail Preview</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/preview/main.tsx"></script>
+  </body>
+</html>

--- a/snapo-network-inspector-web/src/features/network-inspector/components/RequestDetail.test.tsx
+++ b/snapo-network-inspector-web/src/features/network-inspector/components/RequestDetail.test.tsx
@@ -117,6 +117,90 @@ describe("Response Body loading state", () => {
   });
 });
 
+describe("SSE stream status", () => {
+  it("shows a closed status without a completion footer or totals", () => {
+    const markup = renderStream({
+      streamClosed: { timestamp: 2, reason: "completed", totalEvents: 1, totalBytes: 128 }
+    });
+
+    expect(markup).toContain("· Closed");
+    expect(markup).toContain("sample-event");
+    expect(markup).not.toContain("Stream closed");
+    expect(markup).not.toContain("Total events");
+    expect(markup).not.toContain("Total bytes");
+  });
+
+  it("shows streaming while waiting for the first event", () => {
+    const markup = renderStream({ streamEvents: [], streamEventCount: 0 });
+
+    expect(markup).toContain("· Streaming");
+    expect(markup).toContain("Awaiting events...");
+    expect(markup).not.toContain("Stream closed");
+  });
+
+  it("does not keep waiting after an empty stream closes", () => {
+    const markup = renderStream({
+      streamEvents: [],
+      streamEventCount: 0,
+      streamClosed: { timestamp: 2, reason: "completed" }
+    });
+
+    expect(markup).toContain("· Closed");
+    expect(markup).toContain("No events received.");
+    expect(markup).not.toContain("Awaiting events");
+  });
+
+  it("shows a stream failure once, below the retained events", () => {
+    const markup = renderStream({
+      status: { kind: "failure", message: "Read timed out." },
+      streamClosed: { timestamp: 2, reason: "error", message: "Read timed out." }
+    });
+
+    expect(markup).toContain("· Closed");
+    expect(markup).toContain('role="status">Stream closed: Read timed out.</div>');
+    expect(markup.match(/Read timed out\./g)).toHaveLength(1);
+    expect(markup.indexOf("Stream closed:")).toBeGreaterThan(markup.indexOf("sample-event"));
+  });
+
+  it.each([
+    { reason: "error", message: undefined, expected: "Connection error." },
+    { reason: "error", message: "  ", expected: "Connection error." },
+    { reason: "cancelled", message: undefined, expected: "cancelled" }
+  ])("keeps an abnormal close reason when its message is $message", ({ reason, message, expected }) => {
+    const markup = renderStream({ streamClosed: { timestamp: 2, reason, message } });
+
+    expect(markup).toContain(`Stream closed: ${expected}`);
+  });
+
+  it("does not describe a disconnected stream as streaming or closed without evidence", () => {
+    const markup = renderStream({ streamEvents: [], streamEventCount: 0 }, false);
+
+    expect(markup).toContain("· Offline");
+    expect(markup).toContain("No events received.");
+    expect(markup).not.toContain("· Streaming");
+    expect(markup).not.toContain("· Closed");
+    expect(markup).not.toContain("Awaiting events");
+  });
+});
+
+function renderStream(overrides: Partial<RequestRecord>, isConnected = true): string {
+  return renderToStaticMarkup(
+    <RequestDetail
+      client={{} as NetworkClient}
+      record={request({
+        endedAt: undefined,
+        responseHeaders: [{ name: "Content-Type", value: "text/event-stream" }],
+        streamEvents: [{ sequence: 1, timestamp: 1, data: "sample-event", raw: "data: sample-event\n\n" }],
+        streamEventCount: 1,
+        ...overrides
+      })}
+      uiState={expandedUiState}
+      isConnected={isConnected}
+      onRetryResponseBody={() => {}}
+    />
+  );
+}
+
 const expandedUiState: InspectorUiState = {
   sectionExpanded: () => true,
   setSectionExpanded: () => {},

--- a/snapo-network-inspector-web/src/features/network-inspector/components/RequestDetail.test.tsx
+++ b/snapo-network-inspector-web/src/features/network-inspector/components/RequestDetail.test.tsx
@@ -49,7 +49,7 @@ describe("Response Body loading state", () => {
     expect(markup).toContain('<div class="payload-card"><div class="body-loading" role="status">');
     expect(markup).toContain("body-loading-spinner");
     expect(markup).toContain('aria-hidden="true"');
-    expect(markup).toContain("Loading...");
+    expect(markup).toContain("Loading");
   });
 
   it("shows the captured prefix and total size while a truncated body is loading", () => {
@@ -64,7 +64,7 @@ describe("Response Body loading state", () => {
 
     expect(markup).toContain("Response Body");
     expect(markup).toContain("Captured 5.2 MB of 9.4 MB");
-    expect(markup).toContain("Loading...");
+    expect(markup).toContain("Loading");
   });
 
   it("explains when a body is no longer available", () => {
@@ -85,7 +85,7 @@ describe("Response Body loading state", () => {
     expect(markup).toContain("This response is no longer available. Try making the request again.");
     expect(markup).not.toContain("Captured 7.3 MB");
     expect(markup).not.toContain("Retry");
-    expect(markup).not.toContain("Loading...");
+    expect(markup).not.toContain("Loading");
   });
 
   it("offers a retry after a temporary failure", () => {
@@ -100,7 +100,7 @@ describe("Response Body loading state", () => {
     expect(markup).toContain("Couldn’t load the response. Try again.");
     expect(markup).toContain('type="button">Retry</button>');
     expect(markup).not.toContain("no longer available");
-    expect(markup).not.toContain("Loading...");
+    expect(markup).not.toContain("Loading");
   });
 
   it("does not label a genuinely empty response as unavailable", () => {
@@ -130,71 +130,119 @@ describe("SSE stream status", () => {
     expect(markup).not.toContain("Total bytes");
   });
 
-  it.each([false, undefined])(
-    "keeps the SSE handshake pending when hasReceivedResponse is %s",
-    (hasReceivedResponse) => {
-      const markup = renderStream({
-        requestHeaders: [{ name: "Accept", value: "text/event-stream" }],
+  const scenarios: {
+    name: string;
+    record: Partial<RequestRecord>;
+    online: string;
+    offline: string;
+    header: string | null;
+    hasEvents?: boolean;
+  }[] = [
+    {
+      name: "pending handshake",
+      record: { responseHeaders: [], hasReceivedResponse: false, status: { kind: "pending" } },
+      online: "Pending",
+      offline: "Offline",
+      header: null
+    },
+    {
+      name: "missing response metadata",
+      record: { responseHeaders: [], hasReceivedResponse: undefined, status: { kind: "pending" } },
+      online: "Pending",
+      offline: "Offline",
+      header: null
+    },
+    {
+      name: "response before the first event",
+      record: {},
+      online: "Streaming",
+      offline: "Offline",
+      header: "200 OK"
+    },
+    {
+      name: "retained events",
+      record: {},
+      online: "Streaming",
+      offline: "Offline",
+      header: "200 OK",
+      hasEvents: true
+    },
+    {
+      name: "events without response metadata",
+      record: { responseHeaders: [], hasReceivedResponse: undefined, status: { kind: "pending" } },
+      online: "Streaming",
+      offline: "Offline",
+      header: null,
+      hasEvents: true
+    },
+    {
+      name: "empty closed stream",
+      record: { streamClosed: { timestamp: 2, reason: "completed" } },
+      online: "Closed",
+      offline: "Closed",
+      header: "200 OK"
+    },
+    {
+      name: "closed stream with events",
+      record: { streamClosed: { timestamp: 2, reason: "completed" } },
+      online: "Closed",
+      offline: "Closed",
+      header: "200 OK",
+      hasEvents: true
+    },
+    {
+      name: "failed handshake",
+      record: {
         responseHeaders: [],
-        hasReceivedResponse,
-        status: { kind: "pending" },
-        streamEvents: [],
-        streamEventCount: 0
-      });
-
-      expect(markup).toContain("· Pending");
-      expect(markup).toContain("Waiting for response...");
-      expect(markup).not.toContain("· Streaming");
+        hasReceivedResponse: false,
+        status: { kind: "failure", message: "Connection refused." },
+        streamClosed: { timestamp: 2, reason: "error", message: "Connection refused." }
+      },
+      online: "Closed",
+      offline: "Closed",
+      header: "Error"
     }
+  ];
+
+  const states = scenarios.flatMap((scenario) =>
+    [true, false].map((isConnected) => ({
+      ...scenario,
+      isConnected,
+      expectedStatus: isConnected ? scenario.online : scenario.offline
+    }))
   );
 
-  it("shows streaming after the response arrives, before the first event", () => {
-    const markup = renderStream({ streamEvents: [], streamEventCount: 0 });
+  it.each(states)("$name, connected=$isConnected: one $expectedStatus label", (scenario) => {
+    const markup = renderStream(
+      {
+        requestHeaders: [{ name: "Accept", value: "text/event-stream" }],
+        ...(scenario.hasEvents ? {} : { streamEvents: [], streamEventCount: 0 }),
+        ...scenario.record
+      },
+      scenario.isConnected
+    );
+    const header = markup.match(/<header[^>]*>([\s\S]*?)<\/header>/)![1];
+    const headerStatus = header.match(/class="status-label[^"]*">([^<]+)<\/span>/)?.[1] ?? null;
+    const emptyMessages: Record<string, string> = {
+      Pending: "Waiting for response",
+      Streaming: "Awaiting events",
+      Offline: "No events received",
+      Closed: "No events received"
+    };
 
-    expect(markup).toContain("· Streaming");
-    expect(markup).toContain("Awaiting events...");
-    expect(markup).not.toContain("Waiting for response...");
-    expect(markup).not.toContain("Stream closed");
-  });
-
-  it("treats a received event as response evidence when response metadata is missing", () => {
-    const markup = renderStream({
-      responseHeaders: [],
-      hasReceivedResponse: undefined,
-      status: { kind: "pending" }
-    });
-
-    expect(markup).toContain("· Streaming");
-    expect(markup).not.toContain("Waiting for response...");
-  });
-
-  it("keeps a failed handshake closed even without a response", () => {
-    const markup = renderStream({
-      requestHeaders: [{ name: "Accept", value: "text/event-stream" }],
-      responseHeaders: [],
-      hasReceivedResponse: false,
-      status: { kind: "failure", message: "Connection refused." },
-      streamEvents: [],
-      streamEventCount: 0,
-      streamClosed: { timestamp: 2, reason: "error", message: "Connection refused." }
-    });
-
-    expect(markup).toContain("· Closed");
-    expect(markup).toContain("Stream closed: Connection refused.");
-    expect(markup).not.toContain("· Pending");
-    expect(markup).not.toContain("· Streaming");
-  });
-
-  it("does not keep waiting after an empty stream closes", () => {
-    const markup = renderStream({
-      streamEvents: [],
-      streamEventCount: 0,
-      streamClosed: { timestamp: 2, reason: "completed" }
-    });
-
-    expect(markup).toContain("· Closed");
-    expect(markup).toContain("No events received.");
-    expect(markup).not.toContain("Awaiting events");
+    expect(headerStatus).toBe(scenario.header);
+    expect(header).not.toMatch(/Streaming|Offline|Pending|Closed/);
+    expect(markup.match(/class="section-status">· ([^<]+)/g)).toEqual([
+      `class="section-status">· ${scenario.expectedStatus}`
+    ]);
+    expect(markup).not.toContain('class="pending-response"');
+    if (scenario.hasEvents) {
+      expect(markup).toContain("sample-event");
+      expect(markup).not.toContain('class="messages-empty"');
+    } else {
+      expect(markup).toContain(`class="messages-empty">${emptyMessages[scenario.expectedStatus]}</div>`);
+    }
+    expect(markup).not.toMatch(/\.\.\.|…/);
   });
 
   it("shows a stream failure once, below the retained events", () => {
@@ -218,30 +266,6 @@ describe("SSE stream status", () => {
 
     expect(markup).toContain(`Stream closed: ${expected}`);
   });
-
-  it.each([false, true])(
-    "shows a consistent offline state when hasReceivedResponse is %s",
-    (hasReceivedResponse) => {
-      const markup = renderStream(
-        {
-          requestHeaders: [{ name: "Accept", value: "text/event-stream" }],
-          responseHeaders: hasReceivedResponse ? [{ name: "Content-Type", value: "text/event-stream" }] : [],
-          hasReceivedResponse,
-          status: hasReceivedResponse ? { kind: "success", code: 200 } : { kind: "pending" },
-          streamEvents: [],
-          streamEventCount: 0
-        },
-        false
-      );
-
-      expect(markup).toContain("· Offline");
-      expect(markup).toContain("No events received.");
-      expect(markup).not.toContain("· Streaming");
-      expect(markup).not.toContain("· Closed");
-      expect(markup).not.toContain("Awaiting events");
-      expect(markup).not.toContain("Waiting for response...");
-    }
-  );
 });
 
 function renderStream(overrides: Partial<RequestRecord>, isConnected = true): string {

--- a/snapo-network-inspector-web/src/features/network-inspector/components/RequestDetail.test.tsx
+++ b/snapo-network-inspector-web/src/features/network-inspector/components/RequestDetail.test.tsx
@@ -219,15 +219,29 @@ describe("SSE stream status", () => {
     expect(markup).toContain(`Stream closed: ${expected}`);
   });
 
-  it("does not describe a disconnected stream as streaming or closed without evidence", () => {
-    const markup = renderStream({ streamEvents: [], streamEventCount: 0 }, false);
+  it.each([false, true])(
+    "shows a consistent offline state when hasReceivedResponse is %s",
+    (hasReceivedResponse) => {
+      const markup = renderStream(
+        {
+          requestHeaders: [{ name: "Accept", value: "text/event-stream" }],
+          responseHeaders: hasReceivedResponse ? [{ name: "Content-Type", value: "text/event-stream" }] : [],
+          hasReceivedResponse,
+          status: hasReceivedResponse ? { kind: "success", code: 200 } : { kind: "pending" },
+          streamEvents: [],
+          streamEventCount: 0
+        },
+        false
+      );
 
-    expect(markup).toContain("· Offline");
-    expect(markup).toContain("No events received.");
-    expect(markup).not.toContain("· Streaming");
-    expect(markup).not.toContain("· Closed");
-    expect(markup).not.toContain("Awaiting events");
-  });
+      expect(markup).toContain("· Offline");
+      expect(markup).toContain("No events received.");
+      expect(markup).not.toContain("· Streaming");
+      expect(markup).not.toContain("· Closed");
+      expect(markup).not.toContain("Awaiting events");
+      expect(markup).not.toContain("Waiting for response...");
+    }
+  );
 });
 
 function renderStream(overrides: Partial<RequestRecord>, isConnected = true): string {

--- a/snapo-network-inspector-web/src/features/network-inspector/components/RequestDetail.test.tsx
+++ b/snapo-network-inspector-web/src/features/network-inspector/components/RequestDetail.test.tsx
@@ -130,12 +130,59 @@ describe("SSE stream status", () => {
     expect(markup).not.toContain("Total bytes");
   });
 
-  it("shows streaming while waiting for the first event", () => {
+  it.each([false, undefined])(
+    "keeps the SSE handshake pending when hasReceivedResponse is %s",
+    (hasReceivedResponse) => {
+      const markup = renderStream({
+        requestHeaders: [{ name: "Accept", value: "text/event-stream" }],
+        responseHeaders: [],
+        hasReceivedResponse,
+        status: { kind: "pending" },
+        streamEvents: [],
+        streamEventCount: 0
+      });
+
+      expect(markup).toContain("· Pending");
+      expect(markup).toContain("Waiting for response...");
+      expect(markup).not.toContain("· Streaming");
+    }
+  );
+
+  it("shows streaming after the response arrives, before the first event", () => {
     const markup = renderStream({ streamEvents: [], streamEventCount: 0 });
 
     expect(markup).toContain("· Streaming");
     expect(markup).toContain("Awaiting events...");
+    expect(markup).not.toContain("Waiting for response...");
     expect(markup).not.toContain("Stream closed");
+  });
+
+  it("treats a received event as response evidence when response metadata is missing", () => {
+    const markup = renderStream({
+      responseHeaders: [],
+      hasReceivedResponse: undefined,
+      status: { kind: "pending" }
+    });
+
+    expect(markup).toContain("· Streaming");
+    expect(markup).not.toContain("Waiting for response...");
+  });
+
+  it("keeps a failed handshake closed even without a response", () => {
+    const markup = renderStream({
+      requestHeaders: [{ name: "Accept", value: "text/event-stream" }],
+      responseHeaders: [],
+      hasReceivedResponse: false,
+      status: { kind: "failure", message: "Connection refused." },
+      streamEvents: [],
+      streamEventCount: 0,
+      streamClosed: { timestamp: 2, reason: "error", message: "Connection refused." }
+    });
+
+    expect(markup).toContain("· Closed");
+    expect(markup).toContain("Stream closed: Connection refused.");
+    expect(markup).not.toContain("· Pending");
+    expect(markup).not.toContain("· Streaming");
   });
 
   it("does not keep waiting after an empty stream closes", () => {
@@ -189,6 +236,7 @@ function renderStream(overrides: Partial<RequestRecord>, isConnected = true): st
       client={{} as NetworkClient}
       record={request({
         endedAt: undefined,
+        hasReceivedResponse: true,
         responseHeaders: [{ name: "Content-Type", value: "text/event-stream" }],
         streamEvents: [{ sequence: 1, timestamp: 1, data: "sample-event", raw: "data: sample-event\n\n" }],
         streamEventCount: 1,

--- a/snapo-network-inspector-web/src/features/network-inspector/components/RequestDetail.tsx
+++ b/snapo-network-inspector-web/src/features/network-inspector/components/RequestDetail.tsx
@@ -10,7 +10,7 @@ import { responseBodyCaptureMetadata, shouldRequestResponseBody } from "../lib/r
 import { BodySection, payloadMetadata } from "./PayloadView";
 import { HeadersTable, Section } from "./Section";
 import { FailureMessage, StatusBadge } from "./Status";
-import { SseCopyAllButton, SseEventList } from "./StreamEvents";
+import { SseCopyAllButton, SseEventList, type SseStatus } from "./StreamEvents";
 
 export const RequestDetail = memo(function RequestDetail({
   client,
@@ -26,9 +26,7 @@ export const RequestDetail = memo(function RequestDetail({
   onRetryResponseBody(): void;
 }): JSX.Element {
   const isSseResponse = isLikelyStreamingRequest(record);
-  const hasResponseEvidence = record.hasReceivedResponse === true || record.streamEvents.length > 0;
-  const streamStatus =
-    record.streamClosed != null ? "Closed" : !isConnected ? "Offline" : hasResponseEvidence ? "Streaming" : "Pending";
+  const streamStatus = sseStatus(record, isConnected);
   const streamClosedWithError =
     isSseResponse && record.streamClosed != null && record.streamClosed.reason !== "completed";
   const requestBodyDisplayText = useRequestBodyDisplayText(record);
@@ -93,8 +91,8 @@ export const RequestDetail = memo(function RequestDetail({
           />
         </Section>
       )}
-      {isConnected && record.status.kind === "pending" && !hasResponseEvidence ? (
-        <div className="pending-response">Waiting for response...</div>
+      {!isSseResponse && isConnected && record.status.kind === "pending" && !record.hasReceivedResponse ? (
+        <div className="pending-response">Waiting for response</div>
       ) : null}
       {record.responseHeaders.length === 0 ? null : (
         <Section title="Response Headers" storageKey={`${prefix}:responseHeaders`} uiState={uiState}>
@@ -117,7 +115,7 @@ export const RequestDetail = memo(function RequestDetail({
             client={client}
             events={record.streamEvents}
             closed={record.streamClosed}
-            isConnected={isConnected}
+            status={streamStatus}
             storageKey={`${prefix}:stream`}
             uiState={uiState}
           />
@@ -157,7 +155,7 @@ export const RequestDetail = memo(function RequestDetail({
             <div className="payload-card">
               <div className="body-loading" role="status">
                 <LoaderCircle className="body-loading-spinner" size={14} aria-hidden="true" />
-                <span>Loading...</span>
+                <span>Loading</span>
               </div>
             </div>
           ) : (
@@ -173,6 +171,13 @@ export const RequestDetail = memo(function RequestDetail({
     </div>
   );
 });
+
+function sseStatus(record: RequestRecord, isConnected: boolean): SseStatus {
+  if (record.streamClosed != null) return "Closed";
+  if (!isConnected) return "Offline";
+  if (record.hasReceivedResponse || record.streamEvents.length > 0) return "Streaming";
+  return "Pending";
+}
 
 function useRequestBodyDisplayText(record: RequestRecord): string | null {
   const contentEncoding = requestHeaderValue(record.requestHeaders, "content-encoding");

--- a/snapo-network-inspector-web/src/features/network-inspector/components/RequestDetail.tsx
+++ b/snapo-network-inspector-web/src/features/network-inspector/components/RequestDetail.tsx
@@ -26,6 +26,9 @@ export const RequestDetail = memo(function RequestDetail({
   onRetryResponseBody(): void;
 }): JSX.Element {
   const isSseResponse = isLikelyStreamingRequest(record);
+  const hasResponseEvidence = record.hasReceivedResponse === true || record.streamEvents.length > 0;
+  const streamStatus =
+    record.streamClosed != null ? "Closed" : !isConnected ? "Offline" : hasResponseEvidence ? "Streaming" : "Pending";
   const streamClosedWithError =
     isSseResponse && record.streamClosed != null && record.streamClosed.reason !== "completed";
   const requestBodyDisplayText = useRequestBodyDisplayText(record);
@@ -90,7 +93,9 @@ export const RequestDetail = memo(function RequestDetail({
           />
         </Section>
       )}
-      {record.status.kind === "pending" ? <div className="pending-response">Waiting for response...</div> : null}
+      {record.status.kind === "pending" && !hasResponseEvidence ? (
+        <div className="pending-response">Waiting for response...</div>
+      ) : null}
       {record.responseHeaders.length === 0 ? null : (
         <Section title="Response Headers" storageKey={`${prefix}:responseHeaders`} uiState={uiState}>
           <HeadersTable headers={record.responseHeaders} />
@@ -101,9 +106,7 @@ export const RequestDetail = memo(function RequestDetail({
           title={
             <>
               Server-Sent Events
-              <span className="section-status">
-                · {record.streamClosed != null ? "Closed" : isConnected ? "Streaming" : "Offline"}
-              </span>
+              <span className="section-status">· {streamStatus}</span>
             </>
           }
           storageKey={`${prefix}:stream`}

--- a/snapo-network-inspector-web/src/features/network-inspector/components/RequestDetail.tsx
+++ b/snapo-network-inspector-web/src/features/network-inspector/components/RequestDetail.tsx
@@ -93,7 +93,7 @@ export const RequestDetail = memo(function RequestDetail({
           />
         </Section>
       )}
-      {record.status.kind === "pending" && !hasResponseEvidence ? (
+      {isConnected && record.status.kind === "pending" && !hasResponseEvidence ? (
         <div className="pending-response">Waiting for response...</div>
       ) : null}
       {record.responseHeaders.length === 0 ? null : (

--- a/snapo-network-inspector-web/src/features/network-inspector/components/RequestDetail.tsx
+++ b/snapo-network-inspector-web/src/features/network-inspector/components/RequestDetail.tsx
@@ -26,6 +26,8 @@ export const RequestDetail = memo(function RequestDetail({
   onRetryResponseBody(): void;
 }): JSX.Element {
   const isSseResponse = isLikelyStreamingRequest(record);
+  const streamClosedWithError =
+    isSseResponse && record.streamClosed != null && record.streamClosed.reason !== "completed";
   const requestBodyDisplayText = useRequestBodyDisplayText(record);
   const requestBody = makeBodyPayload({
     body: record.requestBody,
@@ -59,7 +61,7 @@ export const RequestDetail = memo(function RequestDetail({
           <StatusBadge record={record} />
           <span>{timingText}</span>
         </div>
-        <FailureMessage status={record.status} />
+        {streamClosedWithError ? null : <FailureMessage status={record.status} />}
       </header>
 
       {record.requestHeaders.length === 0 ? null : (
@@ -96,7 +98,14 @@ export const RequestDetail = memo(function RequestDetail({
       )}
       {isSseResponse ? (
         <Section
-          title="Server-Sent Events"
+          title={
+            <>
+              Server-Sent Events
+              <span className="section-status">
+                · {record.streamClosed != null ? "Closed" : isConnected ? "Streaming" : "Offline"}
+              </span>
+            </>
+          }
           storageKey={`${prefix}:stream`}
           uiState={uiState}
           trailing={<SseCopyAllButton client={client} events={record.streamEvents} />}
@@ -105,6 +114,7 @@ export const RequestDetail = memo(function RequestDetail({
             client={client}
             events={record.streamEvents}
             closed={record.streamClosed}
+            isConnected={isConnected}
             storageKey={`${prefix}:stream`}
             uiState={uiState}
           />

--- a/snapo-network-inspector-web/src/features/network-inspector/components/Section.tsx
+++ b/snapo-network-inspector-web/src/features/network-inspector/components/Section.tsx
@@ -10,7 +10,7 @@ export function Section({
   trailing,
   children
 }: {
-  title: string;
+  title: ReactNode;
   meta?: string | null;
   storageKey: string;
   uiState: InspectorUiState;

--- a/snapo-network-inspector-web/src/features/network-inspector/components/Status.tsx
+++ b/snapo-network-inspector-web/src/features/network-inspector/components/Status.tsx
@@ -10,11 +10,9 @@ export function StatusView({ record }: { record: InspectorRecord }): JSX.Element
   return <span className={`row-status ${statusToneClass(status.code)}`}>{status.code}</span>;
 }
 
-export function StatusBadge({ record }: { record: InspectorRecord }): JSX.Element {
-  if (record.kind === "request" && record.streamEvents.length > 0 && record.streamClosed == null) {
-    return <span className="status-label status-streaming">Streaming</span>;
-  }
+export function StatusBadge({ record }: { record: InspectorRecord }): JSX.Element | null {
   const status = record.status;
+  if (record.kind === "request" && status.kind === "pending") return null;
   if (status.kind === "pending") return <span className="status-label status-pending">Pending</span>;
   if (status.kind === "failure") return <span className="status-label status-error">Error</span>;
   return <span className={`status-label ${statusToneClass(status.code)}`}>{statusDisplayName(status.code)}</span>;

--- a/snapo-network-inspector-web/src/features/network-inspector/components/StreamEvents.tsx
+++ b/snapo-network-inspector-web/src/features/network-inspector/components/StreamEvents.tsx
@@ -33,19 +33,23 @@ export const SseEventList = memo(function SseEventList({
   client,
   events,
   closed,
+  isConnected = true,
   storageKey,
   uiState
 }: {
   client: NetworkClient;
   events: RequestRecord["streamEvents"];
   closed?: RequestRecord["streamClosed"];
+  isConnected?: boolean;
   storageKey: string;
   uiState: InspectorUiState;
 }): JSX.Element {
   return (
     <div className="event-list">
       {events.length === 0 ? (
-        <div className="messages-empty">Awaiting events...</div>
+        <div className="messages-empty">
+          {closed != null || !isConnected ? "No events received." : "Awaiting events..."}
+        </div>
       ) : (
         events.map((event) => (
           <SseEventCard
@@ -57,7 +61,7 @@ export const SseEventList = memo(function SseEventList({
           />
         ))
       )}
-      {closed == null ? null : <StreamClosedInfo closed={closed} />}
+      {closed == null ? null : <StreamCloseMessage closed={closed} />}
     </div>
   );
 });
@@ -83,9 +87,11 @@ const SseEventCard = memo(function SseEventCard({
   return (
     <div className="event-row">
       <div className="event-meta">
-        <span>#{event.sequence}</span>
-        <span>{formatTime(event.timestamp)}</span>
-        {event.eventName ? <span className="event-name">{event.eventName}</span> : null}
+        <div className="event-info">
+          <span>#{event.sequence}</span>
+          <span>{formatTime(event.timestamp)}</span>
+          {event.eventName ? <span className="event-name">{event.eventName}</span> : null}
+        </div>
         <span className="event-actions">
           {prettyText == null ? null : (
             <InlineTextToggle
@@ -107,6 +113,7 @@ const SseEventCard = memo(function SseEventCard({
           showsToggle={false}
           showsCopyButton={false}
           prettyInitiallyExpanded={false}
+          embedded
         />
       )}
       <SseEventMetadata event={event} />
@@ -125,16 +132,12 @@ function SseEventMetadata({ event }: { event: RequestRecord["streamEvents"][numb
   );
 }
 
-function StreamClosedInfo({ closed }: { closed: NonNullable<RequestRecord["streamClosed"]> }): JSX.Element {
+function StreamCloseMessage({ closed }: { closed: NonNullable<RequestRecord["streamClosed"]> }): JSX.Element | null {
+  if (closed.reason === "completed") return null;
+  const message = closed.message?.trim() || (closed.reason === "error" ? "Connection error." : closed.reason);
   return (
-    <div className="stream-closed-info">
-      <div>
-        Stream closed ({closed.reason}) at {formatTime(closed.timestamp)}
-      </div>
-      {closed.message == null || closed.message.length === 0 ? null : <div>Message: {closed.message}</div>}
-      <div>
-        Total events: {closed.totalEvents ?? 0} • Total bytes: {closed.totalBytes ?? 0}
-      </div>
+    <div className="stream-close-message" role="status">
+      Stream closed: {message}
     </div>
   );
 }

--- a/snapo-network-inspector-web/src/features/network-inspector/components/StreamEvents.tsx
+++ b/snapo-network-inspector-web/src/features/network-inspector/components/StreamEvents.tsx
@@ -8,6 +8,15 @@ import type { InspectorUiState } from "../hooks/useInspectorUiState";
 import { formatTime } from "../lib/format";
 import { InlineCopyButton, InlineTextToggle, PayloadView } from "./PayloadView";
 
+const emptyStreamMessages = {
+  Pending: "Waiting for response",
+  Streaming: "Awaiting events",
+  Closed: "No events received",
+  Offline: "No events received"
+};
+
+export type SseStatus = keyof typeof emptyStreamMessages;
+
 export const SseCopyAllButton = memo(function SseCopyAllButton({
   client,
   events
@@ -33,23 +42,21 @@ export const SseEventList = memo(function SseEventList({
   client,
   events,
   closed,
-  isConnected = true,
+  status,
   storageKey,
   uiState
 }: {
   client: NetworkClient;
   events: RequestRecord["streamEvents"];
   closed?: RequestRecord["streamClosed"];
-  isConnected?: boolean;
+  status: SseStatus;
   storageKey: string;
   uiState: InspectorUiState;
 }): JSX.Element {
   return (
     <div className="event-list">
       {events.length === 0 ? (
-        <div className="messages-empty">
-          {closed != null || !isConnected ? "No events received." : "Awaiting events..."}
-        </div>
+        <div className="messages-empty">{emptyStreamMessages[status]}</div>
       ) : (
         events.map((event) => (
           <SseEventCard

--- a/snapo-network-inspector-web/src/features/network-inspector/hooks/useSearchHighlights.ts
+++ b/snapo-network-inspector-web/src/features/network-inspector/hooks/useSearchHighlights.ts
@@ -14,7 +14,7 @@ const HighlightScopes = [
   ".json-outline",
   ".event-name",
   ".stream-event-metadata",
-  ".stream-closed-info",
+  ".stream-close-message",
   ".close-details",
   ".message-payload-size",
   ".message-enqueue-state",

--- a/snapo-network-inspector-web/src/features/network-inspector/lib/search.test.ts
+++ b/snapo-network-inspector-web/src/features/network-inspector/lib/search.test.ts
@@ -51,6 +51,46 @@ describe("network inspector search", () => {
     }
   });
 
+  it.each(["completed", "error"])("does not index hidden totals for %s streams", (reason) => {
+    const record = request({
+      streamClosed: { timestamp: 2, reason, totalEvents: 47281, totalBytes: 938471 }
+    });
+
+    for (const searchText of ["47281", "938471"]) {
+      expect(matchesNetworkSearch(record, parseNetworkSearchQuery(searchText))).toBe(false);
+    }
+  });
+
+  it("does not index the removed completion reason or message", () => {
+    const record = request({
+      streamClosed: { timestamp: 2, reason: "completed", message: "hidden-completion-message" }
+    });
+
+    for (const searchText of ["completed", "hidden-completion-message"]) {
+      expect(matchesNetworkSearch(record, parseNetworkSearchQuery(searchText))).toBe(false);
+    }
+  });
+
+  it.each([
+    { reason: "error", message: "Read timed out.", visibleText: "Read timed out." },
+    { reason: "error", message: undefined, visibleText: "Connection error." },
+    { reason: "error", message: "  ", visibleText: "Connection error." },
+    { reason: "cancelled", message: undefined, visibleText: "cancelled" }
+  ])("keeps the visible close message searchable: $visibleText", ({ reason, message, visibleText }) => {
+    const record = request({ streamClosed: { timestamp: 2, reason, message } });
+
+    expect(matchesNetworkSearch(record, parseNetworkSearchQuery(visibleText))).toBe(true);
+  });
+
+  it("does not index a close reason replaced by its visible message", () => {
+    const record = request({
+      streamClosed: { timestamp: 2, reason: "cancelled", message: "Request stopped by the client." }
+    });
+
+    expect(matchesNetworkSearch(record, parseNetworkSearchQuery("cancelled"))).toBe(false);
+    expect(matchesNetworkSearch(record, parseNetworkSearchQuery("Request stopped by the client."))).toBe(true);
+  });
+
   it("searches retained WebSocket message and lifecycle data", () => {
     const record = webSocket({
       messages: [

--- a/snapo-network-inspector-web/src/features/network-inspector/lib/search.test.ts
+++ b/snapo-network-inspector-web/src/features/network-inspector/lib/search.test.ts
@@ -3,6 +3,19 @@ import type { InspectorRecord, RequestRecord, WebSocketRecord } from "../../../n
 import { matchesNetworkSearch, parseNetworkSearchQuery } from "./search";
 
 describe("network inspector search", () => {
+  it("does not index an unknown HTTP result as a pending response", () => {
+    const record = request({
+      streamEvents: [{ sequence: 1, timestamp: 2, raw: "data: sample-event", data: "sample-event" }],
+      streamEventCount: 1
+    });
+
+    expect(matchesNetworkSearch(record, parseNetworkSearchQuery("Pending"))).toBe(false);
+    expect(matchesNetworkSearch(record, parseNetworkSearchQuery("sample-event"))).toBe(true);
+    expect(matchesNetworkSearch(webSocket({ status: { kind: "pending" } }), parseNetworkSearchQuery("Pending"))).toBe(
+      true
+    );
+  });
+
   it("does not change HTTP matches when lazy bodies are hydrated", () => {
     const bodyless = request();
     const hydrated: RequestRecord = {

--- a/snapo-network-inspector-web/src/features/network-inspector/lib/search.ts
+++ b/snapo-network-inspector-web/src/features/network-inspector/lib/search.ts
@@ -4,7 +4,7 @@ import {
   type KeywordSearchDocument,
   type KeywordSearchQuery
 } from "../../../network/keyword-search";
-import type { Header, InspectorRecord, RequestStatus } from "../../../network/cdp";
+import type { Header, InspectorRecord } from "../../../network/cdp";
 import { formatBytes } from "../../../network/payload";
 import { statusDisplayName } from "./format";
 
@@ -19,7 +19,7 @@ export function matchesNetworkSearch(record: InspectorRecord, query: NetworkSear
 }
 
 export function searchDocumentForRecord(record: InspectorRecord): KeywordSearchDocument {
-  const parts = [record.url, record.method, statusSearchText(record.status)];
+  const parts = [record.url, record.method, statusSearchText(record)];
   parts.push(...headersSearchText(record.requestHeaders), ...headersSearchText(record.responseHeaders));
 
   if (record.kind === "request") {
@@ -66,8 +66,9 @@ function headersSearchText(headers: Header[]): string[] {
   return headers.flatMap((header) => [header.name, header.value, `${header.name}: ${header.value}`]);
 }
 
-function statusSearchText(status: RequestStatus): string {
-  if (status.kind === "pending") return "Pending";
+function statusSearchText(record: InspectorRecord): string {
+  const status = record.status;
+  if (status.kind === "pending") return record.kind === "websocket" ? "Pending" : "";
   if (status.kind === "failure") return `Error ${status.message ?? ""}`;
   return `${status.code} ${statusDisplayName(status.code)}`;
 }

--- a/snapo-network-inspector-web/src/features/network-inspector/lib/search.ts
+++ b/snapo-network-inspector-web/src/features/network-inspector/lib/search.ts
@@ -33,13 +33,9 @@ export function searchDocumentForRecord(record: InspectorRecord): KeywordSearchD
         event.retryMillis == null ? "" : String(event.retryMillis)
       );
     }
-    if (record.streamClosed != null) {
-      parts.push(
-        record.streamClosed.reason,
-        record.streamClosed.message ?? "",
-        record.streamClosed.totalEvents == null ? "" : String(record.streamClosed.totalEvents),
-        record.streamClosed.totalBytes == null ? "" : String(record.streamClosed.totalBytes)
-      );
+    const closed = record.streamClosed;
+    if (closed != null && closed.reason !== "completed") {
+      parts.push(closed.message?.trim() || (closed.reason === "error" ? "Connection error." : closed.reason));
     }
   } else {
     for (const message of record.messages) {

--- a/snapo-network-inspector-web/src/preview/main.tsx
+++ b/snapo-network-inspector-web/src/preview/main.tsx
@@ -1,0 +1,59 @@
+import { StrictMode, useState } from "react";
+import { createRoot } from "react-dom/client";
+import { RequestDetail } from "../features/network-inspector/components/RequestDetail";
+import { useInspectorUiState } from "../features/network-inspector/hooks/useInspectorUiState";
+import { createNetworkClient } from "../network/client";
+import { previewRequests } from "./requests";
+import "../styles.css";
+import "./preview.css";
+
+const client = createNetworkClient();
+
+function RequestDetailPreview(): JSX.Element {
+  const [selectedId, setSelectedId] = useState(
+    () => new URLSearchParams(window.location.search).get("request") ?? previewRequests[0].record.requestId
+  );
+  const uiState = useInspectorUiState();
+  const { record } = previewRequests.find((sample) => sample.record.requestId === selectedId) ?? previewRequests[0];
+
+  return (
+    <div className="request-preview">
+      <nav className="preview-toolbar" aria-label="Preview controls">
+        <label htmlFor="preview-request">Mock request</label>
+        <select
+          id="preview-request"
+          value={record.requestId}
+          onChange={(event) => {
+            const requestId = event.target.value;
+            setSelectedId(requestId);
+            const url = new URL(window.location.href);
+            url.searchParams.set("request", requestId);
+            window.history.replaceState(null, "", url);
+          }}
+        >
+          {previewRequests.map((sample) => (
+            <option key={sample.record.requestId} value={sample.record.requestId}>
+              {sample.label}
+            </option>
+          ))}
+        </select>
+        <span>Synthetic data</span>
+      </nav>
+      <main className="detail-pane">
+        <RequestDetail
+          key={record.requestId}
+          client={client}
+          record={record}
+          uiState={uiState}
+          onRetryResponseBody={() => {}}
+        />
+      </main>
+    </div>
+  );
+}
+
+createRoot(document.getElementById("root") as HTMLElement).render(
+  <StrictMode>
+    <RequestDetailPreview />
+  </StrictMode>
+);

--- a/snapo-network-inspector-web/src/preview/preview.css
+++ b/snapo-network-inspector-web/src/preview/preview.css
@@ -1,0 +1,30 @@
+body {
+  min-width: var(--detail-min-width);
+}
+
+.request-preview {
+  height: 100%;
+  display: grid;
+  grid-template-rows: auto minmax(0, 1fr);
+}
+
+.preview-toolbar {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 8px;
+  padding: 8px 12px;
+  border-bottom: 1px solid var(--outline-variant);
+  background: var(--surface-bright);
+  font-size: 12px;
+}
+
+.preview-toolbar select {
+  min-width: 0;
+  max-width: 100%;
+}
+
+.preview-toolbar > span {
+  margin-left: auto;
+  color: var(--on-surface-variant);
+}

--- a/snapo-network-inspector-web/src/preview/requests.ts
+++ b/snapo-network-inspector-web/src/preview/requests.ts
@@ -1,0 +1,123 @@
+import type { RequestRecord } from "../network/cdp";
+
+const startedAt = Date.parse("2026-08-21T12:00:00Z");
+
+function request(requestId: string, overrides: Partial<RequestRecord> = {}): RequestRecord {
+  const record: RequestRecord = {
+    kind: "request",
+    server: { deviceId: "preview-device", socketName: "preview-socket" },
+    requestId,
+    method: "POST",
+    url: "https://api.example.com/v1/orders?include=items,shipping&locale=en-US",
+    requestHeaders: [
+      { name: "Content-Type", value: "application/json; charset=utf-8" },
+      { name: "Accept", value: "application/json" },
+      { name: "User-Agent", value: "ExampleApp/1.0 (Android)" },
+      { name: "X-Request-ID", value: "preview-request-001" }
+    ],
+    requestBody: JSON.stringify({
+      items: [
+        { product_id: "notebook-01", quantity: 2 },
+        { product_id: "pencil-02", quantity: 3 }
+      ],
+      shipping: { method: "standard", city: "Example City", country: "US" },
+      coupon: null
+    }),
+    responseHeaders: [
+      { name: "Content-Type", value: "application/json; charset=utf-8" },
+      { name: "Cache-Control", value: "no-store" },
+      { name: "Date", value: "Fri, 21 Aug 2026 12:00:00 GMT" },
+      { name: "X-Request-ID", value: "preview-request-001" },
+      { name: "Server-Timing", value: "db;dur=38, app;dur=94" },
+      { name: "Vary", value: "Accept-Encoding, Accept-Language" }
+    ],
+    responseBody: JSON.stringify({
+      id: "order-1042",
+      status: "confirmed",
+      currency: "USD",
+      total: 31.5,
+      items: [
+        { product_id: "notebook-01", name: "Grid notebook", quantity: 2, unit_price: 12 },
+        { product_id: "pencil-02", name: "Drawing pencil", quantity: 3, unit_price: 2.5 }
+      ],
+      shipping: { method: "standard", estimated_days: 4, tracking_url: null },
+      metadata: { source: "android", gift: false, tags: ["stationery", "back-to-school"] }
+    }),
+    responseBodyLoadCompleted: true,
+    hasReceivedResponse: true,
+    status: { kind: "success", code: 201 },
+    startedAt,
+    endedAt: startedAt + 248,
+    updatedAt: startedAt + 248,
+    streamEvents: [],
+    streamEventCount: 0,
+    ...overrides
+  };
+  record.encodedDataLength = new TextEncoder().encode(record.responseBody ?? "").byteLength;
+  return record;
+}
+
+const streamEvents = [
+  { eventName: "progress", data: JSON.stringify({ step: "accepted", progress: 0 }) },
+  { eventName: "progress", data: JSON.stringify({ step: "processing", progress: 50 }) },
+  { eventName: "complete", data: JSON.stringify({ step: "finished", progress: 100, result_id: "export-42" }) }
+].map((event, index) => ({
+  ...event,
+  sequence: index + 1,
+  timestamp: startedAt + (index + 1) * 500,
+  eventId: `event-${index + 1}`,
+  raw: `id: event-${index + 1}\nevent: ${event.eventName}\ndata: ${event.data}\n\n`
+}));
+
+export const previewRequests = [
+  { label: "JSON request and response", record: request("json") },
+  {
+    label: "HTTP 422 · Validation error",
+    record: request("validation-error", {
+      status: { kind: "success", code: 422 },
+      responseBody: JSON.stringify({
+        error: {
+          code: "validation_failed",
+          message: "One or more items could not be ordered.",
+          fields: [{ path: "items[0].quantity", message: "Only one item is currently available.", available: 1 }]
+        },
+        request_id: "preview-request-002"
+      })
+    })
+  },
+  {
+    label: "Server-sent events",
+    record: request("events", {
+      method: "GET",
+      url: "https://api.example.com/v1/exports/export-42/events",
+      requestHeaders: [{ name: "Accept", value: "text/event-stream" }],
+      requestBody: null,
+      responseHeaders: [
+        { name: "Content-Type", value: "text/event-stream" },
+        { name: "Cache-Control", value: "no-cache" }
+      ],
+      responseBody: null,
+      status: { kind: "success", code: 200 },
+      endedAt: startedAt + 1800,
+      updatedAt: startedAt + 1800,
+      streamEvents,
+      streamEventCount: streamEvents.length,
+      streamClosed: { timestamp: startedAt + 1800, reason: "completed", totalEvents: streamEvents.length }
+    })
+  },
+  {
+    label: "Connection failure",
+    record: request("connection-failure", {
+      method: "GET",
+      url: "https://api.example.com/v1/catalog?category=stationery&sort=newest&include=availability,images,dimensions,shipping-estimates&locale=en-US",
+      requestHeaders: [{ name: "Accept", value: "application/json" }],
+      requestBody: null,
+      responseHeaders: [],
+      responseBody: null,
+      hasReceivedResponse: false,
+      status: { kind: "failure", message: "Connection timed out while connecting to api.example.com." },
+      endedAt: startedAt + 10000,
+      updatedAt: startedAt + 10000
+    })
+  }
+];

--- a/snapo-network-inspector-web/src/styles.css
+++ b/snapo-network-inspector-web/src/styles.css
@@ -638,10 +638,6 @@ body.split-pane-resizing {
   color: var(--warning);
 }
 
-.status-streaming {
-  color: var(--accent-blue);
-}
-
 .failure-message {
   margin-top: 8px;
   color: var(--error);

--- a/snapo-network-inspector-web/src/styles.css
+++ b/snapo-network-inspector-web/src/styles.css
@@ -574,11 +574,11 @@ body.split-pane-resizing {
 .detail-scroll {
   min-height: 100%;
   overflow: visible;
-  padding: 16px;
+  padding: 14px 16px;
 }
 
 .detail-header {
-  padding: 0 4px 8px;
+  padding: 0 0 8px;
 }
 
 .title-row {
@@ -705,6 +705,14 @@ body.split-pane-resizing {
   font-size: 10px;
   line-height: 12px;
   font-weight: 500;
+}
+
+.section-status {
+  margin-left: 8px;
+  color: var(--on-surface-variant);
+  font-size: 10px;
+  font-weight: 400;
+  white-space: nowrap;
 }
 
 .section-action {
@@ -1037,6 +1045,7 @@ pre {
   display: flex;
   flex-direction: column;
   gap: 8px;
+  padding-top: 4px;
   padding-bottom: 8px;
 }
 
@@ -1060,7 +1069,18 @@ pre {
 }
 
 .event-meta {
+  align-items: flex-start;
   gap: 12px;
+  margin-bottom: 0;
+}
+
+.event-info {
+  display: flex;
+  align-items: center;
+  flex-wrap: wrap;
+  min-width: 0;
+  gap: 4px 12px;
+  overflow-wrap: anywhere;
 }
 
 .message-meta {
@@ -1076,6 +1096,10 @@ pre {
   gap: 6px;
 }
 
+.event-actions {
+  flex-shrink: 0;
+}
+
 .event-name {
   color: var(--on-surface);
   font-weight: 500;
@@ -1086,7 +1110,6 @@ pre {
 }
 
 .stream-event-metadata,
-.stream-closed-info,
 .close-details {
   margin-top: 6px;
   color: var(--on-surface-variant);
@@ -1095,8 +1118,11 @@ pre {
   line-height: 16px;
 }
 
-.stream-closed-info {
-  margin-top: 0;
+.stream-close-message {
+  color: var(--error);
+  font-size: 12px;
+  line-height: 16px;
+  overflow-wrap: anywhere;
 }
 
 .message-direction {


### PR DESCRIPTION
Network request details had uneven spacing, and the SSE completion footer added clutter. This updates the layout and gives stream lifecycle information one consistent place in the detail view.

## Summary

- Align the request header with its content and tighten SSE card spacing.
- Show only known HTTP results in the request header. Resolve SSE state once for the section label and empty message, including pending handshakes and disconnected apps.
- Remove the completion footer and totals. Keep abnormal closure details below the events and search aligned with visible request data.
- Remove ellipses from waiting and loading text.
- Add a development-only preview with synthetic requests. It is excluded from the production build.

## Validation

- `npm run typecheck`
- `npm run lint`
- `npm test` — 233 tests passed, including a connected/disconnected lifecycle scenario table.
- `npm run build`
- Prettier check on changed files and `git diff --check`.
- Checked browser layouts at 1094px and 400px widths, section collapse/expand, JSON expansion, and raw/pretty controls.
- Verified pending, response-before-event, and streaming states with synthetic browser data. Confirmed one lifecycle label, no duplicate waiting message, and no ellipses in the affected text.
- Native macOS rendering and a live Android SSE stream were not tested.
