### PR TITLE
Fix loading spinner wobble

### DIFF
--- a/snapo-network-inspector-web/src/components/LoadingSpinner.tsx
+++ b/snapo-network-inspector-web/src/components/LoadingSpinner.tsx
@@ -1,0 +1,9 @@
+export function LoadingSpinner({ size }: { size: number }): JSX.Element {
+  return (
+    <span className="body-loading-spinner" aria-hidden="true">
+      <svg width={size} height={size} viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={2}>
+        <circle cx={12} cy={12} r={9} pathLength={100} strokeDasharray="80 20" strokeLinecap="round" />
+      </svg>
+    </span>
+  );
+}

--- a/snapo-network-inspector-web/src/features/app-inspector/components/InspectorWaitingState.tsx
+++ b/snapo-network-inspector-web/src/features/app-inspector/components/InspectorWaitingState.tsx
@@ -1,4 +1,4 @@
-import { LoaderCircle } from "lucide-react";
+import { LoadingSpinner } from "../../../components/LoadingSpinner";
 import type { InspectableApp } from "../../../network/bridge-types";
 import type { AppLaunchControl } from "../useAppLaunch";
 import { OpenAppButton } from "./OpenAppButton";
@@ -18,11 +18,7 @@ export function InspectorWaitingState({
     <div className="inspector-loading">
       <div className="inspector-loading-status" role="status" aria-label={label}>
         <span>{label}</span>
-        {!canOpenApp ? (
-          <span className="body-loading-spinner" aria-hidden="true">
-            <LoaderCircle size={20} />
-          </span>
-        ) : null}
+        {!canOpenApp ? <LoadingSpinner size={20} /> : null}
       </div>
       {app && launch ? <OpenAppButton app={app} launch={launch} /> : null}
       {error ? (

--- a/snapo-network-inspector-web/src/features/app-inspector/components/OpenAppButton.tsx
+++ b/snapo-network-inspector-web/src/features/app-inspector/components/OpenAppButton.tsx
@@ -1,4 +1,4 @@
-import { LoaderCircle } from "lucide-react";
+import { LoadingSpinner } from "../../../components/LoadingSpinner";
 import type { InspectableApp } from "../../../network/bridge-types";
 import type { AppLaunchControl } from "../useAppLaunch";
 
@@ -7,9 +7,7 @@ export function OpenAppButton({ app, launch }: { app: InspectableApp; launch: Ap
     <>
       {launch.pending ? (
         <span className="inspector-open-progress" role="progressbar" aria-label={`Opening ${app.name}`}>
-          <span className="body-loading-spinner" aria-hidden="true">
-            <LoaderCircle size={20} />
-          </span>
+          <LoadingSpinner size={20} />
         </span>
       ) : (
         <button className="inspector-open-app" type="button" onClick={launch.open}>

--- a/snapo-network-inspector-web/src/features/network-inspector/components/RequestDetail.tsx
+++ b/snapo-network-inspector-web/src/features/network-inspector/components/RequestDetail.tsx
@@ -1,5 +1,5 @@
-import { LoaderCircle } from "lucide-react";
 import { memo, useEffect, useState } from "react";
+import { LoadingSpinner } from "../../../components/LoadingSpinner";
 import type { NetworkClient } from "../../../network/client";
 import { recordId, type Header, type RequestRecord } from "../../../network/cdp";
 import { decodeRequestBodyForDisplay, makeBodyPayload } from "../../../network/payload";
@@ -154,9 +154,7 @@ export const RequestDetail = memo(function RequestDetail({
           ) : responseBody == null ? (
             <div className="payload-card">
               <div className="body-loading" role="status">
-                <span className="body-loading-spinner" aria-hidden="true">
-                  <LoaderCircle size={14} />
-                </span>
+                <LoadingSpinner size={14} />
                 <span>Loading</span>
               </div>
             </div>

--- a/snapo-network-inspector-web/src/styles.css
+++ b/snapo-network-inspector-web/src/styles.css
@@ -942,8 +942,17 @@ body.split-pane-resizing {
 .body-loading-spinner {
   display: inline-flex;
   flex: 0 0 auto;
-  transform-origin: center;
-  animation: spin 1s linear infinite;
+}
+
+.body-loading-spinner circle {
+  /* Move the gap so the circle stays fixed on the pixel grid. */
+  animation: loading-spinner-gap 1s linear infinite;
+}
+
+@keyframes loading-spinner-gap {
+  to {
+    stroke-dashoffset: -100;
+  }
 }
 
 .body-load-message {


### PR DESCRIPTION
The inspector loading spinner appeared to wobble while rotating, even though its rotation center stayed fixed. This change keeps the circle stationary and moves its gap to produce a steady loading indicator.

## Summary

- Add a shared SVG spinner that animates the stroke offset instead of rotating the icon.
- Use it for inspector waiting, app launch, and response body loading states.
- Preserve the existing sizes, colors, timing, and accessible status labels.

## Validation

- Confirmed visually that the wobble is resolved.
- Checked fixed centers and gap animation across a full cycle in WebKit at 14px and 20px.
- `npm run lint` and `npm run typecheck` passed.
- `npm test`: all 299 tests passed.
- Built the Mac app, including the web renderer, with code signing disabled.
