### PR TITLE
Document release requirements and add preflight checks

### DIFF
--- a/.github/workflows/snapo-cli.yml
+++ b/.github/workflows/snapo-cli.yml
@@ -8,6 +8,7 @@ on:
       - '.codex-plugin/plugin.json'
       - 'VERSION'
       - 'scripts/snapo'
+      - 'release/**'
       - 'examples/**'
       - 'skills/snap-o-network-inspector/**'
       - 'skills/snap-o-tweaks/**'
@@ -22,6 +23,7 @@ on:
       - '.codex-plugin/plugin.json'
       - 'VERSION'
       - 'scripts/snapo'
+      - 'release/**'
       - 'examples/**'
       - 'skills/snap-o-network-inspector/**'
       - 'skills/snap-o-tweaks/**'
@@ -50,6 +52,10 @@ jobs:
         run: python3 -m py_compile "$SNAPO_CLI" tests/snapo_cli/test_snapo.py
       - name: Test Python CLI
         run: python3 -m unittest discover -s tests/snapo_cli -p 'test_*.py' -v
+      - name: Test release scripts
+        run: |
+          bash -n release/preflight.sh
+          python3 -m unittest discover -s release/tests -p 'test_*.py' -v
       - name: Smoke test command surface
         run: |
           test -x "$SNAPO_CLI"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -12,6 +12,10 @@ Snap-O is a public, open-source Android inspection tool.
 
 Use synthetic data in tests and examples. Never publish credentials, captured private traffic, confidential implementation details, or private issue-tracker links, identifiers, or content. Review the full diff, commit message, and PR text for sensitive information before publishing.
 
+## Release readiness
+
+Follow [release/README.md](release/README.md) when changing protocols, published APIs, version metadata, or packaging. Update `release/` checks and tests when protocol definitions or source paths change.
+
 ## Writing
 
 Use plain technical English in all prose, including READMEs, docs, code comments, UI text, commit messages, and PR descriptions. Prefer common words, active voice, and sentences of about 15 words, with one main idea each. Keep necessary technical terms, explain unfamiliar jargon for the intended reader, and preserve exact meaning. Remove repetition, but do not make the prose choppy or omit useful detail.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -20,6 +20,7 @@ Thank you for considering contributing to Snap-O! We welcome improvements, bug f
 - Follow the existing Swift style and code conventions.
 - Write clear, concise commit messages.
 - Include documentation updates when adding or changing functionality.
+- Follow [the release requirements](release/README.md) when changing protocols, published APIs, versioning, or packaging.
 
 ### macOS Swift Tooling
 

--- a/README.md
+++ b/README.md
@@ -220,6 +220,8 @@ The macOS app requires Xcode 26 or later and Node.js 22.12 or later.
 
 ### Notarizing or shipping builds
 
+For release preparation and acceptance checks, see [Release requirements](release/README.md).
+
 If you need to notarize the app yourself:
 
 1. Copy `snapo-app-mac/Config/Signing.xcconfig.sample` → `snapo-app-mac/Config/Signing.xcconfig`.

--- a/release/README.md
+++ b/release/README.md
@@ -22,7 +22,7 @@ bash release/preflight.sh \
   --android-base <public-android-tag>
 ```
 
-The script reads committed files at `--ref` (default: `HEAD`) and public GitHub release, appcast, and CI data. It does not build or publish. The macOS base defaults to the latest public release; supply the Android base after checking Maven. Repeat the comparison if libraries have different public versions. Resolve missing refs, bases, and protocol definitions before continuing. Local edits are shown but are not included in the comparison.
+The script reports changed files and protocol definitions at `--ref` (default: `HEAD`), plus public GitHub release, appcast, and CI data. Use this report with the criteria below to choose release scope and required tests. The macOS base defaults to the latest public release; supply the Android base after checking Maven. Repeat the comparison if libraries have different public versions. Resolve missing refs, bases, and protocol definitions before continuing. Local edits are shown but are not included in the comparison.
 
 ## Check protocol changes
 

--- a/release/README.md
+++ b/release/README.md
@@ -22,7 +22,7 @@ bash release/preflight.sh \
   --android-base <public-android-tag>
 ```
 
-The script reports changed files and protocol definitions at `--ref` (default: `HEAD`), plus public GitHub release, appcast, and CI data. Use this report with the criteria below to choose release scope and required tests. The macOS base defaults to the latest public release; supply the Android base after checking Maven. Repeat the comparison if libraries have different public versions. Resolve missing refs, bases, and protocol definitions before continuing. Local edits are shown but are not included in the comparison.
+The script reports changed files and protocol definitions at `--ref` (default: `HEAD`), plus public GitHub release and appcast data. Use this report with the criteria below to choose release scope and required tests. The macOS base defaults to the latest public release; supply the Android base after checking Maven. Repeat the comparison if libraries have different public versions. Resolve missing refs, bases, and protocol definitions before continuing. Local edits are shown but are not included in the comparison.
 
 ## Check protocol changes
 
