### PR TITLE
Update Snap-O 5.1.0 appcast and documentation

### DIFF
--- a/appcast.xml
+++ b/appcast.xml
@@ -8,6 +8,15 @@
     <description>Software updates for Snap‑O</description>
 
     <item>
+        <title>Snap‑O 5.1.0</title>
+        <pubDate>Mon, 31 Aug 2026 15:05:55 +0000</pubDate>
+        <sparkle:minimumSystemVersion>15.0</sparkle:minimumSystemVersion>
+        <sparkle:version>20260831.00</sparkle:version>
+        <sparkle:shortVersionString>5.1.0</sparkle:shortVersionString>
+        <enclosure url="https://github.com/openai/snap-o/releases/download/5.1.0/Snap-O.dmg" length="2410056" type="application/octet-stream" sparkle:edSignature="ckeL/0fYpp+i1f8EWikyAPH1BahOvig8FX5YEYWf+JayvI/cQ8B6T16zq3ODij5KTQgMqtezaB2uE/KZWIt3CQ==" />
+    </item>
+
+    <item>
         <title>Snap‑O 5.0.0</title>
         <pubDate>Tue, 25 Aug 2026 14:56:52 +0000</pubDate>
         <sparkle:minimumSystemVersion>15.0</sparkle:minimumSystemVersion>

--- a/network-inspector.html
+++ b/network-inspector.html
@@ -940,10 +940,14 @@ val client = HttpClient(OkHttp) {
             </ol>
             <p class="notice">
               Each running app process has one picker row, with shortcuts for
-              its available inspectors. Snap-O remembers your inspector
-              selection and keeps captured requests visible while disconnected.
-              If the Android app restarts, select its new process to continue
-              with live traffic.
+              its available inspectors. At startup, Snap-O restores your last
+              app and inspector when available, or selects another available app.
+              During a session, it keeps captured requests visible through
+              disconnects and reconnects when the selected app returns.
+            </p>
+            <p class="prose">
+              If the selected Android app stops, click <strong>Open app</strong>
+              on the waiting screen when available, or launch it on your device.
             </p>
             <h3>Filter traffic</h3>
             <p class="prose">

--- a/tweaks.html
+++ b/tweaks.html
@@ -1276,6 +1276,14 @@ fun MotionSection(isExpanded: Boolean) {
                 </li>
               </ol>
 
+              <p class="prose">
+                At startup, Snap-O restores your last app and inspector when
+                available, or selects another available app. During a session,
+                disconnects do not switch apps. If the selected Android app
+                stops, click <strong>Open app</strong> on the waiting screen
+                when available, or launch it on your device.
+              </p>
+
               <p class="notice">
                 Navigate through your Android app to change which controls are
                 visible. Only tweaks belonging to the currently composed UI


### PR DESCRIPTION
Publish the Sparkle update for Snap-O 5.1.0 and document its app selection and launch behavior. The [5.1.0 release](https://github.com/openai/snap-o/releases/tag/5.1.0) and download are public.

## Summary

- Prepend the workflow-generated 5.1.0 appcast item, preserving all 26 previous entries.
- Update the Network and Tweaks guides for startup selection and the Open app action.
- Keep Android dependency examples at 4.1.0. Leave the home page and protocol reference unchanged.

## Validation

- The public DMG download matches its checksum and the verified release artifact.
- The Sparkle signature verifies against the public key in the previously released app.
- Appcast XML and changed HTML5 pages validate. Local links, assets, and anchors pass checks.
- Setup and code examples are unchanged; git diff --check passes.
