### PR TITLE
Use debug builds for implementation and no-op CI checks

### DIFF
--- a/.github/workflows/android-link.yml
+++ b/.github/workflows/android-link.yml
@@ -47,9 +47,12 @@ jobs:
       - name: Grant execute permission for Gradle wrapper
         working-directory: snapo-link-android
         run: chmod +x gradlew
-      - name: Assemble Android libraries and samples
+      - name: Assemble debug libraries and samples with implementations
         working-directory: snapo-link-android
-        run: ./gradlew --no-daemon --profile -Psnapo.samples.minifyRelease=false assemble
+        run: ./gradlew --no-daemon --profile assembleDebug
+      - name: Assemble debug samples with no-ops
+        working-directory: snapo-link-android
+        run: ./gradlew --no-daemon --profile -Psnapo.samples.noop=true assembleDebug
       - name: Upload assembly profile
         if: always()
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
@@ -82,9 +85,12 @@ jobs:
       - name: Grant execute permission for Gradle wrapper
         working-directory: snapo-link-android
         run: chmod +x gradlew
-      - name: Run Android lint and unit tests
+      - name: Lint and test debug libraries and samples with implementations
         working-directory: snapo-link-android
-        run: ./gradlew --no-daemon --profile -Psnapo.samples.minifyRelease=false check -x detekt
+        run: ./gradlew --no-daemon --profile lintDebug testDebugUnitTest
+      - name: Lint and test debug samples with no-ops
+        working-directory: snapo-link-android
+        run: ./gradlew --no-daemon --profile -Psnapo.samples.noop=true lintDebug testDebugUnitTest
       - name: Upload verification profile
         if: always()
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2

--- a/snapo-link-android/samples/README.md
+++ b/snapo-link-android/samples/README.md
@@ -24,6 +24,19 @@ Replace `demo-okhttp` in the build command and select the matching demo and pack
 
 Scroll below the network buttons to **Tasks**. The first request returns HTTP 404. Refreshing or adding a task also fails until interception supplies those responses. Release builds use the no-op integration and do not support interception.
 
+## Check implementation and no-op libraries
+
+Debug samples use the implementation libraries by default. Add `-Psnapo.samples.noop=true` to build them against the no-op libraries instead. No-op samples do not support inspection or interception.
+
+From `snapo-link-android`, run both modes without building release variants:
+
+```bash
+./gradlew assembleDebug lintDebug testDebugUnitTest
+./gradlew -Psnapo.samples.noop=true assembleDebug lintDebug testDebugUnitTest
+```
+
+These commands also build, lint, and test the debug variants of all library modules.
+
 ## Supply task responses
 
 From the repository root, list the sample's network socket and start the existing route example:

--- a/snapo-link-android/samples/demo-httpurlconnection/build.gradle.kts
+++ b/snapo-link-android/samples/demo-httpurlconnection/build.gradle.kts
@@ -20,6 +20,10 @@ android {
     }
 }
 
+val useNoop = providers.gradleProperty("snapo.samples.noop")
+    .map(String::toBooleanStrict)
+    .getOrElse(false)
+
 dependencies {
     implementation(libs.androidx.core.ktx)
     implementation(libs.androidx.lifecycle.runtime.ktx)
@@ -33,6 +37,6 @@ dependencies {
     implementation(project(":samples:demo-shared"))
     implementation(libs.serialization.json)
 
-    debugImplementation(project(":network-httpurlconnection"))
+    debugImplementation(project(if (useNoop) ":network-httpurlconnection-noop" else ":network-httpurlconnection"))
     releaseImplementation(project(":network-httpurlconnection-noop"))
 }

--- a/snapo-link-android/samples/demo-ktor-okhttp/build.gradle.kts
+++ b/snapo-link-android/samples/demo-ktor-okhttp/build.gradle.kts
@@ -20,6 +20,10 @@ android {
     }
 }
 
+val useNoop = providers.gradleProperty("snapo.samples.noop")
+    .map(String::toBooleanStrict)
+    .getOrElse(false)
+
 dependencies {
 
     implementation(libs.androidx.core.ktx)
@@ -44,6 +48,6 @@ dependencies {
     implementation(libs.serialization.json)
     implementation(project(":samples:demo-shared"))
 
-    debugImplementation(project(":network-okhttp3"))
+    debugImplementation(project(if (useNoop) ":network-okhttp3-noop" else ":network-okhttp3"))
     releaseImplementation(project(":network-okhttp3-noop"))
 }

--- a/snapo-link-android/samples/demo-okhttp/build.gradle.kts
+++ b/snapo-link-android/samples/demo-okhttp/build.gradle.kts
@@ -20,6 +20,10 @@ android {
     }
 }
 
+val useNoop = providers.gradleProperty("snapo.samples.noop")
+    .map(String::toBooleanStrict)
+    .getOrElse(false)
+
 dependencies {
 
     implementation(libs.androidx.core.ktx)
@@ -38,6 +42,6 @@ dependencies {
     implementation(libs.serialization.json)
     implementation(project(":samples:demo-shared"))
 
-    debugImplementation(project(":network-okhttp3"))
+    debugImplementation(project(if (useNoop) ":network-okhttp3-noop" else ":network-okhttp3"))
     releaseImplementation(project(":network-okhttp3-noop"))
 }

--- a/snapo-link-android/samples/demo-tweaks/build.gradle.kts
+++ b/snapo-link-android/samples/demo-tweaks/build.gradle.kts
@@ -18,6 +18,10 @@ android {
     }
 }
 
+val useNoop = providers.gradleProperty("snapo.samples.noop")
+    .map(String::toBooleanStrict)
+    .getOrElse(false)
+
 dependencies {
     implementation(libs.androidx.activity.compose)
 
@@ -27,8 +31,8 @@ dependencies {
     implementation(libs.androidx.compose.ui.graphics)
     implementation(libs.androidx.compose.material3)
 
-    debugImplementation(project(":tweaks"))
-    debugImplementation(project(":tweaks-overlay"))
+    debugImplementation(project(if (useNoop) ":tweaks-noop" else ":tweaks"))
+    debugImplementation(project(if (useNoop) ":tweaks-overlay-noop" else ":tweaks-overlay"))
     releaseImplementation(project(":tweaks-noop"))
     releaseImplementation(project(":tweaks-overlay-noop"))
 }


### PR DESCRIPTION
Android CI built debug and release variants to exercise the implementation and no-op libraries. Release compilation, lint, and packaging added work even with shrinking disabled. Both dependency modes can be checked with debug builds.

## Summary

- Build, lint, and run unit tests for debug variants of all Android libraries.
- Check all four samples with implementation dependencies, then with no-op dependencies using `-Psnapo.samples.noop=true`.
- Reuse unchanged debug outputs between passes and keep the existing job names and profile uploads.
- Document both validation commands.

## Validation

- Debug assembly, lint, and unit tests passed in both dependency modes; 309 tests passed.
- Verified all four sample runtime classpaths select the intended implementation or no-op libraries.
- Verified neither mode schedules release, R8, or resource-shrinking tasks.
- Workflow YAML parsing and `git diff --check` passed.
- Local validation used a warm developer machine. CI timing for this change remains unmeasured.
