### PR TITLE
Wait for Live Preview readiness before creating input devices

### DIFF
--- a/snapo-app-mac/Snap-O/CaptureWindow/LivePreviewManager.swift
+++ b/snapo-app-mac/Snap-O/CaptureWindow/LivePreviewManager.swift
@@ -100,14 +100,13 @@ final class LivePreviewManager {
       throw CancellationError()
     }
     activeOperations[operation.id] = operation
-    await pointerInjector.prepare(deviceID: deviceID)
 
     let renderer = LivePreviewRenderer(
       operation: operation
     ) { [weak self] action, source, location, displaySize in
       Task {
         await self?.sendPointerEvent(
-          deviceID: deviceID,
+          operation: operation,
           action: action,
           source: source,
           location: location,
@@ -123,9 +122,12 @@ final class LivePreviewManager {
         guard let self,
               !isStopped,
               activeOperations[operation.id] != nil,
+              session.isReady,
               let device = deviceInfo[deviceID]
         else { return }
         storeMedia(media, for: device)
+        // Failed stream startups must not add and remove Android input devices.
+        await pointerInjector.prepare(deviceID: deviceID)
       } catch {
         if !(error is CancellationError) {
           SnapOLog.ui.error(
@@ -342,14 +344,17 @@ final class LivePreviewManager {
   }
 
   private func sendPointerEvent(
-    deviceID: String,
+    operation: LivePreviewOperationHandle,
     action: LivePreviewPointerAction,
     source: LivePreviewPointerSource,
     location: CGPoint,
     displaySize: CGSize
   ) async {
+    guard !isStopped,
+          activeOperations[operation.id] != nil,
+          operation.session.isReady else { return }
     let event = LivePreviewPointerEvent(
-      deviceID: deviceID,
+      deviceID: operation.deviceID,
       action: action,
       source: source,
       location: location,

--- a/snapo-app-mac/Snap-O/CaptureWindow/LivePreviewManager.swift
+++ b/snapo-app-mac/Snap-O/CaptureWindow/LivePreviewManager.swift
@@ -22,6 +22,7 @@ final class LivePreviewManager {
   private var captureIDs: [String: UUID] = [:]
   private var lastDisplayInfo: [String: DisplayInfo] = [:]
   private var activeOperations: [UUID: LivePreviewOperationHandle] = [:]
+  private var readinessTasks: [UUID: Task<Void, Never>] = [:]
   private var inFlightRendererRequestIDs: Set<UUID> = []
   private var stoppingRendererIDs: Set<UUID> = []
   private var deviceSyncID = UUID()
@@ -116,7 +117,7 @@ final class LivePreviewManager {
     }
 
     let session = operation.session
-    Task { [weak self] in
+    readinessTasks[operation.id] = Task { [weak self] in
       do {
         let media = try await session.waitUntilReady()
         guard let self,
@@ -160,10 +161,10 @@ final class LivePreviewManager {
 
   func stopRenderer(_ renderer: LivePreviewRenderer) async {
     let operationID = renderer.operation.id
-    guard activeOperations.removeValue(forKey: operationID) != nil else { return }
+    guard let operation = activeOperations.removeValue(forKey: operationID) else { return }
     stoppingRendererIDs.insert(operationID)
     defer { stoppingRendererIDs.remove(operationID) }
-    _ = await livePreviewService.stop(renderer.operation)
+    await stopOperation(operation)
     if !activeOperations.values.contains(where: { $0.deviceID == renderer.deviceID }) {
       await pointerInjector.stopDevice(renderer.deviceID)
     }
@@ -183,14 +184,21 @@ final class LivePreviewManager {
     lastDisplayInfo.removeAll()
     notifyMediaChanged()
     await prepared?.discard()
-    await pointerInjector.stopAll()
 
     for operation in operations {
-      _ = await livePreviewService.stop(operation)
+      await stopOperation(operation)
     }
     while !inFlightRendererRequestIDs.isEmpty || !stoppingRendererIDs.isEmpty {
       await Task.yield()
     }
+    await pointerInjector.stopAll()
+  }
+
+  private func stopOperation(_ operation: LivePreviewOperationHandle) async {
+    let readinessTask = readinessTasks.removeValue(forKey: operation.id)
+    // Stopping the session releases readiness waiters before we await queued input setup.
+    _ = await livePreviewService.stop(operation)
+    await readinessTask?.value
   }
 
   // MARK: - Device + Media Management
@@ -221,7 +229,7 @@ final class LivePreviewManager {
       stoppingRendererIDs.remove(cleanupID)
     }
     for operation in removedOperations {
-      _ = await livePreviewService.stop(operation)
+      await stopOperation(operation)
       stoppingRendererIDs.remove(operation.id)
     }
     for deviceID in removedDeviceIDs {

--- a/snapo-app-mac/Snap-O/LivePreview/LivePreviewSession.swift
+++ b/snapo-app-mac/Snap-O/LivePreview/LivePreviewSession.swift
@@ -10,6 +10,10 @@ final class LivePreviewSession {
 
   let deviceID: String
 
+  var isReady: Bool {
+    readyResult != nil && !hasStopped
+  }
+
   var media: Media?
   var sampleBufferHandler: ((CMSampleBuffer) -> Void)? {
     didSet {
@@ -55,8 +59,8 @@ final class LivePreviewSession {
   }
 
   func waitUntilReady() async throws -> Media {
-    if let readyResult { return readyResult }
     if let stopResult { throw stopResult ?? CancellationError() }
+    if let readyResult { return readyResult }
     return try await withCheckedThrowingContinuation { continuation in
       readyContinuations.append(continuation)
     }

--- a/snapo-app-mac/Tests/CaptureMode/CaptureModeTests.swift
+++ b/snapo-app-mac/Tests/CaptureMode/CaptureModeTests.swift
@@ -13,11 +13,17 @@ struct CaptureModeTests {
   static let second = testDevice("second")
 
   static func main() async throws {
+    try await pointerWaitsForReadiness()
+    try await failedStreamsDoNotPreparePointer()
+    try await stoppedPreviewDoesNotPreparePointer()
+    try await removedDeviceDoesNotPreparePointer()
+    try await stoppedRendererIgnoresLateReadiness()
+    try await replacedRendererCannotSendPointer()
     try await stopWaitsForRendererCleanup()
     await stopDuringRendererStart()
     await overlappingDeviceUpdates()
     await modePropagatesCancellation()
-    print("Capture mode tests passed (4 cases)")
+    print("Capture mode tests passed (10 cases)")
   }
 
   static func eventually(_ condition: () async -> Bool) async {
@@ -28,8 +34,124 @@ struct CaptureModeTests {
     fatalError("Condition did not become true")
   }
 
-  static func makeManager(_ service: LivePreviewService) -> LivePreviewManager {
-    LivePreviewManager(livePreviewService: service, adbService: ADBService(), options: options) { _ in }
+  static func makeManager(_ service: LivePreviewService, adb: ADBService = ADBService()) -> LivePreviewManager {
+    LivePreviewManager(livePreviewService: service, adbService: adb, options: options) { _ in }
+  }
+
+  static func settle() async {
+    for _ in 0 ..< 100 {
+      await Task.yield()
+    }
+  }
+
+  static func click(_ renderer: LivePreviewRenderer) {
+    renderer.sendPointer(.down, .touchscreen, .zero, testDisplay.size)
+  }
+
+  static func expectNoPointer(_ adb: ADBService) async {
+    await settle()
+    let preparations = await adb.pointerPreparations
+    let events = await adb.pointerEvents
+    precondition(preparations.isEmpty, "Unready preview must not prepare a virtual touchscreen")
+    precondition(events.isEmpty, "Unready preview must not forward pointer events")
+  }
+
+  static func pointerWaitsForReadiness() async throws {
+    let gate = TestGate()
+    let adb = ADBService()
+    let manager = makeManager(LivePreviewService(readyGate: gate), adb: adb)
+    await manager.start(with: [first])
+    let renderer = try await manager.makeRenderer(for: first.id)
+    await eventually { await gate.waitCount == 1 }
+    click(renderer)
+    await expectNoPointer(adb)
+
+    await gate.open()
+    await eventually { await adb.pointerPreparations == [first.id] }
+    click(renderer)
+    await eventually { await adb.pointerEvents.count == 1 }
+    await manager.stop()
+  }
+
+  static func failedStreamsDoNotPreparePointer() async throws {
+    let adb = ADBService()
+    // Give each failed stream a fresh readiness gate, like a new retry attempt.
+    for _ in 0 ..< 3 {
+      let gate = TestGate()
+      let manager = makeManager(LivePreviewService(readyGate: gate), adb: adb)
+      await manager.start(with: [first])
+      let renderer = try await manager.makeRenderer(for: first.id)
+      await eventually { await gate.waitCount == 1 }
+      await renderer.operation.session.fail()
+      click(renderer)
+      await expectNoPointer(adb)
+      await manager.stopRenderer(renderer)
+      await manager.stop()
+    }
+  }
+
+  static func stoppedPreviewDoesNotPreparePointer() async throws {
+    let gate = TestGate()
+    let adb = ADBService()
+    let manager = makeManager(LivePreviewService(readyGate: gate), adb: adb)
+    await manager.start(with: [first])
+    let renderer = try await manager.makeRenderer(for: first.id)
+    await eventually { await gate.waitCount == 1 }
+    await manager.stop()
+    click(renderer)
+    await expectNoPointer(adb)
+  }
+
+  static func removedDeviceDoesNotPreparePointer() async throws {
+    let gate = TestGate()
+    let adb = ADBService()
+    let manager = makeManager(LivePreviewService(readyGate: gate), adb: adb)
+    await manager.start(with: [first])
+    let renderer = try await manager.makeRenderer(for: first.id)
+    await eventually { await gate.waitCount == 1 }
+    await manager.updateDevices([])
+    click(renderer)
+    await expectNoPointer(adb)
+    await manager.stop()
+  }
+
+  static func stoppedRendererIgnoresLateReadiness() async throws {
+    let readyGate = TestGate()
+    let stopGate = TestGate()
+    let adb = ADBService()
+    let service = LivePreviewService(stopGate: stopGate, readyGate: readyGate)
+    let manager = makeManager(service, adb: adb)
+    await manager.start(with: [first])
+    let renderer = try await manager.makeRenderer(for: first.id)
+    await eventually { await readyGate.waitCount == 1 }
+    let stop = Task { await manager.stopRenderer(renderer) }
+    await eventually { await stopGate.waitCount == 1 }
+    // The stream can become ready after its renderer has started cleanup.
+    await readyGate.open()
+    await eventually { renderer.operation.session.isReady }
+    click(renderer)
+    await expectNoPointer(adb)
+    await stopGate.open()
+    await stop.value
+    await manager.stop()
+  }
+
+  static func replacedRendererCannotSendPointer() async throws {
+    let adb = ADBService()
+    let manager = makeManager(LivePreviewService(), adb: adb)
+    await manager.start(with: [first])
+    let firstRenderer = try await manager.makeRenderer(for: first.id)
+    await eventually { await adb.pointerPreparations.count == 1 }
+    await manager.stopRenderer(firstRenderer)
+    let replacement = try await manager.makeRenderer(for: first.id)
+    await eventually { await adb.pointerPreparations.count == 2 }
+    click(firstRenderer)
+    await settle()
+    let staleEvents = await adb.pointerEvents
+    precondition(staleEvents.isEmpty, "A replaced renderer must not send pointer events")
+    click(replacement)
+    await eventually { await adb.pointerEvents.count == 1 }
+    await manager.stop()
   }
 
   static func stopWaitsForRendererCleanup() async throws {

--- a/snapo-app-mac/Tests/CaptureMode/CaptureModeTests.swift
+++ b/snapo-app-mac/Tests/CaptureMode/CaptureModeTests.swift
@@ -13,6 +13,8 @@ struct CaptureModeTests {
   static let second = testDevice("second")
 
   static func main() async throws {
+    try await teardownWaitsForPointerPreparation()
+    try await removingDevicePreservesOtherPointer()
     try await pointerWaitsForReadiness()
     try await failedStreamsDoNotPreparePointer()
     try await stoppedPreviewDoesNotPreparePointer()
@@ -23,7 +25,7 @@ struct CaptureModeTests {
     await stopDuringRendererStart()
     await overlappingDeviceUpdates()
     await modePropagatesCancellation()
-    print("Capture mode tests passed (10 cases)")
+    print("Capture mode tests passed (12 cases)")
   }
 
   static func eventually(_ condition: () async -> Bool) async {
@@ -54,6 +56,70 @@ struct CaptureModeTests {
     let events = await adb.pointerEvents
     precondition(preparations.isEmpty, "Unready preview must not prepare a virtual touchscreen")
     precondition(events.isEmpty, "Unready preview must not forward pointer events")
+  }
+
+  enum Teardown: CaseIterable {
+    case renderer, device, manager, rendererAndManager, deviceAndManager
+  }
+
+  static func teardownWaitsForPointerPreparation() async throws {
+    for teardown in Teardown.allCases {
+      let preparationGate = TestGate()
+      let adb = ADBService(pointerPreparationGate: preparationGate)
+      let service = LivePreviewService()
+      let manager = makeManager(service, adb: adb)
+      await manager.start(with: [first])
+      let renderer = try await manager.makeRenderer(for: first.id)
+      await eventually { await preparationGate.waitCount == 1 }
+
+      var stopped = false
+      let stop = Task {
+        switch teardown {
+        case .renderer:
+          await manager.stopRenderer(renderer)
+        case .device:
+          await manager.updateDevices([])
+        case .manager:
+          await manager.stop()
+        case .rendererAndManager, .deviceAndManager:
+          let removing = Task {
+            if teardown == .rendererAndManager {
+              await manager.stopRenderer(renderer)
+            } else {
+              await manager.updateDevices([])
+            }
+          }
+          await eventually { await service.stops.count == 1 }
+          await manager.stop()
+          await removing.value
+        }
+        stopped = true
+      }
+      await eventually { await service.active.isEmpty }
+      await settle()
+      precondition(!stopped, "\(teardown) must wait for queued pointer preparation")
+
+      await preparationGate.open()
+      await stop.value
+      let preparations = await adb.pointerPreparations
+      let activeDevices = await adb.activePointerDeviceIDs
+      precondition(preparations == [first.id])
+      precondition(activeDevices.isEmpty, "\(teardown) must not leave an input device registered")
+      await manager.stop()
+    }
+  }
+
+  static func removingDevicePreservesOtherPointer() async throws {
+    let adb = ADBService()
+    let manager = makeManager(LivePreviewService(), adb: adb)
+    await manager.start(with: [first, second])
+    _ = try await manager.makeRenderer(for: first.id)
+    _ = try await manager.makeRenderer(for: second.id)
+    await eventually { await adb.activePointerDeviceIDs == [first.id, second.id] }
+    await manager.updateDevices([second])
+    let activeDevices = await adb.activePointerDeviceIDs
+    precondition(activeDevices == [second.id])
+    await manager.stop()
   }
 
   static func pointerWaitsForReadiness() async throws {

--- a/snapo-app-mac/Tests/CaptureSupport/TestSupport.swift
+++ b/snapo-app-mac/Tests/CaptureSupport/TestSupport.swift
@@ -52,8 +52,14 @@ struct LivePreviewOperationHandle {
 
 @MainActor
 final class LivePreviewSession {
+  enum StreamError: Error { case failed }
+
   private let readyGate: TestGate?
   private var isStopped = false
+  private var hasFormat = false
+  private var stopError: Error?
+
+  var isReady: Bool { hasFormat && !isStopped }
 
   init(readyGate: TestGate?) {
     self.readyGate = readyGate
@@ -61,13 +67,20 @@ final class LivePreviewSession {
 
   func waitUntilReady() async throws -> Media {
     await readyGate?.wait()
+    if let stopError { throw stopError }
     guard !isStopped else { throw CancellationError() }
+    hasFormat = true
     return .livePreview(capturedAt: Date(), display: testDisplay)
   }
 
   func cancel() async {
     isStopped = true
     await readyGate?.open()
+  }
+
+  func fail() async {
+    stopError = StreamError.failed
+    await cancel()
   }
 }
 
@@ -121,6 +134,8 @@ actor ScreenshotService {
 
 actor ADBService {
   private let displayGates: [String: TestGate]
+  private(set) var pointerPreparations: [String] = []
+  private(set) var pointerEvents: [LivePreviewPointerEvent] = []
   init(displayGates: [String: TestGate] = [:]) {
     self.displayGates = displayGates
   }
@@ -137,10 +152,18 @@ actor ADBService {
     await displayGates[deviceID]?.wait()
     return "1080x2400"
   }
+
+  func recordPointerPreparation(deviceID: String) {
+    pointerPreparations.append(deviceID)
+  }
+
+  func recordPointerEvent(_ event: LivePreviewPointerEvent) {
+    pointerEvents.append(event)
+  }
 }
 
 enum LivePreviewPointerAction { case down }
-enum LivePreviewPointerSource { case mouse }
+enum LivePreviewPointerSource { case mouse, touchscreen }
 struct LivePreviewPointerEvent {
   let deviceID: String
   let action: LivePreviewPointerAction
@@ -150,25 +173,37 @@ struct LivePreviewPointerEvent {
 }
 
 actor LivePreviewPointerInjector {
-  init(adb _: ADBService) {}
-  func prepare(deviceID _: String) {}
+  private let adb: ADBService
+
+  init(adb: ADBService) {
+    self.adb = adb
+  }
+
+  func prepare(deviceID: String) async {
+    await adb.recordPointerPreparation(deviceID: deviceID)
+  }
+
   func stopDevice(_: String) {}
   func stopAll() {}
-  func enqueue(_: LivePreviewPointerEvent) {}
+  func enqueue(_ event: LivePreviewPointerEvent) async {
+    await adb.recordPointerEvent(event)
+  }
 }
 
 @MainActor
 final class LivePreviewRenderer {
   let operation: LivePreviewOperationHandle
+  let sendPointer: (LivePreviewPointerAction, LivePreviewPointerSource, CGPoint, CGSize) -> Void
   var deviceID: String {
     operation.deviceID
   }
 
   init(
     operation: LivePreviewOperationHandle,
-    pointerHandler _: @escaping (LivePreviewPointerAction, LivePreviewPointerSource, CGPoint, CGSize) -> Void
+    pointerHandler: @escaping (LivePreviewPointerAction, LivePreviewPointerSource, CGPoint, CGSize) -> Void
   ) {
     self.operation = operation
+    sendPointer = pointerHandler
   }
 }
 

--- a/snapo-app-mac/Tests/CaptureSupport/TestSupport.swift
+++ b/snapo-app-mac/Tests/CaptureSupport/TestSupport.swift
@@ -59,7 +59,9 @@ final class LivePreviewSession {
   private var hasFormat = false
   private var stopError: Error?
 
-  var isReady: Bool { hasFormat && !isStopped }
+  var isReady: Bool {
+    hasFormat && !isStopped
+  }
 
   init(readyGate: TestGate?) {
     self.readyGate = readyGate
@@ -134,10 +136,14 @@ actor ScreenshotService {
 
 actor ADBService {
   private let displayGates: [String: TestGate]
+  private let pointerPreparationGate: TestGate?
   private(set) var pointerPreparations: [String] = []
   private(set) var pointerEvents: [LivePreviewPointerEvent] = []
-  init(displayGates: [String: TestGate] = [:]) {
+  private(set) var activePointerDeviceIDs: Set<String> = []
+
+  init(displayGates: [String: TestGate] = [:], pointerPreparationGate: TestGate? = nil) {
     self.displayGates = displayGates
+    self.pointerPreparationGate = pointerPreparationGate
   }
 
   func exec() -> ADBService {
@@ -153,8 +159,19 @@ actor ADBService {
     return "1080x2400"
   }
 
-  func recordPointerPreparation(deviceID: String) {
+  func recordPointerPreparation(deviceID: String) async {
+    // Model an actor call queued before registration, even if its task is cancelled.
+    await pointerPreparationGate?.wait()
     pointerPreparations.append(deviceID)
+    activePointerDeviceIDs.insert(deviceID)
+  }
+
+  func recordPointerStop(deviceID: String) {
+    activePointerDeviceIDs.remove(deviceID)
+  }
+
+  func recordPointerStopAll() {
+    activePointerDeviceIDs.removeAll()
   }
 
   func recordPointerEvent(_ event: LivePreviewPointerEvent) {
@@ -183,8 +200,14 @@ actor LivePreviewPointerInjector {
     await adb.recordPointerPreparation(deviceID: deviceID)
   }
 
-  func stopDevice(_: String) {}
-  func stopAll() {}
+  func stopDevice(_ deviceID: String) async {
+    await adb.recordPointerStop(deviceID: deviceID)
+  }
+
+  func stopAll() async {
+    await adb.recordPointerStopAll()
+  }
+
   func enqueue(_ event: LivePreviewPointerEvent) async {
     await adb.recordPointerEvent(event)
   }

--- a/snapo-app-mac/Tests/StartupCapture/LivePreviewSessionTests.swift
+++ b/snapo-app-mac/Tests/StartupCapture/LivePreviewSessionTests.swift
@@ -144,6 +144,7 @@ final class H264StreamDecoder: @unchecked Sendable {
 struct LivePreviewSessionTests {
   static func main() async throws {
     let session = try await LivePreviewSession(deviceID: "ready", adb: ADBService())
+    precondition(!session.isReady)
     guard let decoder = H264StreamDecoder.latest else { fatalError("Missing decoder") }
     let first = Task { try await session.waitUntilReady() }
     let second = Task { try await session.waitUntilReady() }
@@ -155,7 +156,10 @@ struct LivePreviewSessionTests {
     let secondMedia = try await second.value
     precondition(firstMedia == secondMedia)
     precondition(firstMedia.size == CGSize(width: 1080, height: 2400))
+    precondition(session.isReady)
     session.cancel()
+    precondition(!session.isReady)
+    await expectCancellation(Task { try await session.waitUntilReady() })
     _ = await session.waitUntilStop()
     await eventually { decoder.finishCount == 1 }
 
@@ -166,6 +170,7 @@ struct LivePreviewSessionTests {
       await Task.yield()
     }
     cancelled.cancel()
+    precondition(!cancelled.isReady)
     await expectCancellation(pendingFirst)
     await expectCancellation(pendingSecond)
     await expectCancellation(Task { try await cancelled.waitUntilReady() })


### PR DESCRIPTION
Live Preview registers its virtual touchscreen before the video stream reports readiness. If startup repeatedly fails, retries can repeatedly add and remove the Android input device. This change delays input setup until the stream is ready.

## Summary

- Prepare the virtual touchscreen after video-format readiness, while the renderer remains active.
- Ignore pointer events from unready, stopped, or replaced renderers.
- Reject cached readiness for stopped sessions.
- Retain each readiness task and await it before stopping pointer input. A shared helper keeps teardown ordering consistent.

## Validation

- Capture mode tests: 12 cases passed, including queued preparation across five teardown scenarios and preservation of another device's pointer.
- Startup tests: 22 cases passed; session, preview visibility, and recording visibility tests passed.
- Pointer delivery tests: 23 cases passed.
- Readiness and teardown regression tests fail against their previous implementations and pass with these fixes.
- Unsigned macOS build passed.
- Full formatting and lint checks passed with the pinned SwiftFormat 0.61.1 and SwiftLint 0.63.2 versions.

No physical-device reproduction was performed. Readiness means the video format has arrived, not that a frame has appeared. Failures after readiness can still cause input-device churn.
