### PR TITLE
Fix saved network exclusions during incomplete searches

### DIFF
--- a/snapo-network-inspector-web/src/features/network-inspector/lib/records.test.ts
+++ b/snapo-network-inspector-web/src/features/network-inspector/lib/records.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import type { RequestRecord, WebSocketRecord } from "../../../network/cdp";
 import {
   countExcludedRecordsForServer,
@@ -64,6 +64,14 @@ describe("persistent exclusion filters", () => {
 
     expect(countExcludedRecordsForServer(records, server, exclusionFilters)).toBe(1);
     expect(filterRecords(records, server, searchText, false, exclusionFilters)).toEqual([visible]);
+  });
+
+  it("traverses stream events once when search and exclusions are empty", () => {
+    const visible = request();
+    const iterateEvents = vi.spyOn(visible.streamEvents, Symbol.iterator);
+
+    expect(filterRecords([visible], server, "", false)).toEqual([visible]);
+    expect(iterateEvents).toHaveBeenCalledTimes(1);
   });
 
   it("applies generic exclusion filters to the same searchable metadata as ordinary filters", () => {

--- a/snapo-network-inspector-web/src/features/network-inspector/lib/records.test.ts
+++ b/snapo-network-inspector-web/src/features/network-inspector/lib/records.test.ts
@@ -46,6 +46,26 @@ describe("persistent exclusion filters", () => {
     ]);
   });
 
+  it.each([
+    { syntax: "an unfinished quote", searchText: '-"noise' },
+    { syntax: "a trailing backslash", searchText: "-noise\\" },
+    { syntax: "a completed quote", searchText: '-"noise"' },
+    { syntax: "an escaped backslash", searchText: "-noise\\\\" }
+  ])("applies saved exclusions and search filters with $syntax", ({ searchText }) => {
+    const hidden = request({ requestId: "hidden", url: "https://events.example.com/track" });
+    const searchHidden = request({
+      requestId: "search-hidden",
+      url: "https://api.example.com/messages",
+      requestHeaders: [{ name: "X-Label", value: "noise\\" }]
+    });
+    const visible = request({ requestId: "visible", url: "https://api.example.com/messages" });
+    const records = [hidden, searchHidden, visible];
+    const exclusionFilters = ["-events.example.com"];
+
+    expect(countExcludedRecordsForServer(records, server, exclusionFilters)).toBe(1);
+    expect(filterRecords(records, server, searchText, false, exclusionFilters)).toEqual([visible]);
+  });
+
   it("applies generic exclusion filters to the same searchable metadata as ordinary filters", () => {
     const hidden = request({ requestId: "hidden", method: "POST", url: "https://api.openai.com/messages" });
     const visible = request({ requestId: "visible", method: "GET", url: "https://api.openai.com/messages" });

--- a/snapo-network-inspector-web/src/features/network-inspector/lib/records.ts
+++ b/snapo-network-inspector-web/src/features/network-inspector/lib/records.ts
@@ -19,10 +19,11 @@ export function filterRecords(
   newestFirst: boolean,
   exclusionFilters: readonly string[] = []
 ): InspectorRecord[] {
-  const searchQuery = parseNetworkSearchQuery([searchText, ...exclusionFilters].join(" "));
+  const searchQuery = parseNetworkSearchQuery(searchText);
+  const exclusionQuery = parseNetworkSearchQuery(exclusionFilters.join(" "));
   const filteredRecords = records
     .filter((record) => serverMatches(selectedServer, record.server))
-    .filter((record) => matchesNetworkSearch(record, searchQuery))
+    .filter((record) => matchesNetworkSearch(record, searchQuery) && matchesNetworkSearch(record, exclusionQuery))
     .sort((a, b) => a.startedAt - b.startedAt);
   if (newestFirst) filteredRecords.reverse();
   return filteredRecords;

--- a/snapo-network-inspector-web/src/features/network-inspector/lib/records.ts
+++ b/snapo-network-inspector-web/src/features/network-inspector/lib/records.ts
@@ -19,11 +19,14 @@ export function filterRecords(
   newestFirst: boolean,
   exclusionFilters: readonly string[] = []
 ): InspectorRecord[] {
+  // Parse separately so unfinished search syntax cannot consume saved exclusions.
   const searchQuery = parseNetworkSearchQuery(searchText);
   const exclusionQuery = parseNetworkSearchQuery(exclusionFilters.join(" "));
+  searchQuery.includes.push(...exclusionQuery.includes);
+  searchQuery.excludes.push(...exclusionQuery.excludes);
   const filteredRecords = records
     .filter((record) => serverMatches(selectedServer, record.server))
-    .filter((record) => matchesNetworkSearch(record, searchQuery) && matchesNetworkSearch(record, exclusionQuery))
+    .filter((record) => matchesNetworkSearch(record, searchQuery))
     .sort((a, b) => a.startedAt - b.startedAt);
   if (newestFirst) filteredRecords.reverse();
   return filteredRecords;


### PR DESCRIPTION
Unfinished quotes or trailing backslashes in the search field could swallow saved exclusions. Excluded requests then reappeared in the list and could enter HAR exports, despite still counting as hidden.

## Summary
- Parse search text and saved exclusions separately, then append the parsed terms and match each record once.
- Keep the existing parser and saved-filter behavior unchanged.
- Add regression tests for unfinished quotes, trailing backslashes, completed quotes, and escaped backslashes.
- Check that empty search and exclusions traverse each record's stream events only once.

## Validation
- Confirmed both unfinished-search regression cases failed before the fix.
- `npm test`: 267 tests passed across 23 files.
- `npm run typecheck` and `npm run build`: passed.
- Prettier and ESLint checks on both changed files and `git diff --check`: passed.
- No manual UI or HAR export check was performed.
