### PR TITLE
Keep Live Preview running while covered

### DIFF
--- a/snapo-app-mac/Snap-O/App/AppDelegate.swift
+++ b/snapo-app-mac/Snap-O/App/AppDelegate.swift
@@ -50,6 +50,7 @@ class AppDelegate: NSObject, NSApplicationDelegate {
     terminationTimeoutTask = Task { [weak self] in
       try? await Task.sleep(for: .seconds(Self.terminationCleanupTimeoutSeconds))
       guard !Task.isCancelled else { return }
+      Perf.end(.appShutdown, finalLabel: "cleanup timeout")
       self?.completeTermination(for: sender)
     }
     return .terminateLater

--- a/snapo-app-mac/Snap-O/App/AppRuntime.swift
+++ b/snapo-app-mac/Snap-O/App/AppRuntime.swift
@@ -97,24 +97,31 @@ final class AppRuntime {
     let captureCoordinator = captureCoordinator
     let captureServices = captureServices
     let task = Task {
+      Perf.start(.appShutdown, name: "App Quit → Cleanup")
       await captureCoordinator.beginShutdown()
       await captureServices.startup.discard()
+      Perf.step(.appShutdown, "startup preparation discarded")
       await withTaskGroup(of: Void.self) { group in
         group.addTask {
           await activeStartupTask?.value
           await deviceTracker.stopTracking()
+          Perf.step(.appShutdown, "device tracking stopped")
         }
         group.addTask {
           await captureServices.screenshots.shutdown()
+          Perf.step(.appShutdown, "screenshots stopped")
         }
         group.addTask {
           await captureServices.recording.shutdown()
+          Perf.step(.appShutdown, "recording stopped")
         }
         group.addTask {
           await captureServices.livePreview.shutdown()
+          Perf.step(.appShutdown, "live preview stopped")
         }
       }
       await captureCoordinator.waitUntilIdle()
+      Perf.end(.appShutdown, finalLabel: "cleanup finished")
     }
     shutdownTask = task
     await task.value

--- a/snapo-app-mac/Snap-O/Capture/LivePreviewService.swift
+++ b/snapo-app-mac/Snap-O/Capture/LivePreviewService.swift
@@ -51,7 +51,7 @@ actor LivePreviewService {
       throw CancellationError()
     }
 
-    let showTouchesOverride = await ShowTouchesOverride.apply(
+    async let applyingShowTouches = ShowTouchesOverride.apply(
       deviceID: deviceID,
       enabled: options.showsTouches,
       using: adb
@@ -60,10 +60,12 @@ actor LivePreviewService {
     do {
       session = try await LivePreviewSession(deviceID: deviceID, adb: adb)
     } catch {
+      let showTouchesOverride = await applyingShowTouches
       await showTouchesOverride.restore(using: adb)
       await coordinator.release(lease)
       throw error
     }
+    let showTouchesOverride = await applyingShowTouches
 
     guard !Task.isCancelled, !isShuttingDown else {
       await session.cancel()

--- a/snapo-app-mac/Snap-O/Capture/ShowTouchesOverride.swift
+++ b/snapo-app-mac/Snap-O/Capture/ShowTouchesOverride.swift
@@ -18,12 +18,13 @@ struct ShowTouchesOverride {
       return ShowTouchesOverride(deviceID: deviceID, originalValue: nil)
     }
 
-    if originalValue != enabled {
-      do {
-        try await exec.setShowTouches(deviceID: deviceID, enabled: enabled)
-      } catch {
-        logFailure(action: "update", deviceID: deviceID, error: error)
-      }
+    guard originalValue != enabled else {
+      return ShowTouchesOverride(deviceID: deviceID, originalValue: nil)
+    }
+    do {
+      try await exec.setShowTouches(deviceID: deviceID, enabled: enabled)
+    } catch {
+      logFailure(action: "update", deviceID: deviceID, error: error)
     }
     return ShowTouchesOverride(deviceID: deviceID, originalValue: originalValue)
   }

--- a/snapo-app-mac/Snap-O/CaptureWindow/LiveCaptureView.swift
+++ b/snapo-app-mac/Snap-O/CaptureWindow/LiveCaptureView.swift
@@ -23,7 +23,7 @@ struct LiveCaptureView<Host: LivePreviewHosting>: View {
   var body: some View {
     ZStack {
       if let renderer {
-        LivePreviewRendererView(renderer: renderer, fileStore: fileStore)
+        LivePreviewRendererView(renderer: renderer, fileStore: fileStore, isVisible: isWindowVisible)
       } else {
         Color(nsColor: .unemphasizedSelectedContentBackgroundColor)
       }
@@ -32,13 +32,13 @@ struct LiveCaptureView<Host: LivePreviewHosting>: View {
     .background {
       WindowVisibilityReader { isVisible in
         isWindowVisible = isVisible
-        updateStreamVisibility()
+        startStreamIfNeeded()
       }
       .frame(width: 0, height: 0)
     }
     .onAppear {
       isViewVisible = true
-      updateStreamVisibility()
+      startStreamIfNeeded()
     }
     .onDisappear {
       isViewVisible = false
@@ -46,16 +46,8 @@ struct LiveCaptureView<Host: LivePreviewHosting>: View {
     }
   }
 
-  private func updateStreamVisibility() {
-    if isViewVisible, isWindowVisible {
-      startStreamIfNeeded()
-    } else {
-      stopStream()
-    }
-  }
-
   private func startStreamIfNeeded() {
-    guard streamTask == nil else { return }
+    guard isViewVisible, isWindowVisible, streamTask == nil else { return }
 
     let deviceID = capture.device.id
     let lifecycleID = UUID()

--- a/snapo-app-mac/Snap-O/LivePreview/LivePreviewSession.swift
+++ b/snapo-app-mac/Snap-O/LivePreview/LivePreviewSession.swift
@@ -145,7 +145,7 @@ final class LivePreviewSession {
       let streamError: Error?
       do {
         while !Task.isCancelled {
-          guard let chunk = try session.read(maxLength: 4096), !chunk.isEmpty else { break }
+          guard let chunk = try session.read(maxLength: 64 * 1024), !chunk.isEmpty else { break }
           decoder.append(chunk)
         }
         streamError = nil
@@ -167,7 +167,6 @@ final class LivePreviewSession {
     streamTask?.cancel()
     streamTask = nil
     screenStream.close()
-    decoder?.finish()
     decoder = nil
     sampleBufferHandler = nil
 

--- a/snapo-app-mac/Snap-O/LivePreview/LivePreviewView.swift
+++ b/snapo-app-mac/Snap-O/LivePreview/LivePreviewView.swift
@@ -19,6 +19,7 @@ struct LivePreviewRenderer {
 struct LivePreviewRendererView: NSViewRepresentable {
   let renderer: LivePreviewRenderer
   let fileStore: FileStore
+  let isVisible: Bool
 
   func makeNSView(context: Context) -> LivePreviewDisplayView {
     let view = LivePreviewDisplayView(fileStore: fileStore)
@@ -28,7 +29,7 @@ struct LivePreviewRendererView: NSViewRepresentable {
   }
 
   func updateNSView(_ nsView: LivePreviewDisplayView, context: Context) {
-    nsView.update(with: renderer)
+    nsView.update(with: renderer, isVisible: isVisible)
   }
 
   static func dismantleNSView(_ nsView: LivePreviewDisplayView, coordinator: Void) {
@@ -69,7 +70,13 @@ final class LivePreviewDisplayView: NSView, NSDraggingSource {
     true
   }
 
-  func update(with renderer: LivePreviewRenderer?) {
+  func update(with renderer: LivePreviewRenderer?, isVisible: Bool = false) {
+    // Keep decoding and retaining the latest frame without compositing hidden previews.
+    CATransaction.begin()
+    CATransaction.setDisableActions(true)
+    displayLayer.isHidden = !isVisible
+    CATransaction.commit()
+
     let shouldDetach: Bool = switch (self.renderer?.session, renderer?.session) {
     case (let lhs?, let rhs?): lhs !== rhs
     case (nil, nil): false

--- a/snapo-app-mac/Snap-O/Utilities/Perf.swift
+++ b/snapo-app-mac/Snap-O/Utilities/Perf.swift
@@ -2,6 +2,7 @@ import Foundation
 
 public enum PerfKey: String, Hashable {
   case appFirstSnapshot
+  case appShutdown
   case captureRequest
   case recordingStart
   case recordingRender

--- a/snapo-app-mac/Tests/LivePreviewFrameExport/LivePreviewFrameExportTests.swift
+++ b/snapo-app-mac/Tests/LivePreviewFrameExport/LivePreviewFrameExportTests.swift
@@ -1,7 +1,10 @@
 import AppKit
+@preconcurrency import AVFoundation
+import CoreImage
 import CoreVideo
 import Foundation
 import OSLog
+import VideoToolbox
 
 enum MediaSaveKind {
   case image
@@ -12,6 +15,35 @@ enum MediaSaveKind {
 
 enum SnapOLog {
   static let storage = Logger(subsystem: "Snap-O.FrameExportTests", category: "storage")
+  static let ui = Logger(subsystem: "Snap-O.FrameExportTests", category: "ui")
+}
+
+struct LivePreviewOperationHandle {
+  let deviceID = "test-device"
+  let session: LivePreviewSession
+}
+
+@MainActor
+final class LivePreviewSession {
+  struct Media { let size: CGSize }
+  let media: Media? = Media(size: CGSize(width: 64, height: 64))
+  var sampleBufferHandler: ((CMSampleBuffer) -> Void)?
+}
+
+enum LivePreviewPointerAction { case down, move, up, cancel }
+enum LivePreviewPointerSource { case mouse, touchscreen }
+
+private final class EncodedSamples: @unchecked Sendable {
+  private let lock = NSLock()
+  private var storage: [CMSampleBuffer] = []
+
+  var samples: [CMSampleBuffer] {
+    lock.withLock { storage }
+  }
+
+  func append(_ sample: CMSampleBuffer) {
+    lock.withLock { storage.append(sample) }
+  }
 }
 
 @main
@@ -43,13 +75,116 @@ struct LivePreviewFrameExportTests {
     let pathA = try store.makeUniqueDragDestination(capturedAt: timestamp, kind: .image)
     let pathB = try store.makeUniqueDragDestination(capturedAt: timestamp, kind: .image)
     precondition(pathA != pathB && pathA.lastPathComponent == pathB.lastPathComponent)
+    if CommandLine.arguments.contains("--render") {
+      hiddenPreviewRetainsLatestFrame(store: store)
+      print("Live preview hidden decoding test passed")
+    }
     print("Live preview frame export tests passed")
   }
 
-  private static func makeBuffer() -> CVPixelBuffer {
+  private static func hiddenPreviewRetainsLatestFrame(store: FileStore) {
+    _ = NSApplication.shared
+    let view = LivePreviewDisplayView(fileStore: store)
+    let window = NSWindow(
+      contentRect: NSRect(x: 0, y: 0, width: 64, height: 64),
+      styleMask: [.borderless], backing: .buffered, defer: false
+    )
+    window.contentView = view
+    window.orderFront(nil)
+    defer { window.orderOut(nil) }
+    guard let layer = view.layer?.sublayers?.first as? AVSampleBufferDisplayLayer else {
+      fatalError("Missing video layer")
+    }
+    // Pixel-buffer inspection requires a paused renderer; advance its clock per test frame.
+    var timebase: CMTimebase?
+    precondition(CMTimebaseCreateWithSourceClock(
+      allocator: kCFAllocatorDefault, sourceClock: CMClockGetHostTimeClock(), timebaseOut: &timebase
+    ) == noErr)
+    guard let timebase else { fatalError("Missing timebase") }
+    layer.controlTimebase = timebase
+    let session = LivePreviewSession()
+    let renderer = LivePreviewRenderer(operation: LivePreviewOperationHandle(session: session)) { _, _, _, _ in }
+    view.update(with: renderer, isVisible: true)
+    let samples = makeEncodedSamples()
+    let imageContext = CIContext()
+    func displays(red: Bool) -> Bool {
+      precondition(layer.sampleBufferRenderer.status != .failed, "Renderer failed: \(String(describing: layer.sampleBufferRenderer.error))")
+      guard let buffer = layer.sampleBufferRenderer.displayedPixelBuffer(),
+            let image = imageContext.createCGImage(CIImage(cvPixelBuffer: buffer), from: CGRect(x: 0, y: 0, width: 64, height: 64)),
+            let color = NSBitmapImageRep(cgImage: image).colorAt(x: 32, y: 32)?.usingColorSpace(.deviceRGB)
+      else { return false }
+      return red ? color.redComponent > 0.8 : color.blueComponent > 0.8
+    }
+
+    session.sampleBufferHandler?(samples[0])
+    eventually("Initial frame must decode") { displays(red: true) }
+    view.update(with: renderer, isVisible: false)
+    precondition(layer.isHidden && session.sampleBufferHandler != nil)
+    CMTimebaseSetTime(timebase, time: CMSampleBufferGetPresentationTimeStamp(samples[1]))
+    session.sampleBufferHandler?(samples[1])
+    RunLoop.main.run(until: Date().addingTimeInterval(0.2))
+
+    view.update(with: renderer, isVisible: true)
+    precondition(!layer.isHidden)
+    eventually("Uncover must show the latest frame without waiting for new video") { displays(red: false) }
+    CMTimebaseSetTime(timebase, time: CMSampleBufferGetPresentationTimeStamp(samples[2]))
+    session.sampleBufferHandler?(samples[2])
+    eventually("Decoding must continue after uncover without a new keyframe") { displays(red: true) }
+    precondition(!layer.sampleBufferRenderer.requiresFlushToResumeDecoding)
+    view.update(with: nil)
+    precondition(session.sampleBufferHandler == nil, "Detaching must release the session callback")
+    window.contentView = nil
+  }
+
+  private static func makeEncodedSamples() -> [CMSampleBuffer] {
+    var compressionSession: VTCompressionSession?
+    let status = VTCompressionSessionCreate(
+      allocator: kCFAllocatorDefault, width: 64, height: 64, codecType: kCMVideoCodecType_H264,
+      encoderSpecification: nil, imageBufferAttributes: nil, compressedDataAllocator: nil,
+      outputCallback: nil, refcon: nil, compressionSessionOut: &compressionSession
+    )
+    guard status == noErr, let compressionSession else { fatalError("Could not create H.264 encoder: \(status)") }
+    defer { VTCompressionSessionInvalidate(compressionSession) }
+    precondition(VTSessionSetProperty(compressionSession, key: kVTCompressionPropertyKey_AllowFrameReordering, value: kCFBooleanFalse) ==
+      noErr)
+    precondition(VTSessionSetProperty(compressionSession, key: kVTCompressionPropertyKey_MaxKeyFrameInterval, value: 600 as CFNumber) ==
+      noErr)
+    let output = EncodedSamples()
+    for index in 0 ..< 3 {
+      let buffer = makeBuffer(width: 64, height: 64)
+      fill(buffer, red: index == 1 ? 0 : 255, blue: index == 1 ? 255 : 0)
+      let result = VTCompressionSessionEncodeFrame(
+        compressionSession, imageBuffer: buffer,
+        presentationTimeStamp: CMTime(value: Int64(index), timescale: 30),
+        duration: CMTime(value: 1, timescale: 30), frameProperties: nil, infoFlagsOut: nil
+      ) { status, _, sample in
+        precondition(status == noErr)
+        if let sample { output.append(sample) }
+      }
+      precondition(result == noErr)
+    }
+    precondition(VTCompressionSessionCompleteFrames(compressionSession, untilPresentationTimeStamp: .invalid) == noErr)
+    let samples = output.samples
+    precondition(samples.count == 3)
+    for sample in samples.dropFirst() {
+      let attachments = CMSampleBufferGetSampleAttachmentsArray(sample, createIfNecessary: false) as? [[CFString: Any]]
+      precondition(attachments?.first?[kCMSampleAttachmentKey_NotSync] as? Bool == true, "Resume test needs dependent frames")
+    }
+    return samples
+  }
+
+  private static func eventually(_ message: String, _ condition: () -> Bool) {
+    let deadline = Date().addingTimeInterval(5)
+    while !condition(), Date() < deadline {
+      RunLoop.main.run(until: Date().addingTimeInterval(0.01))
+    }
+    precondition(condition(), message)
+  }
+
+  private static func makeBuffer(width: Int = 16, height: Int = 24) -> CVPixelBuffer {
     var result: CVPixelBuffer?
     let status = CVPixelBufferCreate(
-      kCFAllocatorDefault, 16, 24, kCVPixelFormatType_32BGRA,
+      kCFAllocatorDefault, width, height, kCVPixelFormatType_32BGRA,
       [kCVPixelBufferIOSurfacePropertiesKey: [:]] as CFDictionary, &result
     )
     guard status == kCVReturnSuccess, let result else { fatalError("Could not create pixel buffer") }

--- a/snapo-app-mac/Tests/StartupCapture/LivePreviewSessionTests.swift
+++ b/snapo-app-mac/Tests/StartupCapture/LivePreviewSessionTests.swift
@@ -1,5 +1,28 @@
 @preconcurrency import AVFoundation
 import Foundation
+import OSLog
+
+enum SnapOLog {
+  static let recording = Logger(subsystem: "Snap-O.SessionTests", category: "test")
+}
+
+enum TestError: Error { case expected }
+
+actor TestGate {
+  private var isOpen = false
+  private var continuation: CheckedContinuation<Void, Never>?
+
+  func wait() async {
+    guard !isOpen else { return }
+    await withCheckedContinuation { continuation = $0 }
+  }
+
+  func open() {
+    isOpen = true
+    continuation?.resume()
+    continuation = nil
+  }
+}
 
 /// A blocking stream that only ends when the production session closes it.
 final class ScreenStreamSession: @unchecked Sendable {
@@ -24,6 +47,30 @@ final class ScreenStreamSession: @unchecked Sendable {
 }
 
 actor ADBService {
+  private let settingsGate: TestGate?
+  private let failsToStart: Bool
+  private let failsSettingRead: Bool
+  private let failsSettingWrite: Bool
+  private var showsTouches: Bool
+  private(set) var settingsReadStarted = false
+  private(set) var writes: [Bool] = []
+  private(set) var streamStarts = 0
+  private(set) var latestStream: ScreenStreamSession?
+
+  init(
+    showsTouches: Bool = false,
+    settingsGate: TestGate? = nil,
+    failsToStart: Bool = false,
+    failsSettingRead: Bool = false,
+    failsSettingWrite: Bool = false
+  ) {
+    self.showsTouches = showsTouches
+    self.settingsGate = settingsGate
+    self.failsToStart = failsToStart
+    self.failsSettingRead = failsSettingRead
+    self.failsSettingWrite = failsSettingWrite
+  }
+
   func exec() -> ADBService {
     self
   }
@@ -33,13 +80,37 @@ actor ADBService {
   }
 
   func startScreenStream(deviceID _: String) throws -> ScreenStreamSession {
-    ScreenStreamSession()
+    streamStarts += 1
+    if failsToStart { throw TestError.expected }
+    let stream = ScreenStreamSession()
+    latestStream = stream
+    return stream
+  }
+
+  func getShowTouches(deviceID _: String) async throws -> Bool {
+    settingsReadStarted = true
+    await settingsGate?.wait()
+    if failsSettingRead { throw TestError.expected }
+    return showsTouches
+  }
+
+  func setShowTouches(deviceID _: String, enabled: Bool) throws {
+    writes.append(enabled)
+    showsTouches = enabled
+    // A failed command may still have changed the device setting.
+    if failsSettingWrite { throw TestError.expected }
   }
 }
 
 final class H264StreamDecoder: @unchecked Sendable {
   @MainActor static var latest: H264StreamDecoder?
   private let formatHandler: (CMFormatDescription) -> Void
+  private let finishLock = NSLock()
+  private var finishes = 0
+
+  var finishCount: Int {
+    finishLock.withLock { finishes }
+  }
 
   @MainActor
   init(
@@ -51,7 +122,10 @@ final class H264StreamDecoder: @unchecked Sendable {
   }
 
   func append(_: Data) {}
-  func finish() {}
+  func finish() {
+    dispatchPrecondition(condition: .notOnQueue(.main))
+    finishLock.withLock { finishes += 1 }
+  }
 
   @MainActor
   func emitFormat() {
@@ -70,6 +144,7 @@ final class H264StreamDecoder: @unchecked Sendable {
 struct LivePreviewSessionTests {
   static func main() async throws {
     let session = try await LivePreviewSession(deviceID: "ready", adb: ADBService())
+    guard let decoder = H264StreamDecoder.latest else { fatalError("Missing decoder") }
     let first = Task { try await session.waitUntilReady() }
     let second = Task { try await session.waitUntilReady() }
     for _ in 0 ..< 20 {
@@ -82,6 +157,7 @@ struct LivePreviewSessionTests {
     precondition(firstMedia.size == CGSize(width: 1080, height: 2400))
     session.cancel()
     _ = await session.waitUntilStop()
+    await eventually { decoder.finishCount == 1 }
 
     let cancelled = try await LivePreviewSession(deviceID: "cancelled", adb: ADBService())
     let pendingFirst = Task { try await cancelled.waitUntilReady() }
@@ -94,7 +170,121 @@ struct LivePreviewSessionTests {
     await expectCancellation(pendingSecond)
     await expectCancellation(Task { try await cancelled.waitUntilReady() })
     _ = await cancelled.waitUntilStop()
-    print("Live preview session tests passed (readiness and cancellation)")
+
+    try await streamCompletionFlushesOnce()
+    await showTouchesRestoration()
+    try await startupOverlapsSettings()
+    try await failedStartupRestoresSettings()
+    try await cancelledStartupRestoresSettings()
+    print("Live preview session tests passed (readiness, cancellation, cleanup, and overlapping startup)")
+  }
+
+  static func streamCompletionFlushesOnce() async throws {
+    let adb = ADBService()
+    let session = try await LivePreviewSession(deviceID: "completed", adb: adb)
+    guard let decoder = H264StreamDecoder.latest else { fatalError("Missing decoder") }
+    await adb.latestStream?.close()
+    _ = await session.waitUntilStop()
+    session.cancel()
+    precondition(decoder.finishCount == 1)
+  }
+
+  static func showTouchesRestoration() async {
+    for original in [false, true] {
+      for requested in [false, true] {
+        let adb = ADBService(showsTouches: original)
+        let override = await ShowTouchesOverride.apply(deviceID: "settings", enabled: requested, using: adb)
+        await override.restore(using: adb)
+        let writes = await adb.writes
+        precondition(writes == (original == requested ? [] : [requested, original]))
+      }
+    }
+
+    let unreadable = ADBService(failsSettingRead: true)
+    let noOverride = await ShowTouchesOverride.apply(deviceID: "unreadable", enabled: true, using: unreadable)
+    await noOverride.restore(using: unreadable)
+    let skippedWrites = await unreadable.writes
+    precondition(skippedWrites.isEmpty)
+
+    let partialWrite = ADBService(failsSettingWrite: true)
+    let override = await ShowTouchesOverride.apply(deviceID: "partial-write", enabled: true, using: partialWrite)
+    await override.restore(using: partialWrite)
+    let restoredWrites = await partialWrite.writes
+    precondition(restoredWrites == [true, false])
+  }
+
+  static func startupOverlapsSettings() async throws {
+    let settingsGate = TestGate()
+    let adb = ADBService(settingsGate: settingsGate)
+    let coordinator = CaptureCoordinator()
+    let service = LivePreviewService(adb: adb, coordinator: coordinator)
+    var returned = false
+    let startup = Task {
+      let handle = try await service.start(for: "overlap", options: LivePreviewOptions(showsTouches: true))
+      returned = true
+      return handle
+    }
+    await eventually { await adb.settingsReadStarted }
+    await eventually { await adb.streamStarts == 1 }
+    precondition(!returned)
+    await settingsGate.open()
+    let handle = try await startup.value
+    let appliedWrites = await adb.writes
+    precondition(appliedWrites == [true])
+    _ = await service.stop(handle)
+    let restoredWrites = await adb.writes
+    precondition(restoredWrites == [true, false])
+    await coordinator.waitUntilIdle()
+  }
+
+  static func failedStartupRestoresSettings() async throws {
+    let settingsGate = TestGate()
+    let adb = ADBService(settingsGate: settingsGate, failsToStart: true)
+    let coordinator = CaptureCoordinator()
+    let service = LivePreviewService(adb: adb, coordinator: coordinator)
+    let startup = Task { try await service.start(for: "failed", options: LivePreviewOptions(showsTouches: true)) }
+    await eventually { await adb.streamStarts == 1 }
+    await settingsGate.open()
+    do {
+      _ = try await startup.value
+      fatalError("Expected startup failure")
+    } catch TestError.expected {
+      // Expected.
+    }
+    let writes = await adb.writes
+    precondition(writes == [true, false])
+    let lease = try await coordinator.acquire(deviceIDs: ["failed"], for: .livePreview)
+    await coordinator.release(lease)
+  }
+
+  static func cancelledStartupRestoresSettings() async throws {
+    let settingsGate = TestGate()
+    let adb = ADBService(settingsGate: settingsGate)
+    let coordinator = CaptureCoordinator()
+    let service = LivePreviewService(adb: adb, coordinator: coordinator)
+    let startup = Task { try await service.start(for: "cancelled-start", options: LivePreviewOptions(showsTouches: true)) }
+    await eventually { await adb.streamStarts == 1 }
+    startup.cancel()
+    await settingsGate.open()
+    do {
+      _ = try await startup.value
+      fatalError("Expected startup cancellation")
+    } catch is CancellationError {
+      // Expected.
+    }
+    let writes = await adb.writes
+    precondition(writes == [true, false])
+    let lease = try await coordinator.acquire(deviceIDs: ["cancelled-start"], for: .livePreview)
+    await coordinator.release(lease)
+  }
+
+  static func eventually(_ condition: () async -> Bool) async {
+    let deadline = ContinuousClock.now.advanced(by: .seconds(5))
+    while ContinuousClock.now < deadline {
+      if await condition() { return }
+      await Task.yield()
+    }
+    fatalError("Condition did not become true")
   }
 
   static func expectCancellation(_ task: Task<Media, Error>) async {

--- a/snapo-app-mac/Tests/StartupCapture/LivePreviewVisibilityTests.swift
+++ b/snapo-app-mac/Tests/StartupCapture/LivePreviewVisibilityTests.swift
@@ -1,4 +1,5 @@
 import AppKit
+import AVFoundation
 import Observation
 import OSLog
 import SwiftUI
@@ -36,6 +37,7 @@ struct LivePreviewRenderer {
 struct LivePreviewRendererView: NSViewRepresentable {
   let renderer: LivePreviewRenderer
   let fileStore: FileStore
+  let isVisible: Bool
 
   @MainActor static var displayView: NSView?
 
@@ -45,7 +47,44 @@ struct LivePreviewRendererView: NSViewRepresentable {
     return view
   }
 
-  func updateNSView(_ nsView: NSView, context: Context) {}
+  func updateNSView(_ nsView: NSView, context: Context) {
+    nsView.isHidden = !isVisible
+  }
+}
+
+/// Exercise the production playback view without loading media or running a decoder.
+@MainActor
+final class AVQueuePlayer {
+  static var latest: AVQueuePlayer?
+  var timeControlStatus = AVPlayer.TimeControlStatus.paused
+
+  init() {
+    Self.latest = self
+  }
+
+  func play() {
+    timeControlStatus = .playing
+  }
+
+  func pause() {
+    timeControlStatus = .paused
+  }
+}
+
+struct AVPlayerItem {
+  let url: URL
+}
+
+struct AVPlayerLooper {
+  let player: AVQueuePlayer
+  let templateItem: AVPlayerItem
+}
+
+struct VideoPlayer: View {
+  let player: AVQueuePlayer
+  var body: some View {
+    Color.clear
+  }
 }
 
 /// Drives the production view lifecycle without a device or an on-screen window.
@@ -122,9 +161,11 @@ struct LivePreviewVisibilityTests {
   static func main() {
     _ = NSApplication.shared
     let host = TestHost()
-    func surface(aspectRatio: CGFloat?) -> some View {
+    func surface(aspectRatio: CGFloat?, mountsPreview: Bool = true) -> some View {
       CaptureSurfaceView(aspectRatio: aspectRatio) {
-        LiveCaptureView(host: host, capture: CaptureMedia(), fileStore: FileStore())
+        if mountsPreview {
+          LiveCaptureView(host: host, capture: CaptureMedia(), fileStore: FileStore())
+        }
       }
     }
     let view = NSHostingView(rootView: surface(aspectRatio: nil))
@@ -159,55 +200,21 @@ struct LivePreviewVisibilityTests {
       precondition(LivePreviewRendererView.displayView === displayView, "Inspector toggles must preserve the display view")
       precondition(displayView?.frame.size == expectedSize, "Preview must fit the device or fill the capture-only pane")
     }
-    host.delayStop = true
-    Visibility.shared.isVisible = false
-    eventually("Cleanup should be pending") { host.stopContinuation != nil }
-    Visibility.shared.isVisible = true
-    eventually("Uncover during pending cleanup") { Visibility.shared.reportedVisibility == true }
-    pump()
-    precondition(host.starts == 1, "Replacement must wait for cleanup")
-    Visibility.shared.isVisible = false
-    eventually("Hide while waiting for cleanup") { Visibility.shared.reportedVisibility == false }
-    Visibility.shared.isVisible = true
-    eventually("Uncover again while waiting for cleanup") { Visibility.shared.reportedVisibility == true }
-    pump()
-    precondition(host.starts == 1, "Repeated visibility changes must not bypass cleanup")
-    host.delayStop = false
-    host.stopContinuation?.resume()
-    host.stopContinuation = nil
-    eventually("Restart once after cleanup") { host.starts == 2 && host.active.count == 1 }
-    Visibility.shared.isVisible = false
-    eventually("Hidden preview must stop") { host.active.isEmpty && host.stops.count == 2 }
-    pump()
-    precondition(host.starts == 2, "Hidden preview must not retry")
-    Visibility.shared.isVisible = true
-    eventually("Visible preview restarts") { host.starts == 3 && host.active.count == 1 }
-    Visibility.shared.isVisible = false
-    eventually("Hidden preview must stop again") { host.active.isEmpty && host.stops.count == 3 }
-    host.delayStart = true
-    Visibility.shared.isVisible = true
-    eventually("Startup should be pending") { host.startContinuation != nil }
-    Visibility.shared.isVisible = false
-    eventually("Hide during pending startup") { Visibility.shared.reportedVisibility == false }
-    Visibility.shared.isVisible = true
-    eventually("Uncover during pending startup") { Visibility.shared.reportedVisibility == true }
-    pump()
-    precondition(host.starts == 4, "Replacement must wait for cancelled startup")
-    host.delayStart = false
-    host.delayStop = true
-    host.startContinuation?.resume()
-    host.startContinuation = nil
-    eventually("Late startup cleanup should be pending") { host.stopContinuation != nil }
-    pump()
-    precondition(host.starts == 4, "Replacement must wait for late startup cleanup")
-    host.delayStop = false
-    host.stopContinuation?.resume()
-    host.stopContinuation = nil
-    eventually("Preview should recover after cancelled startup") { host.active.count == 1 }
-    eventually("Restart after late startup cleanup") { host.starts == 5 && host.stops.count == 4 }
+    let originalSession = host.latestSession
+    for _ in 0 ..< 3 {
+      Visibility.shared.isVisible = false
+      eventually("Covered preview hides its presentation") { displayView?.isHidden == true }
+      pump()
+      precondition(host.active.count == 1 && host.stops.isEmpty, "Covered preview must keep running")
+      Visibility.shared.isVisible = true
+      eventually("Uncovered preview restores presentation") { displayView?.isHidden == false }
+      precondition(host.starts == 1 && host.latestSession === originalSession, "Uncover must reuse the same session")
+      precondition(LivePreviewRendererView.displayView === displayView, "Uncover must preserve the renderer")
+    }
     NotificationCenter.default.post(name: NSApplication.didResignActiveNotification, object: NSApplication.shared)
     pump()
-    precondition(host.active.count == 1 && host.stops.count == 4, "Visible preview must keep running while inactive")
+    precondition(host.active.count == 1 && host.stops.isEmpty, "Visible preview must keep running while inactive")
+
     host.delayStop = true
     host.latestSession?.stop()
     eventually("Spontaneous stop cleanup should be pending") { host.stopContinuation != nil }
@@ -216,15 +223,100 @@ struct LivePreviewVisibilityTests {
     Visibility.shared.isVisible = true
     eventually("Uncover during spontaneous cleanup") { Visibility.shared.reportedVisibility == true }
     pump()
-    precondition(host.starts == 5, "Replacement must wait for spontaneous stop cleanup")
+    precondition(host.starts == 1, "Replacement must wait for spontaneous stop cleanup")
+    Visibility.shared.isVisible = false
+    eventually("Keep recovery hidden") { Visibility.shared.reportedVisibility == false }
     host.delayStop = false
     host.stopContinuation?.resume()
     host.stopContinuation = nil
-    eventually("Restart after spontaneous cleanup") { host.starts == 6 && host.active.count == 1 }
+    eventually("Hidden preview recovers after spontaneous cleanup") { host.starts == 2 && host.active.count == 1 }
+    eventually("Recovered preview stays hidden") { LivePreviewRendererView.displayView?.isHidden == true }
+    Visibility.shared.isVisible = true
+    eventually("Recovered preview becomes visible") { LivePreviewRendererView.displayView?.isHidden == false }
+    precondition(host.starts == 2, "Uncover must not restart a recovered stream")
+
+    host.delayStop = true
+    view.rootView = surface(aspectRatio: nil, mountsPreview: false)
+    eventually("Removing the preview must stop it") { host.stopContinuation != nil }
+    host.delayStop = false
+    host.stopContinuation?.resume()
+    host.stopContinuation = nil
+    eventually("Removed preview releases its operation") { host.active.isEmpty && host.stops.count == 2 }
+
+    host.delayStart = true
+    view.rootView = surface(aspectRatio: nil)
+    eventually("Startup should be pending") { host.startContinuation != nil }
+    Visibility.shared.isVisible = false
+    eventually("Hide during pending startup") { Visibility.shared.reportedVisibility == false }
+    host.delayStart = false
+    host.startContinuation?.resume()
+    host.startContinuation = nil
+    eventually("Pending startup completes while covered") { host.active.count == 1 }
+    eventually("Late renderer stays hidden") { LivePreviewRendererView.displayView?.isHidden == true }
+    precondition(host.starts == 3 && host.stops.count == 2, "Hiding during startup must not cancel it")
+    Visibility.shared.isVisible = true
+    eventually("Late renderer becomes visible") { LivePreviewRendererView.displayView?.isHidden == false }
+    precondition(host.starts == 3, "Uncover must reuse the late renderer")
+    view.rootView = surface(aspectRatio: nil, mountsPreview: false)
+    eventually("Removing the late renderer stops it") { host.active.isEmpty && host.stops.count == 3 }
+
+    host.delayStart = true
+    view.rootView = surface(aspectRatio: nil)
+    eventually("Final startup should be pending") { host.startContinuation != nil }
     window.contentView = nil
-    eventually("Removing the view must stop its renderer") { host.active.isEmpty && host.stops.count == 6 }
+    pump()
+    host.delayStart = false
+    host.startContinuation?.resume()
+    host.startContinuation = nil
+    eventually("Removed view cleans up late startup") { host.active.isEmpty && host.stops.count == 4 }
     precondition(Set(host.stops).count == host.stops.count, "Stop each renderer once")
     precondition(host.busyStarts == 0, "Never restart while the previous operation owns the device")
     print("Live Preview visibility tests passed")
+    testRecordingPlaybackVisibility()
+  }
+
+  static func testRecordingPlaybackVisibility() {
+    Visibility.shared.isVisible = false
+    Visibility.shared.reportedVisibility = nil
+    let view = NSHostingView(rootView: VideoLoopingView(url: URL(fileURLWithPath: "/synthetic-recording.mp4")))
+    let window = NSWindow(
+      contentRect: NSRect(x: 0, y: 0, width: 240, height: 120),
+      styleMask: [.borderless],
+      backing: .buffered,
+      defer: false
+    )
+    window.contentView = view
+    view.layoutSubtreeIfNeeded()
+    eventually("Playback view must attach while hidden") {
+      AVQueuePlayer.latest != nil && Visibility.shared.reportedVisibility == false
+    }
+    guard let player = AVQueuePlayer.latest else { preconditionFailure("Playback player must exist") }
+    precondition(player.timeControlStatus == .paused, "Hidden recording must not autoplay")
+
+    Visibility.shared.isVisible = true
+    eventually("Visible recording autoplays") { player.timeControlStatus == .playing }
+    for _ in 0 ..< 3 {
+      Visibility.shared.isVisible = false
+      eventually("Covered recording pauses") { player.timeControlStatus == .paused }
+      Visibility.shared.isVisible = true
+      eventually("Uncovered recording resumes") { player.timeControlStatus == .playing }
+    }
+
+    player.pause()
+    Visibility.shared.isVisible = false
+    eventually("Cover manually paused recording") { Visibility.shared.reportedVisibility == false }
+    Visibility.shared.isVisible = true
+    eventually("Uncover manually paused recording") { Visibility.shared.reportedVisibility == true }
+    precondition(player.timeControlStatus == .paused, "Uncover must preserve a manual pause")
+
+    player.timeControlStatus = .waitingToPlayAtSpecifiedRate
+    Visibility.shared.isVisible = false
+    eventually("Covered buffering recording pauses") { player.timeControlStatus == .paused }
+    Visibility.shared.isVisible = true
+    eventually("Uncovered buffering recording resumes") { player.timeControlStatus == .playing }
+
+    window.contentView = nil
+    eventually("Removing the playback view pauses it") { player.timeControlStatus == .paused }
+    print("Recording playback visibility tests passed")
   }
 }

--- a/snapo-app-mac/scripts/test-live-preview-frame-export.sh
+++ b/snapo-app-mac/scripts/test-live-preview-frame-export.sh
@@ -7,6 +7,8 @@ cd "$APP_DIR"
 
 xcrun swiftc -swift-version 6 -parse-as-library \
   Snap-O/Storage/FileStore.swift Snap-O/LivePreview/LivePreviewFrameExporter.swift \
+  Snap-O/LivePreview/LivePreviewView.swift Snap-O/Utilities/Perf.swift \
   Tests/LivePreviewFrameExport/LivePreviewFrameExportTests.swift \
   -o "$TEST_DIR/frame-export-tests"
-"$TEST_DIR/frame-export-tests"
+# Pass --render to also check hidden decoding in a small test window.
+"$TEST_DIR/frame-export-tests" "$@"

--- a/snapo-app-mac/scripts/test-startup-capture.sh
+++ b/snapo-app-mac/scripts/test-startup-capture.sh
@@ -20,9 +20,12 @@ xcrun swiftc -swift-version 6 -parse-as-library -I "$TEST_DIR" \
 "$TEST_DIR/startup-tests"
 xcrun swiftc -swift-version 6 -parse-as-library -I "$TEST_DIR" \
   "$TEST_DIR/Device.o" Snap-O/Models/Media.swift Snap-O/LivePreview/LivePreviewSession.swift \
+  Snap-O/Capture/ShowTouchesOverride.swift Snap-O/Capture/LivePreviewService.swift \
+  Snap-O/Capture/CaptureCoordinator.swift \
   Tests/StartupCapture/LivePreviewSessionTests.swift -o "$TEST_DIR/session-tests"
 "$TEST_DIR/session-tests"
 xcrun swiftc -swift-version 6 -parse-as-library \
   Snap-O/CaptureWindow/LiveCaptureView.swift Snap-O/CaptureWindow/CaptureSurfaceView.swift \
+  Snap-O/UI/VideoLoopingView.swift \
   Tests/StartupCapture/LivePreviewVisibilityTests.swift -o "$TEST_DIR/visibility-tests"
 "$TEST_DIR/visibility-tests"


### PR DESCRIPTION
Covering the capture window tore down Live Preview, adding a restart delay when it became visible again. Keep the stream and decoder alive while hiding the video layer, and reduce unnecessary startup and shutdown work.

## Summary

- Preserve the Live Preview session across cover/uncover. Keep cleanup on view removal and mode changes.
- Preserve recording playback's pause-on-cover behavior, including manual pauses.
- Overlap touch-setting setup with stream startup, skip redundant setting restores, use larger stream reads, and flush the decoder once off the main thread.
- Add shutdown timing through the existing performance-tracing flag and expand lifecycle regression coverage.

Covered Live Preview still processes incoming frames; this intentionally trades background CPU for faster resume.

## Validation

- macOS Debug and Release builds passed with signing disabled.
- Startup capture tests (13 cases), session tests, and Live Preview/recording visibility tests passed.
- Capture-mode tests (4 cases) and pointer tests (23 cases) passed.
- Frame-export tests and the opt-in real H.264 hidden-decoding/resume test passed.
- SwiftFormat 0.61.1, strict SwiftLint, shell syntax, and whitespace checks passed.
- Short Release samples with the window covered averaged 11.7% CPU during motion and 1.5% with a still screen. This was a manually driven workload, not a controlled benchmark.
- Remaining manual smoke checks: saved-video cover/uncover playback and quitting with an active preview. Playback visibility tests use a player double.