### PR TITLE
Add a shared Tasks sample for Android network interception

### DIFF
--- a/README.md
+++ b/README.md
@@ -191,6 +191,8 @@ The API follows the fetch-and-replace pattern used by [Playwright routes](https:
 
 See [examples/routes.py](examples/routes.py) for response edits, shared state, and delays, and the [interception protocol](contracts/network/interception.md) for transport details.
 
+The [network samples](snapo-link-android/samples/README.md) share a Tasks section whose API is deliberately unimplemented. Use the Python task handlers with the OkHttp or Ktor demo to test loading, creation, reloads, and errors.
+
 ## Why a web UI for the App Inspector?
 
 The Network and Tweaks inspectors share a React UI hosted in the macOS app's system WebKit runtime. Native Swift code handles ADB and transport through the host computer's existing ADB server, so the distribution does not include Chromium, Node.js, or another ADB executable. The same UI can also run in a browser through its HTTP transport.

--- a/snapo-link-android/gradle/libs.versions.toml
+++ b/snapo-link-android/gradle/libs.versions.toml
@@ -39,6 +39,8 @@ okhttp3-mockwebserver3 = { group = "com.squareup.okhttp3", name = "mockwebserver
 ktor-client-core = { group = "io.ktor", name = "ktor-client-core", version.ref = "ktor" }
 ktor-client-okhttp = { group = "io.ktor", name = "ktor-client-okhttp", version.ref = "ktor" }
 ktor-client-websockets = { group = "io.ktor", name = "ktor-client-websockets", version.ref = "ktor" }
+ktor-client-content-negotiation = { group = "io.ktor", name = "ktor-client-content-negotiation", version.ref = "ktor" }
+ktor-serialization-kotlinx-json = { group = "io.ktor", name = "ktor-serialization-kotlinx-json", version.ref = "ktor" }
 junit4 = { group = "junit", name = "junit", version.ref = "junit4" }
 
 [plugins]

--- a/snapo-link-android/samples/README.md
+++ b/snapo-link-android/samples/README.md
@@ -1,0 +1,52 @@
+# Network samples
+
+The OkHttp, Ktor, and HttpURLConnection demos have network test buttons and a shared Tasks section below them. All requests use an in-app server on localhost. The server deliberately leaves `GET /api/tasks` and `POST /api/tasks` unimplemented, so the Tasks section initially reports that the API is unavailable.
+
+Use Snap-O interception with the OkHttp or Ktor demo to supply task responses. This exercises loading, task creation, errors, and Python state without a backend service. The HttpURLConnection integration currently supports inspection only.
+
+## Run a sample
+
+Build the debug app with Android Studio, or run these commands from the repository root. Select a connected device with `adb devices`.
+
+```bash
+./snapo-link-android/gradlew -p snapo-link-android :samples:demo-okhttp:assembleDebug
+adb -s <serial> install -r snapo-link-android/samples/<demo>/build/outputs/apk/debug/<demo>-debug.apk
+adb -s <serial> shell am start -n <package>/.MainActivity
+```
+
+Replace `demo-okhttp` in the build command and select the matching demo and package below:
+
+| Demo | Package | API client |
+| --- | --- | --- |
+| `demo-okhttp` | `com.openai.snapo.demo` | OkHttp |
+| `demo-ktor-okhttp` | `com.openai.snapo.demo.ktor` | Ktor with the OkHttp engine |
+| `demo-httpurlconnection` | `com.openai.snapo.demo.httpurlconnection` | HttpURLConnection |
+
+Scroll below the network buttons to **Tasks**. The first request returns HTTP 404. Refreshing or adding a task also fails until interception supplies those responses. Release builds use the no-op integration and do not support interception.
+
+## Supply task responses
+
+From the repository root, list the sample's network socket and start the existing route example:
+
+```bash
+scripts/snapo network list -s <serial> --json
+scripts/snapo network intercept examples/routes.py --check
+scripts/snapo network intercept examples/routes.py -s <serial> -n <socket_name>
+```
+
+Select the socket for the OkHttp or Ktor sample's package. Keep the runner open, then tap **Refresh**. The task list starts empty. Enter a title and tap **Add**. The Python POST handler returns a task with status `pending`, and the app reloads the list. Both task handlers return synthetic responses without contacting the in-app server. Each running app needs its own runner and keeps its own Python task list.
+
+Try these flows:
+
+- **Loading:** the list handler waits half a second. Increase its `asyncio.sleep(...)` delay to keep the progress indicator visible longer.
+- **State:** add several tasks and refresh. The Python module keeps them until the runner restarts or successfully reloads.
+- **Reload:** save a change to `examples/routes.py`, then refresh. The runner reloads the file and resets its task list. Invalid Python edits keep the previous handlers active.
+- **HTTP errors:** return `call.json({"error": "unavailable"}, status=503)` from the list handler. Refresh to see the error, then restore the handler and retry.
+- **Timeouts:** restart the runner with `--timeout 1` and make the list handler wait longer than one second. The request fails and the controls become available again.
+- **Stop:** stop the runner with Ctrl-C, then refresh. The app reports that the API is unavailable again.
+
+The existing network buttons remain available while the task routes are active. Inspect task requests with Snap-O's network inspector or `network requests` and `network show`. The full route API is documented in the repository's [Python API overrides guide](../../README.md#python-api-overrides).
+
+## Shared Tasks code
+
+`demo-shared` contains the Tasks UI, state, serializable models, `TasksApi` interface, and common errors. Each demo supplies its own `list()` and `create(title)` implementation. The UI handles loading and displays errors without depending on a specific HTTP client.

--- a/snapo-link-android/samples/demo-httpurlconnection/build.gradle.kts
+++ b/snapo-link-android/samples/demo-httpurlconnection/build.gradle.kts
@@ -31,6 +31,7 @@ dependencies {
     implementation(libs.androidx.compose.ui.tooling.preview)
     implementation(libs.androidx.compose.material3)
     implementation(project(":samples:demo-shared"))
+    implementation(libs.serialization.json)
 
     debugImplementation(project(":network-httpurlconnection"))
     releaseImplementation(project(":network-httpurlconnection-noop"))

--- a/snapo-link-android/samples/demo-httpurlconnection/src/main/java/com/openai/snapo/demo/httpurlconnection/HttpUrlConnectionTasksApi.kt
+++ b/snapo-link-android/samples/demo-httpurlconnection/src/main/java/com/openai/snapo/demo/httpurlconnection/HttpUrlConnectionTasksApi.kt
@@ -1,0 +1,68 @@
+package com.openai.snapo.demo.httpurlconnection
+
+import com.openai.snapo.demo.shared.tasks.CreateTask
+import com.openai.snapo.demo.shared.tasks.DemoTask
+import com.openai.snapo.demo.shared.tasks.TaskList
+import com.openai.snapo.demo.shared.tasks.TasksApi
+import com.openai.snapo.demo.shared.tasks.TasksApiException
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+import kotlinx.serialization.SerializationException
+import kotlinx.serialization.encodeToString
+import kotlinx.serialization.json.Json
+import java.io.IOException
+import java.net.HttpURLConnection
+import java.net.URL
+
+internal class HttpUrlConnectionTasksApi(
+    private val openConnection: (URL) -> HttpURLConnection,
+    private val tasksUrl: suspend () -> String,
+) : TasksApi {
+    private val json = Json { ignoreUnknownKeys = true }
+
+    override suspend fun list(): List<DemoTask> = request<TaskList>("GET").tasks
+
+    override suspend fun create(title: String): DemoTask = request(
+        "POST",
+        json.encodeToString(CreateTask(title)).toByteArray(Charsets.UTF_8),
+    )
+
+    @Suppress("ThrowsCount")
+    private suspend inline fun <reified T> request(method: String, body: ByteArray? = null): T {
+        return try {
+            val url = URL(tasksUrl())
+            withContext(Dispatchers.IO) {
+                val connection = openConnection(url)
+                try {
+                    connection.requestMethod = method
+                    connection.connectTimeout = RequestTimeoutMillis
+                    connection.readTimeout = RequestTimeoutMillis
+                    if (body != null) {
+                        connection.doOutput = true
+                        connection.setRequestProperty("Content-Type", "application/json; charset=utf-8")
+                        connection.setFixedLengthStreamingMode(body.size)
+                        connection.outputStream.use { it.write(body) }
+                    }
+                    val status = connection.responseCode
+                    if (status !in 200..299) {
+                        throw TasksApiException.http(
+                            status,
+                            "This demo supports inspection only. Use the OkHttp or Ktor demo to test interception.",
+                        )
+                    }
+                    connection.inputStream.bufferedReader(Charsets.UTF_8).use {
+                        json.decodeFromString<T>(it.readText())
+                    }
+                } finally {
+                    connection.disconnect()
+                }
+            }
+        } catch (error: SerializationException) {
+            throw TasksApiException.invalidResponse(error)
+        } catch (error: IOException) {
+            throw TasksApiException.transport(error)
+        }
+    }
+}
+
+private const val RequestTimeoutMillis = 30_000

--- a/snapo-link-android/samples/demo-httpurlconnection/src/main/java/com/openai/snapo/demo/httpurlconnection/MainActivity.kt
+++ b/snapo-link-android/samples/demo-httpurlconnection/src/main/java/com/openai/snapo/demo/httpurlconnection/MainActivity.kt
@@ -9,6 +9,8 @@ import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.Button
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
@@ -20,6 +22,9 @@ import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.lifecycleScope
 import com.openai.snapo.demo.shared.DemoMockServer
+import com.openai.snapo.demo.shared.tasks.PreviewTasksApi
+import com.openai.snapo.demo.shared.tasks.TasksApi
+import com.openai.snapo.demo.shared.tasks.TasksSection
 import com.openai.snapo.network.httpurlconnection.SnapOHttpUrlInterceptor
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
@@ -30,6 +35,9 @@ class MainActivity : ComponentActivity() {
 
     private val interceptor = SnapOHttpUrlInterceptor()
     private val mockServer = DemoMockServer()
+    private val tasksApi = HttpUrlConnectionTasksApi(interceptor::open) {
+        withContext(Dispatchers.IO) { mockServer.httpUrl("/api/tasks") }
+    }
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
@@ -42,6 +50,7 @@ class MainActivity : ComponentActivity() {
             DemoScreen(
                 interceptor = interceptor,
                 mockServer = mockServer,
+                tasksApi = tasksApi,
             )
         }
     }
@@ -55,7 +64,7 @@ class MainActivity : ComponentActivity() {
 }
 
 @Composable
-private fun DemoScreen(interceptor: SnapOHttpUrlInterceptor, mockServer: DemoMockServer) {
+private fun DemoScreen(interceptor: SnapOHttpUrlInterceptor, mockServer: DemoMockServer, tasksApi: TasksApi) {
     MaterialTheme {
         val scope = rememberCoroutineScope()
         Scaffold(modifier = Modifier.fillMaxSize()) { innerPadding ->
@@ -66,6 +75,7 @@ private fun DemoScreen(interceptor: SnapOHttpUrlInterceptor, mockServer: DemoMoc
                 onPostRequestClick = {
                     scope.launch { performPostRequest(interceptor, mockServer) }
                 },
+                tasksApi = tasksApi,
                 modifier = Modifier.padding(innerPadding),
             )
         }
@@ -147,11 +157,12 @@ private suspend fun resolveMockHttpUrl(mockServer: DemoMockServer, path: String)
 private fun DemoContent(
     onNetworkRequestClick: () -> Unit,
     onPostRequestClick: () -> Unit,
+    tasksApi: TasksApi,
     modifier: Modifier = Modifier,
 ) {
     Column(
         verticalArrangement = Arrangement.spacedBy(16.dp),
-        modifier = modifier.padding(16.dp),
+        modifier = modifier.verticalScroll(rememberScrollState()).padding(16.dp),
     ) {
         Button(onClick = onNetworkRequestClick) {
             Text("Network Request")
@@ -159,6 +170,7 @@ private fun DemoContent(
         Button(onClick = onPostRequestClick) {
             Text("POST Request")
         }
+        TasksSection(tasksApi)
     }
 }
 
@@ -167,6 +179,7 @@ private fun DemoContent(
 private fun DemoPreview() {
     MaterialTheme {
         DemoContent(
+            tasksApi = PreviewTasksApi,
             onNetworkRequestClick = {},
             onPostRequestClick = {},
         )

--- a/snapo-link-android/samples/demo-ktor-okhttp/build.gradle.kts
+++ b/snapo-link-android/samples/demo-ktor-okhttp/build.gradle.kts
@@ -39,6 +39,9 @@ dependencies {
     implementation(libs.ktor.client.core)
     implementation(libs.ktor.client.okhttp)
     implementation(libs.ktor.client.websockets)
+    implementation(libs.ktor.client.content.negotiation)
+    implementation(libs.ktor.serialization.kotlinx.json)
+    implementation(libs.serialization.json)
     implementation(project(":samples:demo-shared"))
 
     debugImplementation(project(":network-okhttp3"))

--- a/snapo-link-android/samples/demo-ktor-okhttp/src/main/java/com/openai/snapo/demo/ktor/KtorTasksApi.kt
+++ b/snapo-link-android/samples/demo-ktor-okhttp/src/main/java/com/openai/snapo/demo/ktor/KtorTasksApi.kt
@@ -1,0 +1,51 @@
+package com.openai.snapo.demo.ktor
+
+import com.openai.snapo.demo.shared.tasks.CreateTask
+import com.openai.snapo.demo.shared.tasks.DemoTask
+import com.openai.snapo.demo.shared.tasks.TaskList
+import com.openai.snapo.demo.shared.tasks.TasksApi
+import com.openai.snapo.demo.shared.tasks.TasksApiException
+import io.ktor.client.HttpClient
+import io.ktor.client.call.NoTransformationFoundException
+import io.ktor.client.call.body
+import io.ktor.client.plugins.expectSuccess
+import io.ktor.client.request.get
+import io.ktor.client.request.post
+import io.ktor.client.request.setBody
+import io.ktor.client.statement.HttpResponse
+import io.ktor.http.ContentType
+import io.ktor.http.contentType
+import io.ktor.serialization.ContentConvertException
+import java.io.IOException
+
+internal class KtorTasksApi(
+    private val client: HttpClient,
+    private val tasksUrl: suspend () -> String,
+) : TasksApi {
+    override suspend fun list(): List<DemoTask> = request<TaskList> {
+        client.get(tasksUrl()) { expectSuccess = false }
+    }.tasks
+
+    override suspend fun create(title: String): DemoTask = request {
+        client.post(tasksUrl()) {
+            expectSuccess = false
+            contentType(ContentType.Application.Json)
+            setBody(CreateTask(title))
+        }
+    }
+
+    @Suppress("ThrowsCount")
+    private suspend inline fun <reified T> request(send: () -> HttpResponse): T {
+        return try {
+            val response = send()
+            if (response.status.value !in 200..299) throw TasksApiException.http(response.status.value)
+            response.body<T>()
+        } catch (error: ContentConvertException) {
+            throw TasksApiException.invalidResponse(error)
+        } catch (error: NoTransformationFoundException) {
+            throw TasksApiException.invalidResponse(error)
+        } catch (error: IOException) {
+            throw TasksApiException.transport(error)
+        }
+    }
+}

--- a/snapo-link-android/samples/demo-ktor-okhttp/src/main/java/com/openai/snapo/demo/ktor/MainActivity.kt
+++ b/snapo-link-android/samples/demo-ktor-okhttp/src/main/java/com/openai/snapo/demo/ktor/MainActivity.kt
@@ -9,6 +9,8 @@ import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.Button
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
@@ -20,11 +22,15 @@ import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.lifecycleScope
 import com.openai.snapo.demo.shared.DemoMockServer
+import com.openai.snapo.demo.shared.tasks.PreviewTasksApi
+import com.openai.snapo.demo.shared.tasks.TasksApi
+import com.openai.snapo.demo.shared.tasks.TasksSection
 import com.openai.snapo.demo.shared.toWebSocketUrl
 import com.openai.snapo.network.okhttp3.SnapOOkHttpInterceptor
 import com.openai.snapo.network.okhttp3.withSnapOInterceptor
 import io.ktor.client.HttpClient
 import io.ktor.client.engine.okhttp.OkHttp
+import io.ktor.client.plugins.contentnegotiation.ContentNegotiation
 import io.ktor.client.plugins.websocket.WebSockets
 import io.ktor.client.plugins.websocket.webSocket
 import io.ktor.client.request.forms.formData
@@ -35,6 +41,7 @@ import io.ktor.client.request.post
 import io.ktor.client.request.setBody
 import io.ktor.http.ContentType
 import io.ktor.http.contentType
+import io.ktor.serialization.kotlinx.json.json
 import io.ktor.websocket.CloseReason
 import io.ktor.websocket.Frame
 import io.ktor.websocket.close
@@ -42,6 +49,7 @@ import io.ktor.websocket.send
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
+import kotlinx.serialization.json.Json
 import okhttp3.OkHttpClient
 
 class MainActivity : ComponentActivity() {
@@ -59,6 +67,15 @@ class MainActivity : ComponentActivity() {
                 webSocketFactory = okHttpClient.withSnapOInterceptor()
             }
             install(WebSockets)
+            install(ContentNegotiation) {
+                json(Json { ignoreUnknownKeys = true })
+            }
+        }
+    }
+
+    private val tasksApi by lazy {
+        KtorTasksApi(httpClient) {
+            withContext(Dispatchers.IO) { mockServer.httpUrl("/api/tasks") }
         }
     }
 
@@ -73,6 +90,7 @@ class MainActivity : ComponentActivity() {
             DemoScreen(
                 httpClient = httpClient,
                 mockServer = mockServer,
+                tasksApi = tasksApi,
             )
         }
     }
@@ -86,7 +104,7 @@ class MainActivity : ComponentActivity() {
 }
 
 @Composable
-private fun DemoScreen(httpClient: HttpClient, mockServer: DemoMockServer) {
+private fun DemoScreen(httpClient: HttpClient, mockServer: DemoMockServer, tasksApi: TasksApi) {
     MaterialTheme {
         val scope = rememberCoroutineScope()
         Scaffold(modifier = Modifier.fillMaxSize()) { innerPadding ->
@@ -103,6 +121,7 @@ private fun DemoScreen(httpClient: HttpClient, mockServer: DemoMockServer) {
                 onWebSocketDemoClick = {
                     scope.launch { performWebSocketDemo(httpClient, mockServer) }
                 },
+                tasksApi = tasksApi,
                 modifier = Modifier.padding(innerPadding),
             )
         }
@@ -178,11 +197,12 @@ private fun DemoContent(
     onPostRequestClick: () -> Unit,
     onFormRequestClick: () -> Unit,
     onWebSocketDemoClick: () -> Unit,
+    tasksApi: TasksApi,
     modifier: Modifier = Modifier,
 ) {
     Column(
         verticalArrangement = Arrangement.spacedBy(16.dp),
-        modifier = modifier.padding(16.dp),
+        modifier = modifier.verticalScroll(rememberScrollState()).padding(16.dp),
     ) {
         Button(onClick = onNetworkRequestClick) {
             Text("Network Request")
@@ -196,6 +216,7 @@ private fun DemoContent(
         Button(onClick = onWebSocketDemoClick) {
             Text("WebSocket Echo")
         }
+        TasksSection(tasksApi)
     }
 }
 
@@ -204,6 +225,7 @@ private fun DemoContent(
 private fun DemoPreview() {
     MaterialTheme {
         DemoContent(
+            tasksApi = PreviewTasksApi,
             onNetworkRequestClick = {},
             onPostRequestClick = {},
             onFormRequestClick = {},

--- a/snapo-link-android/samples/demo-okhttp/build.gradle.kts
+++ b/snapo-link-android/samples/demo-okhttp/build.gradle.kts
@@ -35,6 +35,7 @@ dependencies {
     implementation(platform(libs.okhttp3.bom))
     implementation(libs.okhttp3.okhttp)
     implementation(libs.okhttp3.coroutines)
+    implementation(libs.serialization.json)
     implementation(project(":samples:demo-shared"))
 
     debugImplementation(project(":network-okhttp3"))

--- a/snapo-link-android/samples/demo-okhttp/src/main/java/com/openai/snapo/demo/MainActivity.kt
+++ b/snapo-link-android/samples/demo-okhttp/src/main/java/com/openai/snapo/demo/MainActivity.kt
@@ -22,6 +22,9 @@ import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.lifecycleScope
 import com.openai.snapo.demo.shared.DemoMockServer
+import com.openai.snapo.demo.shared.tasks.PreviewTasksApi
+import com.openai.snapo.demo.shared.tasks.TasksApi
+import com.openai.snapo.demo.shared.tasks.TasksSection
 import com.openai.snapo.demo.shared.toWebSocketUrl
 import com.openai.snapo.network.okhttp3.SnapOOkHttpInterceptor
 import com.openai.snapo.network.okhttp3.withSnapOInterceptor
@@ -55,6 +58,9 @@ class MainActivity : ComponentActivity() {
 
     private var activeWebSocket: WebSocket? = null
     private val mockServer = DemoMockServer()
+    private val tasksApi = OkHttpTasksApi(client) {
+        withContext(Dispatchers.IO) { mockServer.httpUrl("/api/tasks") }
+    }
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
@@ -78,7 +84,8 @@ class MainActivity : ComponentActivity() {
                         onSseResponseClick = { runSseResponseRequest(scope) },
                         onSlowResponseClick = { runSlowResponseRequest(scope) },
                         onWebSocketDemoClick = { startWebSocketDemo(scope) },
-                        modifier = Modifier.padding(innerPadding)
+                        tasksApi = tasksApi,
+                        modifier = Modifier.padding(innerPadding),
                     )
                 }
             }
@@ -290,6 +297,7 @@ fun Greeting(
     onSseResponseClick: () -> Unit,
     onSlowResponseClick: () -> Unit,
     onWebSocketDemoClick: () -> Unit,
+    tasksApi: TasksApi,
     modifier: Modifier = Modifier,
 ) {
     Column(
@@ -328,6 +336,7 @@ fun Greeting(
         Button(onClick = onWebSocketDemoClick) {
             Text("WebSocket Echo")
         }
+        TasksSection(tasksApi)
     }
 }
 
@@ -336,6 +345,7 @@ fun Greeting(
 private fun GreetingPreview() {
     MaterialTheme {
         Greeting(
+            tasksApi = PreviewTasksApi,
             onNetworkRequestClick = {},
             onPostRequestClick = {},
             onUnknownLengthGzipPostRequestClick = {},

--- a/snapo-link-android/samples/demo-okhttp/src/main/java/com/openai/snapo/demo/OkHttpTasksApi.kt
+++ b/snapo-link-android/samples/demo-okhttp/src/main/java/com/openai/snapo/demo/OkHttpTasksApi.kt
@@ -1,0 +1,51 @@
+package com.openai.snapo.demo
+
+import com.openai.snapo.demo.shared.tasks.CreateTask
+import com.openai.snapo.demo.shared.tasks.DemoTask
+import com.openai.snapo.demo.shared.tasks.TaskList
+import com.openai.snapo.demo.shared.tasks.TasksApi
+import com.openai.snapo.demo.shared.tasks.TasksApiException
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+import kotlinx.serialization.SerializationException
+import kotlinx.serialization.encodeToString
+import kotlinx.serialization.json.Json
+import okhttp3.MediaType.Companion.toMediaType
+import okhttp3.OkHttpClient
+import okhttp3.Request
+import okhttp3.RequestBody.Companion.toRequestBody
+import okhttp3.coroutines.executeAsync
+import java.io.IOException
+
+internal class OkHttpTasksApi(
+    private val client: OkHttpClient,
+    private val tasksUrl: suspend () -> String,
+) : TasksApi {
+    private val json = Json { ignoreUnknownKeys = true }
+
+    override suspend fun list(): List<DemoTask> = request<TaskList> {
+        Request.Builder().url(tasksUrl()).build()
+    }.tasks
+
+    override suspend fun create(title: String): DemoTask = request {
+        val body = json.encodeToString(CreateTask(title))
+            .toRequestBody("application/json; charset=utf-8".toMediaType())
+        Request.Builder().url(tasksUrl()).post(body).build()
+    }
+
+    @Suppress("ThrowsCount")
+    private suspend inline fun <reified T> request(build: () -> Request): T {
+        return try {
+            client.newCall(build()).executeAsync().use { response ->
+                withContext(Dispatchers.IO) {
+                    if (!response.isSuccessful) throw TasksApiException.http(response.code)
+                    json.decodeFromString<T>(response.body.string())
+                }
+            }
+        } catch (error: SerializationException) {
+            throw TasksApiException.invalidResponse(error)
+        } catch (error: IOException) {
+            throw TasksApiException.transport(error)
+        }
+    }
+}

--- a/snapo-link-android/samples/demo-shared/build.gradle.kts
+++ b/snapo-link-android/samples/demo-shared/build.gradle.kts
@@ -1,13 +1,23 @@
 plugins {
     id("snapo.android.library")
     id("snapo.detekt")
+    alias(libs.plugins.kotlin.compose)
+    alias(libs.plugins.kotlinx.serialization)
 }
 
 android {
     namespace = "com.openai.snapo.demo.shared"
+
+    buildFeatures {
+        compose = true
+    }
 }
 
 dependencies {
+    implementation(platform(libs.androidx.compose.bom))
+    implementation(libs.androidx.compose.material3)
+    implementation(libs.kotlinx.coroutines.core)
+    implementation(libs.serialization.json)
     implementation(platform(libs.okhttp3.bom))
     implementation(libs.okhttp3.okhttp)
     implementation(libs.okhttp3.mockwebserver3)

--- a/snapo-link-android/samples/demo-shared/src/main/java/com/openai/snapo/demo/shared/DemoMockServer.kt
+++ b/snapo-link-android/samples/demo-shared/src/main/java/com/openai/snapo/demo/shared/DemoMockServer.kt
@@ -16,6 +16,7 @@ import java.util.concurrent.TimeUnit
 class DemoMockServer {
     private var server: MockWebServer? = null
 
+    @Synchronized
     fun ensureStarted() {
         if (server != null) return
         server = createServer().also { started ->
@@ -24,12 +25,14 @@ class DemoMockServer {
         }
     }
 
+    @Synchronized
     fun httpUrl(path: String): String {
         ensureStarted()
         val port = checkNotNull(server).port
         return "http://$MockHost:$port$path"
     }
 
+    @Synchronized
     fun close() {
         server?.close()
         server = null

--- a/snapo-link-android/samples/demo-shared/src/main/java/com/openai/snapo/demo/shared/tasks/PreviewTasksApi.kt
+++ b/snapo-link-android/samples/demo-shared/src/main/java/com/openai/snapo/demo/shared/tasks/PreviewTasksApi.kt
@@ -1,0 +1,10 @@
+package com.openai.snapo.demo.shared.tasks
+
+object PreviewTasksApi : TasksApi {
+    override suspend fun list(): List<DemoTask> = listOf(
+        DemoTask("1", "Buy groceries", "pending"),
+        DemoTask("2", "Read a chapter", "completed"),
+    )
+
+    override suspend fun create(title: String): DemoTask = DemoTask("preview", title, "pending")
+}

--- a/snapo-link-android/samples/demo-shared/src/main/java/com/openai/snapo/demo/shared/tasks/TasksApi.kt
+++ b/snapo-link-android/samples/demo-shared/src/main/java/com/openai/snapo/demo/shared/tasks/TasksApi.kt
@@ -1,0 +1,41 @@
+package com.openai.snapo.demo.shared.tasks
+
+import kotlinx.serialization.Serializable
+import java.io.IOException
+
+@Serializable
+data class DemoTask(val id: String, val title: String, val status: String)
+
+@Serializable
+data class TaskList(val tasks: List<DemoTask>)
+
+@Serializable
+data class CreateTask(val title: String)
+
+/** Implementations translate request failures to TasksApiException and preserve coroutine cancellation. */
+interface TasksApi {
+    suspend fun list(): List<DemoTask>
+    suspend fun create(title: String): DemoTask
+}
+
+class TasksApiException(override val message: String, cause: Throwable? = null) : Exception(message, cause) {
+    companion object {
+        fun http(
+            statusCode: Int,
+            unavailableHint: String = "Use Snap-O interception to supply responses, then tap Refresh.",
+        ) = TasksApiException(
+            if (statusCode == 404) {
+                "The tasks API is not available. $unavailableHint"
+            } else {
+                "The tasks API returned HTTP $statusCode."
+            },
+        )
+
+        fun invalidResponse(cause: Throwable) = TasksApiException(
+            "The tasks API returned an invalid response. Check the route handler's JSON.",
+            cause,
+        )
+
+        fun transport(cause: IOException) = TasksApiException(cause.message ?: "The request failed. Try again.", cause)
+    }
+}

--- a/snapo-link-android/samples/demo-shared/src/main/java/com/openai/snapo/demo/shared/tasks/TasksSection.kt
+++ b/snapo-link-android/samples/demo-shared/src/main/java/com/openai/snapo/demo/shared/tasks/TasksSection.kt
@@ -1,0 +1,188 @@
+package com.openai.snapo.demo.shared.tasks
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.heightIn
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.widthIn
+import androidx.compose.material3.Button
+import androidx.compose.material3.Checkbox
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.saveable.rememberSaveable
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.alpha
+import androidx.compose.ui.semantics.Role
+import androidx.compose.ui.semantics.contentDescription
+import androidx.compose.ui.semantics.disabled
+import androidx.compose.ui.semantics.role
+import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.semantics.stateDescription
+import androidx.compose.ui.semantics.toggleableState
+import androidx.compose.ui.state.ToggleableState
+import androidx.compose.ui.unit.dp
+import kotlinx.coroutines.launch
+
+private data class TasksState(
+    val tasks: List<DemoTask> = emptyList(),
+    val isLoading: Boolean = false,
+    val hasLoaded: Boolean = false,
+    val error: String? = null,
+)
+
+@Composable
+fun TasksSection(api: TasksApi) {
+    val scope = rememberCoroutineScope()
+    var state by remember { mutableStateOf(TasksState()) }
+    var title by rememberSaveable { mutableStateOf("") }
+
+    suspend fun refresh() {
+        state = state.copy(isLoading = true, error = null)
+        try {
+            state = state.copy(tasks = api.list(), hasLoaded = true)
+        } catch (error: TasksApiException) {
+            state = state.copy(error = error.message)
+        } finally {
+            state = state.copy(isLoading = false)
+        }
+    }
+
+    LaunchedEffect(api) { refresh() }
+
+    TasksContent(
+        state = state,
+        title = title,
+        onTitleChange = { title = it },
+        onRefresh = { scope.launch { if (!state.isLoading) refresh() } },
+        onAdd = {
+            scope.launch {
+                if (state.isLoading || title.isBlank()) return@launch
+                state = state.copy(isLoading = true, error = null)
+                try {
+                    val task = api.create(title.trim())
+                    title = ""
+                    state = state.copy(tasks = state.tasks + task, hasLoaded = true)
+                    refresh()
+                } catch (error: TasksApiException) {
+                    state = state.copy(error = error.message)
+                } finally {
+                    state = state.copy(isLoading = false)
+                }
+            }
+        },
+    )
+}
+
+@Composable
+private fun TasksContent(
+    state: TasksState,
+    title: String,
+    onTitleChange: (String) -> Unit,
+    onRefresh: () -> Unit,
+    onAdd: () -> Unit,
+) {
+    Column(verticalArrangement = Arrangement.spacedBy(12.dp)) {
+        HorizontalDivider(modifier = Modifier.padding(top = 8.dp))
+        Row(
+            modifier = Modifier.fillMaxWidth(),
+            horizontalArrangement = Arrangement.SpaceBetween,
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
+            Text("Tasks", style = MaterialTheme.typography.titleLarge)
+            RefreshButton(isLoading = state.isLoading, onClick = onRefresh)
+        }
+        Row(
+            horizontalArrangement = Arrangement.spacedBy(8.dp),
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
+            OutlinedTextField(
+                value = title,
+                onValueChange = onTitleChange,
+                placeholder = { Text("New task") },
+                singleLine = true,
+                enabled = !state.isLoading,
+                shape = MaterialTheme.shapes.extraSmall,
+                modifier = Modifier.weight(1f).semantics { contentDescription = "New task" },
+            )
+            Button(
+                onClick = onAdd,
+                enabled = !state.isLoading && title.isNotBlank(),
+                shape = MaterialTheme.shapes.extraSmall,
+                modifier = Modifier.height(56.dp).widthIn(min = 80.dp),
+            ) { Text("Add", style = MaterialTheme.typography.bodyLarge) }
+        }
+        state.error?.let { Text(it, color = MaterialTheme.colorScheme.error) }
+        if (state.hasLoaded && state.tasks.isEmpty() && state.error == null) {
+            Text("No tasks yet.", color = MaterialTheme.colorScheme.onSurfaceVariant)
+        }
+        if (state.tasks.isNotEmpty()) {
+            Column {
+                state.tasks.forEach { task -> TaskRow(task) }
+            }
+        }
+    }
+}
+
+@Composable
+private fun RefreshButton(isLoading: Boolean, onClick: () -> Unit) {
+    TextButton(
+        onClick = onClick,
+        enabled = !isLoading,
+        modifier = Modifier.semantics {
+            if (isLoading) stateDescription = "Loading tasks"
+        },
+    ) {
+        Box(contentAlignment = Alignment.Center) {
+            // Keep the label's space so loading does not resize the button.
+            Text("Refresh", modifier = Modifier.alpha(if (isLoading) 0f else 1f))
+            if (isLoading) {
+                CircularProgressIndicator(
+                    modifier = Modifier.size(18.dp),
+                    strokeWidth = 2.dp,
+                )
+            }
+        }
+    }
+}
+
+@Composable
+private fun TaskRow(task: DemoTask) {
+    val isCompleted = task.status == "completed"
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .heightIn(min = 44.dp)
+            .semantics(mergeDescendants = true) {
+                role = Role.Checkbox
+                toggleableState = ToggleableState(isCompleted)
+                disabled()
+            },
+        horizontalArrangement = Arrangement.spacedBy(12.dp),
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        Checkbox(
+            checked = isCompleted,
+            onCheckedChange = null,
+            enabled = false,
+            modifier = Modifier.size(24.dp),
+        )
+        Text(task.title, style = MaterialTheme.typography.bodyLarge)
+    }
+}


### PR DESCRIPTION
The network demos need a stateful UI for exercising intercepted API responses. Add a shared Tasks section that starts with an unavailable API and uses the existing Python route example to test task creation, refreshes, loading, and errors.

## Summary
- Share the Tasks UI, models, and error handling across the OkHttp, Ktor, and HttpURLConnection demos, with a separate API adapter for each client.
- Keep the task endpoints unimplemented in the local server. Creating a task triggers a list refresh to exercise both intercepted requests.
- Add disabled status checkboxes, a Refresh spinner that preserves the layout, sample previews, and a guide to interception workflows.

## Validation
- All three sample apps pass `assembleDebug`.
- All three samples and `demo-shared` pass `lintDebug` and Detekt; `git diff --check` passes.
- Manually verified OkHttp and Ktor task creation and refresh through Python interception, plus the missing-API state after stopping interception.
- Checked the UI in an Android emulator, including disabled checkbox semantics and stable layout bounds during refresh.
- HttpURLConnection remains inspection-only; its Tasks UI explains that limitation.
