### PR TITLE
Preserve WebSocket upgrades when HTTP routes match

### DIFF
--- a/snapo-link-android/network-okhttp3/src/main/java/com/openai/snapo/network/okhttp3/RouteInterception.kt
+++ b/snapo-link-android/network-okhttp3/src/main/java/com/openai/snapo/network/okhttp3/RouteInterception.kt
@@ -27,6 +27,9 @@ internal fun interceptWithRoutes(
     request: Request,
     interception: NetworkInterception,
 ): Response {
+    if (request.header("Upgrade").equals("websocket", ignoreCase = true)) {
+        return chain.proceed(request)
+    }
     if (request.header("Accept")?.contains("text/event-stream", ignoreCase = true) == true) {
         return chain.proceed(request)
     }


### PR DESCRIPTION
An active HTTP route can match a WebSocket handshake and break the connection. Synthetic responses replace the required HTTP 101 upgrade, while upstream handlers try to read OkHttp's unreadable upgrade body. This preserves the documented inspection-only behavior for WebSockets.

## Summary
- Bypass Python route matching for `Upgrade: websocket`, ignoring header case.
- Return the original OkHttp response while keeping normal Snap-O inspection active.

## Validation
- Six real OkHttp/MockWebServer cases passed using a temporary regression harness: matching synthetic and upstream routes, mixed-case upgrade headers, no routes, a different method, and a different path. Both matching-route cases failed before the fix.
- All 71 existing Android network and OkHttp unit tests passed.
- `:network-okhttp3:detekt`, `:samples:demo-okhttp:assembleDebug`, and `git diff --check` passed.
