### PR TITLE
Reduce Android CI build work

### DIFF
--- a/.github/workflows/android-link.yml
+++ b/.github/workflows/android-link.yml
@@ -42,14 +42,49 @@ jobs:
       - name: Grant execute permission for Gradle wrapper
         working-directory: snapo-link-android
         run: chmod +x gradlew
-      - name: Build Android libraries
+      - name: Assemble Android libraries and samples
         working-directory: snapo-link-android
-        run: ./gradlew --no-daemon --profile -Psnapo.samples.minifyRelease=false build -x detekt
-      - name: Upload build profile
+        run: ./gradlew --no-daemon --profile -Psnapo.samples.minifyRelease=false assemble
+      - name: Upload assembly profile
         if: always()
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
-          name: android-build-profile
+          name: android-assemble-profile
+          path: snapo-link-android/build/reports/profile/
+          if-no-files-found: ignore
+          retention-days: 7
+
+  check:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+      - name: Set up Java
+        uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654  # v5.2.0
+        with:
+          distribution: temurin
+          java-version: '17'
+      - name: Set up Gradle
+        uses: gradle/actions/setup-gradle@50e97c2cd7a37755bbfafc9c5b7cafaece252f6e # v6.1.0
+        with:
+          validate-wrappers: true
+      - name: Prepare local.properties
+        working-directory: snapo-link-android
+        run: |
+          cat <<EOL > local.properties
+          sdk.dir=${ANDROID_SDK_ROOT}
+          EOL
+      - name: Grant execute permission for Gradle wrapper
+        working-directory: snapo-link-android
+        run: chmod +x gradlew
+      - name: Run Android lint and unit tests
+        working-directory: snapo-link-android
+        run: ./gradlew --no-daemon --profile -Psnapo.samples.minifyRelease=false check -x detekt
+      - name: Upload verification profile
+        if: always()
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          name: android-check-profile
           path: snapo-link-android/build/reports/profile/
           if-no-files-found: ignore
           retention-days: 7

--- a/.github/workflows/android-link.yml
+++ b/.github/workflows/android-link.yml
@@ -44,7 +44,15 @@ jobs:
         run: chmod +x gradlew
       - name: Build Android libraries
         working-directory: snapo-link-android
-        run: ./gradlew --no-daemon build
+        run: ./gradlew --no-daemon --profile build -x detekt
+      - name: Upload build profile
+        if: always()
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          name: android-build-profile
+          path: snapo-link-android/build/reports/profile/
+          if-no-files-found: ignore
+          retention-days: 7
 
   detekt:
     runs-on: ubuntu-latest

--- a/.github/workflows/android-link.yml
+++ b/.github/workflows/android-link.yml
@@ -44,7 +44,7 @@ jobs:
         run: chmod +x gradlew
       - name: Build Android libraries
         working-directory: snapo-link-android
-        run: ./gradlew --no-daemon --profile build -x detekt
+        run: ./gradlew --no-daemon --profile -Psnapo.samples.minifyRelease=false build -x detekt
       - name: Upload build profile
         if: always()
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2

--- a/.github/workflows/android-link.yml
+++ b/.github/workflows/android-link.yml
@@ -18,6 +18,11 @@ on:
       - '.github/workflows/android-link.yml'
       - 'VERSION'
 
+# Only PR runs share a group; push runs finish to populate Gradle caches.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event_name }}-${{ github.event.pull_request.number || github.run_id }}
+  cancel-in-progress: true
+
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/snapo-link-android/build-logic/src/main/kotlin/com/openai/snapo/buildlogic/android/AndroidApplicationConventionPlugin.kt
+++ b/snapo-link-android/build-logic/src/main/kotlin/com/openai/snapo/buildlogic/android/AndroidApplicationConventionPlugin.kt
@@ -22,7 +22,9 @@ class AndroidApplicationConventionPlugin : Plugin<Project> {
 
             buildTypes {
                 maybeCreate("release").apply {
-                    isMinifyEnabled = true
+                    isMinifyEnabled = target.providers.gradleProperty("snapo.samples.minifyRelease")
+                        .map(String::toBooleanStrict)
+                        .getOrElse(true)
                     isShrinkResources = false
                     proguardFiles(getDefaultProguardFile("proguard-android-optimize.txt"))
                 }

--- a/snapo-link-android/gradle.properties
+++ b/snapo-link-android/gradle.properties
@@ -7,10 +7,8 @@
 # Specifies the JVM arguments used for the daemon process.
 # The setting is particularly useful for tweaking memory settings.
 org.gradle.jvmargs=-Xmx2048m -Dfile.encoding=UTF-8
-# When configured, Gradle will run in incubating parallel mode.
-# This option should only be used with decoupled projects. For more details, visit
-# https://developer.android.com/r/tools/gradle-multi-project-decoupled-projects
-# org.gradle.parallel=true
+org.gradle.caching=true
+org.gradle.parallel=true
 # AndroidX package structure to make it clearer which packages are bundled with the
 # Android operating system, and which are packaged with your app's APK
 # https://developer.android.com/topic/libraries/support-library/androidx-rn


### PR DESCRIPTION
Android CI combines assembly, lint, and unit tests in one job, rebuilds cacheable outputs, and shrinks four sample release apps. This change runs assembly and verification concurrently and removes unnecessary work while preserving build and test coverage.

## Summary

- Run assembly and lint/unit tests in separate jobs on the existing runners. Keep Detekt in its dedicated job.
- Enable Gradle task-output caching and parallel task execution.
- Disable sample release shrinking in CI with `-Psnapo.samples.minifyRelease=false`. Release dependencies are still used, and shrinking remains enabled by default outside this workflow.
- Upload separate assembly and verification timing reports with seven-day retention.
- Cancel superseded runs for the same PR. Allow push builds to finish and populate shared Gradle caches.

## Validation

- Workflow YAML checks and `git diff --check` pass. The cancellation change preserves existing triggers and jobs.
- Offline `assemble` and `check -x detekt` pass with the CI shrinking flag and Java limited to four processors. The initial unrestricted local run exhausted the 2 GB Java heap during release dex merging.
- The [split-job CI run](https://github.com/openai/snap-o/actions/runs/33772420447) passed assembly, verification, and Detekt. Assembly took 3m28s and verification took 2m52s concurrently, compared with 5m31s for the previous combined job. This is a single-run comparison.
- CI validation of the cancellation change is pending.
