### PR TITLE
Fix Android library dependency scopes and BOM exports

### DIFF
--- a/snapo-link-android/gradle/libs.versions.toml
+++ b/snapo-link-android/gradle/libs.versions.toml
@@ -11,6 +11,9 @@ coreKtx = "1.17.0"
 lifecycleRuntimeKtx = "2.10.0"
 activityCompose = "1.12.2"
 composeBom = "2026.01.00"
+# Match the BOM baseline without exporting it from published libraries.
+compose = "1.10.1"
+composeMaterial3 = "1.4.0"
 okhttpBom = "5.3.2"
 ktor = "3.3.3"
 detekt = "1.23.8"
@@ -23,6 +26,7 @@ gradle = { module = "com.android.tools.build:gradle", version.ref = "gradle" }
 kotlin-gradle-plugin = { module = "org.jetbrains.kotlin:kotlin-gradle-plugin", version.ref = "kotlinGradlePlugin" }
 maven-publish-gradle-plugin = { module = "com.vanniktech:gradle-maven-publish-plugin", version.ref = "mavenPublishGradlePlugin" }
 kotlinx-coroutines-core = { group = "org.jetbrains.kotlinx", name = "kotlinx-coroutines-core", version.ref = "coroutines" }
+serialization-core = { group = "org.jetbrains.kotlinx", name = "kotlinx-serialization-core", version.ref = "serialization" }
 serialization-json = { group = "org.jetbrains.kotlinx", name = "kotlinx-serialization-json", version.ref = "serialization" }
 androidx-lifecycle-runtime-ktx = { group = "androidx.lifecycle", name = "lifecycle-runtime-ktx", version.ref = "lifecycleRuntimeKtx" }
 androidx-lifecycle-viewmodel = { group = "androidx.lifecycle", name = "lifecycle-viewmodel", version.ref = "lifecycleRuntimeKtx" }