@@ -50,7 +50,7 @@ Before the version update, run the macOS build for `mac` or `both`, and Android 
   ./gradlew --no-daemon validateMavenCentralRelease)
 ```
 
-Use `snapo-link-android/build/reports/maven-central/publications.tsv` for the complete Android library and file list. Do not use a fixed module count or an old README list.
+Use `snapo-link-android/build/reports/maven-central/publications.tsv` for the Android library coordinates.
 
 Test the release workflow before updating the version when build, signing, packaging, or publishing code changes. Check changes to the Xcode project, macOS build scripts, source CI, and web build files against the release workflow's setup. Source-only changes still need normal tests, but do not require an extra release workflow run when that workflow is unchanged.
 
@@ -87,7 +87,7 @@ Open a temporary copy of the final app and confirm the changed flows work. Revie
 
 ## Publish Android libraries
 
-Check every library and file in the tag's generated `publications.tsv`. Compare the staged files and signatures with that list before publishing.
+For each library in the tag's generated `publications.tsv`, check the staged POM, Gradle metadata, AAR, sources, javadocs, and signatures before publishing.
 
 After Maven Central finishes publishing, fetch each library's POM, Gradle metadata, AAR, sources, and javadocs directly from Maven Central. Also resolve all modules from a clean Android Gradle project using the Android plugin, `google()`, and `mavenCentral()`. Direct Central-only checks must skip transitive dependencies because AndroidX and Compose may require Google's repository.
 

--- a/release/README.md
+++ b/release/README.md
@@ -1,0 +1,119 @@
+# Releasing Snap-O
+
+Run commands below from the repository root. Check product behavior and version metadata against the source commit being released.
+
+## Choose the version and scope
+
+Choose a `MAJOR.MINOR.PATCH` version newer than the relevant public versions. Inspect any existing tag, release, appcast entry, or Maven upload before resuming; never replace a published version.
+
+Choose `mac`, `android`, or `both` from the changes since the last public versions:
+
+- For macOS, use the latest published [GitHub Release](https://github.com/openai/snap-o/releases). An Android-only tag may be newer.
+- For each Android library, check its latest public Maven metadata and files. A tag or successful staging run does not prove publication.
+
+Fetch the required Git refs, then run:
+
+```bash
+bash release/preflight.sh \
+  --snapo-dir . \
+  --ref <source-commit> \
+  --candidate <target-version> \
+  --mac-base <published-macos-tag> \
+  --android-base <public-android-tag>
+```
+
+The script reads committed files at `--ref` (default: `HEAD`) and public GitHub release, appcast, and CI data. It does not build or publish. The macOS base defaults to the latest public release; supply the Android base after checking Maven. Repeat the comparison if libraries have different public versions. Resolve missing refs, bases, and protocol definitions before continuing. Local edits are shown but are not included in the comparison.
+
+## Check protocol changes
+
+Complete this review before updating the version, including for mac-only releases. Compare the [protocol definitions](../contracts/), Android command handlers and payloads, and Mac, web, and CLI clients. Check new or moved code as well as the paths listed by preflight.
+
+- Record old and new Network and Tweaks protocol numbers, client-supported versions, and the versions that enable optional features. List changes to commands, events, fields, and behavior.
+- Classify changes as none, additive, or breaking. Record the required version bump, or explain why keeping the number is compatible and how clients detect new features. An unchanged constant does not prove the API is unchanged.
+- Check clients before bumping a server number. Network clients have used an exact supported version. Tweaks uses version checks to enable features. See the [Tweaks](../contracts/tweaks/README.md) and [interception](../contracts/network/interception.md) definitions.
+- For changed protocols or version handling, test new clients with public servers, public clients with new servers, and the new pair. Check the changed feature and the error or fallback when it is unavailable. Use existing tests where they cover these cases.
+
+Record the decision and test results with the source SHA. Fix failures and merge required protocol, client, and test changes before the version update. Repeat the review if later source changes affect it.
+
+## Build and test
+
+Run the normal checks for changed code. Use the setup and commands in the [macOS/web](../.github/workflows/mac.yml), [Android](../.github/workflows/android-link.yml), and [CLI](../.github/workflows/snapo-cli.yml) workflows. Confirm CI passed on the commit being released.
+
+Before the version update, run the macOS build for `mac` or `both`, and Android publication validation for `android` or `both`:
+
+```bash
+(cd snapo-app-mac && \
+  xcodebuild -project Snap-O.xcodeproj -scheme Snap-O \
+  CODE_SIGNING_ALLOWED=NO CODE_SIGNING_REQUIRED=NO build)
+
+(cd snapo-link-android && \
+  ./gradlew --no-daemon validateMavenCentralRelease)
+```
+
+Use `snapo-link-android/build/reports/maven-central/publications.tsv` for the complete Android library and file list. Do not use a fixed module count or an old README list.
+
+Test the release workflow before updating the version when build, signing, packaging, or publishing code changes. Check changes to the Xcode project, macOS build scripts, source CI, and web build files against the release workflow's setup. Source-only changes still need normal tests, but do not require an extra release workflow run when that workflow is unchanged.
+
+For a macOS test run, verify the signed and notarized app, then open a temporary copy and confirm it works. Keep the installed prior release for the Sparkle update test. Android test runs must validate files without publishing them. Fix failures and repeat affected checks after changes.
+
+To test the release scripts:
+
+```bash
+python3 -m unittest discover -s release/tests -p 'test_*.py' -v
+```
+
+## Update the version and tag
+
+Use a clean checkout based on current `main`. Update `VERSION` and `.codex-plugin/plugin.json` together:
+
+```text
+VERSION = MAJOR.MINOR.PATCH
+BUILD_NUMBER = YYYYMMDD.NN
+```
+
+The plugin version must match `VERSION`, which supplies the macOS app and Maven versions. `BUILD_NUMBER` is the Sparkle version; it must be higher than the top public appcast build. Use the release date and a sequence number for that day.
+
+Keep the version PR limited to those two files. Repeat the applicable build/publication checks, merge the PR, and confirm required PR and main checks pass. Repeat a release test run if packaging changed or the earlier run did not cover the final source.
+
+Tag the validated version-update commit with `VERSION`, without a `v` prefix. Confirm it is reachable from `main`. Retry failed workflow steps on the same tag only if source is unchanged. If source must change after tagging, use a new release version. Do not move the tag or replace Maven files.
+
+## Check the final macOS files
+
+A tagged build must produce `Snap-O.dmg`, `Snap-O.dmg.sha256`, and a generated Sparkle `<item>`. The checksum file contains only the SHA-256 digest. Compare it with the final DMG. Test builds may omit the checksum and Sparkle item.
+
+Mount the DMG and check the app's signature, notarization, embedded web files, and bundled CLI. Confirm the app version and build match the tag. Test relevant CLI commands, including route loading if interception changed. The normal `snapo --help` invocation must exit successfully; a notarization check alone is not enough.
+
+Open a temporary copy of the final app and confirm the changed flows work. Review the release notes before publishing.
+
+## Publish Android libraries
+
+Check every library and file in the tag's generated `publications.tsv`. Compare the staged files and signatures with that list before publishing.
+
+After Maven Central finishes publishing, fetch each library's POM, Gradle metadata, AAR, sources, and javadocs directly from Maven Central. Also resolve all modules from a clean Android Gradle project using the Android plugin, `google()`, and `mavenCentral()`. Direct Central-only checks must skip transitive dependencies because AndroidX and Compose may require Google's repository.
+
+## Release notes and website
+
+Describe user-visible changes since the last public macOS release in short, plain sentences. Before claiming a bug fix, check that the bug existed in that release. Omit fixes for regressions introduced and fixed within the unreleased changes.
+
+Publish the GitHub Release with the version alone as its title and the final DMG and checksum under their exact filenames. Confirm the DMG download works before updating the appcast.
+
+Use the generated Sparkle item without changing or regenerating its signature. Check its app version, build number, minimum macOS version, byte length, URL, and signature. Add it to the latest `gh-pages` appcast after the channel description. Preserve prior entries.
+
+Update affected `gh-pages` documentation from public versions. Use the exact release tag for macOS and the latest public Maven version of each Android library. Do not document dependencies or features that users cannot download. Keep unrelated page design and assets unchanged.
+
+| Page | Sources |
+| --- | --- |
+| `index.html` | Released features and root `README.md` |
+| `network-inspector.html` | Released APIs, setup, and `skills/snap-o-network-inspector/SKILL.md` |
+| `tweaks.html` | Released APIs, setup, CLI examples, `skills/snap-o-tweaks/SKILL.md`, and its interaction-surfaces reference |
+| `tweaks-protocol.html` | `contracts/tweaks/README.md` and `skills/snap-o-tweaks/references/protocol.md` |
+
+Check appcast XML, HTML with a browser or HTML5 parser, links, assets, dependency versions, and API/CLI examples. Confirm the updated pages and appcast are public. Check the downloaded DMG against its checksum. Use a prior published Snap-O app to confirm Sparkle finds and installs the new version.
+
+Android-only releases also need affected dependency examples and guides updated after Maven publication. If no page needs a change, record why.
+
+## Finish
+
+Record the version, source/tag SHA, protocol decisions, test results, release URLs, and website changes. Include build run URLs and any unfinished checks.
+
+Do not mark the release complete while a required publication, website change, app confirmation, Maven resolution, or Sparkle upgrade test is pending.

--- a/release/preflight.sh
+++ b/release/preflight.sh
@@ -79,15 +79,10 @@ resolved_snapo_dir="$(git -C "$SNAPO_DIR" rev-parse --show-toplevel 2>/dev/null 
 SNAPO_DIR="$resolved_snapo_dir"
 
 origin_url="$(git -C "$SNAPO_DIR" remote get-url origin 2>/dev/null || true)"
-case "$origin_url" in
-  https://github.com/openai/snap-o|https://github.com/openai/snap-o.git|\
-  git@github.com:openai/snap-o|git@github.com:openai/snap-o.git|\
-  ssh://git@github.com/openai/snap-o|ssh://git@github.com/openai/snap-o.git) ;;
-  *)
-    printf 'Expected openai/snap-o origin on github.com, got: %s\n' "${origin_url:-<none>}" >&2
-    exit 1
-    ;;
-esac
+[[ "$origin_url" == *openai/snap-o* ]] || {
+  printf 'Expected openai/snap-o origin, got: %s\n' "${origin_url:-<none>}" >&2
+  exit 1
+}
 
 read_value() {
   local key="$1"

--- a/release/preflight.sh
+++ b/release/preflight.sh
@@ -194,6 +194,9 @@ if git -C "$SNAPO_DIR" cat-file -e "$MAC_BASE^{commit}" 2>/dev/null && \
   mac_release_files="$(git -C "$SNAPO_DIR" diff --name-only "$MAC_BASE..$source_sha" -- \
     .github/workflows/mac.yml \
     snapo-app-mac/Snap-O.xcodeproj/project.pbxproj \
+    snapo-app-mac/Config \
+    snapo-app-mac/Snap-O/SnapO.entitlements \
+    snapo-app-mac/Snap-O/Info.plist \
     snapo-app-mac/scripts \
     snapo-network-inspector-web/package.json \
     snapo-network-inspector-web/package-lock.json)"

--- a/release/preflight.sh
+++ b/release/preflight.sh
@@ -79,10 +79,15 @@ resolved_snapo_dir="$(git -C "$SNAPO_DIR" rev-parse --show-toplevel 2>/dev/null 
 SNAPO_DIR="$resolved_snapo_dir"
 
 origin_url="$(git -C "$SNAPO_DIR" remote get-url origin 2>/dev/null || true)"
-[[ "$origin_url" == *openai/snap-o* ]] || {
-  printf 'Expected openai/snap-o origin, got: %s\n' "${origin_url:-<none>}" >&2
-  exit 1
-}
+case "$origin_url" in
+  https://github.com/openai/snap-o|https://github.com/openai/snap-o.git|\
+  git@github.com:openai/snap-o|git@github.com:openai/snap-o.git|\
+  ssh://git@github.com/openai/snap-o|ssh://git@github.com/openai/snap-o.git) ;;
+  *)
+    printf 'Expected openai/snap-o origin on github.com, got: %s\n' "${origin_url:-<none>}" >&2
+    exit 1
+    ;;
+esac
 
 read_value() {
   local key="$1"
@@ -198,6 +203,9 @@ if git -C "$SNAPO_DIR" cat-file -e "$MAC_BASE^{commit}" 2>/dev/null && \
     snapo-app-mac/Snap-O/SnapO.entitlements \
     snapo-app-mac/Snap-O/Info.plist \
     snapo-app-mac/scripts \
+    snapo-network-inspector-web/vite.config.ts \
+    snapo-network-inspector-web/tsconfig.json \
+    snapo-network-inspector-web/index.html \
     snapo-network-inspector-web/package.json \
     snapo-network-inspector-web/package-lock.json)"
   shared_files="$(git -C "$SNAPO_DIR" diff --name-only "$MAC_BASE..$source_sha" -- .github contracts VERSION)"

--- a/release/preflight.sh
+++ b/release/preflight.sh
@@ -1,0 +1,352 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SNAPO_DIR=""
+CANDIDATE=""
+MAC_BASE=""
+ANDROID_BASE=""
+SOURCE_REF="HEAD"
+
+usage() {
+  printf '%s\n' \
+    'Usage: release/preflight.sh --snapo-dir PATH [--ref REF] [--candidate VERSION] [--mac-base TAG] [--android-base TAG]' \
+    '' \
+    'Inspect Snap-O release state without modifying a checkout or triggering a workflow.'
+}
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --snapo-dir)
+      [[ $# -ge 2 ]] || { usage >&2; exit 2; }
+      SNAPO_DIR="$2"
+      shift 2
+      ;;
+    --ref)
+      [[ $# -ge 2 ]] || { usage >&2; exit 2; }
+      SOURCE_REF="$2"
+      shift 2
+      ;;
+    --candidate)
+      [[ $# -ge 2 ]] || { usage >&2; exit 2; }
+      CANDIDATE="$2"
+      shift 2
+      ;;
+    --mac-base)
+      [[ $# -ge 2 ]] || { usage >&2; exit 2; }
+      MAC_BASE="$2"
+      shift 2
+      ;;
+    --android-base)
+      [[ $# -ge 2 ]] || { usage >&2; exit 2; }
+      ANDROID_BASE="$2"
+      shift 2
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      printf 'Unknown argument: %s\n' "$1" >&2
+      usage >&2
+      exit 2
+      ;;
+  esac
+done
+
+[[ -n "$SNAPO_DIR" ]] || {
+  printf '%s\n' '--snapo-dir is required; pass the path to an openai/snap-o checkout.' >&2
+  usage >&2
+  exit 2
+}
+
+for command_name in git gh awk sed sort tr; do
+  command -v "$command_name" >/dev/null 2>&1 || {
+    printf 'Missing required command: %s\n' "$command_name" >&2
+    exit 1
+  }
+done
+
+gh auth status >/dev/null 2>&1 || {
+  printf '%s\n' 'GitHub CLI is not authenticated. Run: gh auth login' >&2
+  exit 1
+}
+
+resolved_snapo_dir="$(git -C "$SNAPO_DIR" rev-parse --show-toplevel 2>/dev/null || true)"
+[[ -n "$resolved_snapo_dir" ]] || {
+  printf 'Snap-O checkout not found: %s\n' "$SNAPO_DIR" >&2
+  exit 1
+}
+SNAPO_DIR="$resolved_snapo_dir"
+[[ -f "$SNAPO_DIR/VERSION" ]] || {
+  printf 'Snap-O VERSION file not found: %s/VERSION\n' "$SNAPO_DIR" >&2
+  exit 1
+}
+
+origin_url="$(git -C "$SNAPO_DIR" remote get-url origin 2>/dev/null || true)"
+[[ "$origin_url" == *openai/snap-o* ]] || {
+  printf 'Expected openai/snap-o origin, got: %s\n' "${origin_url:-<none>}" >&2
+  exit 1
+}
+
+read_value() {
+  local key="$1"
+  local content="$2"
+  awk -F '=' -v key="$key" '
+    $1 ~ "^[[:space:]]*" key "[[:space:]]*$" {
+      gsub(/[[:space:]]/, "", $2)
+      print $2
+      exit
+    }
+  ' <<< "$content"
+}
+
+local_version_file="$(<"$SNAPO_DIR/VERSION")"
+local_version="$(read_value VERSION "$local_version_file")"
+local_build="$(read_value BUILD_NUMBER "$local_version_file")"
+source_sha="$(git -C "$SNAPO_DIR" rev-parse --verify --end-of-options "$SOURCE_REF^{commit}")"
+source_version_file="$(git -C "$SNAPO_DIR" show "$source_sha:VERSION")"
+source_version="$(read_value VERSION "$source_version_file")"
+source_build="$(read_value BUILD_NUMBER "$source_version_file")"
+[[ "$source_version" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ && -n "$source_build" ]] || {
+  printf 'Could not parse VERSION and BUILD_NUMBER at %s.\n' "$source_sha" >&2
+  exit 1
+}
+
+if [[ -z "$CANDIDATE" ]]; then
+  CANDIDATE="$source_version"
+fi
+[[ "$CANDIDATE" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]] || {
+  printf 'Candidate must use MAJOR.MINOR.PATCH: %s\n' "$CANDIDATE" >&2
+  exit 2
+}
+
+remote_tags="$(git ls-remote --tags "$origin_url" 'refs/tags/*')"
+latest_tag="$(awk '
+  {
+    tag = $2
+    sub("refs/tags/", "", tag)
+    if (tag ~ /^[0-9]+\.[0-9]+\.[0-9]+$/) print tag
+  }
+' <<< "$remote_tags" | sort -V | tail -n 1)"
+candidate_tag_sha="$(awk -v tag="refs/tags/$CANDIDATE" '
+  $2 == tag { direct = $1 }
+  $2 == tag "^{}" { peeled = $1 }
+  END { print peeled ? peeled : direct }
+' <<< "$remote_tags")"
+
+mac_metadata="$(gh api repos/openai/snap-o/releases/latest \
+  --jq '[.tag_name, .published_at, .html_url] | @tsv')"
+IFS=$'\t' read -r latest_mac_tag latest_mac_published latest_mac_url <<< "$mac_metadata"
+if [[ -z "$MAC_BASE" ]]; then
+  MAC_BASE="$latest_mac_tag"
+fi
+
+appcast="$(gh api -H 'Accept: application/vnd.github.raw+json' \
+  '/repos/openai/snap-o/contents/appcast.xml?ref=gh-pages')"
+appcast_version="$(sed -n 's#.*<sparkle:shortVersionString>\([^<]*\)</sparkle:shortVersionString>.*#\1#p' <<< "$appcast" | sed -n '1p')"
+appcast_build="$(sed -n 's#.*<sparkle:version>\([^<]*\)</sparkle:version>.*#\1#p' <<< "$appcast" | sed -n '1p')"
+
+printf '%s\n' 'Snap-O release preflight'
+printf '%s\n' '========================'
+printf 'Checkout:             %s\n' "$SNAPO_DIR"
+printf 'Checkout branch:      %s\n' "$(git -C "$SNAPO_DIR" branch --show-current)"
+printf 'Checkout HEAD:        %s\n' "$(git -C "$SNAPO_DIR" rev-parse HEAD)"
+printf 'Compared source:      %s (%s)\n' "$source_sha" "$SOURCE_REF"
+printf 'Local VERSION/build:  %s / %s\n' "${local_version:-<missing>}" "${local_build:-<missing>}"
+printf 'Source VERSION/build: %s / %s\n' "$source_version" "$source_build"
+printf 'Latest stable tag:    %s\n' "${latest_tag:-<none>}"
+printf 'Candidate:            %s\n' "$CANDIDATE"
+if [[ -n "$candidate_tag_sha" ]]; then
+  printf 'Candidate tag:        exists at %s\n' "$candidate_tag_sha"
+else
+  printf '%s\n' 'Candidate tag:        does not exist'
+fi
+printf 'Latest mac release:   %s (%s)\n' "$latest_mac_tag" "$latest_mac_published"
+printf 'Mac release URL:      %s\n' "$latest_mac_url"
+printf 'Appcast top item:     %s / %s\n' "${appcast_version:-<missing>}" "${appcast_build:-<missing>}"
+printf 'Mac notes base:       %s\n' "$MAC_BASE"
+if [[ -n "$ANDROID_BASE" ]]; then
+  printf 'Android public base:    %s\n' "$ANDROID_BASE"
+else
+  printf '%s\n' 'Android public base:    <required; verify public Maven versions and pass --android-base>'
+fi
+printf '%s\n' ''
+printf '%s\n' 'Checkout status:'
+checkout_status="$(git -C "$SNAPO_DIR" status --short --branch)"
+printf '%s\n' "$checkout_status"
+
+printf '%s\n' ''
+printf '%s\n' 'Latest macOS release assets:'
+gh api repos/openai/snap-o/releases/latest \
+  --jq '.assets[] | "  \(.name)  \(.size) bytes  \(.browser_download_url)"'
+
+if git -C "$SNAPO_DIR" cat-file -e "$MAC_BASE^{commit}" 2>/dev/null && \
+  git -C "$SNAPO_DIR" cat-file -e "$source_sha^{commit}" 2>/dev/null; then
+  printf '%s\n' ''
+  printf 'Merged commits since macOS base %s:\n' "$MAC_BASE"
+  git -C "$SNAPO_DIR" log --no-merges --format='  %h %s' "$MAC_BASE..$source_sha" | sed -n '1,120p'
+
+  source_files="$(git -C "$SNAPO_DIR" diff --name-only "$MAC_BASE..$source_sha")"
+  mac_files="$(git -C "$SNAPO_DIR" diff --name-only "$MAC_BASE..$source_sha" -- snapo-app-mac snapo-network-inspector-web)"
+  mac_release_files="$(git -C "$SNAPO_DIR" diff --name-only "$MAC_BASE..$source_sha" -- \
+    .github/workflows/mac.yml \
+    snapo-app-mac/Snap-O.xcodeproj/project.pbxproj \
+    snapo-app-mac/scripts \
+    snapo-network-inspector-web/package.json \
+    snapo-network-inspector-web/package-lock.json)"
+  shared_files="$(git -C "$SNAPO_DIR" diff --name-only "$MAC_BASE..$source_sha" -- .github contracts VERSION)"
+  printf '%s\n' ''
+  printf 'Changed source areas since macOS base %s:\n' "$MAC_BASE"
+  if [[ -n "$source_files" ]]; then
+    awk -F/ '{count[$1]++} END {for (area in count) printf "  %s  %s files\n", area, count[area]}' <<< "$source_files" | sort
+  else
+    printf '%s\n' '  none'
+  fi
+  if [[ -n "$mac_files" ]]; then
+    mac_count="$(awk 'END {print NR}' <<< "$mac_files")"
+    printf 'macOS source files changed since %s: %s\n' "$MAC_BASE" "$mac_count"
+    printf '%s\n' 'Recommendation: run the macOS source build/tests before bumping VERSION.'
+  else
+    printf 'macOS source files changed since %s: none\n' "$MAC_BASE"
+  fi
+  if [[ -n "$mac_release_files" ]]; then
+    mac_release_count="$(awk 'END {print NR}' <<< "$mac_release_files")"
+    printf 'macOS release-sensitive source files changed since %s: %s\n' "$MAC_BASE" "$mac_release_count"
+    sed 's/^/  /' <<< "$mac_release_files" | sed -n '1,160p'
+    printf '%s\n' 'Recommendation: compare the macOS release workflow with these source build changes and rehearse the macOS release flow before bumping VERSION.'
+  fi
+  if [[ -n "$shared_files" ]]; then
+    shared_count="$(awk 'END {print NR}' <<< "$shared_files")"
+    printf 'Shared/build files changed since %s: %s\n' "$MAC_BASE" "$shared_count"
+    sed 's/^/  /' <<< "$shared_files" | sed -n '1,160p'
+    printf '%s\n' 'Recommendation: inspect shared/build changes before deciding which checks and rehearsals are needed.'
+  fi
+else
+  printf '%s\n' ''
+  printf 'Cannot inspect commits from macOS base %s locally; fetch the missing refs first.\n' "$MAC_BASE"
+fi
+
+if [[ -n "$ANDROID_BASE" ]] && \
+  git -C "$SNAPO_DIR" cat-file -e "$ANDROID_BASE^{commit}" 2>/dev/null && \
+  git -C "$SNAPO_DIR" cat-file -e "$source_sha^{commit}" 2>/dev/null; then
+  android_files="$(git -C "$SNAPO_DIR" diff --name-only "$ANDROID_BASE..$source_sha" -- snapo-link-android)"
+  printf '%s\n' ''
+  if [[ -n "$android_files" ]]; then
+    android_count="$(awk 'END {print NR}' <<< "$android_files")"
+    printf 'Android files changed since %s: %s\n' "$ANDROID_BASE" "$android_count"
+    sed 's/^/  /' <<< "$android_files" | sed -n '1,160p'
+    printf '%s\n' 'Recommendation: include the Maven Central release unless these changes are intentionally excluded.'
+  else
+    printf 'Android files changed since %s: none\n' "$ANDROID_BASE"
+    printf '%s\n' 'Recommendation: mac-only is appropriate unless an Android republish is explicitly required.'
+  fi
+elif [[ -n "$ANDROID_BASE" ]]; then
+  printf '%s\n' ''
+  printf 'Cannot inspect Android changes from %s locally; fetch the missing refs first.\n' "$ANDROID_BASE"
+fi
+
+printf '%s\n' ''
+printf '%s\n' 'Protocol review evidence (source: selected commit, not working-tree edits):'
+printf '%s\n' 'Verify --android-base against public Maven metadata and artifacts; a tag alone does not prove publication.'
+
+print_protocol_declaration() {
+  local ref="$1"
+  local label="$2"
+  local pattern="$3"
+  local path="$4"
+  local declarations
+
+  printf '    %s:\n' "$label"
+  if declarations="$(git -C "$SNAPO_DIR" grep -n -E "$pattern" "$ref" -- "$path")"; then
+    sed 's/^/      /' <<< "$declarations"
+  else
+    printf '      UNRESOLVED: %s not found in %s; locate the missing or changed definition.\n' "$label" "$path"
+  fi
+}
+
+print_android_protocol_declarations() {
+  print_protocol_declaration "$1" 'Android Network protocol version' \
+    'const val NetworkProtocolVersion[[:space:]:=]' \
+    'snapo-link-android/network/src/main/java/com/openai/snapo/network/SnapOProtocol.kt'
+  print_protocol_declaration "$1" 'Android Tweaks protocol version' \
+    'const val TweaksProtocolVersion[[:space:]:=]' \
+    'snapo-link-android/tweaks/src/main/java/com/openai/snapo/tweaks/internal/TweakHttpServer.kt'
+}
+
+print_client_protocol_declarations() {
+  print_protocol_declaration "$1" 'Swift Network supported version' \
+    'static let supportedVersion[[:space:]:=]' \
+    'snapo-app-mac/SnapODeviceClient/Sources/SnapODeviceClient/NetworkProtocol.swift'
+  print_protocol_declaration "$1" 'Web Network supported version' \
+    'const supportedProtocolVersion[[:space:]:=]' \
+    'snapo-network-inspector-web/src/features/network-inspector/lib/protocol.ts'
+  print_protocol_declaration "$1" 'Web Tweaks modified-state/reset feature threshold' \
+    'const modifiedTweakProtocolVersion[[:space:]:=]' \
+    'snapo-network-inspector-web/src/features/tweaks-inspector/TweaksInspectorApp.tsx'
+  print_protocol_declaration "$1" 'CLI Tweaks minimum-version checks' \
+    'protocol_version[[:space:]]*<[[:space:]]*[0-9]+' \
+    'scripts/snapo'
+  print_protocol_declaration "$1" 'CLI Tweaks explicit-reset feature threshold' \
+    'explicit_resets[[:space:]]*=[[:space:]]*protocol_version[[:space:]]*>=[[:space:]]*[0-9]+' \
+    'scripts/snapo'
+}
+
+print_protocol_evidence() {
+  local label="$1"
+  local base="$2"
+  local report_declarations="$3"
+  shift 3
+  local ref
+  local changed_files
+
+  printf '\n%s protocol comparison: %s -> %s\n' "$label" "${base:-<missing>}" "$source_sha"
+  if [[ -z "$base" ]] || ! git -C "$SNAPO_DIR" cat-file -e "$base^{commit}" 2>/dev/null || \
+    ! git -C "$SNAPO_DIR" cat-file -e "$source_sha^{commit}" 2>/dev/null; then
+    printf '%s\n' '  UNRESOLVED: supply the public base and fetch missing refs before review.'
+    return
+  fi
+
+  for ref in "$base" "$source_sha"; do
+    printf '  Protocol versions and feature thresholds at %s:\n' "$ref"
+    "$report_declarations" "$ref"
+  done
+
+  changed_files="$(git -C "$SNAPO_DIR" diff --name-status "$base" "$source_sha" -- "$@")"
+  if [[ -n "$changed_files" ]]; then
+    printf '%s\n' '  Paths to review for wire API or compatibility changes:'
+    sed 's/^/    /' <<< "$changed_files"
+    printf '%s\n' '  REVIEW REQUIRED: classify changes and justify the protocol version decision.'
+  else
+    printf '%s\n' '  No changes in these paths; confirm public baselines and check for moved protocol code.'
+  fi
+}
+
+print_protocol_evidence 'Android servers' "$ANDROID_BASE" \
+  print_android_protocol_declarations \
+  contracts snapo-link-android
+print_protocol_evidence 'Mac/web/CLI clients' "$MAC_BASE" \
+  print_client_protocol_declarations \
+  contracts snapo-app-mac/SnapODeviceClient snapo-app-mac/Snap-O/NetworkInspector \
+  snapo-network-inspector-web scripts
+printf '%s\n' 'Protocol review must be recorded for this source SHA before the version bump; this report does not approve compatibility.'
+
+printf '%s\n' ''
+printf '%s\n' 'Recent source CI runs (confirm results cover the selected commit):'
+gh run list --repo openai/snap-o --branch main --limit 12 \
+  --json createdAt,workflowName,displayTitle,status,conclusion,headSha,url \
+  --jq '.[] | "  \(.workflowName)  \(.status)/\(.conclusion)  \(.headSha[0:12])  \(.displayTitle)"'
+
+printf '%s\n' ''
+if [[ "$latest_mac_tag" != "$appcast_version" ]]; then
+  printf 'Warning: latest macOS release (%s) and appcast top item (%s) differ.\n' \
+    "$latest_mac_tag" "${appcast_version:-<missing>}"
+fi
+if [[ -n "$appcast_build" ]] && \
+  [[ "$(printf '%s\n%s\n' "$appcast_build" "$source_build" | sort -V | tail -n 1)" != "$source_build" || "$appcast_build" == "$source_build" ]]; then
+  printf 'Warning: source BUILD_NUMBER (%s) is not newer than the appcast build (%s).\n' \
+    "$source_build" "$appcast_build"
+fi
+if [[ -n "$candidate_tag_sha" && "$candidate_tag_sha" != "$source_sha" ]]; then
+  printf 'Warning: candidate tag %s already exists and does not point at the selected source. Do not move it.\n' "$CANDIDATE"
+fi
+printf '%s\n' 'Preflight complete. No files, tags, releases, or workflows were modified.'

--- a/release/preflight.sh
+++ b/release/preflight.sh
@@ -77,10 +77,6 @@ resolved_snapo_dir="$(git -C "$SNAPO_DIR" rev-parse --show-toplevel 2>/dev/null 
   exit 1
 }
 SNAPO_DIR="$resolved_snapo_dir"
-[[ -f "$SNAPO_DIR/VERSION" ]] || {
-  printf 'Snap-O VERSION file not found: %s/VERSION\n' "$SNAPO_DIR" >&2
-  exit 1
-}
 
 origin_url="$(git -C "$SNAPO_DIR" remote get-url origin 2>/dev/null || true)"
 [[ "$origin_url" == *openai/snap-o* ]] || {
@@ -100,15 +96,22 @@ read_value() {
   ' <<< "$content"
 }
 
-local_version_file="$(<"$SNAPO_DIR/VERSION")"
+local_version_file=""
+if [[ -f "$SNAPO_DIR/VERSION" ]]; then
+  local_version_file="$(<"$SNAPO_DIR/VERSION")"
+fi
 local_version="$(read_value VERSION "$local_version_file")"
 local_build="$(read_value BUILD_NUMBER "$local_version_file")"
 source_sha="$(git -C "$SNAPO_DIR" rev-parse --verify --end-of-options "$SOURCE_REF^{commit}")"
 source_version_file="$(git -C "$SNAPO_DIR" show "$source_sha:VERSION")"
 source_version="$(read_value VERSION "$source_version_file")"
 source_build="$(read_value BUILD_NUMBER "$source_version_file")"
-[[ "$source_version" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ && -n "$source_build" ]] || {
-  printf 'Could not parse VERSION and BUILD_NUMBER at %s.\n' "$source_sha" >&2
+[[ "$source_version" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]] || {
+  printf 'VERSION at %s must use MAJOR.MINOR.PATCH.\n' "$source_sha" >&2
+  exit 1
+}
+[[ "$source_build" =~ ^[0-9]{8}\.[0-9]{2}$ ]] || {
+  printf 'BUILD_NUMBER at %s must use YYYYMMDD.NN.\n' "$source_sha" >&2
   exit 1
 }
 
@@ -187,7 +190,7 @@ if git -C "$SNAPO_DIR" cat-file -e "$MAC_BASE^{commit}" 2>/dev/null && \
   git -C "$SNAPO_DIR" log --no-merges --format='  %h %s' "$MAC_BASE..$source_sha" | sed -n '1,120p'
 
   source_files="$(git -C "$SNAPO_DIR" diff --name-only "$MAC_BASE..$source_sha")"
-  mac_files="$(git -C "$SNAPO_DIR" diff --name-only "$MAC_BASE..$source_sha" -- snapo-app-mac snapo-network-inspector-web)"
+  mac_files="$(git -C "$SNAPO_DIR" diff --name-only "$MAC_BASE..$source_sha" -- snapo-app-mac snapo-network-inspector-web scripts/snapo)"
   mac_release_files="$(git -C "$SNAPO_DIR" diff --name-only "$MAC_BASE..$source_sha" -- \
     .github/workflows/mac.yml \
     snapo-app-mac/Snap-O.xcodeproj/project.pbxproj \

--- a/release/preflight.sh
+++ b/release/preflight.sh
@@ -183,76 +183,27 @@ printf '%s\n' 'Latest macOS release assets:'
 gh api repos/openai/snap-o/releases/latest \
   --jq '.assets[] | "  \(.name)  \(.size) bytes  \(.browser_download_url)"'
 
-if git -C "$SNAPO_DIR" cat-file -e "$MAC_BASE^{commit}" 2>/dev/null && \
-  git -C "$SNAPO_DIR" cat-file -e "$source_sha^{commit}" 2>/dev/null; then
-  printf '%s\n' ''
-  printf 'Merged commits since macOS base %s:\n' "$MAC_BASE"
-  git -C "$SNAPO_DIR" log --no-merges --format='  %h %s' "$MAC_BASE..$source_sha" | sed -n '1,120p'
+print_source_changes() {
+  local label="$1"
+  local base="$2"
+  local changed_files
 
-  source_files="$(git -C "$SNAPO_DIR" diff --name-only "$MAC_BASE..$source_sha")"
-  mac_files="$(git -C "$SNAPO_DIR" diff --name-only "$MAC_BASE..$source_sha" -- snapo-app-mac snapo-network-inspector-web scripts/snapo)"
-  mac_release_files="$(git -C "$SNAPO_DIR" diff --name-only "$MAC_BASE..$source_sha" -- \
-    .github/workflows/mac.yml \
-    snapo-app-mac/Snap-O.xcodeproj/project.pbxproj \
-    snapo-app-mac/Config \
-    snapo-app-mac/Snap-O/SnapO.entitlements \
-    snapo-app-mac/Snap-O/Info.plist \
-    snapo-app-mac/scripts \
-    snapo-network-inspector-web/vite.config.ts \
-    snapo-network-inspector-web/tsconfig.json \
-    snapo-network-inspector-web/index.html \
-    snapo-network-inspector-web/package.json \
-    snapo-network-inspector-web/package-lock.json)"
-  shared_files="$(git -C "$SNAPO_DIR" diff --name-only "$MAC_BASE..$source_sha" -- .github contracts VERSION)"
-  printf '%s\n' ''
-  printf 'Changed source areas since macOS base %s:\n' "$MAC_BASE"
-  if [[ -n "$source_files" ]]; then
-    awk -F/ '{count[$1]++} END {for (area in count) printf "  %s  %s files\n", area, count[area]}' <<< "$source_files" | sort
+  [[ -n "$base" ]] || return 0
+  printf '\nChanged files since %s base %s:\n' "$label" "$base"
+  if ! git -C "$SNAPO_DIR" cat-file -e "$base^{commit}" 2>/dev/null; then
+    printf '%s\n' '  Base is not available locally; fetch the missing ref first.'
+    return
+  fi
+  changed_files="$(git -C "$SNAPO_DIR" diff --name-status "$base" "$source_sha")"
+  if [[ -n "$changed_files" ]]; then
+    sed 's/^/  /' <<< "$changed_files"
   else
     printf '%s\n' '  none'
   fi
-  if [[ -n "$mac_files" ]]; then
-    mac_count="$(awk 'END {print NR}' <<< "$mac_files")"
-    printf 'macOS source files changed since %s: %s\n' "$MAC_BASE" "$mac_count"
-    printf '%s\n' 'Recommendation: run the macOS source build/tests before bumping VERSION.'
-  else
-    printf 'macOS source files changed since %s: none\n' "$MAC_BASE"
-  fi
-  if [[ -n "$mac_release_files" ]]; then
-    mac_release_count="$(awk 'END {print NR}' <<< "$mac_release_files")"
-    printf 'macOS release-sensitive source files changed since %s: %s\n' "$MAC_BASE" "$mac_release_count"
-    sed 's/^/  /' <<< "$mac_release_files" | sed -n '1,160p'
-    printf '%s\n' 'Recommendation: compare the macOS release workflow with these source build changes and rehearse the macOS release flow before bumping VERSION.'
-  fi
-  if [[ -n "$shared_files" ]]; then
-    shared_count="$(awk 'END {print NR}' <<< "$shared_files")"
-    printf 'Shared/build files changed since %s: %s\n' "$MAC_BASE" "$shared_count"
-    sed 's/^/  /' <<< "$shared_files" | sed -n '1,160p'
-    printf '%s\n' 'Recommendation: inspect shared/build changes before deciding which checks and rehearsals are needed.'
-  fi
-else
-  printf '%s\n' ''
-  printf 'Cannot inspect commits from macOS base %s locally; fetch the missing refs first.\n' "$MAC_BASE"
-fi
+}
 
-if [[ -n "$ANDROID_BASE" ]] && \
-  git -C "$SNAPO_DIR" cat-file -e "$ANDROID_BASE^{commit}" 2>/dev/null && \
-  git -C "$SNAPO_DIR" cat-file -e "$source_sha^{commit}" 2>/dev/null; then
-  android_files="$(git -C "$SNAPO_DIR" diff --name-only "$ANDROID_BASE..$source_sha" -- snapo-link-android)"
-  printf '%s\n' ''
-  if [[ -n "$android_files" ]]; then
-    android_count="$(awk 'END {print NR}' <<< "$android_files")"
-    printf 'Android files changed since %s: %s\n' "$ANDROID_BASE" "$android_count"
-    sed 's/^/  /' <<< "$android_files" | sed -n '1,160p'
-    printf '%s\n' 'Recommendation: include the Maven Central release unless these changes are intentionally excluded.'
-  else
-    printf 'Android files changed since %s: none\n' "$ANDROID_BASE"
-    printf '%s\n' 'Recommendation: mac-only is appropriate unless an Android republish is explicitly required.'
-  fi
-elif [[ -n "$ANDROID_BASE" ]]; then
-  printf '%s\n' ''
-  printf 'Cannot inspect Android changes from %s locally; fetch the missing refs first.\n' "$ANDROID_BASE"
-fi
+print_source_changes 'macOS' "$MAC_BASE"
+print_source_changes 'Android' "$ANDROID_BASE"
 
 printf '%s\n' ''
 printf '%s\n' 'Protocol review evidence (source: selected commit, not working-tree edits):'

--- a/release/preflight.sh
+++ b/release/preflight.sh
@@ -89,7 +89,7 @@ read_value() {
   local content="$2"
   awk -F '=' -v key="$key" '
     $1 ~ "^[[:space:]]*" key "[[:space:]]*$" {
-      gsub(/[[:space:]]/, "", $2)
+      gsub(/^[[:space:]]+|[[:space:]]+$/, "", $2)
       print $2
       exit
     }
@@ -289,12 +289,6 @@ print_protocol_evidence 'Mac/web/CLI clients' "$MAC_BASE" \
   contracts snapo-app-mac/SnapODeviceClient snapo-app-mac/Snap-O/NetworkInspector \
   snapo-network-inspector-web scripts
 printf '%s\n' 'Protocol review must be recorded for this source SHA before the version bump; this report does not approve compatibility.'
-
-printf '%s\n' ''
-printf '%s\n' 'Recent source CI runs (confirm results cover the selected commit):'
-gh run list --repo openai/snap-o --branch main --limit 12 \
-  --json createdAt,workflowName,displayTitle,status,conclusion,headSha,url \
-  --jq '.[] | "  \(.workflowName)  \(.status)/\(.conclusion)  \(.headSha[0:12])  \(.displayTitle)"'
 
 printf '%s\n' ''
 if [[ "$latest_mac_tag" != "$appcast_version" ]]; then

--- a/release/tests/test_preflight.py
+++ b/release/tests/test_preflight.py
@@ -133,6 +133,19 @@ class ProtocolReportTests(unittest.TestCase):
         self.assertIn("macOS source files changed since 5.1.0: 1\n", report)
         self.assertIn("Recommendation: run the macOS source build/tests", report)
 
+    def test_signing_and_packaging_changes_recommend_rehearsal(self):
+        for path in ("snapo-app-mac/Config/Base.xcconfig",
+                     "snapo-app-mac/Snap-O/SnapO.entitlements",
+                     "snapo-app-mac/Snap-O/Info.plist"):
+            with self.subTest(path=path):
+                base = self.git("rev-parse", "HEAD").strip()
+                self.write(path, "Release configuration\n")
+                self.commit()
+                report = self.report(base=base)
+                self.assertIn(f"macOS release-sensitive source files changed since {base}: 1\n", report)
+                self.assertIn(f"  {path}\n", report)
+                self.assertIn("rehearse the macOS release flow before bumping VERSION", report)
+
     def test_malformed_committed_build_number_is_rejected(self):
         for build in ("", "20260903", "20260903.0", "20260903.000", "2026093.00", "20260903.xx"):
             with self.subTest(build=build):

--- a/release/tests/test_preflight.py
+++ b/release/tests/test_preflight.py
@@ -85,9 +85,7 @@ class ProtocolReportTests(unittest.TestCase):
 
             args = sys.argv[1:]
             request = " ".join(args)
-            if args[:2] == ["run", "list"] and args[args.index("--repo") + 1] != "openai/snap-o":
-                raise SystemExit("Source checks must only query the source repository")
-            if args[:2] in (["auth", "status"], ["run", "list"]):
+            if args[:2] == ["auth", "status"]:
                 pass
             elif "releases/latest" in request:
                 if ".assets[]" not in request:
@@ -156,6 +154,23 @@ class ProtocolReportTests(unittest.TestCase):
                 self.assertNotEqual(result.returncode, 0)
                 self.assertIn("must use YYYYMMDD.NN", result.stderr)
                 self.assertNotIn("Preflight complete", result.stdout)
+
+    def test_version_values_trim_only_surrounding_whitespace(self):
+        for version, build, error in (
+            ("6.0.0", "20260903.00", None),
+            ("6.0 .0", "20260903.00", "must use MAJOR.MINOR.PATCH"),
+            ("6.0.0", "20260903. 00", "must use YYYYMMDD.NN"),
+        ):
+            with self.subTest(version=version, build=build):
+                self.write("VERSION", f"VERSION = \t{version}\t \nBUILD_NUMBER = \t{build}\t \n")
+                self.commit()
+                result = self.run_preflight()
+                if error:
+                    self.assertNotEqual(result.returncode, 0)
+                    self.assertIn(error, result.stderr)
+                else:
+                    self.assertEqual(result.returncode, 0, result.stdout + result.stderr)
+                    self.assertIn("Source VERSION/build: 6.0.0 / 20260903.00", result.stdout)
 
     def test_local_version_edits_do_not_affect_source_validation(self):
         for content in ("VERSION = invalid\nBUILD_NUMBER = invalid\n", None):

--- a/release/tests/test_preflight.py
+++ b/release/tests/test_preflight.py
@@ -114,14 +114,54 @@ class ProtocolReportTests(unittest.TestCase):
         self.git("add", ".")
         self.git("commit", "-qm", "Fixture")
 
-    def report(self, base="5.1.0", ref="HEAD"):
-        result = subprocess.run(
+    def run_preflight(self, base="5.1.0", ref="HEAD"):
+        return subprocess.run(
             ["bash", str(PREFLIGHT), "--snapo-dir", str(self.repo),
              "--ref", ref, "--candidate", "6.0.0", "--mac-base", base, "--android-base", base],
             env=self.env, capture_output=True, text=True,
         )
+
+    def report(self, base="5.1.0", ref="HEAD"):
+        result = self.run_preflight(base, ref)
         self.assertEqual(result.returncode, 0, result.stdout + result.stderr)
         return result.stdout
+
+    def test_cli_change_counts_as_macos_source(self):
+        self.write("scripts/snapo", self.baseline["scripts/snapo"] + "# CLI change\n")
+        self.commit()
+        report = self.report()
+        self.assertIn("macOS source files changed since 5.1.0: 1\n", report)
+        self.assertIn("Recommendation: run the macOS source build/tests", report)
+
+    def test_malformed_committed_build_number_is_rejected(self):
+        for build in ("", "20260903", "20260903.0", "20260903.000", "2026093.00", "20260903.xx"):
+            with self.subTest(build=build):
+                self.write("VERSION", f"VERSION = 6.0.0\nBUILD_NUMBER = {build}\n")
+                self.commit()
+                result = self.run_preflight()
+                self.assertNotEqual(result.returncode, 0)
+                self.assertIn("must use YYYYMMDD.NN", result.stderr)
+                self.assertNotIn("Preflight complete", result.stdout)
+
+    def test_local_version_edits_do_not_affect_source_validation(self):
+        for content in ("VERSION = invalid\nBUILD_NUMBER = invalid\n", None):
+            with self.subTest(content=content):
+                if content is None:
+                    (self.repo / "VERSION").unlink()
+                else:
+                    self.write("VERSION", content)
+                report = self.report()
+                self.assertIn("Source VERSION/build: 6.0.0 / 20260903.00", report)
+                local_values = "<missing> / <missing>" if content is None else "invalid / invalid"
+                self.assertIn(f"Local VERSION/build:  {local_values}", report)
+
+    def test_missing_committed_version_is_rejected(self):
+        (self.repo / "VERSION").unlink()
+        self.commit()
+        self.write("VERSION", "VERSION = 6.0.0\nBUILD_NUMBER = 20260903.00\n")
+        result = self.run_preflight()
+        self.assertNotEqual(result.returncode, 0)
+        self.assertNotIn("Preflight complete", result.stdout)
 
     def test_reports_all_versions_and_feature_thresholds_at_both_refs(self):
         report = self.report()

--- a/release/tests/test_preflight.py
+++ b/release/tests/test_preflight.py
@@ -114,40 +114,38 @@ class ProtocolReportTests(unittest.TestCase):
         self.git("add", ".")
         self.git("commit", "-qm", "Fixture")
 
-    def run_preflight(self, base="5.1.0", ref="HEAD"):
+    def run_preflight(self, base="5.1.0", ref="HEAD", android_base=None):
         return subprocess.run(
             ["bash", str(PREFLIGHT), "--snapo-dir", str(self.repo),
-             "--ref", ref, "--candidate", "6.0.0", "--mac-base", base, "--android-base", base],
+             "--ref", ref, "--candidate", "6.0.0", "--mac-base", base,
+             "--android-base", base if android_base is None else android_base],
             env=self.env, capture_output=True, text=True,
         )
 
-    def report(self, base="5.1.0", ref="HEAD"):
-        result = self.run_preflight(base, ref)
+    def report(self, base="5.1.0", ref="HEAD", android_base=None):
+        result = self.run_preflight(base, ref, android_base)
         self.assertEqual(result.returncode, 0, result.stdout + result.stderr)
         return result.stdout
 
-    def test_cli_change_counts_as_macos_source(self):
-        self.write("scripts/snapo", self.baseline["scripts/snapo"] + "# CLI change\n")
+    def test_reports_all_changed_files_from_each_public_base(self):
+        self.write("docs/release-note.md", "Release note\n")
         self.commit()
-        report = self.report()
-        self.assertIn("macOS source files changed since 5.1.0: 1\n", report)
-        self.assertIn("Recommendation: run the macOS source build/tests", report)
+        self.git("tag", "5.2.0")
+        scheme = "snapo-app-mac/Snap-O.xcodeproj/xcshareddata/xcschemes/Snap-O.xcscheme"
+        self.write(scheme, "Archive configuration\n")
+        self.write("custom-build/input.txt", "Build input\n")
+        self.commit()
+        self.write("uncommitted.txt", "Local edit\n")
 
-    def test_signing_and_packaging_changes_recommend_rehearsal(self):
-        for path in ("snapo-app-mac/Config/Base.xcconfig",
-                     "snapo-app-mac/Snap-O/SnapO.entitlements",
-                     "snapo-app-mac/Snap-O/Info.plist",
-                     "snapo-network-inspector-web/vite.config.ts",
-                     "snapo-network-inspector-web/tsconfig.json",
-                     "snapo-network-inspector-web/index.html"):
-            with self.subTest(path=path):
-                base = self.git("rev-parse", "HEAD").strip()
-                self.write(path, "Release configuration\n")
-                self.commit()
-                report = self.report(base=base)
-                self.assertIn(f"macOS release-sensitive source files changed since {base}: 1\n", report)
-                self.assertIn(f"  {path}\n", report)
-                self.assertIn("rehearse the macOS release flow before bumping VERSION", report)
+        report = self.report(android_base="5.2.0")
+        mac_files = report.split("Changed files since macOS base 5.1.0:\n", 1)[1].split("\n\n", 1)[0]
+        android_files = report.split("Changed files since Android base 5.2.0:\n", 1)[1].split("\n\n", 1)[0]
+        self.assertEqual(mac_files, "  A\tcustom-build/input.txt\n"
+                         "  A\tdocs/release-note.md\n"
+                         f"  A\t{scheme}")
+        self.assertEqual(android_files, "  A\tcustom-build/input.txt\n"
+                         f"  A\t{scheme}")
+        self.assertNotIn("Recommendation:", report)
 
     def test_malformed_committed_build_number_is_rejected(self):
         for build in ("", "20260903", "20260903.0", "20260903.000", "2026093.00", "20260903.xx"):

--- a/release/tests/test_preflight.py
+++ b/release/tests/test_preflight.py
@@ -1,0 +1,175 @@
+"""Offline protocol-report regression tests: python3 -m unittest discover -s release/tests -v."""
+
+import os
+from pathlib import Path
+import subprocess
+import sys
+import tempfile
+import textwrap
+import unittest
+
+
+PREFLIGHT = Path(__file__).resolve().parents[1] / "preflight.sh"
+DECLARATIONS = [
+    (
+        "Android Network protocol version",
+        "snapo-link-android/network/src/main/java/com/openai/snapo/network/SnapOProtocol.kt",
+        "internal const val NetworkProtocolVersion: Int = 1",
+    ),
+    (
+        "Android Tweaks protocol version",
+        "snapo-link-android/tweaks/src/main/java/com/openai/snapo/tweaks/internal/TweakHttpServer.kt",
+        "internal const val TweaksProtocolVersion: Int = 4",
+    ),
+    (
+        "Swift Network supported version",
+        "snapo-app-mac/SnapODeviceClient/Sources/SnapODeviceClient/NetworkProtocol.swift",
+        "public static let supportedVersion = 1",
+    ),
+    (
+        "Web Network supported version",
+        "snapo-network-inspector-web/src/features/network-inspector/lib/protocol.ts",
+        "export const supportedProtocolVersion = 1;",
+    ),
+    (
+        "Web Tweaks modified-state/reset feature threshold",
+        "snapo-network-inspector-web/src/features/tweaks-inspector/TweaksInspectorApp.tsx",
+        "const modifiedTweakProtocolVersion = 4;",
+    ),
+    (
+        "CLI Tweaks minimum-version checks",
+        "scripts/snapo",
+        "if protocol_version < 1:",
+    ),
+    (
+        "CLI Tweaks explicit-reset feature threshold",
+        "scripts/snapo",
+        "explicit_resets = protocol_version >= 4",
+    ),
+]
+
+
+class ProtocolReportTests(unittest.TestCase):
+    def setUp(self):
+        temporary = tempfile.TemporaryDirectory()
+        self.addCleanup(temporary.cleanup)
+        root = Path(temporary.name)
+        self.repo = root / "openai" / "snap-o"
+        self.repo.mkdir(parents=True)
+        bin_dir = root / "bin"
+        bin_dir.mkdir()
+        self.env = dict(
+            os.environ,
+            PATH=f"{bin_dir}{os.pathsep}{os.environ['PATH']}",
+            GIT_CONFIG_GLOBAL=os.devnull,
+            GIT_CONFIG_NOSYSTEM="1",
+        )
+        self.git("init", "-q", "-b", "main")
+        self.git("config", "user.name", "Preflight Test")
+        self.git("config", "user.email", "preflight@example.invalid")
+        self.git("config", "commit.gpgSign", "false")
+        self.git("remote", "add", "origin", str(self.repo))
+        self.write("VERSION", "VERSION = 6.0.0\nBUILD_NUMBER = 20260903.00\n")
+        self.baseline = {}
+        for _, path, declaration in DECLARATIONS:
+            self.baseline[path] = self.baseline.get(path, "") + declaration + "\n"
+        for path, content in self.baseline.items():
+            self.write(path, content)
+        self.commit()
+        self.git("tag", "5.1.0")
+
+        # Only GitHub responses are stubbed; the full preflight reads real Git refs/files.
+        gh = bin_dir / "gh"
+        gh.write_text(f"#!{sys.executable}\n" + textwrap.dedent('''\
+            import sys
+
+            args = sys.argv[1:]
+            request = " ".join(args)
+            if args[:2] == ["run", "list"] and args[args.index("--repo") + 1] != "openai/snap-o":
+                raise SystemExit("Source checks must only query the source repository")
+            if args[:2] in (["auth", "status"], ["run", "list"]):
+                pass
+            elif "releases/latest" in request:
+                if ".assets[]" not in request:
+                    print("5.1.0\\t2026-09-01T00:00:00Z\\thttps://example.invalid/release")
+            elif "contents/appcast.xml?ref=gh-pages" in request:
+                print("<sparkle:shortVersionString>5.1.0</sparkle:shortVersionString>")
+                print("<sparkle:version>20260901.00</sparkle:version>")
+            else:
+                raise SystemExit(f"Unexpected GitHub request: {args}")
+            '''))
+        gh.chmod(0o755)
+
+    def git(self, *args):
+        return subprocess.check_output(
+            ["git", *args], cwd=self.repo, env=self.env, stderr=subprocess.STDOUT, text=True
+        )
+
+    def write(self, path, content):
+        target = self.repo / path
+        target.parent.mkdir(parents=True, exist_ok=True)
+        target.write_text(content)
+
+    def commit(self):
+        self.git("add", ".")
+        self.git("commit", "-qm", "Fixture")
+
+    def report(self, base="5.1.0", ref="HEAD"):
+        result = subprocess.run(
+            ["bash", str(PREFLIGHT), "--snapo-dir", str(self.repo),
+             "--ref", ref, "--candidate", "6.0.0", "--mac-base", base, "--android-base", base],
+            env=self.env, capture_output=True, text=True,
+        )
+        self.assertEqual(result.returncode, 0, result.stdout + result.stderr)
+        return result.stdout
+
+    def test_reports_all_versions_and_feature_thresholds_at_both_refs(self):
+        report = self.report()
+        self.assertNotIn("UNRESOLVED", report)
+        for label, _, declaration in DECLARATIONS:
+            self.assertEqual(report.count(f"    {label}:\n"), 2)
+            self.assertEqual(report.count(declaration), 2)
+
+    def test_each_missing_declaration_is_unresolved_despite_other_matches(self):
+        debug = "snapo-network-inspector-web/src/features/network-inspector/lib/debug.ts"
+        for label, missing_path, declaration in DECLARATIONS:
+            with self.subTest(label=label):
+                for path, content in self.baseline.items():
+                    self.write(path, content)
+                self.write(missing_path, self.baseline[missing_path].replace(declaration + "\n", ""))
+                self.write(debug, "const supportedProtocolVersion = 1;\n")
+                self.commit()
+                report = self.report()
+                self.assertEqual(report.count("UNRESOLVED:"), 1)
+                self.assertIn(f"UNRESOLVED: {label} not found in {missing_path}", report)
+                for other_label, _, other_declaration in DECLARATIONS:
+                    if other_label != label:
+                        self.assertEqual(report.count(other_declaration), 2)
+
+    def test_reports_changed_values_from_candidate(self):
+        for path, content in self.baseline.items():
+            self.write(path, content.replace("1", "2").replace("4", "5"))
+        self.commit()
+        report = self.report()
+        self.assertNotIn("UNRESOLVED", report)
+        for _, _, declaration in DECLARATIONS:
+            self.assertEqual(report.count(declaration), 1)
+            self.assertEqual(report.count(declaration.replace("1", "2").replace("4", "5")), 1)
+
+    def test_selected_ref_is_used_instead_of_current_main(self):
+        for path, content in self.baseline.items():
+            self.write(path, content.replace("1", "2").replace("4", "5"))
+        self.commit()
+        report = self.report(ref="5.1.0")
+        for _, _, declaration in DECLARATIONS:
+            self.assertEqual(report.count(declaration), 2)
+            self.assertNotIn(declaration.replace("1", "2").replace("4", "5"), report)
+
+    def test_missing_base_is_unresolved(self):
+        report = self.report(base="missing-public-tag")
+        self.assertEqual(report.count("UNRESOLVED:"), 2)
+        self.assertIn("supply the public base and fetch missing refs", report)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/release/tests/test_preflight.py
+++ b/release/tests/test_preflight.py
@@ -2,6 +2,7 @@
 
 import os
 from pathlib import Path
+import shutil
 import subprocess
 import sys
 import tempfile
@@ -68,7 +69,7 @@ class ProtocolReportTests(unittest.TestCase):
         self.git("config", "user.name", "Preflight Test")
         self.git("config", "user.email", "preflight@example.invalid")
         self.git("config", "commit.gpgSign", "false")
-        self.git("remote", "add", "origin", str(self.repo))
+        self.git("remote", "add", "origin", "https://github.com/openai/snap-o.git")
         self.write("VERSION", "VERSION = 6.0.0\nBUILD_NUMBER = 20260903.00\n")
         self.baseline = {}
         for _, path, declaration in DECLARATIONS:
@@ -78,7 +79,20 @@ class ProtocolReportTests(unittest.TestCase):
         self.commit()
         self.git("tag", "5.1.0")
 
-        # Only GitHub responses are stubbed; the full preflight reads real Git refs/files.
+        # Redirect remote tag reads to the fixture; other Git commands run unchanged.
+        git = bin_dir / "git"
+        git.write_text(f"#!{sys.executable}\n" + textwrap.dedent(f'''\
+            import os
+            import sys
+
+            args = sys.argv[1:]
+            if args[:2] == ["ls-remote", "--tags"]:
+                args[2] = {str(self.repo)!r}
+            os.execv({shutil.which("git")!r}, ["git", *args])
+            '''))
+        git.chmod(0o755)
+
+        # GitHub responses are stubbed; the full preflight reads real Git refs/files.
         gh = bin_dir / "gh"
         gh.write_text(f"#!{sys.executable}\n" + textwrap.dedent('''\
             import sys
@@ -126,6 +140,28 @@ class ProtocolReportTests(unittest.TestCase):
         self.assertEqual(result.returncode, 0, result.stdout + result.stderr)
         return result.stdout
 
+    def test_supported_github_origins_are_accepted(self):
+        for url in ("https://github.com/openai/snap-o", "git@github.com:openai/snap-o",
+                    "ssh://git@github.com/openai/snap-o"):
+            for suffix in ("", ".git"):
+                with self.subTest(origin=url + suffix):
+                    self.git("remote", "set-url", "origin", url + suffix)
+                    self.assertIn("Preflight complete.", self.report())
+
+    def test_wrong_or_missing_origin_is_rejected(self):
+        for origin in ("https://github.com/example/snap-o.git",
+                       "https://github.com/openai/snap-o-fork.git",
+                       "https://example.invalid/openai/snap-o.git", str(self.repo), None):
+            with self.subTest(origin=origin):
+                if origin is None:
+                    self.git("remote", "remove", "origin")
+                else:
+                    self.git("remote", "set-url", "origin", origin)
+                result = self.run_preflight()
+                self.assertNotEqual(result.returncode, 0)
+                self.assertIn("Expected openai/snap-o origin on github.com", result.stderr)
+                self.assertNotIn("Preflight complete.", result.stdout)
+
     def test_cli_change_counts_as_macos_source(self):
         self.write("scripts/snapo", self.baseline["scripts/snapo"] + "# CLI change\n")
         self.commit()
@@ -136,7 +172,10 @@ class ProtocolReportTests(unittest.TestCase):
     def test_signing_and_packaging_changes_recommend_rehearsal(self):
         for path in ("snapo-app-mac/Config/Base.xcconfig",
                      "snapo-app-mac/Snap-O/SnapO.entitlements",
-                     "snapo-app-mac/Snap-O/Info.plist"):
+                     "snapo-app-mac/Snap-O/Info.plist",
+                     "snapo-network-inspector-web/vite.config.ts",
+                     "snapo-network-inspector-web/tsconfig.json",
+                     "snapo-network-inspector-web/index.html"):
             with self.subTest(path=path):
                 base = self.git("rev-parse", "HEAD").strip()
                 self.write(path, "Release configuration\n")

--- a/release/tests/test_preflight.py
+++ b/release/tests/test_preflight.py
@@ -2,7 +2,6 @@
 
 import os
 from pathlib import Path
-import shutil
 import subprocess
 import sys
 import tempfile
@@ -69,7 +68,7 @@ class ProtocolReportTests(unittest.TestCase):
         self.git("config", "user.name", "Preflight Test")
         self.git("config", "user.email", "preflight@example.invalid")
         self.git("config", "commit.gpgSign", "false")
-        self.git("remote", "add", "origin", "https://github.com/openai/snap-o.git")
+        self.git("remote", "add", "origin", str(self.repo))
         self.write("VERSION", "VERSION = 6.0.0\nBUILD_NUMBER = 20260903.00\n")
         self.baseline = {}
         for _, path, declaration in DECLARATIONS:
@@ -79,20 +78,7 @@ class ProtocolReportTests(unittest.TestCase):
         self.commit()
         self.git("tag", "5.1.0")
 
-        # Redirect remote tag reads to the fixture; other Git commands run unchanged.
-        git = bin_dir / "git"
-        git.write_text(f"#!{sys.executable}\n" + textwrap.dedent(f'''\
-            import os
-            import sys
-
-            args = sys.argv[1:]
-            if args[:2] == ["ls-remote", "--tags"]:
-                args[2] = {str(self.repo)!r}
-            os.execv({shutil.which("git")!r}, ["git", *args])
-            '''))
-        git.chmod(0o755)
-
-        # GitHub responses are stubbed; the full preflight reads real Git refs/files.
+        # Only GitHub responses are stubbed; the full preflight reads real Git refs/files.
         gh = bin_dir / "gh"
         gh.write_text(f"#!{sys.executable}\n" + textwrap.dedent('''\
             import sys
@@ -139,28 +125,6 @@ class ProtocolReportTests(unittest.TestCase):
         result = self.run_preflight(base, ref)
         self.assertEqual(result.returncode, 0, result.stdout + result.stderr)
         return result.stdout
-
-    def test_supported_github_origins_are_accepted(self):
-        for url in ("https://github.com/openai/snap-o", "git@github.com:openai/snap-o",
-                    "ssh://git@github.com/openai/snap-o"):
-            for suffix in ("", ".git"):
-                with self.subTest(origin=url + suffix):
-                    self.git("remote", "set-url", "origin", url + suffix)
-                    self.assertIn("Preflight complete.", self.report())
-
-    def test_wrong_or_missing_origin_is_rejected(self):
-        for origin in ("https://github.com/example/snap-o.git",
-                       "https://github.com/openai/snap-o-fork.git",
-                       "https://example.invalid/openai/snap-o.git", str(self.repo), None):
-            with self.subTest(origin=origin):
-                if origin is None:
-                    self.git("remote", "remove", "origin")
-                else:
-                    self.git("remote", "set-url", "origin", origin)
-                result = self.run_preflight()
-                self.assertNotEqual(result.returncode, 0)
-                self.assertIn("Expected openai/snap-o origin on github.com", result.stderr)
-                self.assertNotIn("Preflight complete.", result.stdout)
 
     def test_cli_change_counts_as_macos_source(self):
         self.write("scripts/snapo", self.baseline["scripts/snapo"] + "# CLI change\n")


### PR DESCRIPTION
Release preparation needs a visible checklist for protocol compatibility, versions, artifacts, and documentation. Add a guide and read-only preflight report so these checks can be reviewed alongside product changes.

## Summary

- Add `release/README.md` and link it from the README, contributor guide, and agent instructions.
- Report changed files, version metadata, and protocol declarations for a selected source commit and public release bases.
- Use the guide to decide release scope, protocol bumps, and required tests.

## Validation

- Ten preflight tests and macOS/Ubuntu CLI CI passed.
- Shell syntax, workflow lint, Markdown links, and formatting checks passed.
- Read-only preflight checked committed source against public 6.0.0 comparison bases.
- Unsigned macOS app build passed.
