### PR TITLE
Fix inspector selection at startup

### DIFF
--- a/snapo-network-inspector-web/src/App.test.tsx
+++ b/snapo-network-inspector-web/src/App.test.tsx
@@ -169,8 +169,101 @@ describe("app inspector restoration UI", () => {
     vi.useRealTimers();
   });
 
-  it("shows status and an open action without a spinner until the remembered inspector appears", async () => {
+  async function renderWaitingForInspector() {
+    const starter = { ...app(1, ["tweaks"]), processName: "com.example.starter", packageName: "com.example.starter" };
+    vi.mocked(mocks.client.listInspectorApps).mockResolvedValueOnce([starter, ...discovered]);
     await act(async () => root.render(<App />));
+    // Explicit selection can wait for an inspector after startup chooses a usable app.
+    await act(async () => nativeSelectApp(discovered[0].id));
+  }
+
+  it("waits for initial discovery before restoring the saved app and inspector", async () => {
+    const other = { ...app(30, ["tweaks"]), processName: "com.example.other" };
+    discovered = [other, app(20, ["network", "tweaks"])];
+    let finish!: (apps: InspectableApp[]) => void;
+    vi.mocked(mocks.client.listInspectorApps).mockImplementationOnce(
+      () =>
+        new Promise((resolve) => {
+          finish = resolve;
+        })
+    );
+    await act(async () => root.render(<App />));
+    expect(mocks.client.startStream).not.toHaveBeenCalled();
+    expect(mocks.client.saveInspectorPreferences).not.toHaveBeenCalled();
+    expect(mocks.client.appInspectorStateChanged).toHaveBeenLastCalledWith(
+      expect.objectContaining({ selectedApp: null, selection: null })
+    );
+    await act(async () => finish(discovered));
+    expect(container.querySelector('[data-inspector="network"]')?.getAttribute("data-socket")).toBe("snapo_network_20");
+    expect(mocks.client.saveInspectorPreferences).not.toHaveBeenCalled();
+  });
+
+  it("selects and saves a fallback when the remembered app is unavailable", async () => {
+    const other = { ...app(30, ["network"]), processName: "com.example.other", androidUserId: 10 };
+    discovered = [other];
+    await act(async () => root.render(<App />));
+    expect(container.querySelector('[data-inspector="network"]')?.getAttribute("data-socket")).toBe("snapo_network_30");
+    const saved = vi.mocked(mocks.client.saveInspectorPreferences).mock.lastCall![0];
+    expect(JSON.parse(saved!).last).toEqual({
+      deviceId: "phone",
+      processName: "com.example.other",
+      androidUserId: 10,
+      kind: "network"
+    });
+
+    discovered = [app(20, ["network", "tweaks"])];
+    await act(async () => vi.advanceTimersByTimeAsync(2_500));
+    expect(mocks.client.appInspectorStateChanged).toHaveBeenLastCalledWith(
+      expect.objectContaining({
+        selection: null,
+        selectedApp: expect.objectContaining({ id: other.id, androidUserId: 10 })
+      })
+    );
+    expect(mocks.client.saveInspectorPreferences).toHaveBeenCalledTimes(1);
+    expect(mocks.client.startStream).not.toHaveBeenCalledWith(discovered[0].inspectors[0].server);
+  });
+
+  it("saves a fallback for legacy preferences without guessing the saved profile", async () => {
+    const legacy = { deviceId: "phone", processName: "com.example.demo", kind: "network" };
+    vi.mocked(mocks.client.loadInspectorPreferences).mockResolvedValue(
+      JSON.stringify({ last: legacy, apps: [legacy] })
+    );
+    discovered = [
+      { ...app(30, ["tweaks"]), processName: "com.example.other", androidUserId: 10 },
+      app(20, ["network"])
+    ];
+    await act(async () => root.render(<App />));
+    expect(container.querySelector('[data-inspector="tweaks"]')).not.toBeNull();
+    const saved = vi.mocked(mocks.client.saveInspectorPreferences).mock.lastCall![0];
+    expect(JSON.parse(saved!).last).toEqual({
+      deviceId: "phone",
+      processName: "com.example.other",
+      androidUserId: 10,
+      kind: "tweaks"
+    });
+  });
+
+  it("keeps trying discovery until a usable fallback appears", async () => {
+    discovered = [];
+    vi.mocked(mocks.client.listInspectorApps).mockRejectedValueOnce(new Error("Discovery unavailable"));
+    await act(async () => root.render(<App />));
+    await act(async () => vi.advanceTimersByTimeAsync(2_500));
+    expect(mocks.client.saveInspectorPreferences).not.toHaveBeenCalled();
+    discovered = [{ ...app(30, ["network"]), processName: "com.example.other" }];
+    await act(async () => vi.advanceTimersByTimeAsync(2_500));
+    expect(container.querySelector('[data-inspector="network"]')?.getAttribute("data-socket")).toBe("snapo_network_30");
+    expect(mocks.client.saveInspectorPreferences).toHaveBeenCalledTimes(1);
+  });
+
+  it("selects an available inspector when the saved inspector is missing at startup", async () => {
+    await act(async () => root.render(<App />));
+    expect(container.querySelector('[data-inspector="tweaks"]')).not.toBeNull();
+    const saved = vi.mocked(mocks.client.saveInspectorPreferences).mock.lastCall![0];
+    expect(JSON.parse(saved!).last.kind).toBe("tweaks");
+  });
+
+  it("shows status and an open action without a spinner until the remembered inspector appears", async () => {
+    await renderWaitingForInspector();
     expect(container.querySelector('[role="status"] svg')).toBeNull();
     expect(container.querySelector('[role="status"]')?.textContent).toBe("Waiting for inspector");
     expect(container.querySelector("[data-inspector]")).toBeNull();
@@ -191,7 +284,7 @@ describe("app inspector restoration UI", () => {
           finish = resolve;
         })
     );
-    await act(async () => root.render(<App />));
+    await renderWaitingForInspector();
     discovered = [];
     await act(async () => vi.advanceTimersByTimeAsync(2_500));
     const button = container.querySelector<HTMLButtonElement>(".inspector-open-app")!;
@@ -218,7 +311,7 @@ describe("app inspector restoration UI", () => {
 
   it("shows launch errors and allows a retry without stopping discovery", async () => {
     vi.mocked(mocks.client.openApp!).mockRejectedValueOnce(new Error("Device is offline."));
-    await act(async () => root.render(<App />));
+    await renderWaitingForInspector();
     const button = container.querySelector<HTMLButtonElement>(".inspector-open-app")!;
     await act(async () => button.click());
     expect(container.querySelector('[role="alert"]')?.textContent).toBe("Device is offline.");
@@ -235,7 +328,7 @@ describe("app inspector restoration UI", () => {
 
   it("does not offer app launch when the client does not support it", async () => {
     delete mocks.client.openApp;
-    await act(async () => root.render(<App />));
+    await renderWaitingForInspector();
     expect(container.querySelector('[role="status"]')).not.toBeNull();
     expect(container.querySelector(".inspector-open-app")).toBeNull();
     expect(container.querySelector('[role="status"] .body-loading-spinner svg')).not.toBeNull();
@@ -250,7 +343,7 @@ describe("app inspector restoration UI", () => {
     saved.reconcile([{ ...waitingApp, inspectors: app(20, ["network"]).inspectors }]);
     vi.mocked(mocks.client.loadInspectorPreferences).mockResolvedValue(saved.serialize());
     discovered = [waitingApp];
-    await act(async () => root.render(<App />));
+    await renderWaitingForInspector();
     expect(mocks.client.appInspectorStateChanged).toHaveBeenLastCalledWith(
       expect.objectContaining({ selectedApp: expect.objectContaining({ processName: "com.example.demo:worker" }) })
     );
@@ -266,7 +359,7 @@ describe("app inspector restoration UI", () => {
     saved.selectInspector(workApp, { kind: "network", server: { deviceId: "phone", socketName: "snapo_network_20" } });
     vi.mocked(mocks.client.loadInspectorPreferences).mockResolvedValue(saved.serialize());
     discovered = [workApp];
-    await act(async () => root.render(<App />));
+    await renderWaitingForInspector();
     discovered = [{ ...workApp, id: "phone:pid:30", androidUserId: 0 }];
     await act(async () => vi.advanceTimersByTimeAsync(2_500));
     await act(async () => container.querySelector<HTMLButtonElement>(".inspector-open-app")!.click());
@@ -278,7 +371,7 @@ describe("app inspector restoration UI", () => {
   });
 
   it("refreshes immediately after opening and every half second for five seconds", async () => {
-    await act(async () => root.render(<App />));
+    await renderWaitingForInspector();
     const scans = vi.mocked(mocks.client.listInspectorApps);
     const initialScans = scans.mock.calls.length;
     await act(async () => container.querySelector<HTMLButtonElement>(".inspector-open-app")!.click());
@@ -300,7 +393,7 @@ describe("app inspector restoration UI", () => {
   });
 
   it("does not overlap slow scans during the launch window", async () => {
-    await act(async () => root.render(<App />));
+    await renderWaitingForInspector();
     const scans = vi.mocked(mocks.client.listInspectorApps);
     let finish!: (apps: InspectableApp[]) => void;
     scans.mockImplementationOnce(
@@ -319,7 +412,7 @@ describe("app inspector restoration UI", () => {
   });
 
   it("keeps polling after a failed scan and stops fast polling after a launch error", async () => {
-    await act(async () => root.render(<App />));
+    await renderWaitingForInspector();
     const scans = vi.mocked(mocks.client.listInspectorApps);
     let fail!: (error: Error) => void;
     vi.mocked(mocks.client.openApp!).mockImplementationOnce(
@@ -348,7 +441,7 @@ describe("app inspector restoration UI", () => {
           finish = resolve;
         })
     );
-    await act(async () => root.render(<App />));
+    await renderWaitingForInspector();
     await act(async () => container.querySelector<HTMLButtonElement>(".inspector-open-app")!.click());
     await act(async () => vi.advanceTimersByTimeAsync(5_000));
     expect(container.querySelector(".inspector-open-app")).toBeNull();
@@ -365,7 +458,7 @@ describe("app inspector restoration UI", () => {
           finish = resolve;
         })
     );
-    await act(async () => root.render(<App />));
+    await renderWaitingForInspector();
     await act(async () => container.querySelector<HTMLButtonElement>(".inspector-open-app")!.click());
     await act(async () => root.render(null));
     const scans = vi.mocked(mocks.client.listInspectorApps);
@@ -388,7 +481,7 @@ describe("app inspector restoration UI", () => {
           fail = reject;
         })
     );
-    await act(async () => root.render(<App />));
+    await renderWaitingForInspector();
     await act(async () => container.querySelector<HTMLButtonElement>(".inspector-open-app")!.click());
     await act(async () => nativeSelectApp(other.id));
     const button = container.querySelector<HTMLButtonElement>(".inspector-open-app")!;
@@ -408,7 +501,7 @@ describe("app inspector restoration UI", () => {
     const other = { ...app(30, ["tweaks"]), name: "Other", packageName: "com.example.other", processName: null };
     discovered.push(other);
     vi.mocked(mocks.client.openApp!).mockRejectedValueOnce(new Error("Device is offline."));
-    await act(async () => root.render(<App />));
+    await renderWaitingForInspector();
     await act(async () => container.querySelector<HTMLButtonElement>(".inspector-open-app")!.click());
     expect(container.querySelector('[role="alert"]')?.textContent).toBe("Device is offline.");
 
@@ -421,7 +514,7 @@ describe("app inspector restoration UI", () => {
   });
 
   it("honors a native explicit choice while discovery is in flight", async () => {
-    await act(async () => root.render(<App />));
+    await renderWaitingForInspector();
     let finish!: (apps: InspectableApp[]) => void;
     vi.mocked(mocks.client.listInspectorApps).mockImplementationOnce(
       () =>
@@ -458,7 +551,7 @@ describe("app inspector restoration UI", () => {
 
   it("keeps a browser picker available during restoration", async () => {
     Object.assign(mocks.client, { usesNativeServerPicker: false });
-    await act(async () => root.render(<App />));
+    await renderWaitingForInspector();
     expect(container.querySelector('button[aria-label="Select an app"]')).not.toBeNull();
     const tweaks = container.querySelector('button[aria-label="Tweaks"]') as HTMLButtonElement;
     await act(async () => tweaks.click());

--- a/snapo-network-inspector-web/src/App.tweaks.test.tsx
+++ b/snapo-network-inspector-web/src/App.tweaks.test.tsx
@@ -2,7 +2,7 @@
 import { act } from "react";
 import { createRoot, type Root } from "react-dom/client";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import type { InspectableApp, TweakList } from "./network/bridge-types";
+import type { AppInspectorKind, InspectableApp, TweakList } from "./network/bridge-types";
 import type { NetworkClient } from "./network/client";
 import { InspectorRestoration } from "./features/app-inspector/restoration";
 import { App } from "./App";
@@ -14,7 +14,7 @@ vi.mock("./features/network-inspector/hooks/useNetworkInspectorModel", () => ({
 }));
 vi.mock("./features/network-inspector/NetworkInspectorApp", () => ({ NetworkInspectorApp: () => null }));
 
-function app(pid: number): InspectableApp {
+function app(pid: number, kind: AppInspectorKind = "tweaks"): InspectableApp {
   return {
     id: `phone:pid:${pid}`,
     name: "Demo",
@@ -23,9 +23,7 @@ function app(pid: number): InspectableApp {
     processName: "com.example.demo",
     deviceId: "phone",
     deviceDisplayTitle: "Phone",
-    inspectors: [
-      { kind: "tweaks", protocolVersion: 4, server: { deviceId: "phone", socketName: `snapo_tweaks_${pid}` } }
-    ]
+    inspectors: [{ kind, protocolVersion: 4, server: { deviceId: "phone", socketName: `snapo_${kind}_${pid}` } }]
   };
 }
 
@@ -75,6 +73,18 @@ describe("retained Tweaks view", () => {
     vi.useRealTimers();
   });
 
+  async function renderWaitingForTweaks() {
+    const starter = {
+      ...app(1, "network"),
+      processName: "com.example.starter",
+      packageName: "com.example.starter"
+    };
+    discovered = [app(10, "network")];
+    vi.mocked(mocks.client.listInspectorApps).mockResolvedValueOnce([starter, ...discovered]);
+    await act(async () => root.render(<App />));
+    await act(async () => selectApp(discovered[0].id));
+  }
+
   it("preserves the real Tweaks view through disconnect and PID replacement", async () => {
     await act(async () => root.render(<App />));
     const input = container.querySelector<HTMLInputElement>('input[type="text"]')!;
@@ -105,14 +115,6 @@ describe("retained Tweaks view", () => {
   });
 
   it("keeps the launch spinner through the transition into Tweaks and shows data as soon as it loads", async () => {
-    discovered = [
-      {
-        ...app(10),
-        inspectors: [
-          { kind: "network", protocolVersion: 4, server: { deviceId: "phone", socketName: "snapo_network_10" } }
-        ]
-      }
-    ];
     let finish!: (value: TweakList) => void;
     vi.mocked(mocks.client.listTweaks).mockImplementationOnce(
       () =>
@@ -120,7 +122,7 @@ describe("retained Tweaks view", () => {
           finish = resolve;
         })
     );
-    await act(async () => root.render(<App />));
+    await renderWaitingForTweaks();
     expect(container.querySelector(".inspector-loading-shell")).not.toBeNull();
     await act(async () => container.querySelector<HTMLButtonElement>(".inspector-open-app")!.click());
     expect(container.querySelector(".inspector-open-app")).toBeNull();
@@ -143,16 +145,8 @@ describe("retained Tweaks view", () => {
   });
 
   it("restores Open five seconds after the click even when the waiting view changes", async () => {
-    discovered = [
-      {
-        ...app(10),
-        inspectors: [
-          { kind: "network", protocolVersion: 4, server: { deviceId: "phone", socketName: "snapo_network_10" } }
-        ]
-      }
-    ];
     vi.mocked(mocks.client.listTweaks).mockImplementationOnce(() => new Promise(() => {}));
-    await act(async () => root.render(<App />));
+    await renderWaitingForTweaks();
     await act(async () => container.querySelector<HTMLButtonElement>(".inspector-open-app")!.click());
     discovered = [app(20)];
     await act(async () => vi.advanceTimersByTimeAsync(1_500));

--- a/snapo-network-inspector-web/src/features/app-inspector/restoration.test.ts
+++ b/snapo-network-inspector-web/src/features/app-inspector/restoration.test.ts
@@ -121,8 +121,10 @@ describe("inspector restoration", () => {
     expect(saved).not.toContain("snapo_");
     expect(saved).not.toContain("pid:");
     const owner = new InspectorRestoration(saved);
-    expect(owner.reconcile([app(30, ["network"])]).isRestoring).toBe(true);
-    expect(owner.reconcile([app(30)]).selection?.kind).toBe("tweaks");
+    expect(owner.reconcile([]).selection).toBeNull();
+    const other = app(20, ["network"], "com.example.other");
+    expect(owner.reconcile([other, app(30)]).selection).toMatchObject({ appId: "phone:pid:30", kind: "tweaks" });
+    expect(owner.serialize()).toBe(saved);
   });
 
   it("does not switch to another process, device, or app while restoring", () => {
@@ -274,11 +276,110 @@ describe("inspector restoration", () => {
     expect(owner.reconcile([app(30)]).selection).toBeNull();
   });
 
-  it("requires a new selection for saved preferences without an Android user", () => {
-    const legacy = { deviceId: "phone", processName: "com.example.demo", kind: "network" };
+  it.each([undefined, null])("falls back for legacy preferences with Android user %s", (androidUserId) => {
+    const legacy = { deviceId: "phone", processName: "com.example.demo", kind: "network", androidUserId };
     const owner = new InspectorRestoration(JSON.stringify({ last: legacy, apps: [legacy] }));
     const work = app(20, ["network"], "com.example.demo", "phone", 10);
-    expect(owner.reconcile([app(), work]).selection).toBeNull();
-    expect(owner.selectApp(work).selection?.appId).toBe(work.id);
+    const unknownProfile = { ...app(40), androidUserId: null };
+    const first = app(30, ["tweaks"], "com.example.other", "phone", 10);
+    expect(owner.reconcile([first, app(), work, unknownProfile]).selection).toMatchObject({
+      appId: first.id,
+      kind: "tweaks"
+    });
+    expect(JSON.parse(owner.serialize()).last).toEqual({
+      deviceId: "phone",
+      processName: "com.example.other",
+      androidUserId: 10,
+      kind: "tweaks"
+    });
+  });
+
+  it.each([
+    ["another app", app(20, ["network"], "com.example.other")],
+    ["another process", app(20, ["network"], "com.example.demo:worker")],
+    ["another device", app(20, ["network"], "com.example.demo", "tablet")],
+    ["another profile", app(20, ["network"], "com.example.demo", "phone", 10)]
+  ])("saves a startup fallback when only %s is available", (_, first) => {
+    const owner = new InspectorRestoration(selected("tweaks").serialize());
+    const later = app(40, ["tweaks"], "com.example.later");
+    expect(owner.reconcile([first, later]).selection).toMatchObject({ appId: first.id, kind: "network" });
+    expect(JSON.parse(owner.serialize()).last).toEqual({
+      deviceId: first.deviceId,
+      processName: first.processName,
+      androidUserId: first.androidUserId,
+      kind: "network"
+    });
+    expect(new InspectorRestoration(owner.serialize()).reconcile([later, first]).selection?.appId).toBe(first.id);
+    expect(owner.reconcile([app(), first, later]).selection?.appId).toBe(first.id);
+  });
+
+  it("uses an available inspector when the saved inspector is missing at startup", () => {
+    const owner = new InspectorRestoration(selected("tweaks").serialize());
+    expect(owner.reconcile([app(20, ["network"])]).selection?.kind).toBe("network");
+    expect(JSON.parse(owner.serialize()).last.kind).toBe("network");
+    expect(owner.reconcile([app(20)]).selection?.kind).toBe("network");
+  });
+
+  it("falls back to the first usable app instead of waiting for another app's saved inspector", () => {
+    const owner = new InspectorRestoration(selected("tweaks").serialize());
+    const first = app(20, ["network"], "com.example.other");
+    expect(owner.reconcile([first, app(30, ["network"])]).selection?.appId).toBe(first.id);
+  });
+
+  it("uses a fallback app's saved inspector only when it is available", () => {
+    const owner = selected("tweaks");
+    const other = app(20, ["network"], "com.example.other");
+    owner.reconcile([app(), other]);
+    owner.selectApp(other);
+    const saved = owner.serialize();
+    expect(new InspectorRestoration(saved).reconcile([app(30)]).selection?.kind).toBe("tweaks");
+    const restarted = new InspectorRestoration(saved);
+    expect(restarted.reconcile([app(30, ["network"])]).selection?.kind).toBe("network");
+    expect(JSON.parse(restarted.serialize()).last.kind).toBe("network");
+  });
+
+  it.each([null, selected("tweaks").serialize()])(
+    "waits for a usable startup app without losing saved preferences",
+    (saved) => {
+      const owner = new InspectorRestoration(saved);
+      const before = owner.serialize();
+      const unidentified = { ...app(), processName: null };
+      const empty = app(20, [], "com.example.empty");
+      expect(owner.reconcile([]).selection).toBeNull();
+      expect(owner.reconcile([unidentified, empty]).selection).toBeNull();
+      expect(owner.serialize()).toBe(before);
+      const ready = app(30, ["network"], "com.example.ready");
+      expect(owner.reconcile([unidentified, empty, ready]).selection?.appId).toBe(ready.id);
+      expect(JSON.parse(owner.serialize()).last.processName).toBe(ready.processName);
+    }
+  );
+
+  it.each(["restored", "fallback", "explicit"])("does not fall back after a %s selection disconnects", (source) => {
+    const owner = new InspectorRestoration(source === "restored" ? selected().serialize() : null);
+    const target = app(20);
+    const other = app(30, ["network"], "com.example.other");
+    owner.reconcile(source === "explicit" ? [other, target] : [target, other]);
+    if (source === "explicit") owner.selectApp(target);
+    const saved = owner.serialize();
+    const displayedNetwork = owner.snapshot().displayedNetwork;
+    expect(owner.reconcile([]).selection).toBeNull();
+    expect(owner.reconcile([other])).toMatchObject({
+      selection: null,
+      selectedApp: { id: target.id },
+      displayedNetwork
+    });
+    expect(owner.reconcile([app(20, ["tweaks"]), other]).selection).toBeNull();
+    expect(owner.serialize()).toBe(saved);
+    expect(owner.reconcile([other, app(40)]).selection).toMatchObject({ appId: "phone:pid:40", kind: "network" });
+  });
+
+  it("does not override an explicit startup choice while its identity is pending", () => {
+    const owner = new InspectorRestoration(selected().serialize());
+    const pending = { ...app(20), processName: null };
+    owner.reconcile([pending]);
+    owner.selectApp(pending);
+    const other = app(30, ["network"], "com.example.other");
+    expect(owner.reconcile([other, pending]).selection).toBeNull();
+    expect(owner.reconcile([other, app(20)]).selection?.appId).toBe(pending.id);
   });
 });

--- a/snapo-network-inspector-web/src/features/app-inspector/restoration.ts
+++ b/snapo-network-inspector-web/src/features/app-inspector/restoration.ts
@@ -69,6 +69,7 @@ export class InspectorRestoration {
   private retained: Partial<Record<AppInspectorKind, SelectedAppInspector>> = {};
   private apps: InspectableApp[] = [];
   private awaitingAppIdentity = false;
+  private startupSelectionPending = true;
 
   constructor(raw: string | null = null) {
     try {
@@ -122,16 +123,31 @@ export class InspectorRestoration {
     }
     const preference = this.saved.last;
     const exact = this.target && apps.find((app) => app.id === this.target?.id && sameApp(this.target, app));
-    const app = exact || (preference && apps.find((candidate) => matches(candidate, preference)));
+    const app =
+      exact ??
+      (preference?.androidUserId != null ? apps.find((candidate) => matches(candidate, preference)) : undefined);
+
+    // Only startup may replace a missing saved app or inspector.
+    if (this.startupSelectionPending) {
+      const startupApp = app?.inspectors.some((option) => option.kind === this.kind)
+        ? app
+        : apps.find((candidate) => identity(candidate) && candidate.inspectors.length > 0);
+      if (startupApp) {
+        const preferredKind =
+          startupApp === app
+            ? this.kind
+            : (this.saved.apps.find((candidate) => matches(startupApp, candidate))?.kind ?? this.kind);
+        const option =
+          startupApp.inspectors.find((candidate) => candidate.kind === preferredKind) ?? startupApp.inspectors[0];
+        return this.selectInspector(startupApp, option);
+      }
+    }
 
     if (app && this.kind) {
       this.updateTarget(app);
       this.remember(app, this.kind);
       const option = app.inspectors.find((candidate) => candidate.kind === this.kind);
       this.setCurrent(app, option);
-    } else if (this.kind == null) {
-      const first = apps.find((candidate) => identity(candidate) && candidate.inspectors.length > 0);
-      if (first) this.selectApp(first);
     } else {
       this.current = null;
     }
@@ -139,6 +155,7 @@ export class InspectorRestoration {
   }
 
   selectApp(app: InspectableApp): AppInspectorState {
+    this.startupSelectionPending = false;
     if (!identity(app)) {
       this.updateTarget(app);
       this.current = null;
@@ -159,6 +176,7 @@ export class InspectorRestoration {
   }
 
   private selectKind(app: InspectableApp, kind: AppInspectorKind): void {
+    this.startupSelectionPending = false;
     if (!sameApp(this.target, app)) this.retained = {};
     this.awaitingAppIdentity = false;
     this.updateTarget(app);


### PR DESCRIPTION
Snap-O can keep waiting for a saved app or inspector at launch, even when another inspector is available. This change resolves startup selection after discovery while preserving the selected app through later disconnects.

## Summary

- Restore the saved app and inspector using the device, process, and Android profile identity.
- Otherwise select and save the first usable app and inspector. Apply this fallback to legacy preferences and retry when discovery is initially empty.
- End startup fallback after an automatic or explicit selection, so incomplete scans cannot switch apps.

## Validation

- All 318 web tests across 24 files passed, including restoration, fallback, legacy preferences, delayed discovery, and disconnect coverage.
- TypeScript typechecking, ESLint, Stylelint, and formatting checks passed.
- The macOS app built successfully with code signing disabled.
- No physical-device reproduction was performed.
