### PR TITLE
Update Snap-O 6.0.0 appcast

### DIFF
--- a/appcast.xml
+++ b/appcast.xml
@@ -8,6 +8,15 @@
     <description>Software updates for Snap‑O</description>
 
     <item>
+        <title>Snap‑O 6.0.0</title>
+        <pubDate>Thu, 03 Sep 2026 19:24:19 +0000</pubDate>
+        <sparkle:minimumSystemVersion>15.0</sparkle:minimumSystemVersion>
+        <sparkle:version>20260903.00</sparkle:version>
+        <sparkle:shortVersionString>6.0.0</sparkle:shortVersionString>
+        <enclosure url="https://github.com/openai/snap-o/releases/download/6.0.0/Snap-O.dmg" length="2415021" type="application/octet-stream" sparkle:edSignature="i0uhbOZz2Wpi7+7niepwDgRma7HRxvHVpg5WgRavk5CyYqAo3nY3sq+z+R5GdoM3Vpy5hZKOl9g+EFEEyMPCAg==" />
+    </item>
+
+    <item>
         <title>Snap‑O 5.1.0</title>
         <pubDate>Mon, 31 Aug 2026 15:05:55 +0000</pubDate>
         <sparkle:minimumSystemVersion>15.0</sparkle:minimumSystemVersion>


### PR DESCRIPTION
Snap-O 6.0.0 is published, but the update feed still points users to 5.1.0. Add the generated update entry so existing installations can find the new release.

## Summary
- Prepend the generated 6.0.0 / 20260903.00 Sparkle item.
- Preserve its signature and all previous update entries.

## Validation
- Published DMG and checksum downloaded and verified.
- Item version, build, minimum macOS version, URL, and byte length verified.
- XML parsing and git diff checks passed.
- Final app notarization and bundled CLI checks passed.
