### PR TITLE
Load Python routes with runpy

### DIFF
--- a/scripts/snapo
+++ b/scripts/snapo
@@ -9,7 +9,6 @@ import itertools
 import types
 import uuid
 from collections.abc import MutableMapping
-from urllib.parse import urlsplit
 import base64
 import gzip
 import http.client
@@ -888,10 +887,10 @@ class Headers(MutableMapping):
 
 
 class Request:
-    def __init__(self, wire):
+    def __init__(self, wire, path):
         self.method = wire["method"]
         self.url = wire["url"]
-        self.path = urlsplit(self.url).path
+        self.path = path
         self.headers = Headers(wire.get("headerEntries", []))
         self.body = base64.b64decode(wire.get("body", ""), validate=True)
 
@@ -1005,8 +1004,8 @@ def load_routes(path):
 
 
 class Call:
-    def __init__(self, runner, event):
-        self.request = Request(event["request"])
+    def __init__(self, runner, event, path):
+        self.request = Request(event["request"], path)
         self._runner = runner
         self._id = event["exchangeId"]
         self._upstream_task = None
@@ -1078,7 +1077,7 @@ class Runner:
         wire = []
         for index, ((method, path), handler) in enumerate(routes.items()):
             identifier = f"{generation}:{index}"
-            self._handlers[identifier] = handler
+            self._handlers[identifier] = (handler, path)
             wire.append({"id": identifier, "method": method, "path": path})
         await self.command("SnapO.intercept.enable", {"routes": wire, "timeoutMs": int(self.timeout * 1000)})
         # Android may have matched an old route but still be reading its request body.
@@ -1141,8 +1140,8 @@ class Runner:
                 method = message.get("method")
                 if method == "SnapO.intercept.request":
                     identifier = event["exchangeId"]
-                    handler = self._handlers.get(event["routeId"])
-                    self._tasks[identifier] = asyncio.create_task(self._handle(event, handler))
+                    handler, path = self._handlers.get(event["routeId"], (None, None))
+                    self._tasks[identifier] = asyncio.create_task(self._handle(event, handler, path))
                 elif method == "SnapO.intercept.response":
                     call = self._calls.get(event["exchangeId"])
                     if call is not None and not call._response.done():
@@ -1162,9 +1161,9 @@ class Runner:
                     future.set_exception(error)
             raise
 
-    async def _handle(self, event, handler):
+    async def _handle(self, event, handler, path):
         identifier = event["exchangeId"]
-        call = Call(self, event)
+        call = Call(self, event, path)
         self._calls[identifier] = call
         try:
             if handler is None:

--- a/scripts/snapo
+++ b/scripts/snapo
@@ -18,6 +18,7 @@ import math
 import os
 import pathlib
 import re
+import runpy
 import shutil
 import signal
 import socket
@@ -977,16 +978,16 @@ sys.modules["snapo"] = _route_api
 def load_routes(path):
     path = pathlib.Path(path).resolve()
     source = path.read_bytes()
-    module = types.ModuleType(f"snapo_routes_{uuid.uuid4().hex}")
-    module.__file__ = str(path)
-    sys.modules[module.__name__] = module
+    original_path = sys.path.copy()
     # Resolve helpers next to the user's file, as Python does for an ordinary script.
     sys.path.insert(0, str(path.parent))
     try:
-        exec(compile(source, str(path), "exec"), module.__dict__)
+        namespace = runpy.run_path(str(path), run_name=f"snapo_routes_{uuid.uuid4().hex}")
+        if path.read_bytes() != source:
+            raise ValueError("Route file changed while loading; save it again")
         routes = {}
         seen = set()
-        for handler in module.__dict__.values():
+        for handler in namespace.values():
             if id(handler) in seen:
                 continue
             seen.add(id(handler))
@@ -1000,8 +1001,7 @@ def load_routes(path):
             raise ValueError("Register at most 128 routes")
         return routes, hashlib.sha256(source).digest()
     finally:
-        sys.path.pop(0)
-        sys.modules.pop(module.__name__, None)
+        sys.path[:] = original_path
 
 
 class Call:

--- a/tests/snapo_cli/test_intercept.py
+++ b/tests/snapo_cli/test_intercept.py
@@ -182,12 +182,14 @@ class InterceptionTest(unittest.IsolatedAsyncioTestCase):
         routes = await self.start('''from snapo import route
 @route("GET", "api/profile")
 async def profile(call):
+    assert call.request.path == "/api/profile"
+    assert call.request.url.endswith("?source=test")
     response = await call.upstream()
     assert response is await call.upstream()
     response.json["name"] = "Space Captain"
     return response
 ''')
-        await self.request("one", routes["/api/profile"])
+        await self.request("one", routes["/api/profile"], "/api/profile?source=test")
         upstream = await self.next_command("SnapO.intercept.resolve")
         self.assertEqual("upstream", upstream["action"])
         await self.response("one", {"name": "Ada", "role": "engineer"})

