### PR TITLE
Offer manual connection after Live Preview fails

### DIFF
--- a/snapo-app-mac/Snap-O/CaptureWindow/CaptureWindowController.swift
+++ b/snapo-app-mac/Snap-O/CaptureWindow/CaptureWindowController.swift
@@ -509,6 +509,11 @@ final class CaptureWindowController {
     }
   }
 
+  func livePreviewConnection(for deviceID: String) -> LivePreviewConnection? {
+    guard case .livePreview(let livePreviewMode) = mode else { return nil }
+    return livePreviewMode.connection(for: deviceID)
+  }
+
   func startLivePreviewStream(for deviceID: String) async -> LivePreviewRenderer? {
     guard case .livePreview(let livePreviewMode) = mode else { return nil }
     guard !livePreviewMode.isStopping else { return nil }

--- a/snapo-app-mac/Snap-O/CaptureWindow/LiveCaptureView.swift
+++ b/snapo-app-mac/Snap-O/CaptureWindow/LiveCaptureView.swift
@@ -17,15 +17,23 @@ struct LiveCaptureView<Host: LivePreviewHosting>: View {
   @State private var streamTask: Task<Void, Never>?
   @State private var cleanupTask: Task<Void, Never>?
   @State private var streamLifecycleID: UUID?
+  @State private var connectionError: String?
   @State private var isViewVisible = false
   @State private var isWindowVisible = false
 
   var body: some View {
     ZStack {
+      Color(nsColor: .unemphasizedSelectedContentBackgroundColor)
       if let renderer {
         LivePreviewRendererView(renderer: renderer, fileStore: fileStore, isVisible: isWindowVisible)
-      } else {
-        Color(nsColor: .unemphasizedSelectedContentBackgroundColor)
+      } else if let connectionError {
+        VStack(spacing: 8) {
+          Text(connectionError)
+            .foregroundStyle(.secondary)
+            .multilineTextAlignment(.center)
+          Button("Connect", action: connect)
+        }
+        .padding(16)
       }
     }
     .frame(maxWidth: .infinity, maxHeight: .infinity)
@@ -47,7 +55,7 @@ struct LiveCaptureView<Host: LivePreviewHosting>: View {
   }
 
   private func startStreamIfNeeded() {
-    guard isViewVisible, isWindowVisible, streamTask == nil else { return }
+    guard isViewVisible, isWindowVisible, streamTask == nil, connectionError == nil else { return }
 
     let deviceID = capture.device.id
     let lifecycleID = UUID()
@@ -59,6 +67,12 @@ struct LiveCaptureView<Host: LivePreviewHosting>: View {
       cleanupTask = nil
       await runRendererLifecycle(deviceID: deviceID, lifecycleID: lifecycleID)
     }
+  }
+
+  private func connect() {
+    guard streamTask == nil else { return }
+    connectionError = nil
+    startStreamIfNeeded()
   }
 
   private func stopStream() {
@@ -83,56 +97,39 @@ struct LiveCaptureView<Host: LivePreviewHosting>: View {
 
   @MainActor
   private func runRendererLifecycle(deviceID: String, lifecycleID: UUID) async {
-    var retryAttempt = 0
-
-    while isLifecycleActive(lifecycleID) {
-      let newRenderer = await host.startLivePreviewStream(for: deviceID)
-      guard isLifecycleActive(lifecycleID) else {
-        if let newRenderer {
-          await host.stopLivePreviewStream(newRenderer)
-        }
-        return
+    defer {
+      if streamLifecycleID == lifecycleID {
+        streamLifecycleID = nil
+        streamTask = nil
       }
-
-      guard let newRenderer else {
-        guard await waitBeforeRetry(attempt: retryAttempt, lifecycleID: lifecycleID) else { return }
-        retryAttempt += 1
-        continue
+    }
+    let newRenderer = await host.startLivePreviewStream(for: deviceID)
+    guard isLifecycleActive(lifecycleID) else {
+      if let newRenderer {
+        await host.stopLivePreviewStream(newRenderer)
       }
-
-      renderer = newRenderer
-      let stopError = await newRenderer.session.waitUntilStop()
-      guard streamLifecycleID == lifecycleID,
-            renderer?.operation.id == newRenderer.operation.id else { return }
-
-      renderer = nil
-      await host.stopLivePreviewStream(newRenderer)
-      if let stopError {
-        SnapOLog.ui.error(
-          "Live preview stopped: \(stopError.localizedDescription, privacy: .public)"
-        )
-      }
-
-      guard await waitBeforeRetry(attempt: retryAttempt, lifecycleID: lifecycleID) else { return }
-      retryAttempt += 1
+      return
     }
 
-    if streamLifecycleID == lifecycleID {
-      streamLifecycleID = nil
-      streamTask = nil
+    guard let newRenderer else {
+      connectionError = "Live preview unavailable"
+      return
     }
-  }
 
-  @MainActor
-  private func waitBeforeRetry(attempt: Int, lifecycleID: UUID) async -> Bool {
-    let exponent = min(attempt, 4)
-    let delayMilliseconds = min(200 * (1 << exponent), 2000)
-    do {
-      try await Task.sleep(for: .milliseconds(delayMilliseconds))
-    } catch {
-      return false
+    renderer = newRenderer
+    let stopError = await newRenderer.session.waitUntilStop()
+    guard isLifecycleActive(lifecycleID),
+          renderer?.operation.id == newRenderer.operation.id else { return }
+
+    renderer = nil
+    await host.stopLivePreviewStream(newRenderer)
+    guard isLifecycleActive(lifecycleID) else { return }
+    if let stopError {
+      SnapOLog.ui.error(
+        "Live preview stopped: \(stopError.localizedDescription, privacy: .public)"
+      )
     }
-    return isLifecycleActive(lifecycleID)
+    connectionError = "Live preview unavailable"
   }
 
   @MainActor

--- a/snapo-app-mac/Snap-O/CaptureWindow/LiveCaptureView.swift
+++ b/snapo-app-mac/Snap-O/CaptureWindow/LiveCaptureView.swift
@@ -4,6 +4,7 @@ import SwiftUI
 
 @MainActor
 protocol LivePreviewHosting: AnyObject {
+  func livePreviewConnection(for deviceID: String) -> LivePreviewConnection?
   func startLivePreviewStream(for deviceID: String) async -> LivePreviewRenderer?
   func stopLivePreviewStream(_ renderer: LivePreviewRenderer) async
 }
@@ -12,26 +13,33 @@ struct LiveCaptureView<Host: LivePreviewHosting>: View {
   let host: Host
   let capture: CaptureMedia
   let fileStore: FileStore
+  private let connection: LivePreviewConnection?
 
   @State private var renderer: LivePreviewRenderer?
   @State private var streamTask: Task<Void, Never>?
-  @State private var cleanupTask: Task<Void, Never>?
   @State private var streamLifecycleID: UUID?
-  @State private var connectionError: String?
   @State private var isViewVisible = false
   @State private var isWindowVisible = false
+
+  init(host: Host, capture: CaptureMedia, fileStore: FileStore) {
+    self.host = host
+    self.capture = capture
+    self.fileStore = fileStore
+    connection = host.livePreviewConnection(for: capture.device.id)
+  }
 
   var body: some View {
     ZStack {
       Color(nsColor: .unemphasizedSelectedContentBackgroundColor)
       if let renderer {
         LivePreviewRendererView(renderer: renderer, fileStore: fileStore, isVisible: isWindowVisible)
-      } else if let connectionError {
+      } else if connection?.hasFailed == true {
         VStack(spacing: 8) {
-          Text(connectionError)
+          Text("Live preview unavailable")
             .foregroundStyle(.secondary)
             .multilineTextAlignment(.center)
           Button("Connect", action: connect)
+            .disabled(streamTask != nil)
         }
         .padding(16)
       }
@@ -55,23 +63,24 @@ struct LiveCaptureView<Host: LivePreviewHosting>: View {
   }
 
   private func startStreamIfNeeded() {
-    guard isViewVisible, isWindowVisible, streamTask == nil, connectionError == nil else { return }
+    guard isViewVisible, isWindowVisible, streamTask == nil,
+          let connection, !connection.hasFailed else { return }
 
     let deviceID = capture.device.id
     let lifecycleID = UUID()
-    let previousCleanup = cleanupTask
+    let previousCleanup = connection.cleanupTask
     streamLifecycleID = lifecycleID
     streamTask = Task(priority: .userInitiated) { @MainActor in
       await previousCleanup?.value
       guard isLifecycleActive(lifecycleID) else { return }
-      cleanupTask = nil
-      await runRendererLifecycle(deviceID: deviceID, lifecycleID: lifecycleID)
+      connection.cleanupTask = nil
+      await runRendererLifecycle(deviceID: deviceID, lifecycleID: lifecycleID, connection: connection)
     }
   }
 
   private func connect() {
-    guard streamTask == nil else { return }
-    connectionError = nil
+    guard streamTask == nil, let connection else { return }
+    connection.hasFailed = false
     startStreamIfNeeded()
   }
 
@@ -82,10 +91,10 @@ struct LiveCaptureView<Host: LivePreviewHosting>: View {
     streamTask = nil
     let rendererToStop = renderer
     renderer = nil
-    guard taskToStop != nil || rendererToStop != nil else { return }
+    guard let connection, taskToStop != nil || rendererToStop != nil else { return }
 
-    let previousCleanup = cleanupTask
-    cleanupTask = Task {
+    let previousCleanup = connection.cleanupTask
+    connection.cleanupTask = Task {
       await previousCleanup?.value
       if let rendererToStop {
         await host.stopLivePreviewStream(rendererToStop)
@@ -96,7 +105,7 @@ struct LiveCaptureView<Host: LivePreviewHosting>: View {
   }
 
   @MainActor
-  private func runRendererLifecycle(deviceID: String, lifecycleID: UUID) async {
+  private func runRendererLifecycle(deviceID: String, lifecycleID: UUID, connection: LivePreviewConnection) async {
     defer {
       if streamLifecycleID == lifecycleID {
         streamLifecycleID = nil
@@ -112,7 +121,7 @@ struct LiveCaptureView<Host: LivePreviewHosting>: View {
     }
 
     guard let newRenderer else {
-      connectionError = "Live preview unavailable"
+      connection.hasFailed = true
       return
     }
 
@@ -121,15 +130,18 @@ struct LiveCaptureView<Host: LivePreviewHosting>: View {
     guard isLifecycleActive(lifecycleID),
           renderer?.operation.id == newRenderer.operation.id else { return }
 
+    connection.hasFailed = true
     renderer = nil
-    await host.stopLivePreviewStream(newRenderer)
+    // Retain cleanup across selection changes before exposing a manual retry.
+    let cleanup = Task { await host.stopLivePreviewStream(newRenderer) }
+    connection.cleanupTask = cleanup
+    await cleanup.value
     guard isLifecycleActive(lifecycleID) else { return }
     if let stopError {
       SnapOLog.ui.error(
         "Live preview stopped: \(stopError.localizedDescription, privacy: .public)"
       )
     }
-    connectionError = "Live preview unavailable"
   }
 
   @MainActor

--- a/snapo-app-mac/Snap-O/CaptureWindow/LivePreviewConnection.swift
+++ b/snapo-app-mac/Snap-O/CaptureWindow/LivePreviewConnection.swift
@@ -1,0 +1,9 @@
+import Foundation
+import Observation
+
+@Observable
+@MainActor
+final class LivePreviewConnection {
+  var hasFailed = false
+  @ObservationIgnored var cleanupTask: Task<Void, Never>?
+}

--- a/snapo-app-mac/Snap-O/CaptureWindow/LivePreviewMode.swift
+++ b/snapo-app-mac/Snap-O/CaptureWindow/LivePreviewMode.swift
@@ -13,6 +13,7 @@ final class LivePreviewMode {
   private let onMediaApplied: @MainActor () -> Void
   private var preparedLivePreview: PreparedLivePreview?
   private var manager: LivePreviewManager?
+  @ObservationIgnored private var connections: [String: LivePreviewConnection] = [:]
   @ObservationIgnored private var stopTask: Task<Void, Never>?
   private(set) var isStopping: Bool = false
 
@@ -58,6 +59,13 @@ final class LivePreviewMode {
 
   func updateDevices(_ devices: [Device]) async {
     await manager?.updateDevices(devices)
+  }
+
+  func connection(for deviceID: String) -> LivePreviewConnection {
+    if let connection = connections[deviceID] { return connection }
+    let connection = LivePreviewConnection()
+    connections[deviceID] = connection
+    return connection
   }
 
   func makeRenderer(for deviceID: String) async throws -> LivePreviewRenderer {

--- a/snapo-app-mac/Tests/CaptureMode/CaptureModeTests.swift
+++ b/snapo-app-mac/Tests/CaptureMode/CaptureModeTests.swift
@@ -25,7 +25,8 @@ struct CaptureModeTests {
     await stopDuringRendererStart()
     await overlappingDeviceUpdates()
     await modePropagatesCancellation()
-    print("Capture mode tests passed (12 cases)")
+    await modeRetainsPerDeviceFailures()
+    print("Capture mode tests passed (13 cases)")
   }
 
   static func eventually(_ condition: () async -> Bool) async {
@@ -305,5 +306,36 @@ struct CaptureModeTests {
     await stop.value
     let active = await service.active
     precondition(active.isEmpty)
+  }
+
+  static func modeRetainsPerDeviceFailures() async {
+    func makeMode() -> LivePreviewMode {
+      LivePreviewMode(
+        livePreviewService: LivePreviewService(), adbService: ADBService(), options: options,
+        mediaDisplayMode: MediaDisplayMode(), preferredDeviceIDProvider: { first.id }, onMediaApplied: {}
+      )
+    }
+    let mode = makeMode()
+    await mode.start(with: [first, second])
+    let firstConnection = mode.connection(for: first.id)
+    firstConnection.hasFailed = true
+    let secondConnection = mode.connection(for: second.id)
+    precondition(!secondConnection.hasFailed, "Failures must be isolated per device")
+    secondConnection.hasFailed = true
+
+    await mode.updateDevices([second])
+    await mode.updateDevices([first, second])
+    precondition(mode.connection(for: first.id) === firstConnection)
+    precondition(firstConnection.hasFailed, "Device updates must retain failures for this mode")
+    firstConnection.hasFailed = false
+    precondition(mode.connection(for: second.id).hasFailed, "Retry clears only the selected device")
+    await mode.stop()
+
+    let nextMode = makeMode()
+    precondition(nextMode.connection(for: first.id) !== firstConnection)
+    precondition(!nextMode.connection(for: second.id).hasFailed, "A new mode must start without old failures")
+    firstConnection.hasFailed = true
+    precondition(!nextMode.connection(for: first.id).hasFailed, "Old views must not change a new mode's failure state")
+    await nextMode.stop()
   }
 }

--- a/snapo-app-mac/Tests/CaptureSupport/TestSupport.swift
+++ b/snapo-app-mac/Tests/CaptureSupport/TestSupport.swift
@@ -242,6 +242,7 @@ struct FileStore {}
 
 @MainActor
 protocol LivePreviewHosting: AnyObject {
+  func livePreviewConnection(for deviceID: String) -> LivePreviewConnection?
   func startLivePreviewStream(for deviceID: String) async -> LivePreviewRenderer?
   func stopLivePreviewStream(_ renderer: LivePreviewRenderer) async
 }

--- a/snapo-app-mac/Tests/StartupCapture/LivePreviewVisibilityTests.swift
+++ b/snapo-app-mac/Tests/StartupCapture/LivePreviewVisibilityTests.swift
@@ -6,7 +6,11 @@ import SwiftUI
 
 struct CaptureMedia {
   struct Device { let id: String }
-  let device = Device(id: "test-device")
+  let device: Device
+
+  init(deviceID: String = "test-device") {
+    device = Device(id: deviceID)
+  }
 }
 
 struct FileStore {}
@@ -113,6 +117,7 @@ struct WindowVisibilityReader: View {
 
 @MainActor
 final class TestHost: LivePreviewHosting {
+  var connections: [String: LivePreviewConnection] = [:]
   var starts = 0
   var requestedDeviceIDs: [String] = []
   var failsToStart = false
@@ -124,6 +129,13 @@ final class TestHost: LivePreviewHosting {
   var delayStop = false
   var stopContinuation: CheckedContinuation<Void, Never>?
   var latestSession: LivePreviewSession?
+  func livePreviewConnection(for deviceID: String) -> LivePreviewConnection? {
+    if let connection = connections[deviceID] { return connection }
+    let connection = LivePreviewConnection()
+    connections[deviceID] = connection
+    return connection
+  }
+
   func startLivePreviewStream(for deviceID: String) async -> LivePreviewRenderer? {
     starts += 1
     requestedDeviceIDs.append(deviceID)
@@ -305,6 +317,9 @@ struct LivePreviewVisibilityTests {
     precondition(host.busyStarts == 0, "Never restart while the previous operation owns the device")
     print("Live Preview visibility tests passed")
     testFailedConnection()
+    testFailureSurvivesSelection(failsToStart: true)
+    testFailureSurvivesSelection(failsToStart: false)
+    testSelectionDuringFailureCleanup()
     testRecordingPlaybackVisibility()
   }
 
@@ -352,6 +367,93 @@ struct LivePreviewVisibilityTests {
     window.contentView = nil
     eventually("Removing reconnected preview releases it") { host.active.isEmpty }
     print("Live Preview manual connection tests passed")
+  }
+
+  static func testFailureSurvivesSelection(failsToStart: Bool) {
+    Visibility.shared.isVisible = true
+    let host = TestHost()
+    host.failsToStart = failsToStart
+    func preview(_ deviceID: String) -> some View {
+      LiveCaptureView(host: host, capture: CaptureMedia(deviceID: deviceID), fileStore: FileStore())
+        .id(UUID())
+    }
+    let view = NSHostingView(rootView: preview("first"))
+    let window = NSWindow(
+      contentRect: NSRect(x: 0, y: 0, width: 360, height: 220),
+      styleMask: [.borderless], backing: .buffered, defer: false
+    )
+    window.contentView = view
+    view.layoutSubtreeIfNeeded()
+    eventually("First device starts once") { host.starts == 1 }
+    if !failsToStart {
+      eventually("First device connects") { host.active.count == 1 }
+      host.latestSession?.stop()
+    }
+    eventually("First device shows failure") { accessibleElement(named: "Connect", in: view) != nil && host.active.isEmpty }
+
+    host.failsToStart = false
+    view.rootView = preview("second")
+    eventually("Another device connects independently") { host.starts == 2 && host.active.count == 1 }
+    host.latestSession?.stop()
+    eventually("Second device shows failure") { accessibleElement(named: "Connect", in: view) != nil && host.active.isEmpty }
+
+    view.rootView = preview("first")
+    pump()
+    precondition(host.starts == 2, "Returning to a failed device must not reconnect automatically")
+    eventually("Remounted preview retains failure") { accessibleElement(named: "Live preview unavailable", in: view) != nil }
+    connect(in: view)
+    eventually("Connect retries the selected device") { host.starts == 3 && host.active.count == 1 }
+    precondition(host.requestedDeviceIDs == ["first", "second", "first"])
+    window.contentView = nil
+    eventually("Retry releases its renderer") { host.active.isEmpty }
+
+    view.rootView = preview("second")
+    window.contentView = view
+    view.layoutSubtreeIfNeeded()
+    pump()
+    precondition(host.starts == 3, "Retrying one device must not reset another device's failure")
+    eventually("Other device still requires Connect") { accessibleElement(named: "Connect", in: view) != nil }
+    window.contentView = nil
+    print("Live Preview selection preserves \(failsToStart ? "startup" : "stream") failures")
+  }
+
+  static func testSelectionDuringFailureCleanup() {
+    Visibility.shared.isVisible = true
+    let host = TestHost()
+    func preview() -> some View {
+      LiveCaptureView(host: host, capture: CaptureMedia(), fileStore: FileStore())
+        .id(UUID())
+    }
+    let view = NSHostingView(rootView: preview())
+    let window = NSWindow(
+      contentRect: NSRect(x: 0, y: 0, width: 360, height: 220),
+      styleMask: [.borderless], backing: .buffered, defer: false
+    )
+    window.contentView = view
+    view.layoutSubtreeIfNeeded()
+    eventually("Initial stream connects") { host.starts == 1 && host.active.count == 1 }
+    host.delayStop = true
+    host.latestSession?.stop()
+    eventually("Failed stream begins cleanup") { host.stopContinuation != nil }
+    window.contentView = nil
+    pump()
+    view.rootView = preview()
+    window.contentView = view
+    view.layoutSubtreeIfNeeded()
+    eventually("Remount remembers failure during cleanup") { accessibleElement(named: "Connect", in: view) != nil }
+    pump()
+    precondition(host.starts == 1, "Selection must not reconnect during cleanup")
+    connect(in: view)
+    pump()
+    precondition(host.starts == 1, "Connect must await the previous view's cleanup")
+    host.delayStop = false
+    host.stopContinuation?.resume()
+    host.stopContinuation = nil
+    eventually("Manual retry starts after cleanup") { host.starts == 2 && host.active.count == 1 }
+    precondition(host.busyStarts == 0, "Remount must not overlap operations")
+    window.contentView = nil
+    eventually("Remounted preview releases its renderer") { host.active.isEmpty }
+    print("Live Preview selection preserves pending cleanup")
   }
 
   static func testRecordingPlaybackVisibility() {

--- a/snapo-app-mac/Tests/StartupCapture/LivePreviewVisibilityTests.swift
+++ b/snapo-app-mac/Tests/StartupCapture/LivePreviewVisibilityTests.swift
@@ -114,6 +114,8 @@ struct WindowVisibilityReader: View {
 @MainActor
 final class TestHost: LivePreviewHosting {
   var starts = 0
+  var requestedDeviceIDs: [String] = []
+  var failsToStart = false
   var stops: [UUID] = []
   var active: Set<UUID> = []
   var busyStarts = 0
@@ -122,13 +124,15 @@ final class TestHost: LivePreviewHosting {
   var delayStop = false
   var stopContinuation: CheckedContinuation<Void, Never>?
   var latestSession: LivePreviewSession?
-  func startLivePreviewStream(for _: String) async -> LivePreviewRenderer? {
+  func startLivePreviewStream(for deviceID: String) async -> LivePreviewRenderer? {
     starts += 1
+    requestedDeviceIDs.append(deviceID)
     guard active.isEmpty else {
       busyStarts += 1
       return nil
     }
     if delayStart { await withCheckedContinuation { startContinuation = $0 } }
+    if failsToStart { return nil }
     let renderer = LivePreviewRenderer(session: LivePreviewSession())
     latestSession = renderer.session
     active.insert(renderer.operation.id)
@@ -158,8 +162,30 @@ struct LivePreviewVisibilityTests {
     RunLoop.main.run(until: Date().addingTimeInterval(0.3))
   }
 
+  static func accessibleElement(named name: String, in element: AnyObject) -> AnyObject? {
+    let value: String? = element.accessibilityValue?()
+    if element.accessibilityLabel?() == name || element.accessibilityTitle?() == name
+      || value == name {
+      return element
+    }
+    for child in element.accessibilityChildren?() ?? [] {
+      if let found = accessibleElement(named: name, in: child as AnyObject) {
+        return found
+      }
+    }
+    return nil
+  }
+
+  static func connect(in view: NSView) {
+    guard let button = accessibleElement(named: "Connect", in: view) else {
+      preconditionFailure("Missing Connect button")
+    }
+    precondition(button.accessibilityPerformPress?() == true, "Connect must be accessible")
+  }
+
   static func main() {
-    _ = NSApplication.shared
+    // Enable SwiftUI accessibility nodes without requiring VoiceOver or an external test app.
+    NSApplication.shared.accessibilitySetValue(true, forAttribute: NSAccessibility.Attribute(rawValue: "AXEnhancedUserInterface"))
     let host = TestHost()
     func surface(aspectRatio: CGFloat?, mountsPreview: Bool = true) -> some View {
       CaptureSurfaceView(aspectRatio: aspectRatio) {
@@ -229,11 +255,17 @@ struct LivePreviewVisibilityTests {
     host.delayStop = false
     host.stopContinuation?.resume()
     host.stopContinuation = nil
-    eventually("Hidden preview recovers after spontaneous cleanup") { host.starts == 2 && host.active.count == 1 }
-    eventually("Recovered preview stays hidden") { LivePreviewRendererView.displayView?.isHidden == true }
+    eventually("Stopped preview releases its operation") { host.active.isEmpty }
+    pump()
+    precondition(host.starts == 1, "Hidden preview must not reconnect automatically")
     Visibility.shared.isVisible = true
-    eventually("Recovered preview becomes visible") { LivePreviewRendererView.displayView?.isHidden == false }
-    precondition(host.starts == 2, "Uncover must not restart a recovered stream")
+    eventually("Dropped stream shows its error") { accessibleElement(named: "Live preview unavailable", in: view) != nil }
+    pump()
+    precondition(host.starts == 1, "Uncover must not reconnect a failed stream")
+    connect(in: view)
+    eventually("Connect starts a replacement") { host.starts == 2 && host.active.count == 1 }
+    eventually("Replacement becomes visible") { LivePreviewRendererView.displayView?.isHidden == false }
+    eventually("Connected preview hides the failure action") { accessibleElement(named: "Connect", in: view) == nil }
 
     host.delayStop = true
     view.rootView = surface(aspectRatio: nil, mountsPreview: false)
@@ -272,7 +304,54 @@ struct LivePreviewVisibilityTests {
     precondition(Set(host.stops).count == host.stops.count, "Stop each renderer once")
     precondition(host.busyStarts == 0, "Never restart while the previous operation owns the device")
     print("Live Preview visibility tests passed")
+    testFailedConnection()
     testRecordingPlaybackVisibility()
+  }
+
+  static func testFailedConnection() {
+    Visibility.shared.isVisible = true
+    let host = TestHost()
+    host.failsToStart = true
+    let view = NSHostingView(rootView: LiveCaptureView(host: host, capture: CaptureMedia(), fileStore: FileStore()))
+    let window = NSWindow(
+      contentRect: NSRect(x: 0, y: 0, width: 360, height: 220),
+      styleMask: [.borderless],
+      backing: .buffered,
+      defer: false
+    )
+    window.contentView = view
+    view.layoutSubtreeIfNeeded()
+    eventually("Failed startup shows a concise error") { accessibleElement(named: "Live preview unavailable", in: view) != nil }
+    pump()
+    precondition(host.starts == 1 && host.active.isEmpty, "Failed startup must not retry automatically")
+
+    for _ in 0 ..< 3 {
+      Visibility.shared.isVisible = false
+      pump()
+      Visibility.shared.isVisible = true
+      pump()
+    }
+    precondition(host.starts == 1, "Window visibility must not restart failed startup")
+
+    connect(in: view)
+    eventually("Manual retry can fail again") { host.starts == 2 && accessibleElement(named: "Connect", in: view) != nil }
+    pump()
+    precondition(host.starts == 2, "Failed manual retry must wait for another click")
+
+    host.failsToStart = false
+    host.delayStart = true
+    connect(in: view)
+    eventually("Connect starts one pending attempt") { host.starts == 3 && host.startContinuation != nil }
+    eventually("Pending attempt hides Connect") { accessibleElement(named: "Connect", in: view) == nil }
+    host.delayStart = false
+    host.startContinuation?.resume()
+    host.startContinuation = nil
+    eventually("Manual connection succeeds") { host.active.count == 1 }
+    precondition(host.requestedDeviceIDs == Array(repeating: "test-device", count: 3), "Connect must keep the same device")
+    precondition(host.busyStarts == 0, "Connect must not overlap attempts")
+    window.contentView = nil
+    eventually("Removing reconnected preview releases it") { host.active.isEmpty }
+    print("Live Preview manual connection tests passed")
   }
 
   static func testRecordingPlaybackVisibility() {

--- a/snapo-app-mac/scripts/test-capture-modes.sh
+++ b/snapo-app-mac/scripts/test-capture-modes.sh
@@ -12,6 +12,7 @@ xcrun swiftc -swift-version 6 -parse-as-library -I "$TEST_DIR" \
   "$TEST_DIR/Device.o" Snap-O/Models/Media.swift Snap-O/Models/Device+Formatting.swift \
   Snap-O/Capture/CaptureMedia.swift Snap-O/Capture/PreparedLivePreview.swift Snap-O/Utilities/Perf.swift \
   Snap-O/CaptureWindow/LivePreviewManager.swift Snap-O/CaptureWindow/LivePreviewMode.swift \
+  Snap-O/CaptureWindow/LivePreviewConnection.swift \
   Tests/CaptureSupport/TestSupport.swift Tests/CaptureMode/CaptureModeTests.swift \
   -o "$TEST_DIR/capture-mode-tests"
 "$TEST_DIR/capture-mode-tests"

--- a/snapo-app-mac/scripts/test-startup-capture.sh
+++ b/snapo-app-mac/scripts/test-startup-capture.sh
@@ -18,6 +18,7 @@ xcrun swiftc -swift-version 6 -parse-as-library -I "$TEST_DIR" \
   Snap-O/Capture/CaptureServices.swift Snap-O/CaptureWindow/CaptureWindowController.swift \
   Snap-O/CaptureWindow/CaptureWindowMode.swift Snap-O/CaptureWindow/RecordingMode.swift \
   Snap-O/CaptureWindow/LivePreviewMode.swift Snap-O/CaptureWindow/MediaDisplayMode.swift \
+  Snap-O/CaptureWindow/LivePreviewConnection.swift \
   Snap-O/CaptureWindow/CaptureSnapshotController.swift \
   Tests/CaptureSupport/TestSupport.swift Tests/StartupCapture/StartupCaptureTests.swift \
   -o "$TEST_DIR/startup-tests"
@@ -30,6 +31,7 @@ xcrun swiftc -swift-version 6 -parse-as-library -I "$TEST_DIR" \
 "$TEST_DIR/session-tests"
 xcrun swiftc -swift-version 6 -parse-as-library \
   Snap-O/CaptureWindow/LiveCaptureView.swift Snap-O/CaptureWindow/CaptureSurfaceView.swift \
+  Snap-O/CaptureWindow/LivePreviewConnection.swift \
   Snap-O/UI/VideoLoopingView.swift \
   Tests/StartupCapture/LivePreviewVisibilityTests.swift -o "$TEST_DIR/visibility-tests"
 "$TEST_DIR/visibility-tests"


### PR DESCRIPTION
Live Preview retries indefinitely after connection failures or dropped streams. Repeated attempts can wake the device and recreate input devices. This change lets the user decide when to connect again.

## Summary

- Show “Live preview unavailable” above a native Connect button after either failure.
- Make one initial attempt, then wait for Connect to retry on the same device.
- Preserve cleanup ordering and keep healthy previews running while covered. Covering and uncovering a failed preview does not retry it.
- Retain failure and cleanup state per device in the active preview mode, so switching devices cannot retry a failed preview. A new preview mode starts with fresh state.
- Test the actual Connect action, failed startup, dropped streams, device selection, pending cleanup, repeated failures, and successful recovery.

## Validation

- Startup capture, session, visibility, manual connection, and recording visibility tests passed.
- Selection regressions passed for failed startup, dropped streams, and pending cleanup. The original implementation fails the new selection regression.
- Capture mode, Live Preview pointer, and frame export tests passed.
- Pinned SwiftFormat and SwiftLint checks passed.
- Unsigned macOS app build passed.
- Interrupted a preview on a connected device and inspected the failure state in the full app window.
- Visibility tests pass with a deprecation warning from their accessibility setup.
