### PR TITLE
Update Snap-O 5.0.0 appcast and documentation

### DIFF
--- a/appcast.xml
+++ b/appcast.xml
@@ -8,6 +8,15 @@
     <description>Software updates for Snap‑O</description>
 
     <item>
+        <title>Snap‑O 5.0.0</title>
+        <pubDate>Tue, 25 Aug 2026 14:56:52 +0000</pubDate>
+        <sparkle:minimumSystemVersion>15.0</sparkle:minimumSystemVersion>
+        <sparkle:version>20260825.00</sparkle:version>
+        <sparkle:shortVersionString>5.0.0</sparkle:shortVersionString>
+        <enclosure url="https://github.com/openai/snap-o/releases/download/5.0.0/Snap-O.dmg" length="2388714" type="application/octet-stream" sparkle:edSignature="40IKudeQDm37+iujV0gKQ5ALHvsm3gDf81Ri+I2G8gXIcw6gkkhs33GP40k0a0UR1zlnGok7mZ0vgW1YIk7EAQ==" />
+    </item>
+
+    <item>
         <title>Snap‑O 4.1.0</title>
         <pubDate>Fri, 07 Aug 2026 15:36:21 +0000</pubDate>
         <sparkle:minimumSystemVersion>15.0</sparkle:minimumSystemVersion>

--- a/index.html
+++ b/index.html
@@ -347,10 +347,10 @@
           <section class="product-section">
             <h2 class="product-title">Screen capture</h2>
             <p class="product-copy">
-              Capture, review, and share without first saving files to disk.
-              Recordings open for immediate playback and frame-by-frame
-              inspection, then simply drag and drop screenshots or clips into
-              pull requests, chats, or docs.
+              Start in Live Preview and Option-drag the current frame to share
+              a screenshot. Recordings open for immediate playback and
+              frame-by-frame inspection. Drag screenshots or clips into pull
+              requests, chats, or docs without saving them first.
             </p>
           </section>
 

--- a/network-inspector.html
+++ b/network-inspector.html
@@ -934,13 +934,31 @@ val client = HttpClient(OkHttp) {
             <ol class="verify-list">
               <li><span>Install and launch the debug build on an authorized Android device or emulator.</span></li>
               <li><span>Open Snap-O on macOS and select the connected device.</span></li>
-              <li><span>Open <strong>Tools → Network Inspector</strong>, use the toolbar network icon, or press <strong>⌘⌥I</strong>.</span></li>
-              <li><span>Select the app process if prompted, then trigger a request in the Android app.</span></li>
+              <li><span>Open <strong>Tools → Show App Inspector</strong>, use the toolbar inspector button, or press <strong>⌘⌥I</strong>.</span></li>
+              <li><span>Find the app process in the picker and click its <strong>Network</strong> icon, then trigger a request in the Android app.</span></li>
               <li><span>Open the request to inspect headers, bodies, timing, SSE, or WebSocket messages.</span></li>
             </ol>
             <p class="notice">
-              If the Android app restarts, Snap-O may offer a newer process in
-              the inspector sidebar. Switch to it to continue with live traffic.
+              Each running app process has one picker row, with shortcuts for
+              its available inspectors. Snap-O remembers your inspector
+              selection and keeps captured requests visible while disconnected.
+              If the Android app restarts, select its new process to continue
+              with live traffic.
+            </p>
+            <h3>Filter traffic</h3>
+            <p class="prose">
+              Right-click a request to add its host to the exclusion filter.
+              Exclusion filters are saved across sessions. Use the settings
+              button beside the exclusion summary to add or remove filters.
+              You can also search requests without changing your saved filters.
+            </p>
+            <h3>Inspect responses</h3>
+            <p class="prose">
+              Use the arrow keys to move between requests. Server-Sent Events
+              show whether the stream is pending, streaming, closed, or offline.
+              When a response body is unavailable, Snap-O explains whether it
+              is no longer retained or is not cached on this Mac. If loading
+              fails while connected, click <strong>Retry</strong>.
             </p>
             </div>
           </section>

--- a/tweaks.html
+++ b/tweaks.html
@@ -1249,9 +1249,10 @@ fun MotionSection(isExpanded: Boolean) {
 
               <h3 id="app-inspector">Mac App Inspector</h3>
               <p class="prose">
-                Snap-O’s App Inspector discovers the running app with Tweaks
-                enabled and shows the controls registered by its current
-                Compose screen.
+                Snap-O’s App Inspector shows one picker row per running app
+                process, with shortcuts for Network and Tweaks when available.
+                The Tweaks inspector shows controls registered by the app’s
+                current Compose screen.
               </p>
 
               <ol class="verify-list">
@@ -1265,7 +1266,7 @@ fun MotionSection(isExpanded: Boolean) {
                   <span>Choose <strong>Tools → Show App Inspector</strong>, or press <strong>⌘⌥I</strong>.</span>
                 </li>
                 <li>
-                  <span>Select your app and its <strong>Tweaks</strong> entry in the inspector picker.</span>
+                  <span>Find your app process in the picker and click its <strong>Tweaks</strong> icon. Click the row instead to keep your current inspector type when available.</span>
                 </li>
                 <li>
                   <span>Adjust a value or enum option, or invoke an app-owned action, and watch the running Compose UI update.</span>


### PR DESCRIPTION
Publish the Snap-O 5.0.0 update feed and align the website with the released macOS app. The [GitHub Release](https://github.com/openai/snap-o/releases/tag/5.0.0) and both download assets are already public.

## Summary

- Prepend the generated Sparkle item for 5.0.0, build 20260825.00, preserving all 25 existing entries.
- Document Live Preview screenshot sharing, the process-grouped app picker, saved network exclusions, and response retry/status guidance.
- Keep Android dependency examples at their latest public version, 4.1.0. Leave styles, scripts, assets, and code examples unchanged.

## Validation

- Public DMG download matches the published checksum and verified release artifact.
- Appcast version, build, minimum macOS version, URL, byte length, and signature match the generated item.
- `xmllint --noout appcast.xml` and `git diff --check` passed.
- Changed pages pass HTML5 parsing and local link, anchor, and asset checks.
- Canonical Maven Central metadata confirms 4.1.0 for all documented Android coordinates.
- Public Pages deployment and an installed 4.1.0 Sparkle update check will follow the merge.