--- a/tests/snapo_cli/test_intercept.py
+++ b/tests/snapo_cli/test_intercept.py
@@ -1,8 +1,11 @@
 import asyncio
 import base64
 import contextlib
+import hashlib
 import json
+import os
 import pathlib
+import py_compile
 import shutil
 import subprocess
 import sys
@@ -37,11 +40,65 @@ class ResponseTest(unittest.TestCase):
         with tempfile.TemporaryDirectory() as directory:
             script = pathlib.Path(directory) / "snapo"
             shutil.copyfile(root / "scripts/snapo", script)
+            script.chmod(0o755)
             routes = pathlib.Path(directory) / "routes.py"
             routes.write_text('from snapo import route\n@route("GET", "/api/tasks")\nasync def tasks(call):\n    return call.json([])\n')
-            result = subprocess.run([sys.executable, "-I", str(script), "network", "intercept", str(routes), "--check"], cwd=directory, capture_output=True, text=True, timeout=10)
-            self.assertEqual(0, result.returncode, result.stderr)
-            self.assertIn("GET /api/tasks", result.stdout)
+            for command in ([sys.executable, "-I", str(script)], [str(script)]):
+                with self.subTest(command=command):
+                    result = subprocess.run([*command, "network", "intercept", str(routes), "--check"], cwd=directory, capture_output=True, text=True, timeout=10)
+                    self.assertEqual(0, result.returncode, result.stderr)
+                    self.assertIn("GET /api/tasks", result.stdout)
+
+
+class RouteLoaderTest(unittest.IsolatedAsyncioTestCase):
+    async def test_reload_ignores_cached_bytecode_for_same_size_and_timestamp(self):
+        source = '''from snapo import route
+version = "old"
+@route("GET", "/api/profile")
+async def profile(call):
+    return version
+'''
+        with tempfile.TemporaryDirectory() as directory:
+            path = pathlib.Path(directory) / "routes.py"
+            path.write_text(source)
+            stamp = path.stat()
+            cache = pathlib.Path(py_compile.compile(
+                str(path), doraise=True, invalidation_mode=py_compile.PycInvalidationMode.TIMESTAMP,
+            ))
+            cached_bytes = cache.read_bytes()
+            old_routes, old_digest = load_routes(path)
+            updated = source.replace('"old"', '"new"')
+            path.write_text(updated)
+            os.utime(path, ns=(stamp.st_atime_ns, stamp.st_mtime_ns))
+            new_routes, new_digest = load_routes(path)
+
+            self.assertEqual("old", await old_routes["GET", "/api/profile"](None))
+            self.assertEqual("new", await new_routes["GET", "/api/profile"](None))
+            self.assertEqual(hashlib.sha256(source.encode()).digest(), old_digest)
+            self.assertEqual(hashlib.sha256(updated.encode()).digest(), new_digest)
+            self.assertEqual(cached_bytes, cache.read_bytes())
+
+    async def test_route_file_can_import_sibling_helpers_and_define_dataclasses(self):
+        with tempfile.TemporaryDirectory() as directory:
+            root = pathlib.Path(directory)
+            helper = "snapo_test_route_helper"
+            (root / f"{helper}.py").write_text('VERSION = "example"\n')
+            self.addCleanup(sys.modules.pop, helper, None)
+            path = root / "routes"
+            path.write_text('''from __future__ import annotations
+from dataclasses import dataclass
+from snapo import route
+from snapo_test_route_helper import VERSION
+@dataclass
+class State:
+    version: str
+@route("GET", "/api/profile")
+async def profile(call):
+    return State(VERSION)
+''')
+            routes, _ = load_routes(path)
+            state = await routes["GET", "/api/profile"](None)
+            self.assertEqual("example", state.version)
 
 
 class InterceptionTest(unittest.IsolatedAsyncioTestCase):


### PR DESCRIPTION
The standalone CLI manually compiled route source into a temporary module. This change uses Python's standard file execution API while preserving fresh route state, reliable reloads, and request path metadata.

## Summary

- Load route files with `runpy.run_path()` under a fresh module name.
- Reject a load when the route file changes during execution.
- Restore the original import path after each load.
- Use the registered route path instead of parsing each intercepted request URL.
- Cover direct standalone execution, stale bytecode, sibling imports, extensionless route files, and request paths with query strings.

## Validation

- `python3 -m unittest discover -s tests/snapo_cli -p 'test_*.py' -v` (120 tests)
- Direct help checks for all 13 command groups
- `scripts/snapo network intercept examples/routes.py --check`
- macOS Debug build with code signing disabled
- Bundled CLI direct help and route validation

The registered-path change is covered by the interception protocol test. It was not rerun against a connected Android device.
