### PR TITLE
Teach Snap-O skills to use network interception

### DIFF
--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "snap-o",
   "version": "5.1.0",
-  "description": "Inspect Android network traffic and adjust live UI tweaks with Snap-O.",
+  "description": "Inspect Android network traffic, override API responses, and adjust live UI tweaks with Snap-O.",
   "author": {
     "name": "OpenAI",
     "url": "https://openai.com"
@@ -12,6 +12,8 @@
   "keywords": [
     "android",
     "network",
+    "interception",
+    "overrides",
     "tweaks",
     "ui",
     "adb",
@@ -20,8 +22,8 @@
   "skills": "./skills/",
   "interface": {
     "displayName": "Snap-O",
-    "shortDescription": "Inspect Android network traffic and live UI tweaks",
-    "longDescription": "Inspect live and captured Android network requests, or inspect and adjust live Android UI tweaks on macOS and Linux.",
+    "shortDescription": "Inspect Android traffic, override responses, and adjust UI tweaks",
+    "longDescription": "Inspect live and captured Android network requests, override HTTP responses with Python route handlers, or adjust live Android UI tweaks on macOS and Linux.",
     "developerName": "OpenAI",
     "category": "Productivity",
     "capabilities": [
@@ -33,6 +35,7 @@
       "Inspect the latest Android network requests with Snap-O.",
       "Show failed requests from the attached Android device.",
       "Show the request and response bodies for an API call.",
+      "Override an Android API response with a Python route handler.",
       "Show the active UI tweaks in the attached Android app.",
       "Adjust a live Android UI tweak and reset it to its default."
     ]

--- a/skills/snap-o-network-inspector/SKILL.md
+++ b/skills/snap-o-network-inspector/SKILL.md
@@ -1,11 +1,11 @@
 ---
 name: snap-o-network-inspector
-description: Fetch and inspect Android network captures for a selected device/socket using the Snap-O CLI. Use when you need raw CDP request/response data, headers, bodies, status, or websocket events.
+description: Inspect Android network captures and intercept HTTP calls with the Snap-O CLI for a selected device/socket. Use for request/response details, websocket events, API response overrides, mock responses, or delays with Python route handlers.
 ---
 
 # Snap-O Network Inspector
 
-Use this skill to pull raw network evidence from Snap-O.
+Use this skill to inspect network traffic or override API responses in an Android app.
 
 ## CLI Path
 
@@ -24,6 +24,7 @@ The script resolves `adb` from `PATH`, `ANDROID_SDK_ROOT`, or `ANDROID_HOME`. Us
 - `snapo network list`: lists available Snap-O Network Inspector servers.
 - `snapo network requests`: emits CDP network events for a server.
 - `snapo network show`: shows full details for a request id, including headers and bodies.
+- `snapo network intercept <file.py>`: runs [Python route handlers](references/interception.md) to edit or mock HTTP responses; requires Snap-O OkHttp interception support in the app.
 
 Useful global selectors:
 
@@ -33,7 +34,7 @@ Useful global selectors:
 - `--adb`: use a specific ADB executable or wrapper.
 - `--adb-host`, `--adb-port`: connect directly to an explicit remote ADB server; otherwise the configured ADB command selects its endpoint.
 
-## Core Flow
+## Inspection Flow
 
 1. List available servers.
 
@@ -41,7 +42,7 @@ Useful global selectors:
 "$SNAPO_BIN" network list --json
 ```
 
-For a remote ADB endpoint, append `--adb-host <host> --adb-port <port>` to `list`, `requests`, or `show`; the script uses the ADB server directly. Otherwise, its localhost forward is removed automatically when the command exits.
+For a remote ADB endpoint, append `--adb-host <host> --adb-port <port>` to `list`, `requests`, `show`, or `intercept`; the script uses the ADB server directly. Otherwise, its localhost forward is removed automatically when the command exits.
 
 Use `--no-app-info` to skip package and app metadata lookup.
 
@@ -73,6 +74,7 @@ This output can contain URL query values and request or response bodies.
 "$SNAPO_BIN" network list --help
 "$SNAPO_BIN" network requests --help
 "$SNAPO_BIN" network show --help
+"$SNAPO_BIN" network intercept --help
 ```
 
 ## Output Notes
@@ -80,4 +82,5 @@ This output can contain URL query values and request or response bodies.
 - `--json` emits NDJSON, so process it line by line.
 - `network requests` emits Chrome DevTools Protocol-style records with top-level `method` and `params` fields.
 - Use `--no-stream` for a one-shot buffered snapshot.
-- The Android transport admits clients with `HelloSnapO`, returns `SnapO.appInfo`, and gates delivery with `SnapO.startStream` and `SnapO.stopStream`.
+- `network intercept` writes runner logs to stderr and does not accept `--json`, `--filter`, or `--no-stream`.
+- The Android transport admits clients with `HelloSnapO` and returns `SnapO.appInfo`. `SnapO.startStream` and `SnapO.stopStream` gate inspection events; interception runs independently.

--- a/skills/snap-o-network-inspector/agents/openai.yaml
+++ b/skills/snap-o-network-inspector/agents/openai.yaml
@@ -1,4 +1,4 @@
 interface:
   display_name: "Snap-O Network Inspector"
-  short_description: "Inspect Android network requests with Snap-O"
-  default_prompt: "Use $snap-o-network-inspector to inspect network data from the attached Android device/emulator."
+  short_description: "Inspect Android traffic and override API responses"
+  default_prompt: "Use $snap-o-network-inspector to inspect Android network traffic or override API responses with Python route handlers."

--- a/skills/snap-o-network-inspector/references/interception.md
+++ b/skills/snap-o-network-inspector/references/interception.md
@@ -1,0 +1,73 @@
+# Network interception
+
+Use `network intercept` to change HTTP responses delivered to an Android app. The app must use a Snap-O OkHttp integration that supports interception. If it reports unsupported routes, rebuild the app with that integration; updating the CLI alone is insufficient.
+
+## Write and check routes
+
+Resolve `SNAPO_BIN` as described in the skill. Save handlers in a Python file in the user's workspace. Run that file through the bundled CLI, not `python prototype.py`: the CLI provides `from snapo import route` without an installed Python package.
+
+```python
+import asyncio
+
+from snapo import route
+
+
+@route("GET", "/api/profile")
+async def profile(call):
+    response = await call.upstream()
+    response.json["display_name"] = "Space Captain"
+    return response
+
+
+@route("GET", "/api/tasks")
+async def tasks(call):
+    await asyncio.sleep(0.5)
+    return call.json({"tasks": [{"id": "1", "title": "Example task"}]})
+```
+
+Adapt the method, path, and response shape to the app. The profile handler sends the original request through Android, then edits its response. The tasks handler returns synthetic JSON without contacting the server. Every handler must use `async def` and return a response; returning a plain dictionary or `None` fails the request.
+
+Validate the file before connecting:
+
+```bash
+"$SNAPO_BIN" network intercept /path/to/prototype.py --check
+```
+
+`--check` loads the file and prints its routes without ADB or a device. It executes module-level code but does not run handlers or prove the app supports interception.
+
+## Run and verify
+
+List servers with `network list --json`, then select the device serial and network socket:
+
+```bash
+"$SNAPO_BIN" network intercept /path/to/prototype.py -s <serial> -n <socket_name>
+```
+
+Keep the runner alive while triggering the matching request in the app. Wait for `Loaded N route(s)` before reproducing the behavior. Check runner logs for the method, path, and returned status, or handler errors. `network requests` and `network show` can inspect the delivered response from another connection. Inspection shows what the app received, without a before/after diff; also verify the requested app behavior.
+
+Stop this runner with Ctrl-C when the override session is finished, unless the user wants it left running. Stopping removes its routes and fails its paused calls. New calls then follow normal behavior unless another runner matches them.
+
+## Matching and response APIs
+
+- Routes match the exact HTTP method and encoded URL path on any host. A leading slash is optional. Query parameters are ignored. Wildcards, regular expressions, and `network requests --filter` syntax are not supported for routes.
+- For host or query conditions, inspect `call.request.url` inside the handler. Return `await call.upstream()` when the condition does not apply. Requests without a matching route follow their normal path.
+- Register between 1 and 128 unique method/path pairs per file. Avoid overlapping routes across runners: only one matching handler runs, and selection order is unspecified.
+- `call.request` exposes `method`, `url`, `path`, `headers`, `body` (bytes), and `json`. Editing it does not rewrite the original request.
+- `await call.upstream()` uses the Android app's authentication and transport. Repeated calls reuse the same response; they do not resend the request. For a mocked operation that must avoid server changes, return a synthetic response without calling upstream.
+- Edit `response.json`, `response.status`, or `response.headers`, then return the response. Nested JSON edits are detected. Reading JSON alone preserves the original body. `response.body` accepts bytes; when replacing raw bytes, keep content type and encoding consistent with them.
+- `call.json(value, status=201, headers={"X-Example": "mock"})` creates a synthetic response. Status defaults to 200; supported response statuses are 200–599. Responses to HEAD and statuses 204, 205, and 304 have no delivered body.
+- Headers are case-insensitive. Use `headers.add(name, value)` and `headers.get_all(name)` for repeated values. The runner adjusts content length and removes transfer framing. JSON edits also set JSON content type and remove content encoding.
+
+## Reloads, state, and failures
+
+The runner watches the entry file by default. Successful reloads reset module state for new calls. Calls already in progress finish with their original handlers and state. Invalid file edits keep the previous handlers active; check the reload logs. Only the entry file is watched, so restart after changing imported helpers. `--no-watch` disables automatic reloads.
+
+Module variables can share state across handlers. Handlers run concurrently; use `await asyncio.sleep(...)` for delays or `asyncio.Event` for coordination. Blocking calls such as `time.sleep(...)` block all handlers.
+
+`--timeout 30` sets the deadline in seconds, including upstream waiting time. The default is 30; accepted values are 0.1–120. Handler errors and deadlines fail the affected request without sending it upstream as a fallback. The app's own retry policy still applies. Each runner owns its routes: stopping or reloading one leaves other runners active.
+
+## Supported traffic
+
+Interception supports bounded, non-streaming OkHttp HTTP traffic with bodies up to 1 MiB. Request bodies must be repeatable and declare their size. Requests accepting SSE and WebSocket upgrades bypass interception. Unexpected SSE responses fail without buffering the stream. HttpURLConnection traffic remains inspection-only.
+
+Use the normal network path for larger uploads and streaming traffic. Interception uses the app's existing transport and does not require a proxy certificate.


### PR DESCRIPTION
Snap-O supports Python route interception, but its skill and plugin metadata only describe inspection. Agents need guidance to discover the feature and use response overrides correctly.

## Summary

- Add interception to the existing network inspector skill and plugin descriptions, keywords, and prompts.
- Document upstream response edits, synthetic responses, delays, route matching, reloads, failures, and supported traffic.
- Link the guide directly from the command entry and clarify interception options and event delivery.

## Validation

- Skill validator, plugin JSON, and skill UI metadata checks passed.
- Documented handlers loaded with `--check` and produced the expected responses using synthetic calls.
- All 118 CLI tests passed; Python compilation and `git diff --check` passed.
- macOS app built successfully with code signing disabled.
- No live device interception test was performed for this documentation update.
