### PR TITLE
Keep capture commands during Live Preview startup

### DIFF
--- a/snapo-app-mac/Snap-O/CaptureWindow/CaptureWindow.swift
+++ b/snapo-app-mac/Snap-O/CaptureWindow/CaptureWindow.swift
@@ -476,10 +476,8 @@ struct CaptureWindow: View {
   private func handle(_ command: SnapOCommand, controller: CaptureWindowController) async {
     switch command {
     case .record:
-      guard controller.canStartRecordingNow else { return }
       await controller.startRecording()
     case .capture:
-      guard controller.canCaptureNow else { return }
       await controller.captureScreenshots()
     case .livepreview:
       guard controller.canStartLivePreviewNow else { return }

--- a/snapo-app-mac/Snap-O/CaptureWindow/CaptureWindowController.swift
+++ b/snapo-app-mac/Snap-O/CaptureWindow/CaptureWindowController.swift
@@ -29,6 +29,7 @@ final class CaptureWindowController {
   private var pendingPreferredDeviceID: String?
   @ObservationIgnored private var hasStartedInitialCapture = false
   @ObservationIgnored private var initialCaptureTask: Task<Void, Never>?
+  @ObservationIgnored private var initialCaptureWaiters: [UUID: CheckedContinuation<Void, Never>] = [:]
   @ObservationIgnored private var cachedCaptureProgressText: String?
   @ObservationIgnored private var isTornDown = false
 
@@ -339,6 +340,7 @@ final class CaptureWindowController {
         guard let self, !isTornDown, !isStoppingLivePreview else { return }
         isProcessing = false
         pendingPreferredDeviceID = nil
+        resumeInitialCaptureWaiters()
       }
     )
     mode = .livePreview(livePreviewMode)
@@ -370,6 +372,7 @@ final class CaptureWindowController {
     isTornDown = true
     initialCaptureTask?.cancel()
     initialCaptureTask = nil
+    resumeInitialCaptureWaiters()
     deviceStreamTask?.cancel()
     deviceStreamTask = nil
 
@@ -463,10 +466,14 @@ final class CaptureWindowController {
     guard case .idle = mode else { return }
     hasStartedInitialCapture = true
     initialCaptureTask = Task { [weak self] in
-      guard let self, !Task.isCancelled, !isTornDown, case .idle = mode else { return }
+      guard let self else { return }
       defer {
-        if !Task.isCancelled { initialCaptureTask = nil }
+        if !Task.isCancelled {
+          initialCaptureTask = nil
+          resumeInitialCaptureWaiters()
+        }
       }
+      guard !Task.isCancelled, !isTornDown, case .idle = mode else { return }
       switch AppSettings.shared.startupCaptureMode {
       case .livePreview: await startLivePreview(useStartupPreparation: true)
       case .screenshot: await captureScreenshots(useStartupPreparation: true)
@@ -475,10 +482,31 @@ final class CaptureWindowController {
   }
 
   private func waitForInitialCaptureSetup() async -> Bool {
-    // A ready preview can stop normally, even if other devices are still loading.
-    let task = isProcessing ? initialCaptureTask : nil
-    await task?.value
-    return task?.isCancelled != true && !Task.isCancelled
+    guard isProcessing, let task = initialCaptureTask else { return !Task.isCancelled }
+    // Preview readiness can unblock captures before all startup display queries finish.
+    let id = UUID()
+    await withTaskCancellationHandler {
+      await withCheckedContinuation { continuation in
+        if Task.isCancelled {
+          continuation.resume()
+        } else {
+          initialCaptureWaiters[id] = continuation
+        }
+      }
+    } onCancel: {
+      Task { @MainActor [weak self] in
+        self?.initialCaptureWaiters.removeValue(forKey: id)?.resume()
+      }
+    }
+    return !task.isCancelled && !Task.isCancelled
+  }
+
+  private func resumeInitialCaptureWaiters() {
+    let waiters = initialCaptureWaiters.values
+    initialCaptureWaiters.removeAll()
+    for waiter in waiters {
+      waiter.resume()
+    }
   }
 
   func startLivePreviewStream(for deviceID: String) async -> LivePreviewRenderer? {

--- a/snapo-app-mac/Snap-O/CaptureWindow/CaptureWindowController.swift
+++ b/snapo-app-mac/Snap-O/CaptureWindow/CaptureWindowController.swift
@@ -28,6 +28,7 @@ final class CaptureWindowController {
   @ObservationIgnored private var deviceStreamTask: Task<Void, Never>?
   private var pendingPreferredDeviceID: String?
   @ObservationIgnored private var hasStartedInitialCapture = false
+  @ObservationIgnored private var initialCaptureTask: Task<Void, Never>?
   @ObservationIgnored private var cachedCaptureProgressText: String?
   @ObservationIgnored private var isTornDown = false
 
@@ -200,6 +201,9 @@ final class CaptureWindowController {
   }
 
   func captureScreenshots(useStartupPreparation: Bool = false) async {
+    if !useStartupPreparation {
+      guard await waitForInitialCaptureSetup() else { return }
+    }
     guard canCaptureNow else { return }
     hasStartedInitialCapture = true
     isProcessing = true
@@ -237,7 +241,7 @@ final class CaptureWindowController {
   }
 
   func startRecording() async {
-    guard canStartRecordingNow else { return }
+    guard await waitForInitialCaptureSetup(), canStartRecordingNow else { return }
     hasStartedInitialCapture = true
     isProcessing = true
     await startupPreparation.discard()
@@ -364,6 +368,8 @@ final class CaptureWindowController {
   func tearDown() async {
     guard !isTornDown else { return }
     isTornDown = true
+    initialCaptureTask?.cancel()
+    initialCaptureTask = nil
     deviceStreamTask?.cancel()
     deviceStreamTask = nil
 
@@ -456,13 +462,23 @@ final class CaptureWindowController {
     guard mediaList.isEmpty else { return }
     guard case .idle = mode else { return }
     hasStartedInitialCapture = true
-    Task { [weak self] in
-      guard let self, !isTornDown, case .idle = mode else { return }
+    initialCaptureTask = Task { [weak self] in
+      guard let self, !Task.isCancelled, !isTornDown, case .idle = mode else { return }
+      defer {
+        if !Task.isCancelled { initialCaptureTask = nil }
+      }
       switch AppSettings.shared.startupCaptureMode {
       case .livePreview: await startLivePreview(useStartupPreparation: true)
       case .screenshot: await captureScreenshots(useStartupPreparation: true)
       }
     }
+  }
+
+  private func waitForInitialCaptureSetup() async -> Bool {
+    // A ready preview can stop normally, even if other devices are still loading.
+    let task = isProcessing ? initialCaptureTask : nil
+    await task?.value
+    return task?.isCancelled != true && !Task.isCancelled
   }
 
   func startLivePreviewStream(for deviceID: String) async -> LivePreviewRenderer? {

--- a/snapo-app-mac/Tests/CaptureSupport/TestSupport.swift
+++ b/snapo-app-mac/Tests/CaptureSupport/TestSupport.swift
@@ -11,8 +11,10 @@ enum SnapOLog {
 actor TestGate {
   private var isOpen = false
   private var waiters: [CheckedContinuation<Void, Never>] = []
+  private(set) var waitCount = 0
 
   func wait() async {
+    waitCount += 1
     guard !isOpen else { return }
     await withCheckedContinuation { waiters.append($0) }
   }
@@ -167,5 +169,80 @@ final class LivePreviewRenderer {
     pointerHandler _: @escaping (LivePreviewPointerAction, LivePreviewPointerSource, CGPoint, CGSize) -> Void
   ) {
     self.operation = operation
+  }
+}
+
+@MainActor
+final class AppSettings {
+  static let shared = AppSettings()
+  var startupCaptureMode = StartupCaptureMode.livePreview
+  var recordAsBugReport = false
+  var showTouchesDuringCapture = false
+}
+
+struct FileStore {}
+
+@MainActor
+protocol LivePreviewHosting: AnyObject {
+  func startLivePreviewStream(for deviceID: String) async -> LivePreviewRenderer?
+  func stopLivePreviewStream(_ renderer: LivePreviewRenderer) async
+}
+
+actor DeviceTracker {
+  private(set) var latestDevices: [Device]
+  private var continuation: AsyncStream<[Device]>.Continuation?
+
+  init(devices: [Device]) {
+    latestDevices = devices
+  }
+
+  func deviceStream() -> AsyncStream<[Device]> {
+    let (stream, continuation) = AsyncStream<[Device]>.makeStream()
+    self.continuation = continuation
+    continuation.yield(latestDevices)
+    return stream
+  }
+
+  func updateDevices(_ devices: [Device]) {
+    latestDevices = devices
+    continuation?.yield(devices)
+  }
+}
+
+struct RecordingOptions {
+  let recordsBugReport: Bool
+  let showsTouches: Bool
+}
+
+struct RecordingOperationHandle {
+  let completion = TestGate()
+}
+
+struct RecordingOperationResult {
+  let media: [CaptureMedia]
+  let error: Error?
+}
+
+actor RecordingService {
+  private(set) var requests: [[String]] = []
+
+  func start(for devices: [Device], options _: RecordingOptions) throws -> RecordingOperationHandle {
+    requests.append(devices.map(\.id))
+    return RecordingOperationHandle()
+  }
+
+  func waitForCompletion(of handle: RecordingOperationHandle) async -> RecordingOperationResult? {
+    await handle.completion.wait()
+    return nil
+  }
+
+  func updateConnectedDeviceIDs(_: Set<String>, for _: RecordingOperationHandle) {}
+
+  func finish(_ handle: RecordingOperationHandle) async {
+    await handle.completion.open()
+  }
+
+  func cancel(_ handle: RecordingOperationHandle) async {
+    await handle.completion.open()
   }
 }

--- a/snapo-app-mac/Tests/StartupCapture/StartupCaptureTests.swift
+++ b/snapo-app-mac/Tests/StartupCapture/StartupCaptureTests.swift
@@ -29,7 +29,9 @@ struct StartupCaptureTests {
     await disconnectDuringQueuedCommand()
     await commandAfterPreparedPreviewReady()
     await cancelledQueuedCommand()
-    print("Startup capture tests passed (20 cases)")
+    await commandDuringAutomaticPreview(recordsVideo: true, previewReadyFirst: true)
+    await commandDuringAutomaticPreview(recordsVideo: false, previewReadyFirst: true)
+    print("Startup capture tests passed (22 cases)")
   }
 
   static func eventually(_ message: String = "Condition did not become true", _ condition: () async -> Bool) async {
@@ -331,12 +333,13 @@ struct StartupCaptureTests {
     let stopGate = TestGate()
     let screenshots = ScreenshotService()
     let recording = RecordingService()
-    let tracker = DeviceTracker(devices: [first])
+    let tracker: DeviceTracker
     let live: LivePreviewService
     let controller: CaptureWindowController
 
-    init() {
+    init(devices: [Device] = [first], blockedDisplayDevice: Device = first) {
       AppSettings.shared.startupCaptureMode = .livePreview
+      tracker = DeviceTracker(devices: devices)
       live = LivePreviewService(stopGate: stopGate, readyGate: readyGate)
       controller = CaptureWindowController(
         captureServices: CaptureServices(
@@ -347,7 +350,7 @@ struct StartupCaptureTests {
         ),
         deviceTracker: tracker,
         fileStore: FileStore(),
-        adbService: ADBService(displayGates: [first.id: displayGate])
+        adbService: ADBService(displayGates: [blockedDisplayDevice.id: displayGate])
       )
     }
 
@@ -379,23 +382,27 @@ struct StartupCaptureTests {
     }
   }
 
-  static func commandDuringAutomaticPreview(recordsVideo: Bool) async {
-    let fixture = ControllerFixture()
+  static func commandDuringAutomaticPreview(recordsVideo: Bool, previewReadyFirst: Bool = false) async {
+    let fixture = ControllerFixture(devices: [first, second], blockedDisplayDevice: second)
     await fixture.start()
     let command = await fixture.request(recordsVideo: recordsVideo)
     await fixture.assertNoCaptureRequests()
 
-    await fixture.displayGate.open()
+    if previewReadyFirst {
+      await fixture.readyGate.open()
+    } else {
+      await fixture.displayGate.open()
+    }
     await eventually("The explicit command must stop the automatic preview") { await fixture.live.stops.count == 1 }
     await fixture.assertNoCaptureRequests()
     await fixture.stopGate.open()
     await command.value
 
     if recordsVideo {
-      await eventually { await fixture.recording.requests == [[first.id]] }
+      await eventually { await fixture.recording.requests == [[first.id, second.id]] }
       precondition(fixture.controller.isRecording)
     } else {
-      await eventually { await fixture.screenshots.requests == [[first.id]] }
+      await eventually { await fixture.screenshots.requests == [[first.id, second.id]] }
       await eventually { !fixture.controller.isProcessing }
       guard case .image = fixture.controller.currentCapture?.media else {
         fatalError("Expected the explicit screenshot after automatic preview startup")
@@ -403,6 +410,7 @@ struct StartupCaptureTests {
     }
     let active = await fixture.live.active
     precondition(active.isEmpty)
+    await fixture.displayGate.open()
     await fixture.controller.tearDown()
   }
 
@@ -412,8 +420,8 @@ struct StartupCaptureTests {
     let command = await fixture.request(recordsVideo: recordsVideo)
     await fixture.stopGate.open()
     await fixture.controller.tearDown()
+    await waitForCommand(command)
     await fixture.displayGate.open()
-    await command.value
     await fixture.assertNoCaptureRequests()
     precondition(!fixture.controller.isRecording && !fixture.controller.isLivePreviewActive)
   }
@@ -450,10 +458,20 @@ struct StartupCaptureTests {
     await fixture.start()
     let command = await fixture.request(recordsVideo: false)
     command.cancel()
+    await waitForCommand(command)
     await fixture.displayGate.open()
-    await command.value
     await fixture.assertNoCaptureRequests()
     await fixture.stopGate.open()
     await fixture.controller.tearDown()
+  }
+
+  static func waitForCommand(_ command: Task<Void, Never>) async {
+    var finished = false
+    let completion = Task {
+      await command.value
+      finished = true
+    }
+    await eventually("The queued command must finish while display queries remain blocked") { finished }
+    await completion.value
   }
 }

--- a/snapo-app-mac/Tests/StartupCapture/StartupCaptureTests.swift
+++ b/snapo-app-mac/Tests/StartupCapture/StartupCaptureTests.swift
@@ -22,15 +22,22 @@ struct StartupCaptureTests {
     await stopDuringRendererClaim()
     await disconnectWaitsForCleanup()
     await overlappingDeviceUpdates()
-    print("Startup capture tests passed (13 cases)")
+    await commandDuringAutomaticPreview(recordsVideo: true)
+    await commandDuringAutomaticPreview(recordsVideo: false)
+    await tearDownDuringQueuedCommand(recordsVideo: true)
+    await tearDownDuringQueuedCommand(recordsVideo: false)
+    await disconnectDuringQueuedCommand()
+    await commandAfterPreparedPreviewReady()
+    await cancelledQueuedCommand()
+    print("Startup capture tests passed (20 cases)")
   }
 
-  static func eventually(_ condition: () async -> Bool) async {
+  static func eventually(_ message: String = "Condition did not become true", _ condition: () async -> Bool) async {
     for _ in 0 ..< 10000 {
       if await condition() { return }
       await Task.yield()
     }
-    fatalError("Condition did not become true")
+    fatalError(message)
   }
 
   static func prepare(
@@ -315,5 +322,138 @@ struct StartupCaptureTests {
     await start.value
     precondition(displayed == [second.id])
     await manager.stop()
+  }
+
+  @MainActor
+  struct ControllerFixture {
+    let displayGate = TestGate()
+    let readyGate = TestGate()
+    let stopGate = TestGate()
+    let screenshots = ScreenshotService()
+    let recording = RecordingService()
+    let tracker = DeviceTracker(devices: [first])
+    let live: LivePreviewService
+    let controller: CaptureWindowController
+
+    init() {
+      AppSettings.shared.startupCaptureMode = .livePreview
+      live = LivePreviewService(stopGate: stopGate, readyGate: readyGate)
+      controller = CaptureWindowController(
+        captureServices: CaptureServices(
+          screenshots: screenshots,
+          recording: recording,
+          livePreview: live,
+          startup: StartupCapturePreparation(screenshots: screenshots, livePreview: live)
+        ),
+        deviceTracker: tracker,
+        fileStore: FileStore(),
+        adbService: ADBService(displayGates: [first.id: displayGate])
+      )
+    }
+
+    func start() async {
+      await controller.start()
+      await eventually { await displayGate.waitCount > 0 }
+      await eventually { await readyGate.waitCount > 0 }
+      precondition(controller.isLivePreviewActive && controller.isProcessing)
+    }
+
+    func request(recordsVideo: Bool) async -> Task<Void, Never> {
+      var didStart = false
+      let task = Task {
+        didStart = true
+        if recordsVideo {
+          await controller.startRecording()
+        } else {
+          await controller.captureScreenshots()
+        }
+      }
+      await eventually { didStart }
+      return task
+    }
+
+    func assertNoCaptureRequests() async {
+      let recordings = await recording.requests
+      let captures = await screenshots.requests
+      precondition(recordings.isEmpty && captures.isEmpty)
+    }
+  }
+
+  static func commandDuringAutomaticPreview(recordsVideo: Bool) async {
+    let fixture = ControllerFixture()
+    await fixture.start()
+    let command = await fixture.request(recordsVideo: recordsVideo)
+    await fixture.assertNoCaptureRequests()
+
+    await fixture.displayGate.open()
+    await eventually("The explicit command must stop the automatic preview") { await fixture.live.stops.count == 1 }
+    await fixture.assertNoCaptureRequests()
+    await fixture.stopGate.open()
+    await command.value
+
+    if recordsVideo {
+      await eventually { await fixture.recording.requests == [[first.id]] }
+      precondition(fixture.controller.isRecording)
+    } else {
+      await eventually { await fixture.screenshots.requests == [[first.id]] }
+      await eventually { !fixture.controller.isProcessing }
+      guard case .image = fixture.controller.currentCapture?.media else {
+        fatalError("Expected the explicit screenshot after automatic preview startup")
+      }
+    }
+    let active = await fixture.live.active
+    precondition(active.isEmpty)
+    await fixture.controller.tearDown()
+  }
+
+  static func tearDownDuringQueuedCommand(recordsVideo: Bool) async {
+    let fixture = ControllerFixture()
+    await fixture.start()
+    let command = await fixture.request(recordsVideo: recordsVideo)
+    await fixture.stopGate.open()
+    await fixture.controller.tearDown()
+    await fixture.displayGate.open()
+    await command.value
+    await fixture.assertNoCaptureRequests()
+    precondition(!fixture.controller.isRecording && !fixture.controller.isLivePreviewActive)
+  }
+
+  static func disconnectDuringQueuedCommand() async {
+    let fixture = ControllerFixture()
+    await fixture.start()
+    let command = await fixture.request(recordsVideo: true)
+    await fixture.tracker.updateDevices([])
+    await eventually { !fixture.controller.hasDevices }
+    await fixture.stopGate.open()
+    await fixture.displayGate.open()
+    await command.value
+    await fixture.assertNoCaptureRequests()
+    await fixture.controller.tearDown()
+  }
+
+  static func commandAfterPreparedPreviewReady() async {
+    let fixture = ControllerFixture()
+    await fixture.start()
+    await fixture.readyGate.open()
+    await eventually { fixture.controller.canStartRecordingNow }
+    let command = await fixture.request(recordsVideo: true)
+    await fixture.stopGate.open()
+    await eventually { await fixture.recording.requests == [[first.id]] }
+    await command.value
+    precondition(fixture.controller.isRecording)
+    await fixture.displayGate.open()
+    await fixture.controller.tearDown()
+  }
+
+  static func cancelledQueuedCommand() async {
+    let fixture = ControllerFixture()
+    await fixture.start()
+    let command = await fixture.request(recordsVideo: false)
+    command.cancel()
+    await fixture.displayGate.open()
+    await command.value
+    await fixture.assertNoCaptureRequests()
+    await fixture.stopGate.open()
+    await fixture.controller.tearDown()
   }
 }

--- a/snapo-app-mac/scripts/test-startup-capture.sh
+++ b/snapo-app-mac/scripts/test-startup-capture.sh
@@ -15,6 +15,10 @@ xcrun swiftc -swift-version 6 -parse-as-library -I "$TEST_DIR" \
   Snap-O/Capture/CaptureMedia.swift Snap-O/Utilities/Perf.swift \
   Snap-O/Capture/PreparedLivePreview.swift Snap-O/Capture/StartupCapturePreparation.swift \
   Snap-O/CaptureWindow/PreparingScreenshotMode.swift Snap-O/CaptureWindow/LivePreviewManager.swift \
+  Snap-O/Capture/CaptureServices.swift Snap-O/CaptureWindow/CaptureWindowController.swift \
+  Snap-O/CaptureWindow/CaptureWindowMode.swift Snap-O/CaptureWindow/RecordingMode.swift \
+  Snap-O/CaptureWindow/LivePreviewMode.swift Snap-O/CaptureWindow/MediaDisplayMode.swift \
+  Snap-O/CaptureWindow/CaptureSnapshotController.swift \
   Tests/CaptureSupport/TestSupport.swift Tests/StartupCapture/StartupCaptureTests.swift \
   -o "$TEST_DIR/startup-tests"
 "$TEST_DIR/startup-tests"


### PR DESCRIPTION
Automatic Live Preview setup temporarily blocks captures. Screenshot and recording commands received during that interval were silently dropped, including commands from `snapo://capture` and `snapo://record`.

## Summary

- Resume explicit capture commands when the preview becomes ready or automatic setup finishes, then recheck availability.
- Remove URL-handler guards that discarded commands before they reached the controller.
- Preserve preview cleanup and cancellation, with nine new production-controller regression cases.

## Validation

- Startup capture suite: 22 cases passed, plus session and visibility tests. Covers commands queued before preview readiness while a secondary device's display query remains blocked.
- Capture-mode suite: four cases passed.
- SwiftFormat 0.61.1 and SwiftLint checks passed.
- macOS app built with code signing disabled.
- No physical-device URL-launch test was run.
