### PR TITLE
Preserve Live Preview when toggling the inspector pane

### DIFF
--- a/snapo-app-mac/Snap-O/CaptureWindow/CaptureSurfaceView.swift
+++ b/snapo-app-mac/Snap-O/CaptureWindow/CaptureSurfaceView.swift
@@ -1,0 +1,19 @@
+import SwiftUI
+
+struct CaptureSurfaceView<Content: View>: View {
+  let aspectRatio: CGFloat?
+  @ViewBuilder var content: () -> Content
+
+  var body: some View {
+    GeometryReader { geometry in
+      let paneAspectRatio = geometry.size.width / max(geometry.size.height, 1)
+
+      ZStack {
+        Color(nsColor: .unemphasizedSelectedContentBackgroundColor)
+        // Keep the media view mounted when the inspector changes the sizing policy.
+        content()
+          .aspectRatio(aspectRatio ?? paneAspectRatio, contentMode: .fit)
+      }
+    }
+  }
+}

--- a/snapo-app-mac/Snap-O/CaptureWindow/CaptureWindow.swift
+++ b/snapo-app-mac/Snap-O/CaptureWindow/CaptureWindow.swift
@@ -343,25 +343,10 @@ struct CaptureWindow: View {
     controller: CaptureWindowController,
     layout: WorkspaceLayout
   ) -> some View {
-    captureSurface(controller: controller, layout: layout)
-      .background(captureAreaBackground)
-  }
-
-  private func captureSurface(
-    controller: CaptureWindowController,
-    layout: WorkspaceLayout
-  ) -> some View {
-    Group {
-      if layout.showsNetwork, let displayInfo = controller.displayInfoForSizing {
-        ZStack {
-          captureLetterboxBackground
-          captureContent(controller: controller)
-            .aspectRatio(displayInfo.aspectRatio, contentMode: .fit)
-        }
-      } else {
-        captureContent(controller: controller)
-      }
+    CaptureSurfaceView(aspectRatio: layout.showsNetwork ? controller.displayInfoForSizing?.aspectRatio : nil) {
+      captureContent(controller: controller)
     }
+    .background(captureAreaBackground)
   }
 
   private var captureAreaBackground: Color {

--- a/snapo-app-mac/Tests/StartupCapture/LivePreviewVisibilityTests.swift
+++ b/snapo-app-mac/Tests/StartupCapture/LivePreviewVisibilityTests.swift
@@ -33,12 +33,19 @@ struct LivePreviewRenderer {
   let session: LivePreviewSession
 }
 
-struct LivePreviewRendererView: View {
+struct LivePreviewRendererView: NSViewRepresentable {
   let renderer: LivePreviewRenderer
   let fileStore: FileStore
-  var body: some View {
-    Color.green
+
+  @MainActor static var displayView: NSView?
+
+  func makeNSView(context: Context) -> NSView {
+    let view = NSView()
+    Self.displayView = view
+    return view
   }
+
+  func updateNSView(_ nsView: NSView, context: Context) {}
 }
 
 /// Drives the production view lifecycle without a device or an on-screen window.
@@ -115,9 +122,14 @@ struct LivePreviewVisibilityTests {
   static func main() {
     _ = NSApplication.shared
     let host = TestHost()
-    let view = NSHostingView(rootView: LiveCaptureView(host: host, capture: CaptureMedia(), fileStore: FileStore()))
+    func surface(aspectRatio: CGFloat?) -> some View {
+      CaptureSurfaceView(aspectRatio: aspectRatio) {
+        LiveCaptureView(host: host, capture: CaptureMedia(), fileStore: FileStore())
+      }
+    }
+    let view = NSHostingView(rootView: surface(aspectRatio: nil))
     let window = NSWindow(
-      contentRect: NSRect(x: 0, y: 0, width: 120, height: 120),
+      contentRect: NSRect(x: 0, y: 0, width: 240, height: 120),
       styleMask: [.borderless],
       backing: .buffered,
       defer: false
@@ -129,6 +141,24 @@ struct LivePreviewVisibilityTests {
     Visibility.shared.isVisible = true
     eventually("Visible preview starts once") { host.starts == 1 && host.active.count == 1 }
     precondition(!NSApplication.shared.isActive, "Test must leave the app inactive")
+    eventually("Renderer must attach") { LivePreviewRendererView.displayView != nil }
+    let displayView = LivePreviewRendererView.displayView
+    let sizingCases: [(CGFloat?, CGSize)] = [
+      (nil, CGSize(width: 240, height: 120)),
+      (0.5, CGSize(width: 60, height: 120)),
+      (nil, CGSize(width: 240, height: 120)),
+      (4, CGSize(width: 240, height: 60)),
+      (0.5, CGSize(width: 60, height: 120)),
+      (nil, CGSize(width: 240, height: 120))
+    ]
+    for (aspectRatio, expectedSize) in sizingCases {
+      view.rootView = surface(aspectRatio: aspectRatio)
+      view.layoutSubtreeIfNeeded()
+      pump()
+      precondition(host.starts == 1 && host.stops.isEmpty, "Inspector toggles must not restart the stream")
+      precondition(LivePreviewRendererView.displayView === displayView, "Inspector toggles must preserve the display view")
+      precondition(displayView?.frame.size == expectedSize, "Preview must fit the device or fill the capture-only pane")
+    }
     host.delayStop = true
     Visibility.shared.isVisible = false
     eventually("Cleanup should be pending") { host.stopContinuation != nil }

--- a/snapo-app-mac/scripts/test-startup-capture.sh
+++ b/snapo-app-mac/scripts/test-startup-capture.sh
@@ -23,6 +23,6 @@ xcrun swiftc -swift-version 6 -parse-as-library -I "$TEST_DIR" \
   Tests/StartupCapture/LivePreviewSessionTests.swift -o "$TEST_DIR/session-tests"
 "$TEST_DIR/session-tests"
 xcrun swiftc -swift-version 6 -parse-as-library \
-  Snap-O/CaptureWindow/LiveCaptureView.swift \
+  Snap-O/CaptureWindow/LiveCaptureView.swift Snap-O/CaptureWindow/CaptureSurfaceView.swift \
   Tests/StartupCapture/LivePreviewVisibilityTests.swift -o "$TEST_DIR/visibility-tests"
 "$TEST_DIR/visibility-tests"


### PR DESCRIPTION
Toggling the inspector pane replaced the capture view with a different SwiftUI branch. This stopped Live Preview, briefly showed gray, and restarted the stream. Keep the capture view mounted so pane changes affect only its sizing.

## Summary

- Keep capture content in a stable view hierarchy while switching between full-pane and device-aspect sizing.
- Remove the redundant capture-surface forwarding method.
- Extend the existing lifecycle test to verify uninterrupted streaming, display-view identity, and portrait and landscape sizing.

## Validation

- The regression test failed with the previous branching layout and passes with the fix.
- Startup capture tests passed (13 cases), along with session and visibility lifecycle tests.
- macOS app built with code signing disabled.
- SwiftFormat 0.61.1, SwiftLint 0.63.2, and `git diff --check` passed.
- Not yet verified with a connected Android device.