@@ -30,15 +34,17 @@ androidx-lifecycle-viewmodel-savedstate = { group = "androidx.lifecycle", name =
 androidx-activity-ktx = { group = "androidx.activity", name = "activity-ktx", version.ref = "activityCompose" }
 androidx-activity-compose = { group = "androidx.activity", name = "activity-compose", version.ref = "activityCompose" }
 androidx-compose-bom = { group = "androidx.compose", name = "compose-bom", version.ref = "composeBom" }
-androidx-compose-foundation = { group = "androidx.compose.foundation", name = "foundation" }
-androidx-compose-ui = { group = "androidx.compose.ui", name = "ui" }
-androidx-compose-ui-graphics = { group = "androidx.compose.ui", name = "ui-graphics" }
-androidx-compose-ui-tooling-preview = { group = "androidx.compose.ui", name = "ui-tooling-preview" }
-androidx-compose-material3 = { group = "androidx.compose.material3", name = "material3" }
+androidx-compose-runtime = { group = "androidx.compose.runtime", name = "runtime", version.ref = "compose" }
+androidx-compose-foundation = { group = "androidx.compose.foundation", name = "foundation", version.ref = "compose" }
+androidx-compose-ui = { group = "androidx.compose.ui", name = "ui", version.ref = "compose" }
+androidx-compose-ui-graphics = { group = "androidx.compose.ui", name = "ui-graphics", version.ref = "compose" }
+androidx-compose-ui-tooling-preview = { group = "androidx.compose.ui", name = "ui-tooling-preview", version.ref = "compose" }
+androidx-compose-material3 = { group = "androidx.compose.material3", name = "material3", version.ref = "composeMaterial3" }
+androidx-compose-material-ripple = { group = "androidx.compose.material", name = "material-ripple", version.ref = "compose" }
 okhttp3-bom = { group = "com.squareup.okhttp3", name = "okhttp-bom", version.ref = "okhttpBom" }
-okhttp3-coroutines = { group = "com.squareup.okhttp3", name = "okhttp-coroutines" }
-okhttp3-okhttp = { group = "com.squareup.okhttp3", name = "okhttp" }
-okhttp3-mockwebserver3 = { group = "com.squareup.okhttp3", name = "mockwebserver3" }
+okhttp3-coroutines = { group = "com.squareup.okhttp3", name = "okhttp-coroutines", version.ref = "okhttpBom" }
+okhttp3-okhttp = { group = "com.squareup.okhttp3", name = "okhttp", version.ref = "okhttpBom" }
+okhttp3-mockwebserver3 = { group = "com.squareup.okhttp3", name = "mockwebserver3", version.ref = "okhttpBom" }
 ktor-client-core = { group = "io.ktor", name = "ktor-client-core", version.ref = "ktor" }
 ktor-client-okhttp = { group = "io.ktor", name = "ktor-client-okhttp", version.ref = "ktor" }
 ktor-client-websockets = { group = "io.ktor", name = "ktor-client-websockets", version.ref = "ktor" }

--- a/snapo-link-android/network-okhttp3-noop/build.gradle.kts
+++ b/snapo-link-android/network-okhttp3-noop/build.gradle.kts
@@ -11,7 +11,6 @@ android {
 }
 
 dependencies {
-    api(platform(libs.okhttp3.bom))
     api(libs.okhttp3.okhttp)
     api(libs.kotlinx.coroutines.core)
 }

--- a/snapo-link-android/network-okhttp3/build.gradle.kts
+++ b/snapo-link-android/network-okhttp3/build.gradle.kts
@@ -12,7 +12,6 @@ android {
 
 dependencies {
     implementation(project(":network"))
-    api(platform(libs.okhttp3.bom))
     api(libs.okhttp3.okhttp)
     api(libs.kotlinx.coroutines.core)
     testImplementation(libs.junit4)

--- a/snapo-link-android/network/build.gradle.kts
+++ b/snapo-link-android/network/build.gradle.kts
@@ -12,8 +12,10 @@ android {
 }
 
 dependencies {
+    api(libs.kotlinx.coroutines.core)
+    api(libs.serialization.core)
+
     implementation(libs.androidx.core.ktx)
-    implementation(libs.kotlinx.coroutines.core)
     implementation(libs.serialization.json)
     testImplementation(libs.junit4)
 }

--- a/snapo-link-android/samples/demo-shared/build.gradle.kts
+++ b/snapo-link-android/samples/demo-shared/build.gradle.kts
@@ -14,13 +14,15 @@ android {
 }
 
 dependencies {
-    implementation(libs.androidx.lifecycle.viewmodel)
-    implementation(libs.androidx.lifecycle.viewmodel.savedstate)
+    api(libs.androidx.lifecycle.viewmodel)
+    api(libs.androidx.lifecycle.viewmodel.savedstate)
+    api(libs.androidx.compose.runtime)
+    api(libs.kotlinx.coroutines.core)
+    api(libs.serialization.core)
+
     implementation(platform(libs.androidx.compose.bom))
     implementation(libs.androidx.compose.material3)
     implementation(libs.androidx.compose.ui.tooling.preview)
-    implementation(libs.kotlinx.coroutines.core)
-    implementation(libs.serialization.json)
     implementation(platform(libs.okhttp3.bom))
     implementation(libs.okhttp3.okhttp)
     implementation(libs.okhttp3.mockwebserver3)

--- a/snapo-link-android/tweaks-noop/build.gradle.kts
+++ b/snapo-link-android/tweaks-noop/build.gradle.kts
@@ -16,8 +16,7 @@ android {
 }
 
 dependencies {
-    api(platform(libs.androidx.compose.bom))
-    api("androidx.compose.runtime:runtime")
+    api(libs.androidx.compose.runtime)
     api(libs.androidx.compose.ui.graphics)
     api(libs.kotlinx.coroutines.core)
 }

--- a/snapo-link-android/tweaks-overlay-noop/build.gradle.kts
+++ b/snapo-link-android/tweaks-overlay-noop/build.gradle.kts
@@ -16,8 +16,6 @@ android {
 }
 
 dependencies {
-    api(platform(libs.androidx.compose.bom))
+    api(libs.androidx.compose.runtime)
     api(libs.androidx.compose.ui)
-
-    implementation(libs.androidx.compose.foundation)
 }

--- a/snapo-link-android/tweaks-overlay/build.gradle.kts
+++ b/snapo-link-android/tweaks-overlay/build.gradle.kts
@@ -18,12 +18,14 @@ android {
 dependencies {
     implementation(project(":tweaks"))
 
-    api(platform(libs.androidx.compose.bom))
+    api(libs.androidx.compose.runtime)
     api(libs.androidx.compose.ui)
-    api(libs.androidx.compose.ui.graphics)
 
+    implementation(libs.androidx.compose.ui.graphics)
     implementation(libs.androidx.compose.foundation)
     implementation(libs.androidx.compose.material3)
+    // Preserve the ripple version previously selected by the Compose BOM.
+    implementation(libs.androidx.compose.material.ripple)
     implementation(libs.androidx.core.ktx)
 
     testImplementation(libs.junit4)

--- a/snapo-link-android/tweaks/build.gradle.kts
+++ b/snapo-link-android/tweaks/build.gradle.kts
@@ -16,8 +16,7 @@ android {
 }
 
 dependencies {
-    api(platform(libs.androidx.compose.bom))
-    api("androidx.compose.runtime:runtime")
+    api(libs.androidx.compose.runtime)
     api(libs.androidx.compose.ui.graphics)
     api(libs.kotlinx.coroutines.core)
 


### PR DESCRIPTION
Snap-O libraries exported Compose and OkHttp BOMs to consuming apps, while some public API types were missing from their compile dependencies. The overlay no-op also carried an unused Foundation dependency. This change narrows the dependency surface while preserving the existing version baseline.

## Summary

- Replace published BOM dependencies with explicit module versions, including the existing ripple version.
- Use `api` for public types in the network, tweaks, overlay, and shared sample modules; keep implementation details private.
- Remove Foundation from the overlay no-op and unused JSON from the shared sample. Preserve all existing dependency versions and SDK/toolchain settings.

## Validation

- `./gradlew build validateMavenCentralRelease` passed, including 309 tests and all sample debug/release builds.
- Independent consumers of all nine published artifacts compiled using Gradle module metadata and POM-only resolution. Rechecked publication dependencies after rebasing onto main.
- A separate shared-sample consumer compiled the public ViewModel, saved-state, coroutine, Compose, and serializer APIs without extra dependencies.
- Verified no dependency downgrades, BOM exports, or live Snap-O dependencies in no-op artifacts. `git diff --check` passed.
