### PR TITLE
Open Android apps from inspector waiting states

### DIFF
--- a/snapo-app-mac/Snap-O/App/ADBService.swift
+++ b/snapo-app-mac/Snap-O/App/ADBService.swift
@@ -200,7 +200,7 @@ actor ADBService {
   private func presentPromptUI() async -> (alert: NSAlert, style: PresentationStyle) {
     let alert = NSAlert()
     alert.alertStyle = .informational
-    alert.messageText = "Waiting for ADB server..."
+    alert.messageText = "Waiting for ADB server"
     alert.informativeText = """
     You may need to start the ADB server with "adb start-server".
     Snap-O can do it automatically if you set your ADB path.

--- a/snapo-app-mac/Snap-O/CaptureWindow/CaptureToolbar.swift
+++ b/snapo-app-mac/Snap-O/CaptureWindow/CaptureToolbar.swift
@@ -234,7 +234,7 @@ struct CaptureToolbar: View {
           .progressViewStyle(.circular)
           .controlSize(.small)
       }
-      .help("Stopping Recording…")
+      .help("Stopping Recording")
       .disabled(true)
     } else {
       Button {

--- a/snapo-app-mac/Snap-O/CaptureWindow/IdleOverlayView.swift
+++ b/snapo-app-mac/Snap-O/CaptureWindow/IdleOverlayView.swift
@@ -35,7 +35,7 @@ struct IdleOverlayView: View {
           .tint(.primary)
           .controlSize(.large)
       } else if !hasDevices, isDeviceListInitialized {
-        Text("Waiting for device…")
+        Text("Waiting for device")
           .foregroundStyle(.gray)
       }
 

--- a/snapo-app-mac/Snap-O/CaptureWindow/WaitingForDeviceView.swift
+++ b/snapo-app-mac/Snap-O/CaptureWindow/WaitingForDeviceView.swift
@@ -16,12 +16,12 @@ struct WaitingForDeviceView: View {
         HStack(spacing: 8) {
           ProgressView()
             .controlSize(.small)
-          Text("Loading devices…")
+          Text("Loading devices")
             .foregroundStyle(.secondary)
         }
         .transition(.opacity)
       } else {
-        Text("Waiting for device…")
+        Text("Waiting for device")
           .foregroundStyle(.gray)
           .transition(.opacity)
       }

--- a/snapo-app-mac/Snap-O/NetworkInspector/NetworkInspectorBridgeModels.swift
+++ b/snapo-app-mac/Snap-O/NetworkInspector/NetworkInspectorBridgeModels.swift
@@ -17,8 +17,9 @@ struct AppInspectorOption: Codable, Identifiable {
 struct InspectableApp: Codable, Identifiable {
   let id: String
   let name: String
-  let packageName: String
+  let packageName: String?
   let processName: String?
+  let androidUserId: Int?
   let deviceId: String
   let deviceDisplayTitle: String
   let appIconBase64: String?
@@ -28,6 +29,7 @@ struct InspectableApp: Codable, Identifiable {
 struct OpenAppInput: Codable {
   let deviceId: String
   let packageName: String
+  let androidUserId: Int
 }
 
 struct SelectedAppInspector: Codable {

--- a/snapo-app-mac/Snap-O/NetworkInspector/NetworkInspectorBridgeModels.swift
+++ b/snapo-app-mac/Snap-O/NetworkInspector/NetworkInspectorBridgeModels.swift
@@ -25,6 +25,11 @@ struct InspectableApp: Codable, Identifiable {
   let inspectors: [AppInspectorOption]
 }
 
+struct OpenAppInput: Codable {
+  let deviceId: String
+  let packageName: String
+}
+
 struct SelectedAppInspector: Codable {
   let appId: String
   let kind: AppInspectorKind

--- a/snapo-app-mac/Snap-O/NetworkInspector/NetworkInspectorServerPicker.swift
+++ b/snapo-app-mac/Snap-O/NetworkInspector/NetworkInspectorServerPicker.swift
@@ -195,7 +195,7 @@ private struct AppInspectorPickerAppRow: View {
     }
     .buttonStyle(.plain)
     .disabled(app.inspectors.isEmpty)
-    .help(app.packageName)
+    .help(app.packageName ?? app.processName ?? app.name)
     .overlay(alignment: .trailing) {
       HStack(spacing: 0) {
         ForEach(app.inspectors) { option in

--- a/snapo-app-mac/Snap-O/NetworkInspector/NetworkInspectorService.swift
+++ b/snapo-app-mac/Snap-O/NetworkInspector/NetworkInspectorService.swift
@@ -124,6 +124,11 @@ actor NetworkInspectorService {
     return orderedInspectorApps(apps)
   }
 
+  func openApp(_ input: OpenAppInput) async throws {
+    let adb = await adbService.exec()
+    try await adb.openApp(deviceID: input.deviceId, packageName: input.packageName)
+  }
+
   private func orderedInspectorApps(_ apps: [InspectableApp]) -> [InspectableApp] {
     let previousOrder = Dictionary(
       uniqueKeysWithValues: inspectorServerOrder.enumerated().map { ($0.element, $0.offset) }

--- a/snapo-app-mac/Snap-O/NetworkInspector/NetworkInspectorService.swift
+++ b/snapo-app-mac/Snap-O/NetworkInspector/NetworkInspectorService.swift
@@ -13,6 +13,7 @@ actor NetworkInspectorService {
     var deviceDisplayTitle: String
     var appInfo: NetworkAppInfo?
     var packageNameHint: String?
+    var androidUserID: Int?
   }
 
   private struct RefreshFlight {
@@ -69,20 +70,18 @@ actor NetworkInspectorService {
   func listInspectorApps() async -> [InspectableApp] {
     await refresh()
     let tweakApps = await tweaksService.currentApps()
-    let networkEndpoints = currentServers().map { server in
+    let networkEndpoints = servers.values.map { state in
       InspectorEndpoint(
         kind: .network,
-        reference: NetworkServerReference(
-          deviceId: server.deviceId,
-          socketName: server.socketName
-        ),
-        deviceDisplayTitle: server.deviceDisplayTitle,
-        protocolVersion: server.protocolVersion,
+        reference: state.reference,
+        deviceDisplayTitle: state.deviceDisplayTitle,
+        protocolVersion: state.appInfo?.protocolVersion,
         metadata: InspectorAppMetadata(
-          processName: server.appName ?? server.packageName,
-          packageName: server.hasAppInfo ? server.packageName : nil,
-          packageNameHint: server.packageName,
-          appIconBase64: server.appIconBase64
+          processName: state.appInfo?.processName ?? state.packageNameHint,
+          packageName: state.appInfo?.packageName,
+          packageNameHint: state.packageNameHint,
+          androidUserID: state.androidUserID,
+          appIconBase64: state.appInfo?.icon?.base64Data
         )
       )
     }
@@ -99,6 +98,7 @@ actor NetworkInspectorService {
           appName: app.name,
           processName: app.processName,
           packageName: app.packageName,
+          androidUserID: app.androidUserID,
           appIconBase64: app.appIconBase64
         )
       )
@@ -107,8 +107,9 @@ actor NetworkInspectorService {
       InspectableApp(
         id: process.id,
         name: process.name,
-        packageName: process.metadata.packageName ?? process.metadata.packageNameHint ?? process.name,
+        packageName: process.metadata.packageName,
         processName: process.metadata.processName ?? process.metadata.packageNameHint,
+        androidUserId: process.metadata.androidUserID,
         deviceId: process.deviceId,
         deviceDisplayTitle: process.deviceDisplayTitle,
         appIconBase64: process.metadata.appIconBase64,
@@ -126,7 +127,7 @@ actor NetworkInspectorService {
 
   func openApp(_ input: OpenAppInput) async throws {
     let adb = await adbService.exec()
-    try await adb.openApp(deviceID: input.deviceId, packageName: input.packageName)
+    try await adb.openApp(deviceID: input.deviceId, packageName: input.packageName, androidUserID: input.androidUserId)
   }
 
   private func orderedInspectorApps(_ apps: [InspectableApp]) -> [InspectableApp] {
@@ -431,6 +432,9 @@ actor NetworkInspectorService {
       if var state = servers[reference.key] {
         state.deviceDisplayTitle = device.displayTitle
         servers[reference.key] = state
+        if state.packageNameHint == nil || state.androidUserID == nil {
+          await populateProcessMetadata(reference: reference, connectionID: state.connectionID, using: adb)
+        }
       } else {
         await connect(device: device, reference: reference, using: adb)
       }
@@ -482,28 +486,23 @@ actor NetworkInspectorService {
         appInfo: nil,
         packageNameHint: nil
       )
-      await populatePackageNameHint(reference: reference, connectionID: connectionID, using: adb)
+      await populateProcessMetadata(reference: reference, connectionID: connectionID, using: adb)
     } catch {
       return
     }
   }
 
-  private func populatePackageNameHint(
+  private func populateProcessMetadata(
     reference: NetworkServerReference,
     connectionID: UUID,
     using adb: ADBClient
   ) async {
-    guard let packageName = await NetworkServerDiscovery.packageNameHint(for: reference, using: adb) else { return }
-    setPackageNameHint(packageName, reference: reference, connectionID: connectionID)
-  }
-
-  private func setPackageNameHint(
-    _ packageName: String,
-    reference: NetworkServerReference,
-    connectionID: UUID
-  ) {
+    async let packageName = NetworkServerDiscovery.packageNameHint(for: reference, using: adb)
+    async let androidUserID = NetworkServerDiscovery.androidUserID(for: reference, using: adb)
+    let metadata = await (packageName: packageName, androidUserID: androidUserID)
     guard var state = servers[reference.key], state.connectionID == connectionID else { return }
-    state.packageNameHint = packageName
+    state.packageNameHint = metadata.packageName ?? state.packageNameHint
+    state.androidUserID = metadata.androidUserID ?? state.androidUserID
     servers[reference.key] = state
   }
 

--- a/snapo-app-mac/Snap-O/NetworkInspector/NetworkInspectorWebBridge.swift
+++ b/snapo-app-mac/Snap-O/NetworkInspector/NetworkInspectorWebBridge.swift
@@ -76,6 +76,10 @@ final class NetworkInspectorWebBridge: NSObject, WKScriptMessageHandlerWithReply
       return try await Self.jsonObject(service.listServers())
     case "listInspectorApps":
       return try await Self.jsonObject(service.listInspectorApps())
+    case "openApp":
+      let input = try Self.decode(OpenAppInput.self, from: payload)
+      try await service.openApp(input)
+      return nil
     case "loadInspectorPreferences":
       return UserDefaults.standard.string(forKey: "inspectorPreferences")
     case "saveInspectorPreferences":

--- a/snapo-app-mac/Snap-O/NetworkInspector/TweaksInspectorService.swift
+++ b/snapo-app-mac/Snap-O/NetworkInspector/TweaksInspectorService.swift
@@ -9,6 +9,7 @@ actor TweaksInspectorService {
     var name: String?
     var packageName: String?
     var processName: String?
+    var androidUserID: Int?
     var protocolVersion: Int?
     var appIconBase64: String?
   }
@@ -185,7 +186,9 @@ actor TweaksInspectorService {
         throw NetworkInspectorError.invalidBridgeMessage
       }
 
-      let processName = await NetworkServerDiscovery.packageNameHint(for: reference, using: adb)
+      async let processName = NetworkServerDiscovery.packageNameHint(for: reference, using: adb)
+      async let androidUserID = NetworkServerDiscovery.androidUserID(for: reference, using: adb)
+      let metadata = await (processName: processName, androidUserID: androidUserID)
       guard !Task.isCancelled, !isStopped else {
         await adb.removeForward(handle)
         return
@@ -194,7 +197,8 @@ actor TweaksInspectorService {
         deviceID: reference.deviceId,
         deviceDisplayTitle: deviceDisplayTitle,
         socketName: reference.socketName,
-        processName: processName
+        processName: metadata.processName,
+        androidUserID: metadata.androidUserID
       )
       connections[key] = Connection(id: UUID(), app: app, forward: handle, baseURL: baseURL)
       populateMetadata(for: key)
@@ -207,7 +211,8 @@ actor TweaksInspectorService {
 
   private func populateMetadata(for key: String) {
     guard let connection = connections[key],
-          connection.app.protocolVersion == nil || connection.app.processName == nil || !connection.hasLoadedIcon,
+          connection.app.protocolVersion == nil || connection.app.processName == nil
+          || connection.app.androidUserID == nil || !connection.hasLoadedIcon,
           connection.metadataTask == nil else { return }
     connections[key]?.metadataTask = Task { [weak self] in
       await self?.loadMetadata(for: key, connectionID: connection.id)
@@ -222,11 +227,14 @@ actor TweaksInspectorService {
     }
     guard let connection = connections[key], connection.id == connectionID else { return }
 
-    if connection.app.processName == nil {
+    if connection.app.processName == nil || connection.app.androidUserID == nil {
       let adb = await adbService.exec()
-      let processName = await NetworkServerDiscovery.packageNameHint(for: connection.reference, using: adb)
+      async let processName = NetworkServerDiscovery.packageNameHint(for: connection.reference, using: adb)
+      async let androidUserID = NetworkServerDiscovery.androidUserID(for: connection.reference, using: adb)
+      let metadata = await (processName: processName, androidUserID: androidUserID)
       guard !Task.isCancelled, connections[key]?.id == connectionID else { return }
-      connections[key]?.app.processName = processName
+      connections[key]?.app.processName = metadata.processName ?? connection.app.processName
+      connections[key]?.app.androidUserID = metadata.androidUserID ?? connection.app.androidUserID
     }
 
     if connection.app.protocolVersion == nil,

--- a/snapo-app-mac/SnapODeviceClient/Sources/SnapODeviceClient/ADB/ADBAppLaunch.swift
+++ b/snapo-app-mac/SnapODeviceClient/Sources/SnapODeviceClient/ADB/ADBAppLaunch.swift
@@ -1,0 +1,110 @@
+import Foundation
+
+public extension ADBClient {
+  func openApp(deviceID: String, packageName: String) async throws {
+    try await AppLaunchCommand.open(packageName: packageName) { command in
+      try await runShellString(deviceID: deviceID, command: command)
+    }
+  }
+}
+
+enum AppLaunchCommand {
+  private static let exitMarker = "SNAPO_APP_LAUNCH_EXIT:"
+
+  static func open(packageName: String, runShell: (String) async throws -> String) async throws {
+    let query = try launcherQuery(packageName: packageName)
+    let output = try await runShell(query)
+    let component = try launcherComponent(output: output, packageName: packageName)
+    let command = try command(packageName: packageName, component: component)
+    try await validate(output: runShell(command))
+  }
+
+  static func launcherQuery(packageName: String) throws -> String {
+    guard isPackageName(packageName) else {
+      throw ADBError.protocolFailure("The app's package name is unavailable or invalid.")
+    }
+
+    // Implicit starts require DEFAULT filters; launcher queries must not.
+    return withExitStatus(
+      "cmd package query-activities --components --query-flags 0 --user current "
+        + "-a android.intent.action.MAIN -c android.intent.category.LAUNCHER -p '\(packageName)'"
+    )
+  }
+
+  static func launcherComponent(output: String, packageName: String) throws -> String {
+    try validate(output: output)
+    let components = output.split(whereSeparator: \.isNewline).map {
+      $0.trimmingCharacters(in: .whitespaces)
+    }
+    guard let component = components.first(where: { isComponent($0, inPackage: packageName) }) else {
+      throw AppLaunchError.noLauncher(packageName)
+    }
+    return component
+  }
+
+  static func command(packageName: String, component: String) throws -> String {
+    guard isComponent(component, inPackage: packageName) else {
+      throw ADBError.protocolFailure("The app's launcher activity is invalid.")
+    }
+
+    // Match a launcher tap without stopping the app or clearing its task.
+    return withExitStatus(
+      "am start --user current -a android.intent.action.MAIN -c android.intent.category.LAUNCHER "
+        + "-n '\(component)' -f 0x10200000"
+    )
+  }
+
+  static func validate(output: String) throws {
+    let lines = output.split(whereSeparator: \.isNewline).map {
+      $0.trimmingCharacters(in: .whitespaces)
+    }
+    guard let lastLine = lines.last,
+          lastLine.hasPrefix(exitMarker),
+          let status = Int32(lastLine.dropFirst(exitMarker.count))
+    else {
+      throw ADBError.parseFailure("No app launch result was returned.")
+    }
+
+    if let error = lines.first(where: { $0.hasPrefix("Error:") }) {
+      throw AppLaunchError.failed(String(error.dropFirst("Error:".count)).trimmingCharacters(in: .whitespaces))
+    }
+    let message = lines.dropLast().joined(separator: "\n")
+    guard status == 0 else {
+      throw ADBError.nonZeroExit(status, stderr: message)
+    }
+    // Some Android versions report activity errors with a successful shell exit.
+    if let error = lines.first(where: { $0.hasPrefix("Error type ") }) {
+      throw AppLaunchError.failed(error)
+    }
+  }
+
+  private static func isComponent(_ component: String, inPackage packageName: String) -> Bool {
+    let parts = component.split(separator: "/", omittingEmptySubsequences: false)
+    guard isPackageName(packageName), parts.count == 2, parts[0] == packageName else {
+      return false
+    }
+    return parts[1].wholeMatch(of: /\.?[A-Za-z_$][A-Za-z0-9_$]*(\.[A-Za-z_$][A-Za-z0-9_$]*)*/) != nil
+  }
+
+  private static func isPackageName(_ packageName: String) -> Bool {
+    packageName.wholeMatch(of: /[A-Za-z][A-Za-z0-9_]*(\.[A-Za-z][A-Za-z0-9_]*)+/) != nil
+  }
+
+  private static func withExitStatus(_ command: String) -> String {
+    "\(command) 2>&1; printf '\\n\(exitMarker)%s\\n' \"$?\""
+  }
+}
+
+enum AppLaunchError: LocalizedError {
+  case noLauncher(String)
+  case failed(String)
+
+  var errorDescription: String? {
+    switch self {
+    case .noLauncher(let packageName):
+      "No launcher activity was found for \(packageName) on this device."
+    case .failed(let message):
+      message
+    }
+  }
+}

--- a/snapo-app-mac/SnapODeviceClient/Sources/SnapODeviceClient/ADB/ADBAppLaunch.swift
+++ b/snapo-app-mac/SnapODeviceClient/Sources/SnapODeviceClient/ADB/ADBAppLaunch.swift
@@ -1,8 +1,8 @@
 import Foundation
 
 public extension ADBClient {
-  func openApp(deviceID: String, packageName: String) async throws {
-    try await AppLaunchCommand.open(packageName: packageName) { command in
+  func openApp(deviceID: String, packageName: String, androidUserID: Int) async throws {
+    try await AppLaunchCommand.open(packageName: packageName, androidUserID: androidUserID) { command in
       try await runShellString(deviceID: deviceID, command: command)
     }
   }
@@ -11,22 +11,25 @@ public extension ADBClient {
 enum AppLaunchCommand {
   private static let exitMarker = "SNAPO_APP_LAUNCH_EXIT:"
 
-  static func open(packageName: String, runShell: (String) async throws -> String) async throws {
-    let query = try launcherQuery(packageName: packageName)
+  static func open(packageName: String, androidUserID: Int, runShell: (String) async throws -> String) async throws {
+    let query = try launcherQuery(packageName: packageName, androidUserID: androidUserID)
     let output = try await runShell(query)
     let component = try launcherComponent(output: output, packageName: packageName)
-    let command = try command(packageName: packageName, component: component)
+    let command = try command(packageName: packageName, component: component, androidUserID: androidUserID)
     try await validate(output: runShell(command))
   }
 
-  static func launcherQuery(packageName: String) throws -> String {
+  static func launcherQuery(packageName: String, androidUserID: Int) throws -> String {
+    guard androidUserID >= 0 else {
+      throw ADBError.protocolFailure("The app's Android user is unavailable or invalid.")
+    }
     guard isPackageName(packageName) else {
       throw ADBError.protocolFailure("The app's package name is unavailable or invalid.")
     }
 
     // Implicit starts require DEFAULT filters; launcher queries must not.
     return withExitStatus(
-      "cmd package query-activities --components --query-flags 0 --user current "
+      "cmd package query-activities --components --query-flags 0 --user \(androidUserID) "
         + "-a android.intent.action.MAIN -c android.intent.category.LAUNCHER -p '\(packageName)'"
     )
   }
@@ -42,14 +45,17 @@ enum AppLaunchCommand {
     return component
   }
 
-  static func command(packageName: String, component: String) throws -> String {
+  static func command(packageName: String, component: String, androidUserID: Int) throws -> String {
+    guard androidUserID >= 0 else {
+      throw ADBError.protocolFailure("The app's Android user is unavailable or invalid.")
+    }
     guard isComponent(component, inPackage: packageName) else {
       throw ADBError.protocolFailure("The app's launcher activity is invalid.")
     }
 
     // Match a launcher tap without stopping the app or clearing its task.
     return withExitStatus(
-      "am start --user current -a android.intent.action.MAIN -c android.intent.category.LAUNCHER "
+      "am start --user \(androidUserID) -a android.intent.action.MAIN -c android.intent.category.LAUNCHER "
         + "-n '\(component)' -f 0x10200000"
     )
   }

--- a/snapo-app-mac/SnapODeviceClient/Sources/SnapODeviceClient/InspectorDiscovery.swift
+++ b/snapo-app-mac/SnapODeviceClient/Sources/SnapODeviceClient/InspectorDiscovery.swift
@@ -22,6 +22,7 @@ public struct InspectorAppMetadata: Sendable, Equatable {
   public let processName: String?
   public let packageName: String?
   public let packageNameHint: String?
+  public let androidUserID: Int?
   public let appIconBase64: String?
 
   public init(
@@ -29,12 +30,14 @@ public struct InspectorAppMetadata: Sendable, Equatable {
     processName: String? = nil,
     packageName: String? = nil,
     packageNameHint: String? = nil,
+    androidUserID: Int? = nil,
     appIconBase64: String? = nil
   ) {
     self.appName = Self.nonempty(appName)
     self.processName = Self.nonempty(processName)
     self.packageName = Self.nonempty(packageName)
     self.packageNameHint = Self.nonempty(packageNameHint)
+    self.androidUserID = androidUserID
     self.appIconBase64 = Self.nonempty(appIconBase64)
   }
 
@@ -44,6 +47,7 @@ public struct InspectorAppMetadata: Sendable, Equatable {
       processName: processName ?? other.processName,
       packageName: packageName ?? other.packageName,
       packageNameHint: packageNameHint ?? other.packageNameHint,
+      androidUserID: androidUserID ?? other.androidUserID,
       appIconBase64: appIconBase64 ?? other.appIconBase64
     )
   }

--- a/snapo-app-mac/SnapODeviceClient/Sources/SnapODeviceClient/NetworkServerDiscovery.swift
+++ b/snapo-app-mac/SnapODeviceClient/Sources/SnapODeviceClient/NetworkServerDiscovery.swift
@@ -29,6 +29,14 @@ public enum NetworkServerDiscovery {
       .first { !$0.isEmpty }
   }
 
+  public static func androidUserID(inProcStatus output: String) -> Int? {
+    guard let line = output.split(whereSeparator: \.isNewline).first(where: { $0.hasPrefix("Uid:") }),
+          let value = line.split(whereSeparator: \.isWhitespace).dropFirst().first,
+          let uid = UInt32(value) else { return nil }
+    // Android assigns each user a range of 100,000 UIDs.
+    return Int(uid / 100_000)
+  }
+
   public static func connectedDeviceIDs(inDevicesList output: String) -> [String] {
     output
       .split(separator: "\n")
@@ -81,5 +89,17 @@ public enum NetworkServerDiscovery {
       return nil
     }
     return packageName(inCmdline: output)
+  }
+
+  public static func androidUserID(
+    for reference: NetworkServerReference,
+    using adb: ADBClient
+  ) async -> Int? {
+    guard let pid = InspectorKind.allCases.compactMap({ $0.pid(inSocketName: reference.socketName) }).first,
+          let output = try? await adb.runShellString(
+            deviceID: reference.deviceId,
+            command: "cat /proc/\(pid)/status 2>/dev/null"
+          ) else { return nil }
+    return androidUserID(inProcStatus: output)
   }
 }

--- a/snapo-app-mac/SnapODeviceClient/Tests/SnapODeviceClientTests/ADBAppLaunchTests.swift
+++ b/snapo-app-mac/SnapODeviceClient/Tests/SnapODeviceClientTests/ADBAppLaunchTests.swift
@@ -1,0 +1,159 @@
+@testable import SnapODeviceClient
+import Testing
+
+@Suite("ADB app launch")
+struct ADBAppLaunchTests {
+  @Test("queries launcher activities without requiring a DEFAULT filter")
+  func launcherQuery() throws {
+    let query = try AppLaunchCommand.launcherQuery(packageName: "com.example.demo_app")
+    #expect(query.contains("cmd package query-activities --components --query-flags 0 --user current"))
+    #expect(query.contains("-a android.intent.action.MAIN -c android.intent.category.LAUNCHER -p 'com.example.demo_app'"))
+  }
+
+  @Test("starts the explicit launcher without stopping or clearing the app")
+  func launcherCommand() throws {
+    let command = try AppLaunchCommand.command(packageName: "com.example.demo_app", component: "com.example.demo_app/.Launcher")
+    #expect(command.contains("am start --user current -a android.intent.action.MAIN"))
+    #expect(command.contains("-c android.intent.category.LAUNCHER -n 'com.example.demo_app/.Launcher' -f 0x10200000"))
+    #expect(command.contains("2>&1; printf '\\nSNAPO_APP_LAUNCH_EXIT:%s\\n' \"$?\""))
+    #expect(!command.contains("force-stop"))
+    #expect(!command.contains(" -S"))
+  }
+
+  @Test("rejects placeholders, process names, and shell syntax", arguments: [
+    "", "snapo_network_123", "com.example.demo:worker", "com.example.demo;id",
+    "com.example.'demo'", "com.example.demo\n", "com.example.$(id)", "-p com.example.demo"
+  ])
+  func invalidPackage(packageName: String) {
+    #expect(throws: ADBError.self) {
+      try AppLaunchCommand.launcherQuery(packageName: packageName)
+    }
+  }
+
+  @Test("accepts a new launch and an existing task brought to the foreground", arguments: [
+    "Starting: Intent { act=android.intent.action.MAIN }\n",
+    "Starting: Intent { act=android.intent.action.MAIN }\r\n"
+      + "Warning: Activity not started, its current task has been brought to the front\r\n",
+    "Warning: Activity not started, intent has been delivered to currently running top-most instance.\n"
+  ])
+  func successfulLaunch(output: String) throws {
+    try AppLaunchCommand.validate(output: output + "\nSNAPO_APP_LAUNCH_EXIT:0\n")
+  }
+
+  @Test("reports activity errors even when the shell succeeds", arguments: [
+    "Error: Activity not started, unable to resolve Intent\nSNAPO_APP_LAUNCH_EXIT:0\n",
+    "Error type 3\nSNAPO_APP_LAUNCH_EXIT:0\n"
+  ])
+  func activityError(output: String) {
+    #expect(throws: AppLaunchError.self) {
+      try AppLaunchCommand.validate(output: output)
+    }
+  }
+
+  @Test("uses a queried launcher alias instead of an implicit package intent")
+  func resolvesBeforeLaunching() async throws {
+    var commands: [String] = []
+    try await AppLaunchCommand.open(packageName: "com.example.demo") { command in
+      commands.append(command)
+      if commands.count == 1 {
+        return "com.example.demo/com.example.ui.LauncherAlias\nSNAPO_APP_LAUNCH_EXIT:0\n"
+      }
+      return "Starting: Intent\nSNAPO_APP_LAUNCH_EXIT:0\n"
+    }
+    #expect(commands.count == 2)
+    #expect(commands[0].contains("query-activities --components --query-flags 0"))
+    #expect(commands[1].contains("-n 'com.example.demo/com.example.ui.LauncherAlias'"))
+    #expect(!commands[1].contains(" -p "))
+  }
+
+  @Test("accepts relative, full, and nested activity names", arguments: [
+    "com.example.demo/.Launcher", "com.example.demo/com.example.ui.MainActivity",
+    "com.example.demo/com.example.ui.MainActivity$Launcher"
+  ])
+  func componentNames(component: String) throws {
+    let selected = try AppLaunchCommand.launcherComponent(
+      output: "\(component)\r\nSNAPO_APP_LAUNCH_EXIT:0\r\n",
+      packageName: "com.example.demo"
+    )
+    #expect(selected == component)
+    let command = try AppLaunchCommand.command(packageName: "com.example.demo", component: selected)
+    #expect(command.contains("-n '\(component)'"))
+  }
+
+  @Test("uses the first returned launcher for the selected package")
+  func multipleLaunchers() throws {
+    let component = try AppLaunchCommand.launcherComponent(
+      output: "com.example.demo/.First\ncom.example.demo/.Second\nSNAPO_APP_LAUNCH_EXIT:0\n",
+      packageName: "com.example.demo"
+    )
+    #expect(component == "com.example.demo/.First")
+  }
+
+  @Test("rejects foreign components and shell syntax", arguments: [
+    "com.example.other/.Launcher", "com.example.demo/.Launcher;id", "com.example.demo/$(id)",
+    "com.example.demo/.Launcher'", "com.example.demo/.Launcher\n", "com.example.demo/"
+  ])
+  func invalidComponent(component: String) {
+    #expect(throws: ADBError.self) {
+      try AppLaunchCommand.command(packageName: "com.example.demo", component: component)
+    }
+  }
+
+  @Test("does not try to launch when no launcher activity exists")
+  func missingLauncher() async {
+    var commands: [String] = []
+    await #expect {
+      try await AppLaunchCommand.open(packageName: "com.example.demo") { command in
+        commands.append(command)
+        return "No activities found\nSNAPO_APP_LAUNCH_EXIT:0\n"
+      }
+    } throws: { error in
+      guard case AppLaunchError.noLauncher("com.example.demo") = error else { return false }
+      return true
+    }
+    #expect(commands.count == 1)
+  }
+
+  @Test("stops if launcher discovery fails")
+  func failedQuery() async {
+    var count = 0
+    await #expect(throws: ADBError.self) {
+      try await AppLaunchCommand.open(packageName: "com.example.demo") { _ in
+        count += 1
+        throw ADBError.serverUnavailable("Device disconnected")
+      }
+    }
+    #expect(count == 1)
+  }
+
+  @Test("shows the activity error without the raw intent dump")
+  func readableActivityError() {
+    #expect {
+      try AppLaunchCommand.validate(
+        output: "Starting: Intent { act=android.intent.action.MAIN }\nError: Permission denied\nSNAPO_APP_LAUNCH_EXIT:1\n"
+      )
+    } throws: { error in
+      guard case AppLaunchError.failed("Permission denied") = error else { return false }
+      return true
+    }
+  }
+
+  @Test("preserves command failures for the user")
+  func failedLaunch() {
+    #expect {
+      try AppLaunchCommand.validate(output: "Permission denied\nSNAPO_APP_LAUNCH_EXIT:1\n")
+    } throws: { error in
+      guard case ADBError.nonZeroExit(1, stderr: "Permission denied") = error else { return false }
+      return true
+    }
+  }
+
+  @Test("does not mistake missing or malformed results for success", arguments: [
+    "", "Starting: Intent", "SNAPO_APP_LAUNCH_EXIT:unknown", "SNAPO_APP_LAUNCH_EXIT:0\ntrailing data"
+  ])
+  func missingResult(output: String) {
+    #expect(throws: ADBError.self) {
+      try AppLaunchCommand.validate(output: output)
+    }
+  }
+}

--- a/snapo-app-mac/SnapODeviceClient/Tests/SnapODeviceClientTests/ADBAppLaunchTests.swift
+++ b/snapo-app-mac/SnapODeviceClient/Tests/SnapODeviceClientTests/ADBAppLaunchTests.swift
@@ -5,15 +5,19 @@ import Testing
 struct ADBAppLaunchTests {
   @Test("queries launcher activities without requiring a DEFAULT filter")
   func launcherQuery() throws {
-    let query = try AppLaunchCommand.launcherQuery(packageName: "com.example.demo_app")
-    #expect(query.contains("cmd package query-activities --components --query-flags 0 --user current"))
+    let query = try AppLaunchCommand.launcherQuery(packageName: "com.example.demo_app", androidUserID: 0)
+    #expect(query.contains("cmd package query-activities --components --query-flags 0 --user 0"))
     #expect(query.contains("-a android.intent.action.MAIN -c android.intent.category.LAUNCHER -p 'com.example.demo_app'"))
   }
 
   @Test("starts the explicit launcher without stopping or clearing the app")
   func launcherCommand() throws {
-    let command = try AppLaunchCommand.command(packageName: "com.example.demo_app", component: "com.example.demo_app/.Launcher")
-    #expect(command.contains("am start --user current -a android.intent.action.MAIN"))
+    let command = try AppLaunchCommand.command(
+      packageName: "com.example.demo_app",
+      component: "com.example.demo_app/.Launcher",
+      androidUserID: 0
+    )
+    #expect(command.contains("am start --user 0 -a android.intent.action.MAIN"))
     #expect(command.contains("-c android.intent.category.LAUNCHER -n 'com.example.demo_app/.Launcher' -f 0x10200000"))
     #expect(command.contains("2>&1; printf '\\nSNAPO_APP_LAUNCH_EXIT:%s\\n' \"$?\""))
     #expect(!command.contains("force-stop"))
@@ -26,7 +30,7 @@ struct ADBAppLaunchTests {
   ])
   func invalidPackage(packageName: String) {
     #expect(throws: ADBError.self) {
-      try AppLaunchCommand.launcherQuery(packageName: packageName)
+      try AppLaunchCommand.launcherQuery(packageName: packageName, androidUserID: 0)
     }
   }
 
@@ -50,10 +54,10 @@ struct ADBAppLaunchTests {
     }
   }
 
-  @Test("uses a queried launcher alias instead of an implicit package intent")
-  func resolvesBeforeLaunching() async throws {
+  @Test("queries and launches an explicit activity in the inspector's Android user", arguments: [0, 10, 11])
+  func resolvesBeforeLaunching(androidUserID: Int) async throws {
     var commands: [String] = []
-    try await AppLaunchCommand.open(packageName: "com.example.demo") { command in
+    try await AppLaunchCommand.open(packageName: "com.example.demo", androidUserID: androidUserID) { command in
       commands.append(command)
       if commands.count == 1 {
         return "com.example.demo/com.example.ui.LauncherAlias\nSNAPO_APP_LAUNCH_EXIT:0\n"
@@ -64,6 +68,8 @@ struct ADBAppLaunchTests {
     #expect(commands[0].contains("query-activities --components --query-flags 0"))
     #expect(commands[1].contains("-n 'com.example.demo/com.example.ui.LauncherAlias'"))
     #expect(!commands[1].contains(" -p "))
+    #expect(commands.allSatisfy { $0.contains("--user \(androidUserID) ") })
+    #expect(commands.allSatisfy { !$0.contains("--user current") })
   }
 
   @Test("accepts relative, full, and nested activity names", arguments: [
@@ -76,7 +82,7 @@ struct ADBAppLaunchTests {
       packageName: "com.example.demo"
     )
     #expect(selected == component)
-    let command = try AppLaunchCommand.command(packageName: "com.example.demo", component: selected)
+    let command = try AppLaunchCommand.command(packageName: "com.example.demo", component: selected, androidUserID: 0)
     #expect(command.contains("-n '\(component)'"))
   }
 
@@ -95,7 +101,7 @@ struct ADBAppLaunchTests {
   ])
   func invalidComponent(component: String) {
     #expect(throws: ADBError.self) {
-      try AppLaunchCommand.command(packageName: "com.example.demo", component: component)
+      try AppLaunchCommand.command(packageName: "com.example.demo", component: component, androidUserID: 0)
     }
   }
 
@@ -103,7 +109,7 @@ struct ADBAppLaunchTests {
   func missingLauncher() async {
     var commands: [String] = []
     await #expect {
-      try await AppLaunchCommand.open(packageName: "com.example.demo") { command in
+      try await AppLaunchCommand.open(packageName: "com.example.demo", androidUserID: 0) { command in
         commands.append(command)
         return "No activities found\nSNAPO_APP_LAUNCH_EXIT:0\n"
       }
@@ -118,7 +124,7 @@ struct ADBAppLaunchTests {
   func failedQuery() async {
     var count = 0
     await #expect(throws: ADBError.self) {
-      try await AppLaunchCommand.open(packageName: "com.example.demo") { _ in
+      try await AppLaunchCommand.open(packageName: "com.example.demo", androidUserID: 0) { _ in
         count += 1
         throw ADBError.serverUnavailable("Device disconnected")
       }
@@ -154,6 +160,21 @@ struct ADBAppLaunchTests {
   func missingResult(output: String) {
     #expect(throws: ADBError.self) {
       try AppLaunchCommand.validate(output: output)
+    }
+  }
+
+  @Test("rejects Android user selectors that do not identify one user", arguments: [-1, -2])
+  func invalidAndroidUser(androidUserID: Int) async {
+    var commands: [String] = []
+    await #expect(throws: ADBError.self) {
+      try await AppLaunchCommand.open(packageName: "com.example.demo", androidUserID: androidUserID) { command in
+        commands.append(command)
+        return ""
+      }
+    }
+    #expect(commands.isEmpty)
+    #expect(throws: ADBError.self) {
+      try AppLaunchCommand.command(packageName: "com.example.demo", component: "com.example.demo/.Launcher", androidUserID: androidUserID)
     }
   }
 }

--- a/snapo-app-mac/SnapODeviceClient/Tests/SnapODeviceClientTests/InspectorDiscoveryTests.swift
+++ b/snapo-app-mac/SnapODeviceClient/Tests/SnapODeviceClientTests/InspectorDiscoveryTests.swift
@@ -63,13 +63,15 @@ struct InspectorDiscoveryTests {
     ))
     let tweaks = endpoint(.tweaks, metadata: InspectorAppMetadata(
       appName: "Demo App",
-      packageName: "com.example.demo"
+      packageName: "com.example.demo",
+      androidUserID: 10
     ))
     let loaded = try #require(InspectorDiscovery.processes(from: [tweaks, network]).first)
 
     #expect(loaded.id == initial.id)
     #expect(loaded.name == "Demo App")
     #expect(loaded.metadata.packageName == "com.example.demo")
+    #expect(loaded.metadata.androidUserID == 10)
     #expect(loaded.metadata.appIconBase64 == "network-icon")
     #expect(loaded.inspectors.map(\.reference.socketName) == ["snapo_network_42", "snapo_tweaks_42"])
   }
@@ -90,6 +92,8 @@ struct InspectorDiscoveryTests {
     let network = endpoint(.network, metadata: InspectorAppMetadata(
       processName: " \n", packageNameHint: "com.example.demo:worker", appIconBase64: ""
     ))
+    let legacy = try #require(InspectorDiscovery.processes(from: [network]).first)
+    #expect(legacy.metadata.packageName == nil)
     let tweaks = endpoint(.tweaks, metadata: InspectorAppMetadata(
       appName: " ", packageName: "com.example.demo", appIconBase64: "tweaks-icon"
     ))

--- a/snapo-app-mac/SnapODeviceClient/Tests/SnapODeviceClientTests/NetworkServerDiscoveryTests.swift
+++ b/snapo-app-mac/SnapODeviceClient/Tests/SnapODeviceClientTests/NetworkServerDiscoveryTests.swift
@@ -40,4 +40,18 @@ struct NetworkServerDiscoveryTests {
         == ["emulator-5554", "usb-phone"]
     )
   }
+
+  @Test("extracts the Android user from the process UID")
+  func parsesAndroidUser() {
+    #expect(NetworkServerDiscovery.androidUserID(inProcStatus: "Name:\tdemo\nUid:\t10234\t10234\t10234\t10234\n") == 0)
+    #expect(NetworkServerDiscovery.androidUserID(inProcStatus: "Uid:\t1010234\t1010234\t1010234\t1010234\n") == 10)
+    #expect(NetworkServerDiscovery.androidUserID(inProcStatus: "Uid: 1110234 1110234 1110234 1110234\r\n") == 11)
+  }
+
+  @Test("does not assume the current Android user when process metadata is unavailable", arguments: [
+    "", "cat: permission denied", "Name:\tdemo\n", "Uid:", "Uid:\t-1", "Uid:\tunknown", "Uid:\t4294967296"
+  ])
+  func missingAndroidUser(output: String) {
+    #expect(NetworkServerDiscovery.androidUserID(inProcStatus: output) == nil)
+  }
 }

--- a/snapo-network-inspector-web/src/App.test.tsx
+++ b/snapo-network-inspector-web/src/App.test.tsx
@@ -89,6 +89,7 @@ describe("app inspector restoration UI", () => {
   let container: HTMLDivElement;
   let discovered: InspectableApp[];
   let nativeSelect: (selection: SelectedAppInspector) => void;
+  let nativeSelectApp: (id: string) => void;
   let events: Set<(event: StreamEvent) => void>;
 
   beforeEach(() => {
@@ -104,6 +105,7 @@ describe("app inspector restoration UI", () => {
       loadInspectorPreferences: vi.fn(async () => saved.serialize()),
       saveInspectorPreferences: vi.fn(async () => {}),
       listInspectorApps: vi.fn(async () => discovered),
+      openApp: vi.fn(async () => {}),
       listServers: vi.fn(async () =>
         discovered.flatMap((app) =>
           app.inspectors
@@ -150,7 +152,10 @@ describe("app inspector restoration UI", () => {
         nativeSelect = callback;
         return () => {};
       }),
-      onNativeSelectedApp: vi.fn(() => () => {})
+      onNativeSelectedApp: vi.fn((callback) => {
+        nativeSelectApp = callback;
+        return () => {};
+      })
     } as unknown as NetworkClient;
     container = document.createElement("div");
     document.body.append(container);
@@ -163,16 +168,215 @@ describe("app inspector restoration UI", () => {
     vi.useRealTimers();
   });
 
-  it("shows a spinner and status text until the remembered inspector appears", async () => {
+  it("shows status and an open action without a spinner until the remembered inspector appears", async () => {
     await act(async () => root.render(<App />));
-    expect(container.querySelector('[role="status"] svg')).not.toBeNull();
+    expect(container.querySelector('[role="status"] svg')).toBeNull();
     expect(container.querySelector('[role="status"]')?.textContent).toBe("Waiting for inspector");
     expect(container.querySelector("[data-inspector]")).toBeNull();
+    expect(container.querySelector(".inspector-open-app")?.textContent).toBe("Open Demo");
 
     discovered = [app(20, ["network", "tweaks"])];
     await act(async () => vi.advanceTimersByTimeAsync(2_500));
     expect(container.querySelector('[data-inspector="network"]')?.getAttribute("data-socket")).toBe("snapo_network_20");
     expect(container.querySelector('[role="status"]')).toBeNull();
+    expect(container.querySelector(".inspector-open-app")).toBeNull();
+  });
+
+  it("opens the remembered app on its device and prevents duplicate launches", async () => {
+    let finish!: () => void;
+    vi.mocked(mocks.client.openApp!).mockImplementationOnce(
+      () =>
+        new Promise((resolve) => {
+          finish = resolve;
+        })
+    );
+    await act(async () => root.render(<App />));
+    discovered = [];
+    await act(async () => vi.advanceTimersByTimeAsync(2_500));
+    const button = container.querySelector<HTMLButtonElement>(".inspector-open-app")!;
+    await act(async () => {
+      button.click();
+      button.click();
+    });
+    expect(mocks.client.openApp).toHaveBeenCalledExactlyOnceWith({
+      deviceId: "phone",
+      packageName: "com.example.demo"
+    });
+    expect(container.querySelector(".inspector-open-app")).toBeNull();
+    expect(container.querySelectorAll('[role="progressbar"]')).toHaveLength(1);
+    expect(container.querySelector('[role="status"]')?.textContent).toBe("Waiting for inspector");
+    await act(async () => finish());
+    expect(container.querySelector(".inspector-open-app")).toBeNull();
+    expect(container.querySelector('[role="progressbar"]')).not.toBeNull();
+    await act(async () => vi.advanceTimersByTimeAsync(5_000));
+    expect(container.querySelector(".inspector-open-app")?.textContent).toBe("Open Demo");
+    expect(container.querySelector('[role="progressbar"]')).toBeNull();
+    expect(container.querySelector('[role="status"]')).not.toBeNull();
+  });
+
+  it("shows launch errors and allows a retry without stopping discovery", async () => {
+    vi.mocked(mocks.client.openApp!).mockRejectedValueOnce(new Error("Device is offline."));
+    await act(async () => root.render(<App />));
+    const button = container.querySelector<HTMLButtonElement>(".inspector-open-app")!;
+    await act(async () => button.click());
+    expect(container.querySelector('[role="alert"]')?.textContent).toBe("Device is offline.");
+    expect(container.querySelector('[role="progressbar"]')).toBeNull();
+    await act(async () => container.querySelector<HTMLButtonElement>(".inspector-open-app")!.click());
+    expect(container.querySelector('[role="alert"]')).toBeNull();
+    expect(mocks.client.openApp).toHaveBeenCalledTimes(2);
+
+    discovered = [app(20, ["network", "tweaks"])];
+    await act(async () => vi.advanceTimersByTimeAsync(500));
+    expect(container.querySelector('[data-inspector="network"]')).not.toBeNull();
+    expect(container.querySelector(".inspector-open-app")).toBeNull();
+  });
+
+  it("does not offer app launch when the client does not support it", async () => {
+    delete mocks.client.openApp;
+    await act(async () => root.render(<App />));
+    expect(container.querySelector('[role="status"]')).not.toBeNull();
+    expect(container.querySelector(".inspector-open-app")).toBeNull();
+    expect(container.querySelector('[role="status"] .body-loading-spinner svg')).not.toBeNull();
+  });
+
+  it("refreshes immediately after opening and every half second for five seconds", async () => {
+    await act(async () => root.render(<App />));
+    const scans = vi.mocked(mocks.client.listInspectorApps);
+    const initialScans = scans.mock.calls.length;
+    await act(async () => container.querySelector<HTMLButtonElement>(".inspector-open-app")!.click());
+    expect(scans).toHaveBeenCalledTimes(initialScans + 1);
+    await act(async () => vi.advanceTimersByTimeAsync(499));
+    expect(scans).toHaveBeenCalledTimes(initialScans + 1);
+    await act(async () => vi.advanceTimersByTimeAsync(1));
+    expect(scans).toHaveBeenCalledTimes(initialScans + 2);
+    await act(async () => vi.advanceTimersByTimeAsync(4_499));
+    expect(scans).toHaveBeenCalledTimes(initialScans + 10);
+    expect(container.querySelector(".inspector-open-app")).toBeNull();
+    await act(async () => vi.advanceTimersByTimeAsync(1));
+    expect(scans).toHaveBeenCalledTimes(initialScans + 11);
+    expect(container.querySelector(".inspector-open-app")).not.toBeNull();
+    await act(async () => vi.advanceTimersByTimeAsync(2_499));
+    expect(scans).toHaveBeenCalledTimes(initialScans + 11);
+    await act(async () => vi.advanceTimersByTimeAsync(1));
+    expect(scans).toHaveBeenCalledTimes(initialScans + 12);
+  });
+
+  it("does not overlap slow scans during the launch window", async () => {
+    await act(async () => root.render(<App />));
+    const scans = vi.mocked(mocks.client.listInspectorApps);
+    let finish!: (apps: InspectableApp[]) => void;
+    scans.mockImplementationOnce(
+      () =>
+        new Promise((resolve) => {
+          finish = resolve;
+        })
+    );
+    await act(async () => container.querySelector<HTMLButtonElement>(".inspector-open-app")!.click());
+    const scanCount = scans.mock.calls.length;
+    await act(async () => vi.advanceTimersByTimeAsync(2_000));
+    expect(scans).toHaveBeenCalledTimes(scanCount);
+    await act(async () => finish(discovered));
+    await act(async () => vi.advanceTimersByTimeAsync(500));
+    expect(scans).toHaveBeenCalledTimes(scanCount + 1);
+  });
+
+  it("keeps polling after a failed scan and stops fast polling after a launch error", async () => {
+    await act(async () => root.render(<App />));
+    const scans = vi.mocked(mocks.client.listInspectorApps);
+    let fail!: (error: Error) => void;
+    vi.mocked(mocks.client.openApp!).mockImplementationOnce(
+      () =>
+        new Promise((_, reject) => {
+          fail = reject;
+        })
+    );
+    scans.mockRejectedValueOnce(new Error("Discovery unavailable"));
+    const scanCount = scans.mock.calls.length;
+    await act(async () => container.querySelector<HTMLButtonElement>(".inspector-open-app")!.click());
+    await act(async () => vi.advanceTimersByTimeAsync(1_000));
+    expect(scans).toHaveBeenCalledTimes(scanCount + 2);
+    expect(container.querySelector('[role="progressbar"]')).not.toBeNull();
+    await act(async () => fail(new Error("Device disconnected")));
+    expect(container.querySelector(".inspector-open-app")).not.toBeNull();
+    await act(async () => vi.advanceTimersByTimeAsync(1_000));
+    expect(scans).toHaveBeenCalledTimes(scanCount + 2);
+  });
+
+  it("does not allow another launch while adb is still running after the wait window", async () => {
+    let finish!: () => void;
+    vi.mocked(mocks.client.openApp!).mockImplementationOnce(
+      () =>
+        new Promise((resolve) => {
+          finish = resolve;
+        })
+    );
+    await act(async () => root.render(<App />));
+    await act(async () => container.querySelector<HTMLButtonElement>(".inspector-open-app")!.click());
+    await act(async () => vi.advanceTimersByTimeAsync(5_000));
+    expect(container.querySelector(".inspector-open-app")).toBeNull();
+    expect(container.querySelector('[role="progressbar"]')).not.toBeNull();
+    await act(async () => finish());
+    expect(container.querySelector(".inspector-open-app")).not.toBeNull();
+  });
+
+  it("cancels launch polling and ignores a late launch result after unmount", async () => {
+    let finish!: () => void;
+    vi.mocked(mocks.client.openApp!).mockImplementationOnce(
+      () =>
+        new Promise((resolve) => {
+          finish = resolve;
+        })
+    );
+    await act(async () => root.render(<App />));
+    await act(async () => container.querySelector<HTMLButtonElement>(".inspector-open-app")!.click());
+    await act(async () => root.render(null));
+    const scans = vi.mocked(mocks.client.listInspectorApps);
+    const scanCount = scans.mock.calls.length;
+    await act(async () => finish());
+    await act(async () => vi.advanceTimersByTimeAsync(7_500));
+    expect(scans).toHaveBeenCalledTimes(scanCount);
+  });
+
+  it("does not carry a pending launch or its error into another app selection", async () => {
+    const other = { ...app(30, ["tweaks"]), name: "Other", packageName: "com.example.other", processName: null };
+    discovered.push(other);
+    let fail!: (error: Error) => void;
+    vi.mocked(mocks.client.openApp!).mockImplementationOnce(
+      () =>
+        new Promise((_, reject) => {
+          fail = reject;
+        })
+    );
+    await act(async () => root.render(<App />));
+    await act(async () => container.querySelector<HTMLButtonElement>(".inspector-open-app")!.click());
+    await act(async () => nativeSelectApp(other.id));
+    const button = container.querySelector<HTMLButtonElement>(".inspector-open-app")!;
+    expect(button.textContent).toBe("Open Other");
+    expect(button.disabled).toBe(false);
+    const scans = vi.mocked(mocks.client.listInspectorApps);
+    const scanCount = scans.mock.calls.length;
+    await act(async () => vi.advanceTimersByTimeAsync(500));
+    expect(scans).toHaveBeenCalledTimes(scanCount);
+    await act(async () => fail(new Error("Old launch failed.")));
+    expect(container.querySelector('[role="alert"]')).toBeNull();
+    await act(async () => button.click());
+    expect(mocks.client.openApp).toHaveBeenLastCalledWith({ deviceId: "phone", packageName: "com.example.other" });
+  });
+
+  it("clears a launch error when leaving and returning to the same app", async () => {
+    const other = { ...app(30, ["tweaks"]), name: "Other", packageName: "com.example.other", processName: null };
+    discovered.push(other);
+    vi.mocked(mocks.client.openApp!).mockRejectedValueOnce(new Error("Device is offline."));
+    await act(async () => root.render(<App />));
+    await act(async () => container.querySelector<HTMLButtonElement>(".inspector-open-app")!.click());
+    expect(container.querySelector('[role="alert"]')?.textContent).toBe("Device is offline.");
+
+    await act(async () => {
+      nativeSelectApp(other.id);
+      nativeSelectApp(discovered[0].id);
+    });
+    expect(container.querySelector('[role="alert"]')).toBeNull();
+    expect(container.querySelector(".inspector-open-app")?.textContent).toBe("Open Demo");
   });
 
   it("honors a native explicit choice while discovery is in flight", async () => {
@@ -198,6 +402,8 @@ describe("app inspector restoration UI", () => {
     expect(container.querySelector('[role="status"]')).not.toBeNull();
     expect(container.querySelector("[data-inspector]")).toBeNull();
     expect(mocks.client.startStream).not.toHaveBeenCalled();
+    expect(container.querySelector(".inspector-open-app")).toBeNull();
+    expect(container.querySelector('[role="status"] .body-loading-spinner svg')).not.toBeNull();
     expect(mocks.client.appInspectorStateChanged).toHaveBeenLastCalledWith(
       expect.objectContaining({ selectedApp: null, selection: null, isRestoring: true })
     );

--- a/snapo-network-inspector-web/src/App.test.tsx
+++ b/snapo-network-inspector-web/src/App.test.tsx
@@ -73,6 +73,7 @@ function app(pid: number, kinds: AppInspectorKind[]): InspectableApp {
     id: `phone:pid:${pid}`,
     name: "Demo",
     packageName: "com.example.demo",
+    androidUserId: 0,
     processName: "com.example.demo",
     deviceId: "phone",
     deviceDisplayTitle: "Phone",
@@ -200,7 +201,8 @@ describe("app inspector restoration UI", () => {
     });
     expect(mocks.client.openApp).toHaveBeenCalledExactlyOnceWith({
       deviceId: "phone",
-      packageName: "com.example.demo"
+      packageName: "com.example.demo",
+      androidUserId: 0
     });
     expect(container.querySelector(".inspector-open-app")).toBeNull();
     expect(container.querySelectorAll('[role="progressbar"]')).toHaveLength(1);
@@ -237,6 +239,42 @@ describe("app inspector restoration UI", () => {
     expect(container.querySelector('[role="status"]')).not.toBeNull();
     expect(container.querySelector(".inspector-open-app")).toBeNull();
     expect(container.querySelector('[role="status"] .body-loading-spinner svg')).not.toBeNull();
+  });
+
+  it.each([
+    { packageName: null, androidUserId: 0 },
+    { packageName: "com.example.demo", androidUserId: null }
+  ])("does not offer app launch without a confirmed package and Android user", async (metadata) => {
+    const waitingApp = { ...app(20, ["tweaks"]), ...metadata, processName: "com.example.demo:worker" };
+    const saved = new InspectorRestoration();
+    saved.reconcile([{ ...waitingApp, inspectors: app(20, ["network"]).inspectors }]);
+    vi.mocked(mocks.client.loadInspectorPreferences).mockResolvedValue(saved.serialize());
+    discovered = [waitingApp];
+    await act(async () => root.render(<App />));
+    expect(mocks.client.appInspectorStateChanged).toHaveBeenLastCalledWith(
+      expect.objectContaining({ selectedApp: expect.objectContaining({ processName: "com.example.demo:worker" }) })
+    );
+    expect(container.querySelector('[role="status"]')).not.toBeNull();
+    expect(container.querySelector(".inspector-open-app")).toBeNull();
+    expect(mocks.client.openApp).not.toHaveBeenCalled();
+  });
+
+  it("opens a retained secondary process in its own Android user", async () => {
+    const workApp = { ...app(20, ["tweaks"]), androidUserId: 10, processName: "com.example.demo:worker" };
+    const saved = new InspectorRestoration();
+    saved.reconcile([workApp]);
+    saved.selectInspector(workApp, { kind: "network", server: { deviceId: "phone", socketName: "snapo_network_20" } });
+    vi.mocked(mocks.client.loadInspectorPreferences).mockResolvedValue(saved.serialize());
+    discovered = [workApp];
+    await act(async () => root.render(<App />));
+    discovered = [{ ...workApp, id: "phone:pid:30", androidUserId: 0 }];
+    await act(async () => vi.advanceTimersByTimeAsync(2_500));
+    await act(async () => container.querySelector<HTMLButtonElement>(".inspector-open-app")!.click());
+    expect(mocks.client.openApp).toHaveBeenCalledExactlyOnceWith({
+      deviceId: "phone",
+      packageName: "com.example.demo",
+      androidUserId: 10
+    });
   });
 
   it("refreshes immediately after opening and every half second for five seconds", async () => {
@@ -337,8 +375,11 @@ describe("app inspector restoration UI", () => {
     expect(scans).toHaveBeenCalledTimes(scanCount);
   });
 
-  it("does not carry a pending launch or its error into another app selection", async () => {
-    const other = { ...app(30, ["tweaks"]), name: "Other", packageName: "com.example.other", processName: null };
+  it.each([
+    { packageName: "com.example.other", androidUserId: 0 },
+    { packageName: "com.example.demo", androidUserId: 10 }
+  ])("does not carry a pending launch or its error into another app or profile", async (target) => {
+    const other = { ...app(30, ["tweaks"]), ...target, name: "Other", processName: null };
     discovered.push(other);
     let fail!: (error: Error) => void;
     vi.mocked(mocks.client.openApp!).mockImplementationOnce(
@@ -360,7 +401,7 @@ describe("app inspector restoration UI", () => {
     await act(async () => fail(new Error("Old launch failed.")));
     expect(container.querySelector('[role="alert"]')).toBeNull();
     await act(async () => button.click());
-    expect(mocks.client.openApp).toHaveBeenLastCalledWith({ deviceId: "phone", packageName: "com.example.other" });
+    expect(mocks.client.openApp).toHaveBeenLastCalledWith({ deviceId: "phone", ...target });
   });
 
   it("clears a launch error when leaving and returning to the same app", async () => {

--- a/snapo-network-inspector-web/src/App.tsx
+++ b/snapo-network-inspector-web/src/App.tsx
@@ -51,7 +51,9 @@ export function App(): JSX.Element {
       ) : displayedTweaks ? (
         <TweaksInspectorApp
           key={
-            selectedApp ? `${selectedApp.deviceId}:${selectedApp.processName ?? selectedApp.id}` : displayedTweaks.appId
+            selectedApp
+              ? `${selectedApp.deviceId}:${selectedApp.androidUserId ?? "unknown"}:${selectedApp.processName ?? selectedApp.id}`
+              : displayedTweaks.appId
           }
           client={client}
           apps={apps}

--- a/snapo-network-inspector-web/src/App.tsx
+++ b/snapo-network-inspector-web/src/App.tsx
@@ -19,7 +19,8 @@ export function App(): JSX.Element {
     preferredKind,
     isRestoring,
     loading,
-    select
+    select,
+    appLaunch
   } = useAppInspector(client);
   const pending =
     loading ||
@@ -45,7 +46,7 @@ export function App(): JSX.Element {
               onSelect={select}
             />
           ) : null}
-          <InspectorWaitingState />
+          <InspectorWaitingState launch={appLaunch} app={selectedApp} />
         </main>
       ) : displayedTweaks ? (
         <TweaksInspectorApp
@@ -57,6 +58,7 @@ export function App(): JSX.Element {
           selection={displayedTweaks}
           isConnected={selection?.kind === "tweaks" && !pending}
           selectedApp={selectedApp}
+          appLaunch={appLaunch}
           onSelect={select}
         />
       ) : (
@@ -65,6 +67,7 @@ export function App(): JSX.Element {
           inspectorApps={apps}
           inspectorSelection={displayedNetwork}
           selectedApp={selectedApp}
+          appLaunch={appLaunch}
           preferredKind={preferredKind}
           onInspectorSelect={select}
         />

--- a/snapo-network-inspector-web/src/App.tweaks.test.tsx
+++ b/snapo-network-inspector-web/src/App.tweaks.test.tsx
@@ -19,6 +19,7 @@ function app(pid: number): InspectableApp {
     id: `phone:pid:${pid}`,
     name: "Demo",
     packageName: "com.example.demo",
+    androidUserId: 0,
     processName: "com.example.demo",
     deviceId: "phone",
     deviceDisplayTitle: "Phone",
@@ -173,9 +174,12 @@ describe("retained Tweaks view", () => {
     expect(container.querySelector('[role="status"]')).toBeNull();
   });
 
-  it("does not show another app's cached values while loading", async () => {
+  it.each([
+    { packageName: "com.example.other", processName: "com.example.other", androidUserId: 0 },
+    { packageName: "com.example.demo", processName: "com.example.demo", androidUserId: 10 }
+  ])("does not show another app or profile's cached values while loading", async (target) => {
     await act(async () => root.render(<App />));
-    const other = { ...app(20), packageName: "com.example.other", processName: "com.example.other" };
+    const other = { ...app(20), ...target };
     discovered = [app(10), other];
     await act(async () => vi.advanceTimersByTimeAsync(2_500));
     let finish!: (value: TweakList) => void;

--- a/snapo-network-inspector-web/src/App.tweaks.test.tsx
+++ b/snapo-network-inspector-web/src/App.tweaks.test.tsx
@@ -45,6 +45,7 @@ describe("retained Tweaks view", () => {
       loadInspectorPreferences: vi.fn(async () => saved.serialize()),
       saveInspectorPreferences: vi.fn(async () => {}),
       listInspectorApps: vi.fn(async () => discovered),
+      openApp: vi.fn(async () => {}),
       appInspectorStateChanged: vi.fn(),
       onNativeSelectedInspector: vi.fn(() => () => {}),
       onNativeSelectedApp: vi.fn((callback) => {
@@ -100,6 +101,66 @@ describe("retained Tweaks view", () => {
     );
     expect(input.value).toBe("Fresh value");
     expect(container.querySelector("fieldset")?.disabled).toBe(false);
+  });
+
+  it("keeps the launch spinner through the transition into Tweaks and shows data as soon as it loads", async () => {
+    discovered = [
+      {
+        ...app(10),
+        inspectors: [
+          { kind: "network", protocolVersion: 4, server: { deviceId: "phone", socketName: "snapo_network_10" } }
+        ]
+      }
+    ];
+    let finish!: (value: TweakList) => void;
+    vi.mocked(mocks.client.listTweaks).mockImplementationOnce(
+      () =>
+        new Promise((resolve) => {
+          finish = resolve;
+        })
+    );
+    await act(async () => root.render(<App />));
+    expect(container.querySelector(".inspector-loading-shell")).not.toBeNull();
+    await act(async () => container.querySelector<HTMLButtonElement>(".inspector-open-app")!.click());
+    expect(container.querySelector(".inspector-open-app")).toBeNull();
+    expect(container.querySelectorAll('[role="progressbar"]')).toHaveLength(1);
+
+    discovered = [app(20)];
+    await act(async () => vi.advanceTimersByTimeAsync(500));
+    expect(container.querySelector(".tweaks-inspector")).not.toBeNull();
+    expect(container.querySelector(".inspector-loading-shell")).toBeNull();
+    expect(container.querySelector(".inspector-open-app")).toBeNull();
+    expect(container.querySelectorAll('[role="progressbar"]')).toHaveLength(1);
+    expect(container.querySelector('[role="status"]')?.textContent).toBe("Waiting for inspector");
+
+    await act(async () =>
+      finish({ tweaks: [{ name: "Demo title", type: "string", value: "Ready", default: "Default" }] })
+    );
+    expect(container.querySelector<HTMLInputElement>('input[type="text"]')?.value).toBe("Ready");
+    expect(container.querySelector('[role="progressbar"]')).toBeNull();
+    expect(container.querySelector(".inspector-open-app")).toBeNull();
+  });
+
+  it("restores Open five seconds after the click even when the waiting view changes", async () => {
+    discovered = [
+      {
+        ...app(10),
+        inspectors: [
+          { kind: "network", protocolVersion: 4, server: { deviceId: "phone", socketName: "snapo_network_10" } }
+        ]
+      }
+    ];
+    vi.mocked(mocks.client.listTweaks).mockImplementationOnce(() => new Promise(() => {}));
+    await act(async () => root.render(<App />));
+    await act(async () => container.querySelector<HTMLButtonElement>(".inspector-open-app")!.click());
+    discovered = [app(20)];
+    await act(async () => vi.advanceTimersByTimeAsync(1_500));
+    expect(container.querySelector(".tweaks-inspector")).not.toBeNull();
+    await act(async () => vi.advanceTimersByTimeAsync(3_499));
+    expect(container.querySelector(".inspector-open-app")).toBeNull();
+    await act(async () => vi.advanceTimersByTimeAsync(1));
+    expect(container.querySelector(".inspector-open-app")?.textContent).toBe("Open Demo");
+    expect(container.querySelector('[role="progressbar"]')).toBeNull();
   });
 
   it("keeps a successfully loaded empty view through disconnect", async () => {

--- a/snapo-network-inspector-web/src/features/app-inspector/components/AppInspectorPicker.tsx
+++ b/snapo-network-inspector-web/src/features/app-inspector/components/AppInspectorPicker.tsx
@@ -156,7 +156,7 @@ export function AppInspectorMenu({
               role="menuitemradio"
               aria-checked={selected}
               aria-label={`${app.name}, ${app.deviceDisplayTitle}`}
-              title={app.packageName}
+              title={app.packageName ?? app.processName ?? app.name}
               disabled={!option}
               onClick={() => {
                 if (option) onSelect(app);

--- a/snapo-network-inspector-web/src/features/app-inspector/components/InspectorWaitingState.tsx
+++ b/snapo-network-inspector-web/src/features/app-inspector/components/InspectorWaitingState.tsx
@@ -1,11 +1,35 @@
 import { LoaderCircle } from "lucide-react";
+import type { InspectableApp } from "../../../network/bridge-types";
+import type { AppLaunchControl } from "../useAppLaunch";
+import { OpenAppButton } from "./OpenAppButton";
 
-export function InspectorWaitingState(): JSX.Element {
+export function InspectorWaitingState({
+  launch,
+  app,
+  error
+}: {
+  launch?: AppLaunchControl | null;
+  app?: InspectableApp | null;
+  error?: string | null;
+}): JSX.Element {
   const label = "Waiting for inspector";
+  const canOpenApp = app != null && launch != null;
   return (
-    <div className="inspector-loading" role="status" aria-label={label}>
-      <span>{label}</span>
-      <LoaderCircle className="body-loading-spinner" size={20} aria-hidden="true" />
+    <div className="inspector-loading">
+      <div className="inspector-loading-status" role="status" aria-label={label}>
+        <span>{label}</span>
+        {!canOpenApp ? (
+          <span className="body-loading-spinner" aria-hidden="true">
+            <LoaderCircle size={20} />
+          </span>
+        ) : null}
+      </div>
+      {app && launch ? <OpenAppButton app={app} launch={launch} /> : null}
+      {error ? (
+        <p className="inspector-open-error" role="alert">
+          {error}
+        </p>
+      ) : null}
     </div>
   );
 }

--- a/snapo-network-inspector-web/src/features/app-inspector/components/OpenAppButton.tsx
+++ b/snapo-network-inspector-web/src/features/app-inspector/components/OpenAppButton.tsx
@@ -1,0 +1,26 @@
+import { LoaderCircle } from "lucide-react";
+import type { InspectableApp } from "../../../network/bridge-types";
+import type { AppLaunchControl } from "../useAppLaunch";
+
+export function OpenAppButton({ app, launch }: { app: InspectableApp; launch: AppLaunchControl }): JSX.Element {
+  return (
+    <>
+      {launch.pending ? (
+        <span className="inspector-open-progress" role="progressbar" aria-label={`Opening ${app.name}`}>
+          <span className="body-loading-spinner" aria-hidden="true">
+            <LoaderCircle size={20} />
+          </span>
+        </span>
+      ) : (
+        <button className="inspector-open-app" type="button" onClick={launch.open}>
+          Open {app.name}
+        </button>
+      )}
+      {launch.error ? (
+        <p className="inspector-open-error" role="alert">
+          {launch.error}
+        </p>
+      ) : null}
+    </>
+  );
+}

--- a/snapo-network-inspector-web/src/features/app-inspector/restoration.test.ts
+++ b/snapo-network-inspector-web/src/features/app-inspector/restoration.test.ts
@@ -6,13 +6,15 @@ function app(
   pid = 10,
   kinds: AppInspectorKind[] = ["network", "tweaks"],
   processName = "com.example.demo",
-  deviceId = "phone"
+  deviceId = "phone",
+  androidUserId = 0
 ): InspectableApp {
   return {
     id: `${deviceId}:pid:${pid}`,
     name: "Demo",
     packageName: processName.split(":")[0],
     processName,
+    androidUserId,
     deviceId,
     deviceDisplayTitle: "Phone",
     inspectors: kinds.map((kind) => ({ kind, server: { deviceId, socketName: `snapo_${kind}_${pid}` } }))
@@ -232,5 +234,51 @@ describe("inspector restoration", () => {
   it("selects an available inspector when there is no saved choice", () => {
     const owner = new InspectorRestoration("invalid JSON");
     expect(owner.reconcile([app(20, ["tweaks"])]).selection?.kind).toBe("tweaks");
+  });
+
+  it("keeps profile selection and inspector preferences across disconnect and a new PID", () => {
+    const personal = app();
+    const work = app(20, ["network", "tweaks"], "com.example.demo", "phone", 10);
+    const owner = new InspectorRestoration();
+    owner.reconcile([personal, work]);
+    owner.selectInspector(work, work.inspectors[1]);
+    expect(owner.reconcile([personal]).selection).toBeNull();
+    expect(owner.snapshot().selectedApp?.androidUserId).toBe(10);
+    const replacement = app(40, ["network", "tweaks"], "com.example.demo", "phone", 10);
+    expect(owner.reconcile([personal, replacement]).selection?.appId).toBe(replacement.id);
+    const restored = new InspectorRestoration(owner.serialize());
+    expect(restored.reconcile([personal, replacement]).selection).toMatchObject({
+      appId: replacement.id,
+      kind: "tweaks"
+    });
+    expect(restored.selectApp(personal)).toMatchObject({
+      selection: { appId: personal.id, kind: "network" },
+      displayedTweaks: null
+    });
+  });
+
+  it("keeps the selected launch target while a scan cannot confirm its Android user", () => {
+    const owner = selected();
+    const saved = owner.serialize();
+    expect(owner.reconcile([{ ...app(), androidUserId: null, packageName: null }]).selection).toBeNull();
+    expect(owner.snapshot().selectedApp).toMatchObject({ packageName: "com.example.demo", androidUserId: 0 });
+    expect(owner.serialize()).toBe(saved);
+  });
+
+  it("learns the Android user for the selected process without restoring another profile", () => {
+    const owner = new InspectorRestoration();
+    owner.reconcile([{ ...app(), androidUserId: null }]);
+    const work = { ...app(), androidUserId: 10 };
+    expect(owner.reconcile([work]).selectedApp?.androidUserId).toBe(10);
+    expect(JSON.parse(owner.serialize()).last.androidUserId).toBe(10);
+    expect(owner.reconcile([app(30)]).selection).toBeNull();
+  });
+
+  it("requires a new selection for saved preferences without an Android user", () => {
+    const legacy = { deviceId: "phone", processName: "com.example.demo", kind: "network" };
+    const owner = new InspectorRestoration(JSON.stringify({ last: legacy, apps: [legacy] }));
+    const work = app(20, ["network"], "com.example.demo", "phone", 10);
+    expect(owner.reconcile([app(), work]).selection).toBeNull();
+    expect(owner.selectApp(work).selection?.appId).toBe(work.id);
   });
 });

--- a/snapo-network-inspector-web/src/features/app-inspector/restoration.ts
+++ b/snapo-network-inspector-web/src/features/app-inspector/restoration.ts
@@ -9,6 +9,7 @@ import type {
 interface InspectorPreference {
   deviceId: string;
   processName: string;
+  androidUserId?: number | null;
   kind: AppInspectorKind;
 }
 
@@ -23,18 +24,29 @@ function identity(app: InspectableApp): string | null {
 }
 
 function matches(app: InspectableApp, preference: InspectorPreference): boolean {
-  return app.deviceId === preference.deviceId && identity(app) === preference.processName;
+  return (
+    app.deviceId === preference.deviceId &&
+    (app.androidUserId ?? null) === (preference.androidUserId ?? null) &&
+    identity(app) === preference.processName
+  );
 }
 
 function sameApp(a: InspectableApp | null, b: InspectableApp): boolean {
   if (!a || a.deviceId !== b.deviceId) return false;
+  // An unknown user can become known only for the same process ID.
+  if ((a.androidUserId ?? null) !== (b.androidUserId ?? null) && (a.androidUserId != null || a.id !== b.id))
+    return false;
   const first = identity(a);
   const second = identity(b);
   return first && second ? first === second : a.id === b.id;
 }
 
 function samePreference(a: InspectorPreference, b: InspectorPreference): boolean {
-  return a.deviceId === b.deviceId && a.processName === b.processName;
+  return (
+    a.deviceId === b.deviceId &&
+    (a.androidUserId ?? null) === (b.androidUserId ?? null) &&
+    a.processName === b.processName
+  );
 }
 
 function isPreference(value: unknown): value is InspectorPreference {
@@ -44,6 +56,7 @@ function isPreference(value: unknown): value is InspectorPreference {
     typeof p.deviceId === "string" &&
     typeof p.processName === "string" &&
     p.processName.length > 0 &&
+    (p.androidUserId == null || (Number.isInteger(p.androidUserId) && p.androidUserId >= 0)) &&
     (p.kind === "network" || p.kind === "tweaks")
   );
 }
@@ -108,8 +121,7 @@ export class InspectorRestoration {
       return this.snapshot();
     }
     const preference = this.saved.last;
-    const exact =
-      this.target && apps.find((app) => app.id === this.target?.id && (!preference || matches(app, preference)));
+    const exact = this.target && apps.find((app) => app.id === this.target?.id && sameApp(this.target, app));
     const app = exact || (preference && apps.find((candidate) => matches(candidate, preference)));
 
     if (app && this.kind) {
@@ -155,7 +167,7 @@ export class InspectorRestoration {
     this.saved.last = null;
     this.remember(app, kind);
     // Cached toolbar options express intent, never permission to reuse an old socket.
-    const liveApp = this.apps.find((candidate) => candidate.id === app.id && sameApp(candidate, app));
+    const liveApp = this.apps.find((candidate) => candidate.id === app.id && sameApp(app, candidate));
     const option = liveApp?.inspectors.find((candidate) => candidate.kind === kind);
     this.setCurrent(liveApp ?? app, option);
   }
@@ -190,7 +202,7 @@ export class InspectorRestoration {
   private remember(app: InspectableApp, kind: AppInspectorKind): void {
     const processName = identity(app);
     if (!processName) return;
-    const preference = { deviceId: app.deviceId, processName, kind };
+    const preference = { deviceId: app.deviceId, processName, androidUserId: app.androidUserId, kind };
     this.saved.last = preference;
     this.saved.apps = [...this.saved.apps.filter((entry) => !samePreference(entry, preference)), preference];
   }

--- a/snapo-network-inspector-web/src/features/app-inspector/useAppInspector.ts
+++ b/snapo-network-inspector-web/src/features/app-inspector/useAppInspector.ts
@@ -2,6 +2,7 @@ import { useCallback, useEffect, useRef, useState } from "react";
 import type { AppInspectorOption, InspectableApp } from "../../network/bridge-types";
 import type { NetworkClient } from "../../network/client";
 import { InspectorRestoration } from "./restoration";
+import { useAppLaunch } from "./useAppLaunch";
 
 export function useAppInspector(client: NetworkClient) {
   const [owner] = useState(() => new InspectorRestoration());
@@ -9,9 +10,13 @@ export function useAppInspector(client: NetworkClient) {
   const [loading, setLoading] = useState(true);
   const lastSaved = useRef<string | null>(null);
   const saveQueue = useRef(Promise.resolve());
+  const requestRefresh = useRef<(() => void) | null>(null);
+  const refreshNow = useCallback(() => requestRefresh.current?.(), []);
+  const { appLaunch, reconcileSelection, isPolling } = useAppLaunch(client, state.selectedApp, refreshNow);
 
   const publish = useCallback(() => {
     const snapshot = owner.snapshot();
+    reconcileSelection(snapshot.selectedApp);
     setState(snapshot);
     client.appInspectorStateChanged(snapshot);
     const saved = owner.serialize();
@@ -23,7 +28,7 @@ export function useAppInspector(client: NetworkClient) {
           if (lastSaved.current === saved) lastSaved.current = null;
         });
     }
-  }, [client, owner]);
+  }, [client, owner, reconcileSelection]);
 
   const select = useCallback(
     (app: InspectableApp, option?: AppInspectorOption) => {
@@ -54,6 +59,7 @@ export function useAppInspector(client: NetworkClient) {
         refreshing = false;
       }
     };
+    requestRefresh.current = () => void refresh();
 
     const unsubscribeInspector = client.onNativeSelectedInspector((selection) => {
       const state = owner.snapshot();
@@ -81,15 +87,16 @@ export function useAppInspector(client: NetworkClient) {
         void refresh();
       });
     const interval = window.setInterval(() => {
-      if (!document.hidden) void refresh();
+      if (!document.hidden && !isPolling()) void refresh();
     }, 2_500);
     return () => {
       disposed = true;
+      requestRefresh.current = null;
       window.clearInterval(interval);
       unsubscribeInspector();
       unsubscribeApp();
     };
-  }, [client, owner, publish, select]);
+  }, [client, isPolling, owner, publish, select]);
 
-  return { ...state, loading, select };
+  return { ...state, loading, select, appLaunch };
 }

--- a/snapo-network-inspector-web/src/features/app-inspector/useAppLaunch.ts
+++ b/snapo-network-inspector-web/src/features/app-inspector/useAppLaunch.ts
@@ -1,0 +1,99 @@
+import { useCallback, useEffect, useRef, useState } from "react";
+import type { InspectableApp } from "../../network/bridge-types";
+import type { NetworkClient } from "../../network/client";
+
+export interface AppLaunchControl {
+  pending: boolean;
+  error: string | null;
+  open(): void;
+}
+
+interface LaunchAttempt {
+  opening: boolean;
+  waiting: boolean;
+  timeout?: number;
+  interval?: number;
+}
+
+function appKey(app: InspectableApp | null): string | null {
+  return app ? `${app.deviceId}:${app.packageName}` : null;
+}
+
+export function useAppLaunch(client: NetworkClient, selectedApp: InspectableApp | null, refresh: () => void) {
+  const [launchState, setLaunchState] = useState<{ key: string; pending: boolean; error: string | null } | null>(null);
+  const activeLaunch = useRef<LaunchAttempt | null>(null);
+  const currentApp = useRef(selectedApp);
+
+  const cancelLaunch = useCallback(() => {
+    const attempt = activeLaunch.current;
+    if (attempt) {
+      window.clearTimeout(attempt.timeout);
+      window.clearInterval(attempt.interval);
+      activeLaunch.current = null;
+    }
+  }, []);
+
+  const reconcileSelection = useCallback(
+    (app: InspectableApp | null) => {
+      const previous = currentApp.current;
+      currentApp.current = app;
+      // Native selection changes must cancel a launch before React renders the next app.
+      if (appKey(previous) !== appKey(app)) {
+        cancelLaunch();
+        setLaunchState(null);
+      }
+    },
+    [cancelLaunch]
+  );
+
+  const openSelectedApp = useCallback(async () => {
+    const app = currentApp.current;
+    const key = appKey(app);
+    if (!app || !key || !client.openApp || activeLaunch.current) return;
+
+    const attempt: LaunchAttempt = { opening: true, waiting: true };
+    activeLaunch.current = attempt;
+    setLaunchState({ key, pending: true, error: null });
+    attempt.timeout = window.setTimeout(() => {
+      if (activeLaunch.current !== attempt) return;
+      attempt.waiting = false;
+      window.clearInterval(attempt.interval);
+      refresh();
+      if (!attempt.opening) activeLaunch.current = null;
+      setLaunchState({ key, pending: attempt.opening, error: null });
+    }, 5_000);
+    attempt.interval = window.setInterval(refresh, 500);
+
+    try {
+      await client.openApp({ deviceId: app.deviceId, packageName: app.packageName });
+      if (activeLaunch.current !== attempt) return;
+      attempt.opening = false;
+      if (!attempt.waiting) activeLaunch.current = null;
+      setLaunchState({ key, pending: attempt.waiting, error: null });
+      refresh();
+    } catch (cause) {
+      if (activeLaunch.current !== attempt) return;
+      cancelLaunch();
+      setLaunchState({
+        key,
+        pending: false,
+        error: cause instanceof Error ? cause.message : `Unable to open ${app.name}.`
+      });
+    }
+  }, [cancelLaunch, client, refresh]);
+
+  useEffect(() => cancelLaunch, [cancelLaunch, client]);
+
+  const isPolling = useCallback(() => activeLaunch.current?.waiting === true, []);
+  const currentLaunch = launchState?.key === appKey(selectedApp) ? launchState : null;
+  const appLaunch: AppLaunchControl | null =
+    selectedApp && client.openApp
+      ? {
+          pending: currentLaunch?.pending ?? false,
+          error: currentLaunch?.error ?? null,
+          open: () => void openSelectedApp()
+        }
+      : null;
+
+  return { appLaunch, reconcileSelection, isPolling };
+}

--- a/snapo-network-inspector-web/src/features/app-inspector/useAppLaunch.ts
+++ b/snapo-network-inspector-web/src/features/app-inspector/useAppLaunch.ts
@@ -1,5 +1,5 @@
 import { useCallback, useEffect, useRef, useState } from "react";
-import type { InspectableApp } from "../../network/bridge-types";
+import type { InspectableApp, OpenAppInput } from "../../network/bridge-types";
 import type { NetworkClient } from "../../network/client";
 
 export interface AppLaunchControl {
@@ -16,7 +16,16 @@ interface LaunchAttempt {
 }
 
 function appKey(app: InspectableApp | null): string | null {
-  return app ? `${app.deviceId}:${app.packageName}` : null;
+  return app
+    ? `${app.deviceId}:${app.androidUserId ?? "unknown"}:${app.processName ?? app.packageName ?? app.id}`
+    : null;
+}
+
+function launchInput(app: InspectableApp | null): OpenAppInput | null {
+  if (!app?.packageName || app.androidUserId == null || !Number.isInteger(app.androidUserId) || app.androidUserId < 0) {
+    return null;
+  }
+  return { deviceId: app.deviceId, packageName: app.packageName, androidUserId: app.androidUserId };
 }
 
 export function useAppLaunch(client: NetworkClient, selectedApp: InspectableApp | null, refresh: () => void) {
@@ -49,7 +58,8 @@ export function useAppLaunch(client: NetworkClient, selectedApp: InspectableApp 
   const openSelectedApp = useCallback(async () => {
     const app = currentApp.current;
     const key = appKey(app);
-    if (!app || !key || !client.openApp || activeLaunch.current) return;
+    const input = launchInput(app);
+    if (!app || !key || !input || !client.openApp || activeLaunch.current) return;
 
     const attempt: LaunchAttempt = { opening: true, waiting: true };
     activeLaunch.current = attempt;
@@ -65,7 +75,7 @@ export function useAppLaunch(client: NetworkClient, selectedApp: InspectableApp 
     attempt.interval = window.setInterval(refresh, 500);
 
     try {
-      await client.openApp({ deviceId: app.deviceId, packageName: app.packageName });
+      await client.openApp(input);
       if (activeLaunch.current !== attempt) return;
       attempt.opening = false;
       if (!attempt.waiting) activeLaunch.current = null;
@@ -87,7 +97,7 @@ export function useAppLaunch(client: NetworkClient, selectedApp: InspectableApp 
   const isPolling = useCallback(() => activeLaunch.current?.waiting === true, []);
   const currentLaunch = launchState?.key === appKey(selectedApp) ? launchState : null;
   const appLaunch: AppLaunchControl | null =
-    selectedApp && client.openApp
+    launchInput(selectedApp) && client.openApp
       ? {
           pending: currentLaunch?.pending ?? false,
           error: currentLaunch?.error ?? null,

--- a/snapo-network-inspector-web/src/features/network-inspector/NetworkInspectorApp.tsx
+++ b/snapo-network-inspector-web/src/features/network-inspector/NetworkInspectorApp.tsx
@@ -6,6 +6,7 @@ import type {
   SelectedAppInspector
 } from "../../network/bridge-types";
 import { DetailContent } from "./components/DetailPane";
+import type { AppLaunchControl } from "../app-inspector/useAppLaunch";
 import { Sidebar } from "./components/Sidebar";
 import type { NetworkInspectorModel } from "./hooks/useNetworkInspectorModel";
 import { usePersistentSplitPane } from "./hooks/usePersistentSplitPane";
@@ -16,6 +17,7 @@ export function NetworkInspectorApp({
   inspectorApps = [],
   inspectorSelection = null,
   selectedApp = null,
+  appLaunch,
   preferredKind,
   onInspectorSelect
 }: {
@@ -23,6 +25,7 @@ export function NetworkInspectorApp({
   inspectorApps?: InspectableApp[];
   inspectorSelection?: SelectedAppInspector | null;
   selectedApp?: InspectableApp | null;
+  appLaunch?: AppLaunchControl | null;
   preferredKind?: AppInspectorKind | null;
   onInspectorSelect?(app: InspectableApp, option?: AppInspectorOption): void;
 }): JSX.Element {
@@ -105,6 +108,8 @@ export function NetworkInspectorApp({
           record={model.selectedRecord}
           servers={model.servers}
           selectedServer={model.selectedServer}
+          selectedApp={selectedApp}
+          appLaunch={appLaunch}
           serverScopedItems={model.serverRecordCount}
           streamIsRetrying={model.streamIsRetrying}
           uiState={model.uiState}

--- a/snapo-network-inspector-web/src/features/network-inspector/components/DetailPane.test.tsx
+++ b/snapo-network-inspector-web/src/features/network-inspector/components/DetailPane.test.tsx
@@ -1,0 +1,91 @@
+import { renderToStaticMarkup } from "react-dom/server";
+import { describe, expect, it, vi } from "vitest";
+import type { InspectableApp, SnapOServer } from "../../../network/bridge-types";
+import type { NetworkClient } from "../../../network/client";
+import { useInspectorUiState } from "../hooks/useInspectorUiState";
+import { DetailContent } from "./DetailPane";
+
+const app: InspectableApp = {
+  id: "phone:pid:10",
+  name: "Demo",
+  packageName: "com.example.demo",
+  deviceId: "phone",
+  deviceDisplayTitle: "Phone",
+  inspectors: []
+};
+const server: SnapOServer = {
+  server: app.id,
+  deviceId: app.deviceId,
+  socketName: "snapo_network_10",
+  deviceDisplayTitle: "Phone",
+  displayName: "Demo",
+  isConnected: true,
+  hasAppInfo: true,
+  isProtocolNewerThanSupported: false,
+  isProtocolOlderThanSupported: false
+};
+
+function render(
+  selectedServer: SnapOServer | null,
+  count = 0,
+  retrying = false,
+  selectedApp: InspectableApp | null = app,
+  launchPending = false,
+  canOpenApp = true
+) {
+  const client = { openApp: vi.fn(async () => {}) } as unknown as NetworkClient;
+  function View() {
+    return (
+      <DetailContent
+        client={client}
+        record={null}
+        servers={selectedServer ? [selectedServer] : []}
+        selectedServer={selectedServer}
+        selectedApp={selectedApp}
+        appLaunch={canOpenApp ? { pending: launchPending, error: null, open: vi.fn() } : null}
+        serverScopedItems={count}
+        streamIsRetrying={retrying}
+        uiState={useInspectorUiState()}
+        onOpenDocs={() => {}}
+        onRetryResponseBody={() => {}}
+      />
+    );
+  }
+  return renderToStaticMarkup(<View />);
+}
+
+describe("network waiting action", () => {
+  it.each([null, { ...server, hasAppInfo: false }, { ...server, isConnected: false }])(
+    "offers to open the selected app while its server is unavailable",
+    (selectedServer) => expect(render(selectedServer)).toContain("Open Demo")
+  );
+
+  it("offers to open the app while retrying its first network stream", () => {
+    expect(render(server, 0, true)).toContain("Open Demo");
+  });
+
+  it.each([false, true])("omits the manual opening hint when the launch action is available", (pending) => {
+    const markup = render({ ...server, hasAppInfo: false }, 0, false, app, pending);
+    expect(markup).toContain("Waiting for connection");
+    expect(markup).not.toContain("Open the app on your device to connect.");
+  });
+
+  it("keeps the manual opening hint when the launch action is unavailable", () => {
+    const markup = render({ ...server, hasAppInfo: false }, 0, false, app, false, false);
+    expect(markup).toContain("Open the app on your device to connect.");
+    expect(markup).not.toContain("Open Demo");
+  });
+
+  it("replaces the action with progress without changing the waiting text", () => {
+    const markup = render({ ...server, hasAppInfo: false }, 0, false, app, true);
+    expect(markup).toContain("Waiting for connection");
+    expect(markup).toContain('role="progressbar"');
+    expect(markup).not.toContain('class="inspector-open-app"');
+  });
+
+  it("hides the action once connected, with retained records, or without a selected app", () => {
+    expect(render(server)).not.toContain("Open Demo");
+    expect(render({ ...server, isConnected: false }, 1, true)).not.toContain("Open Demo");
+    expect(render(null, 0, false, null)).not.toContain("inspector-open-app");
+  });
+});

--- a/snapo-network-inspector-web/src/features/network-inspector/components/DetailPane.tsx
+++ b/snapo-network-inspector-web/src/features/network-inspector/components/DetailPane.tsx
@@ -1,7 +1,9 @@
 import { memo } from "react";
 import type { NetworkClient } from "../../../network/client";
 import type { InspectorRecord } from "../../../network/cdp";
-import type { SnapOServer } from "../../../network/bridge-types";
+import type { InspectableApp, SnapOServer } from "../../../network/bridge-types";
+import { OpenAppButton } from "../../app-inspector/components/OpenAppButton";
+import type { AppLaunchControl } from "../../app-inspector/useAppLaunch";
 import type { InspectorUiState } from "../hooks/useInspectorUiState";
 import { resolveDetailEmptyState } from "../lib/records";
 import { isUnsupportedLegacyProtocolRequestSelection, unsupportedLegacyProtocolMessage } from "../lib/protocol";
@@ -13,6 +15,8 @@ export const DetailContent = memo(function DetailContent({
   record,
   servers,
   selectedServer,
+  selectedApp,
+  appLaunch,
   serverScopedItems,
   streamIsRetrying,
   uiState,
@@ -23,6 +27,8 @@ export const DetailContent = memo(function DetailContent({
   record: InspectorRecord | null;
   servers: SnapOServer[];
   selectedServer: SnapOServer | null;
+  selectedApp?: InspectableApp | null;
+  appLaunch?: AppLaunchControl | null;
   serverScopedItems: number;
   streamIsRetrying: boolean;
   uiState: InspectorUiState;
@@ -30,9 +36,16 @@ export const DetailContent = memo(function DetailContent({
   onRetryResponseBody(): void;
 }): JSX.Element {
   if (record == null) {
-    const empty = resolveDetailEmptyState({ servers, selectedServer, serverScopedItems, streamIsRetrying });
+    const canOpenApp =
+      selectedApp != null &&
+      appLaunch != null &&
+      serverScopedItems === 0 &&
+      (!selectedServer?.isConnected || !selectedServer.hasAppInfo || streamIsRetrying);
+    const empty = resolveDetailEmptyState({ servers, selectedServer, serverScopedItems, streamIsRetrying, canOpenApp });
     return (
-      <EmptyState title={empty.title} body={empty.body} showDocsLink={empty.showDocsLink} onOpenDocs={onOpenDocs} />
+      <EmptyState title={empty.title} body={empty.body} showDocsLink={empty.showDocsLink} onOpenDocs={onOpenDocs}>
+        {canOpenApp ? <OpenAppButton app={selectedApp} launch={appLaunch} /> : null}
+      </EmptyState>
     );
   }
 
@@ -63,17 +76,20 @@ function EmptyState({
   title,
   body,
   showDocsLink,
-  onOpenDocs
+  onOpenDocs,
+  children
 }: {
   title: string;
-  body: string;
+  body: string | null;
   showDocsLink: boolean;
   onOpenDocs(): void;
+  children?: React.ReactNode;
 }): JSX.Element {
   return (
     <section className="empty-detail">
       <h1>{title}</h1>
-      <p>{emptyStateBody(body)}</p>
+      {body != null ? <p>{emptyStateBody(body)}</p> : null}
+      {children}
       {showDocsLink ? (
         <button className="text-button" type="button" onClick={onOpenDocs}>
           Read the developer guide

--- a/snapo-network-inspector-web/src/features/network-inspector/components/RequestDetail.tsx
+++ b/snapo-network-inspector-web/src/features/network-inspector/components/RequestDetail.tsx
@@ -154,7 +154,9 @@ export const RequestDetail = memo(function RequestDetail({
           ) : responseBody == null ? (
             <div className="payload-card">
               <div className="body-loading" role="status">
-                <LoaderCircle className="body-loading-spinner" size={14} aria-hidden="true" />
+                <span className="body-loading-spinner" aria-hidden="true">
+                  <LoaderCircle size={14} />
+                </span>
                 <span>Loading</span>
               </div>
             </div>

--- a/snapo-network-inspector-web/src/features/network-inspector/lib/records.ts
+++ b/snapo-network-inspector-web/src/features/network-inspector/lib/records.ts
@@ -199,10 +199,10 @@ export function sidebarPlaceholderText(input: {
   selectedServer: SnapOServer | null;
   streamIsRetrying?: boolean;
 }): string | null {
-  if (input.streamIsRetrying === true && input.serverScopedItems === 0) return "Reconnecting to network stream...";
+  if (input.streamIsRetrying === true && input.serverScopedItems === 0) return "Reconnecting to network stream";
   if (input.totalItems === 0) return "No activity yet";
   if (input.serverScopedItems === 0) {
-    if (input.selectedServer == null || !input.selectedServer.hasAppInfo) return "Waiting for connection...";
+    if (input.selectedServer == null || !input.selectedServer.hasAppInfo) return "Waiting for connection";
     return "No activity for this app yet";
   }
   if (input.filteredItems === 0) return "No matches";
@@ -225,7 +225,8 @@ export function resolveDetailEmptyState(input: {
   selectedServer: SnapOServer | null;
   serverScopedItems: number;
   streamIsRetrying?: boolean;
-}): { title: string; body: string; showDocsLink: boolean } {
+  canOpenApp?: boolean;
+}): { title: string; body: string | null; showDocsLink: boolean } {
   if (input.servers.length === 0) {
     return {
       title: "No compatible apps detected",
@@ -235,7 +236,7 @@ export function resolveDetailEmptyState(input: {
   }
   if (input.streamIsRetrying === true && input.serverScopedItems === 0) {
     return {
-      title: "Reconnecting...",
+      title: "Reconnecting",
       body: "Snap-O will resume capturing requests when the network stream is available.",
       showDocsLink: false
     };
@@ -244,8 +245,8 @@ export function resolveDetailEmptyState(input: {
     const waitingForConnection = input.selectedServer == null || !input.selectedServer.hasAppInfo;
     if (waitingForConnection) {
       return {
-        title: "Waiting for connection...",
-        body: "Snap-O is waiting for the app to publish its network server metadata.",
+        title: "Waiting for connection",
+        body: input.canOpenApp ? null : "Open the app on your device to connect.",
         showDocsLink: false
       };
     }

--- a/snapo-network-inspector-web/src/features/tweaks-inspector/TweaksInspectorApp.recovery.test.tsx
+++ b/snapo-network-inspector-web/src/features/tweaks-inspector/TweaksInspectorApp.recovery.test.tsx
@@ -32,6 +32,7 @@ describe("Tweaks connection recovery", () => {
     Object.assign(globalThis, { IS_REACT_ACT_ENVIRONMENT: true });
     client = {
       usesNativeServerPicker: true,
+      openApp: vi.fn(async () => {}),
       listTweaks: vi.fn(async () => response),
       startTweakStream: vi.fn(async () => ({ streamId: "stream-1" })),
       stopTweakStream: vi.fn(async () => {}),
@@ -64,7 +65,20 @@ describe("Tweaks connection recovery", () => {
         <TweaksInspectorApp
           client={client}
           apps={[]}
+          selectedApp={{
+            id: selected.appId,
+            name: "Demo",
+            packageName: "com.example.demo",
+            deviceId: selected.server.deviceId,
+            deviceDisplayTitle: "Phone",
+            inspectors: [selected]
+          }}
           selection={selected}
+          appLaunch={{
+            pending: false,
+            error: null,
+            open: () => void client.openApp!({ deviceId: selected.server.deviceId, packageName: "com.example.demo" })
+          }}
           isConnected={isConnected}
           onSelect={() => {}}
         />
@@ -84,7 +98,8 @@ describe("Tweaks connection recovery", () => {
     await render();
     const status = container.querySelector('[role="status"]');
     expect(status?.textContent).toBe("Waiting for inspector");
-    expect(status?.querySelector('svg[aria-hidden="true"]')).not.toBeNull();
+    expect(status?.querySelector("svg")).toBeNull();
+    expect(container.querySelector(".inspector-open-app")).not.toBeNull();
     expect(container.querySelector(".tweaks-inspector-toolbar") != null).toBe(!usesNativeServerPicker);
 
     await act(async () => finish(response));
@@ -97,11 +112,16 @@ describe("Tweaks connection recovery", () => {
     await render();
     expect(container.querySelector('[role="alert"]')?.textContent).toContain(connectionError.message);
     expect(client.startTweakStream).not.toHaveBeenCalled();
+    const openButton = container.querySelector<HTMLButtonElement>(".inspector-open-app")!;
+    expect(openButton.textContent).toBe("Open Demo");
+    await act(async () => openButton.click());
+    expect(client.openApp).toHaveBeenCalledExactlyOnceWith({ deviceId: "phone", packageName: "com.example.demo" });
 
     await act(async () => vi.advanceTimersByTimeAsync(250));
     expect(client.listTweaks).toHaveBeenCalledTimes(2);
     expect(client.startTweakStream).toHaveBeenCalledExactlyOnceWith(selection.server);
     expect(container.querySelector('[role="alert"]')).toBeNull();
+    expect(container.querySelector(".inspector-open-app")).toBeNull();
     expect(container.querySelector<HTMLInputElement>('input[type="text"]')?.value).toBe("Recovered");
     await act(async () => vi.advanceTimersByTimeAsync(10_000));
     expect(client.startTweakStream).toHaveBeenCalledTimes(1);

--- a/snapo-network-inspector-web/src/features/tweaks-inspector/TweaksInspectorApp.recovery.test.tsx
+++ b/snapo-network-inspector-web/src/features/tweaks-inspector/TweaksInspectorApp.recovery.test.tsx
@@ -77,7 +77,12 @@ describe("Tweaks connection recovery", () => {
           appLaunch={{
             pending: false,
             error: null,
-            open: () => void client.openApp!({ deviceId: selected.server.deviceId, packageName: "com.example.demo" })
+            open: () =>
+              void client.openApp!({
+                deviceId: selected.server.deviceId,
+                packageName: "com.example.demo",
+                androidUserId: 0
+              })
           }}
           isConnected={isConnected}
           onSelect={() => {}}
@@ -115,7 +120,11 @@ describe("Tweaks connection recovery", () => {
     const openButton = container.querySelector<HTMLButtonElement>(".inspector-open-app")!;
     expect(openButton.textContent).toBe("Open Demo");
     await act(async () => openButton.click());
-    expect(client.openApp).toHaveBeenCalledExactlyOnceWith({ deviceId: "phone", packageName: "com.example.demo" });
+    expect(client.openApp).toHaveBeenCalledExactlyOnceWith({
+      deviceId: "phone",
+      packageName: "com.example.demo",
+      androidUserId: 0
+    });
 
     await act(async () => vi.advanceTimersByTimeAsync(250));
     expect(client.listTweaks).toHaveBeenCalledTimes(2);

--- a/snapo-network-inspector-web/src/features/tweaks-inspector/TweaksInspectorApp.tsx
+++ b/snapo-network-inspector-web/src/features/tweaks-inspector/TweaksInspectorApp.tsx
@@ -14,6 +14,7 @@ import type {
 import type { NativeColorPanelChange, NetworkClient } from "../../network/client";
 import { AppInspectorPicker } from "../app-inspector/components/AppInspectorPicker";
 import { InspectorWaitingState } from "../app-inspector/components/InspectorWaitingState";
+import type { AppLaunchControl } from "../app-inspector/useAppLaunch";
 import { TweakUpdateQueue } from "./tweak-update-queue";
 
 interface TweakSection {
@@ -41,6 +42,7 @@ export function TweaksInspectorApp({
   apps,
   selection,
   selectedApp,
+  appLaunch,
   isConnected = true,
   onSelect
 }: {
@@ -48,6 +50,7 @@ export function TweaksInspectorApp({
   apps: InspectableApp[];
   selection: SelectedAppInspector;
   selectedApp?: InspectableApp | null;
+  appLaunch?: AppLaunchControl | null;
   isConnected?: boolean;
   onSelect(app: InspectableApp, option?: AppInspectorOption): void;
 }): JSX.Element {
@@ -326,15 +329,15 @@ export function TweaksInspectorApp({
         </header>
       ) : null}
 
-      {!hasSnapshot && !connectionError ? (
-        <InspectorWaitingState />
+      {!hasSnapshot ? (
+        <InspectorWaitingState launch={appLaunch} app={selectedApp} error={connectionError} />
       ) : hasSnapshot && !error && tweaks.length === 0 ? (
         <TweaksEmptyState onOpenDocs={() => void client.openExternal(docsUrl)} />
       ) : (
         <div className="tweaks-inspector-content">
-          {error || (!hasSnapshot && connectionError) ? (
+          {error ? (
             <p className="tweaks-error" role="alert">
-              {error ?? connectionError}
+              {error}
             </p>
           ) : null}
           <fieldset

--- a/snapo-network-inspector-web/src/network/bridge-types.ts
+++ b/snapo-network-inspector-web/src/network/bridge-types.ts
@@ -32,12 +32,19 @@ export interface AppInspectorOption {
 export interface InspectableApp {
   id: string;
   name: string;
-  packageName: string;
+  packageName?: string | null;
   processName?: string | null;
+  androidUserId?: number | null;
   deviceId: string;
   deviceDisplayTitle: string;
   appIconBase64?: string | null;
   inspectors: AppInspectorOption[];
+}
+
+export interface OpenAppInput {
+  deviceId: string;
+  packageName: string;
+  androidUserId: number;
 }
 
 export interface SelectedAppInspector {

--- a/snapo-network-inspector-web/src/network/client.test.ts
+++ b/snapo-network-inspector-web/src/network/client.test.ts
@@ -8,17 +8,19 @@ describe("native app launch bridge", () => {
     const postMessage = vi.fn().mockResolvedValue(undefined);
     stubNativeBridge(postMessage);
     const client = createNetworkClient();
-    await expect(client.openApp!({ deviceId: "phone-2", packageName: "com.example.demo" })).resolves.toBeUndefined();
+    await expect(
+      client.openApp!({ deviceId: "phone-2", packageName: "com.example.demo", androidUserId: 10 })
+    ).resolves.toBeUndefined();
     expect(postMessage).toHaveBeenCalledWith({
       command: "openApp",
-      payload: { deviceId: "phone-2", packageName: "com.example.demo" }
+      payload: { deviceId: "phone-2", packageName: "com.example.demo", androidUserId: 10 }
     });
   });
 
   it("propagates native launch failures", async () => {
     stubNativeBridge(vi.fn().mockRejectedValue(new Error("Device is offline.")));
     await expect(
-      createNetworkClient().openApp!({ deviceId: "phone", packageName: "com.example.demo" })
+      createNetworkClient().openApp!({ deviceId: "phone", packageName: "com.example.demo", androidUserId: 0 })
     ).rejects.toThrow("Device is offline.");
   });
 });

--- a/snapo-network-inspector-web/src/network/client.test.ts
+++ b/snapo-network-inspector-web/src/network/client.test.ts
@@ -3,6 +3,26 @@ import { createNetworkClient } from "./client";
 
 afterEach(() => vi.unstubAllGlobals());
 
+describe("native app launch bridge", () => {
+  it("opens a package on the selected device without an inspector connection", async () => {
+    const postMessage = vi.fn().mockResolvedValue(undefined);
+    stubNativeBridge(postMessage);
+    const client = createNetworkClient();
+    await expect(client.openApp!({ deviceId: "phone-2", packageName: "com.example.demo" })).resolves.toBeUndefined();
+    expect(postMessage).toHaveBeenCalledWith({
+      command: "openApp",
+      payload: { deviceId: "phone-2", packageName: "com.example.demo" }
+    });
+  });
+
+  it("propagates native launch failures", async () => {
+    stubNativeBridge(vi.fn().mockRejectedValue(new Error("Device is offline.")));
+    await expect(
+      createNetworkClient().openApp!({ deviceId: "phone", packageName: "com.example.demo" })
+    ).rejects.toThrow("Device is offline.");
+  });
+});
+
 describe("native persistent exclusion filter bridge", () => {
   it("explicitly restores conventional exclusion filters instead of relying on an early page event", async () => {
     const postMessage = vi.fn().mockResolvedValue(["-example.com", "-statsig.com"]);

--- a/snapo-network-inspector-web/src/network/client.ts
+++ b/snapo-network-inspector-web/src/network/client.ts
@@ -32,6 +32,7 @@ export interface NetworkClient {
   readonly usesNativeServerPicker: boolean;
   appVersion(): Promise<string>;
   listInspectorApps(): Promise<InspectableApp[]>;
+  openApp?(app: Pick<InspectableApp, "deviceId" | "packageName">): Promise<void>;
   loadInspectorPreferences(): Promise<string | null>;
   saveInspectorPreferences(value: string): Promise<void>;
   appInspectorStateChanged(state: AppInspectorState): void;
@@ -100,6 +101,10 @@ class WebKitNetworkClient implements NetworkClient {
 
   listInspectorApps(): Promise<InspectableApp[]> {
     return this.invoke<InspectableApp[]>("listInspectorApps");
+  }
+
+  openApp(app: Pick<InspectableApp, "deviceId" | "packageName">): Promise<void> {
+    return this.invoke<void>("openApp", { deviceId: app.deviceId, packageName: app.packageName });
   }
 
   loadInspectorPreferences(): Promise<string | null> {

--- a/snapo-network-inspector-web/src/network/client.ts
+++ b/snapo-network-inspector-web/src/network/client.ts
@@ -7,6 +7,7 @@ import type {
   LoadBodiesInput,
   NativeInspectorState,
   NativeTweaksState,
+  OpenAppInput,
   RequestBodies,
   SaveFileInput,
   SaveFileResult,
@@ -32,7 +33,7 @@ export interface NetworkClient {
   readonly usesNativeServerPicker: boolean;
   appVersion(): Promise<string>;
   listInspectorApps(): Promise<InspectableApp[]>;
-  openApp?(app: Pick<InspectableApp, "deviceId" | "packageName">): Promise<void>;
+  openApp?(app: OpenAppInput): Promise<void>;
   loadInspectorPreferences(): Promise<string | null>;
   saveInspectorPreferences(value: string): Promise<void>;
   appInspectorStateChanged(state: AppInspectorState): void;
@@ -103,8 +104,8 @@ class WebKitNetworkClient implements NetworkClient {
     return this.invoke<InspectableApp[]>("listInspectorApps");
   }
 
-  openApp(app: Pick<InspectableApp, "deviceId" | "packageName">): Promise<void> {
-    return this.invoke<void>("openApp", { deviceId: app.deviceId, packageName: app.packageName });
+  openApp(app: OpenAppInput): Promise<void> {
+    return this.invoke<void>("openApp", app);
   }
 
   loadInspectorPreferences(): Promise<string | null> {
@@ -305,7 +306,7 @@ class HttpNetworkClient implements NetworkClient {
       return servers.map((server) => ({
         id: inspectorProcessId("network", server),
         name: server.appName || server.displayName,
-        packageName: server.packageName ?? server.displayName,
+        packageName: server.hasAppInfo ? server.packageName : null,
         processName: server.appName ?? server.packageName,
         deviceId: server.deviceId,
         deviceDisplayTitle: server.deviceDisplayTitle,

--- a/snapo-network-inspector-web/src/styles.css
+++ b/snapo-network-inspector-web/src/styles.css
@@ -924,8 +924,25 @@ body.split-pane-resizing {
   text-align: center;
 }
 
+.inspector-loading-status {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 12px;
+}
+
+.inspector-open-error {
+  max-width: 480px;
+  margin: 0;
+  padding-inline: 16px;
+  color: var(--error);
+  overflow-wrap: anywhere;
+}
+
 .body-loading-spinner {
+  display: inline-flex;
   flex: 0 0 auto;
+  transform-origin: center;
   animation: spin 1s linear infinite;
 }
 
@@ -1678,12 +1695,24 @@ pre {
   margin-left: auto;
 }
 
-.tweaks-action-button {
+.tweaks-action-button,
+.inspector-open-app {
   all: revert;
   min-height: 27px;
   padding-inline: 10px;
   font: inherit;
   font-size: 11px;
+}
+
+.inspector-open-app {
+  max-width: 100%;
+  overflow-wrap: anywhere;
+}
+
+.inspector-open-progress {
+  display: inline-flex;
+  min-height: 27px;
+  align-items: center;
 }
 
 .tweaks-action-conflict {


### PR DESCRIPTION
Apps show up in the app list because their port is still listed, even though they can't actually accept a connection at the moment. When you select this app in Snap-O, it just says it's waiting for a connection.

I thought it'd be nice to add an "Open <app>" button in the "Waiting for connection" screen so that you could have it bring the app into the foreground, to get the inspector connection working again, without having to find the app on your Android device.

## Summary

- Open the selected app in its Android user through the native bridge and ADB, without stopping it or clearing its task.
- Resolve a launcher activity explicitly, validate shell arguments, and report readable launch errors.
- Keep launch state in `useAppLaunch`. Poll discovery every 500 ms for five seconds and preserve progress across inspector transitions.
- Center loading spinners, remove redundant opening instructions, and simplify waiting status text.
- Require a confirmed package and Android user before offering Open. Keep profile identity in saved selections and launch state.

## Validation

- Web: 299 tests passed; TypeScript, ESLint, Stylelint, and Prettier checks passed.
- Swift device client: 50 tests passed, including launcher resolution, Android users, invalid arguments, and command failures. SwiftLint and SwiftFormat checks passed.
- Frontend production build and macOS `xcodebuild` passed with code signing disabled.
- Browser checks with a mocked native bridge confirmed progress through Tweaks loading and retry after five seconds.
- Verified launcher resolution and foregrounding an existing task on an Android device.

App launching is available in the native macOS client only. The HTTP client keeps its manual opening instructions.

Managed-profile behavior is covered by synthetic tests; no physical work-profile test was run. Older saved selections lack an Android user ID and require selecting the app once again.
