### PR TITLE
Add live Bézier curve tweaks and editors

### DIFF
--- a/contracts/tweaks/README.md
+++ b/contracts/tweaks/README.md
@@ -37,11 +37,11 @@ Return the app's user-facing Android label, package name, and Tweaks protocol ve
 {
   "name": "Snap-O Tweaks Demo",
   "packageName": "com.openai.snapo.demo.tweaks",
-  "protocolVersion": 4
+  "protocolVersion": 5
 }
 ```
 
-Resolve `name` from the actual Android app label. An absent `protocolVersion` identifies the original version 1, which exposes value tweaks only. Version 2 adds action descriptors and `POST /tweaks/action`. Version 3 adds best-effort batch updates with per-item errors. Version 4 adds explicit null resets and authoritative modification status. The Tweaks protocol version is independent of the Network Inspector protocol version; hosts can use it to select compatible behavior.
+Resolve `name` from the actual Android app label. An absent `protocolVersion` identifies the original version 1, which exposes value tweaks only. Version 2 adds action descriptors and `POST /tweaks/action`. Version 3 adds best-effort batch updates with per-item errors. Version 4 adds explicit null resets and authoritative modification status. Version 5 adds Bézier curve descriptors and optional Y bounds. The Tweaks protocol version is independent of the Network Inspector protocol version; hosts can use it to select compatible behavior.
 
 ### GET /app/icon
 
@@ -150,7 +150,7 @@ Registry-owned usages with the same name must agree on the tweak type, default, 
 
 In protocol version 4, only modified value tweaks include `"modified": true`; otherwise the field is absent. A missing field always means false, even when `value` differs from `default`. Standard tweaks compare value and default. App-owned tweaks report whether their own override exists. Versions 1, 2, and 3 omit this field; determine their modification status by comparing `value` with `default`. Action descriptors never include `modified`.
 
-Supported value types are `int`, `float`, `boolean`, `color`, `string`, and `enum`. The `action` type describes an explicitly registered parameterless app-owned callback. Actions do not have `value`, `default`, options, or numeric constraints; clients must not attempt to patch or reset them. Integer tweaks accept only whole numbers; float tweaks accept whole or fractional numbers. Numeric tweaks may include `min`, `max`, and `step`. Only include constraints actually supplied by the app. A `step` is relative to `min`, or to `default` if no `min` is supplied. Colors use `#RRGGBB`, or `#RRGGBBAA` when translucent.
+Supported value types are `int`, `float`, `boolean`, `color`, `string`, `enum`, and `bezier`. The `action` type describes an explicitly registered parameterless app-owned callback. Actions do not have `value`, `default`, options, or numeric constraints; clients must not attempt to patch or reset them. Integer tweaks accept only whole numbers; float tweaks accept whole or fractional numbers. Numeric tweaks may include `min`, `max`, and `step`. Only include constraints actually supplied by the app. A `step` is relative to `min`, or to `default` if no `min` is supplied. Colors use `#RRGGBB`, or `#RRGGBBAA` when translucent.
 
 Enum tweaks include an ordered, nonempty `options` array containing the unique enum constant names. The descriptor's `default`, current `value`, picker text, and `PATCH` values all use those exact names. Preserve declaration order when rendering pickers; reject any value not present in `options`.
 
@@ -169,6 +169,52 @@ Conflicting actions remain discoverable but cannot be invoked until exactly one 
 Compose color defaults keep their exact in-process identity, including color space, component precision, and `Color.Unspecified`. The HTTP protocol still presents colors as sRGB hex; non-sRGB defaults are projected, and `Color.Unspecified` appears as `#00000000`. An explicit reset restores the original in-process color, even when its wire representation is projected.
 
 Numeric JSON values may contain at most 128 characters and 64 significant digits, with a decimal scale between -64 and 64. Reject values outside those limits with `422` before changing any tweaks.
+
+### Bézier curves
+
+A `bezier` tweak is one cubic curve with fixed endpoints `(0, 0)` and `(1, 1)`.
+Its value and default are objects with four named numeric coordinates:
+
+```json
+{
+  "name": "Halo/Curve",
+  "type": "bezier",
+  "default": {"x1": 0.25, "y1": 0.1, "x2": 0.25, "y2": 1.0},
+  "value": {"x1": 0.4, "y1": 0.0, "x2": 0.2, "y2": 1.0},
+  "modified": true,
+  "yMin": 0.0,
+  "yMax": 1.0
+}
+```
+
+All coordinates must be finite numbers between 0 and 1, inclusive.
+Optional `yMin` and `yMax` fields can narrow the Y range within these limits.
+These bounds must be increasing and apply to both Y coordinates.
+Curves do not use numeric `min`, `max`, or `step` fields.
+
+Coordinates are JSON numbers. The numeric precision and scale limits above still apply.
+Missing or unknown coordinate names, nonnumeric values, and out-of-bounds coordinates
+produce per-item errors. Duplicate names are malformed requests. Arrays, nested objects,
+and objects with more than four fields are rejected at the request level.
+Validate and replace the complete curve together; never apply individual coordinates separately.
+Reset uses `null` and restores the complete default or invokes the app-owned reset.
+
+Curve inspection requires clients that support protocol 5 structured values.
+Earlier clients that accept only primitives cannot decode lists containing curves.
+New clients still support earlier servers. The Network Inspector protocol is unchanged.
+
+```kotlin
+val curve by tweak(
+    BezierCurve(0.25f, 0.1f, 0.25f, 1f),
+    "Halo/Curve",
+    yRange = 0f..1f,
+)
+```
+
+The same overload is available on `TweakScope`, returning `StateFlow<BezierCurve>`.
+Generic app-owned sources also accept `BezierCurve`. Sources use the type's default bounds:
+all coordinates in `[0, 1]`. Their setters may reject additional app-specific constraints.
+No-op artifacts expose the same value class and overloads.
 
 ### GET /tweaks?include=adjusted
 
@@ -274,7 +320,7 @@ curl -fsS -X PATCH http://127.0.0.1:43817/tweaks \
 
 For protocol version 4, use `null` to reset a tweak; a request can mix changes and resets. App-owned tweaks call their source's `reset()` method and return the current effective value. Reset all only active, non-action tweaks marked `"modified": true`. For versions 1, 2, and 3, reset each changed tweak by sending its `default` value instead.
 
-Return `400` for malformed requests, `404` when an endpoint does not exist, `405` for an unsupported method, `413` for an oversized body, and `422` for invalid numeric literals or nonprimitive values. In protocol versions 1 and 2, an unknown tweak returns `404`, an invalid value returns `422`, and the entire batch is rejected. In versions 3 and later, unknown tweaks, invalid values, and action targets are reported as per-item errors without preventing other changes. Request-level errors use a small JSON body:
+Return `400` for malformed requests, `404` when an endpoint does not exist, `405` for an unsupported method, `413` for an oversized body, and `422` for invalid numeric literals or unsupported structured values. In protocol versions 1 and 2, an unknown tweak returns `404`, an invalid value returns `422`, and the entire batch is rejected. In versions 3 and later, unknown tweaks, invalid values, and action targets are reported as per-item errors without preventing other changes. Request-level errors use a small JSON body:
 
 ```json
 {
@@ -391,11 +437,11 @@ Box(
 
 Each remembered usage registers with composition and removes the tweak from the active list only after its final usage leaves. Returning registry-owned declarations restore their previously edited values; app-owned sources control their own persistence. Request `GET /tweaks?include=adjusted` to inspect prior ordinary or app-owned adjustments from screens no longer in composition.
 
-Provide overloaded `tweak(default, name)` functions for `Int`, `Float`, `Color`, `Boolean`, `String`, and enum defaults; each returns its corresponding `State<T>`. For strings, name the second argument to distinguish the label from the default, as in `tweak("Hello", name = "Greeting")`. Numeric tweaks accept an optional range and `step` of the same type. Enum tweaks infer their options from declaration order and use each constant's name everywhere. Convert delegated integer values into Compose units at the call site, such as `fontSize.sp`. The real and no-op artifacts expose the same package and public Compose API.
+Provide overloaded `tweak(default, name)` functions for `Int`, `Float`, `Color`, `Boolean`, `String`, `BezierCurve`, and enum defaults; each returns its corresponding `State<T>`. For strings, name the second argument to distinguish the label from the default, as in `tweak("Hello", name = "Greeting")`. Numeric tweaks accept an optional range and `step` of the same type. Enum tweaks infer their options from declaration order and use each constant's name everywhere. Convert delegated integer values into Compose units at the call site, such as `fontSize.sp`. The real and no-op artifacts expose the same package and public Compose API.
 
 Declare a parameterless action with the `TweakAction(name) { ... }` composable. It returns `Unit` and does not execute its callback during composition or return a callable function. The action is available only while its owning composable is in composition, always uses its most recent callback, and is exposed with its explicit name rather than an inferred or generated identifier. Register each action exactly once at the composable that owns the state or operation; multiple owners using the same name produce a visible conflict and all invocation attempts fail closed. The release/no-op implementation accepts the same API without retaining or invoking the callback.
 
-App-owned tweaks implement `TweakSource<T>`, supporting `Boolean`, `Int`, `Float`, `String`, and `Color`. The source owns its current value, reset behavior, modification status, and change notifications:
+App-owned tweaks implement `TweakSource<T>`, supporting `Boolean`, `Int`, `Float`, `String`, `Color`, and `BezierCurve`. The source owns its current value, reset behavior, modification status, and change notifications:
 
 ```kotlin
 private class SharedPreferencesBooleanSource(
@@ -482,6 +528,9 @@ fun App() {
     }
 }
 ```
+
+Set the host activity’s `android:windowSoftInputMode` to `adjustResize`.
+The overlay handles keyboard insets; pan mode can shift it a second time.
 
 The overlay is disabled by default. Expose its app-wide setting from a developer-settings screen:
 

--- a/release/protocol-reviews/2026-09-08-bezier.md
+++ b/release/protocol-reviews/2026-09-08-bezier.md
@@ -1,0 +1,38 @@
+# Bézier curve tweaks
+
+Implementation base:
+`3d938fa03ceb9fd118eeddfa1206c3eb6bab0b7a`.
+
+## Protocol decision
+
+Tweaks advances from 4 to 5. Network remains at 1.
+The new `bezier` type stores a complete `{x1, y1, x2, y2}` object in
+value, default, patch responses, and event snapshots. Optional `yMin` and `yMax`
+narrow the Y range. All four coordinates must be in [0, 1]. Updates and resets operate on one complete curve.
+
+This changes the value representation beyond primitive JSON values.
+Curve inspection requires a client with protocol 5 structured-value support;
+older primitive-only clients cannot decode lists containing curves.
+This rollout deliberately requires updated clients for curves. New clients still
+support older servers and their existing reset and modification semantics.
+No compatibility encoding or alternate string representation is provided.
+
+The Kotlin core and Compose APIs expose `BezierCurve`, including app-owned sources
+and matching no-op overloads. Swift, web, and CLI clients support the object value.
+Endpoints and existing tweak types retain their behavior.
+
+## Validation
+
+- Android live libraries and samples: debug assembly, unit tests, and lint.
+- Android no-op libraries and samples: debug assembly, unit tests, and lint.
+- Android static analysis, including curve validation and overlay coordinate tests.
+- Web type checking, lint, tests, and production build.
+- macOS unsigned debug build with the structured-value bridge and embedded web UI.
+- CLI suite, including malformed objects, finite float limits, and Y bounds.
+- Release preflight tests, including the protocol 4-to-5 transition.
+- Browser interaction checks: drag, keyboard movement, presets, coordinate bounds,
+  complete reset, and closing the editor.
+
+The Android demo was installed and inspected on a Pixel. Keyboard placement was
+verified on the device; corner hit testing and drag offsets have automated coverage.
+The Mac editor also has regression coverage for delayed replies during dragging.

--- a/release/tests/test_preflight.py
+++ b/release/tests/test_preflight.py
@@ -125,6 +125,19 @@ class ProtocolReportTests(unittest.TestCase):
         self.assertEqual(result.returncode, 0, result.stdout + result.stderr)
         return result.stdout
 
+    def test_reports_structured_curve_protocol_transition(self):
+        old_path = DECLARATIONS[1][1]
+        (self.repo / old_path).unlink()
+        core_path = old_path.replace("/tweaks/", "/tweaks-core/", 1)
+        self.write(core_path, "internal const val TweaksProtocolVersion: Int = 5\n")
+        self.write("contracts/tweaks/README.md", "Curve values have numeric x1, y1, x2, y2 fields.\n")
+        self.commit()
+        report = self.report()
+        self.assertIn("TweaksProtocolVersion: Int = 4", report)
+        self.assertIn("TweaksProtocolVersion: Int = 5", report)
+        self.assertIn(core_path, report)
+        self.assertIn("REVIEW REQUIRED", report)
+
     def test_reports_all_changed_files_from_each_public_base(self):
         self.write("docs/release-note.md", "Release note\n")
         self.commit()

--- a/scripts/snapo
+++ b/scripts/snapo
@@ -1520,6 +1520,23 @@ def parse_tweak_value(descriptor, raw):
         if not math.isfinite(value):
             raise SnapOError(f"Tweak '{descriptor.get('name', '')}' requires a finite numeric value")
         return value
+    if kind == "bezier":
+        try:
+            value = json.loads(raw)
+        except ValueError as error:
+            raise SnapOError("Expected a JSON object with x1, y1, x2, and y2 coordinates") from error
+        keys = {"x1", "y1", "x2", "y2"}
+        if not isinstance(value, dict) or set(value) != keys:
+            raise SnapOError("Expected a JSON object with x1, y1, x2, and y2 coordinates")
+        if any(type(point) not in (int, float) or abs(point) > 3.4028234663852886e38 or
+               not math.isfinite(point) for point in value.values()):
+            raise SnapOError("Bezier coordinates must be finite float values")
+        if any(value[key] < 0 or value[key] > 1 for key in keys):
+            raise SnapOError("Bezier coordinates must be between 0 and 1")
+        if any(value[key] < descriptor.get("yMin", -math.inf) or
+               value[key] > descriptor.get("yMax", math.inf) for key in ("y1", "y2")):
+            raise SnapOError("Bezier Y coordinates exceed the declared bounds")
+        return value
     if kind == "color":
         if not re.fullmatch(r"#[0-9a-fA-F]{6}(?:[0-9a-fA-F]{2})?", raw):
             raise SnapOError(f"Tweak '{descriptor.get('name', '')}' requires a #RRGGBB or #RRGGBBAA color")

--- a/skills/snap-o-tweaks/SKILL.md
+++ b/skills/snap-o-tweaks/SKILL.md
@@ -66,7 +66,7 @@ ADB resolves from `PATH`, `ANDROID_SDK_ROOT`, or `ANDROID_HOME`. Use `--adb <pat
 
 ## Change values only when requested
 
-Inspect the descriptor first: the CLI parses `int`, `float`, `boolean`, `color`, `string`, and `enum` according to their declared types. Enum descriptors include an ordered list of enum names in `options`; use an exact option name when setting one. Quote names containing spaces or `/`, string values containing spaces, and hex colors.
+Inspect the descriptor first: the CLI parses `int`, `float`, `boolean`, `color`, `string`, `enum`, and `bezier` according to their declared types. Enum descriptors include an ordered list of enum names in `options`; use an exact option name when setting one. Quote names containing spaces or `/`, string values containing spaces, and hex colors.
 
 ```bash
 "$SNAPO_BIN" tweaks set 'Typography/Font size' 42 -s <serial> -n <socket>

--- a/skills/snap-o-tweaks/references/protocol.md
+++ b/skills/snap-o-tweaks/references/protocol.md
@@ -32,7 +32,7 @@ For remote ADB servers, an `adb forward` is local to the ADB server's host, not 
 
 | Request | Result |
 | --- | --- |
-| `GET /app` | JSON app metadata: `{"name":"Example","packageName":"com.example","protocolVersion":4}`. |
+| `GET /app` | JSON app metadata: `{"name":"Example","packageName":"com.example","protocolVersion":5}`. |
 | `GET /app/icon` | Optional application icon image; `404` if unavailable. Use its response `Content-Type` without assuming a particular format or size. |
 | `GET /tweaks` | Current active tweak and app-owned action descriptors. |
 | `GET /tweaks?include=adjusted` | Active descriptors plus previously adjusted ordinary or app-owned value snapshots retained outside composition. |
@@ -42,7 +42,7 @@ For remote ADB servers, an `adb forward` is local to the ADB server's host, not 
 
 Ordinary responses close their connection and include a content length. The event response stays open and uses `Content-Type: text/event-stream`.
 
-`protocolVersion` is specific to Tweaks and independent of the Network Inspector protocol. Version 1 predates this field and supports only value tweaks; treat a missing version as 1. Version 2 adds app-owned action descriptors and `POST /tweaks/action`. Version 3 adds best-effort batch updates with per-item errors. Version 4 adds explicit null resets and authoritative modification status. Use the reported version to select compatible update, status, and reset behavior.
+`protocolVersion` is specific to Tweaks and independent of the Network Inspector protocol. Version 1 predates this field and supports only value tweaks; treat a missing version as 1. Version 2 adds app-owned action descriptors and `POST /tweaks/action`. Version 3 adds best-effort batch updates with per-item errors. Version 4 adds explicit null resets and authoritative modification status. Version 5 adds `bezier` curves. Use the reported version to select compatible update, status, and reset behavior.
 
 ### Read metadata and active values
 
@@ -187,6 +187,18 @@ These relative URLs assume your host serves both the page and the proxy. The And
 
 ## Errors and security
 
-Request-level errors use `{"error":"description"}`. Expect `400` for malformed input, `404` for missing endpoints, `405` for unsupported methods, `409` for conflicting action registrations, `413` for oversized bodies, and `422` for invalid numeric literals or nonprimitive values. Versions 1 and 2 also return `404` for inactive tweaks and `422` for invalid values. Versions 3 and later report unknown or invalid tweaks as named per-item errors in an HTTP 200 response.
+Request-level errors use `{"error":"description"}`. Expect `400` for malformed input, `404` for missing endpoints, `405` for unsupported methods, `409` for conflicting action registrations, `413` for oversized bodies, and `422` for invalid numeric literals or unsupported structured values. Versions 1 and 2 also return `404` for inactive tweaks and `422` for invalid values. Versions 3 and later report unknown or invalid tweaks as named per-item errors in an HTTP 200 response.
 
 The socket is app-local and normally enabled only when the Android app is debuggable. Release activation requires an explicit `snapo.tweaks.allow_release` manifest opt-in; release no-op artifacts are preferred. There is no HTTP bearer-token layer: access is controlled by the local socket and the connected ADB boundary. Do not expose a forwarded port or proxy publicly, and treat tweak names and values as potentially sensitive.
+
+## Bézier curves
+
+A `bezier` descriptor carries objects with numeric `x1`, `y1`, `x2`, and `y2` fields in `default` and `value`.
+All coordinates must be finite and in `[0, 1]`.
+Optional `yMin` and `yMax` fields narrow the range for both Y coordinates. Read those bounds before editing.
+Send all four coordinates as one value; reset the entire curve with `null`.
+Curve inspection requires a client that supports protocol 5 structured values.
+
+```bash
+snapo tweaks set 'Motion/Curve' '{"x1":0.4,"y1":0,"x2":0.2,"y2":1}' -s "$serial" -n "$socket"
+```

--- a/skills/snap-o-tweaks/references/protocol.md
+++ b/skills/snap-o-tweaks/references/protocol.md
@@ -93,7 +93,7 @@ The tweak response has this shape:
 
 In protocol version 4, only modified value tweaks include `"modified": true`. A missing `modified` field always means false, even when `value` differs from `default`; never infer version-4 status by comparing those fields. Registry-owned tweaks compare their current value with their default, while app-owned tweaks report whether their owner has an override. In versions 1, 2, and 3, `modified` is absent; compare `value` with `default` instead. Actions never include `modified`.
 
-The available value types are `int`, `float`, `boolean`, `color`, `string`, and `enum`. Preserve actual JSON types: booleans are not strings, integer values cannot be fractional, and floats accept whole or fractional finite numbers. Colors are strings in `#RRGGBB` or `#RRGGBBAA` format. Numeric descriptors may include `min`, `max`, and `step`; step alignment starts at `min`, or at `default` if there is no minimum. Actions use `"type":"action"` and have no `value`, `default`, or `options`.
+The available value types are `int`, `float`, `boolean`, `color`, `string`, `enum`, and `bezier`. Preserve actual JSON types: booleans are not strings, integer values cannot be fractional, and floats accept whole or fractional finite numbers. Colors are strings in `#RRGGBB` or `#RRGGBBAA` format. Numeric descriptors may include `min`, `max`, and `step`; step alignment starts at `min`, or at `default` if there is no minimum. Actions use `"type":"action"` and have no `value`, `default`, or `options`.
 
 Enum descriptors include a nonempty, ordered `options` array containing unique, nonblank enum name strings. The `default` and current `value` are names from that list. Send an exact option name in `PATCH /tweaks`.
 

--- a/snapo-app-mac/Snap-O/NetworkInspector/NetworkInspectorBridgeModels.swift
+++ b/snapo-app-mac/Snap-O/NetworkInspector/NetworkInspectorBridgeModels.swift
@@ -49,11 +49,19 @@ struct AppInspectorState: Codable {
   let isRestoring: Bool
 }
 
+struct BezierCurve: Codable {
+  let x1: Double
+  let y1: Double
+  let x2: Double
+  let y2: Double
+}
+
 enum TweakValue: Codable {
   case bool(Bool)
   case int(Int)
   case double(Double)
   case string(String)
+  case bezier(BezierCurve)
 
   init(from decoder: Decoder) throws {
     let container = try decoder.singleValueContainer()
@@ -63,6 +71,8 @@ enum TweakValue: Codable {
       self = .int(value)
     } else if let value = try? container.decode(Double.self) {
       self = .double(value)
+    } else if let value = try? container.decode(BezierCurve.self) {
+      self = .bezier(value)
     } else {
       self = try .string(container.decode(String.self))
     }
@@ -79,6 +89,8 @@ enum TweakValue: Codable {
       try container.encode(value)
     case .string(let value):
       try container.encode(value)
+    case .bezier(let value):
+      try container.encode(value)
     }
   }
 }
@@ -93,6 +105,8 @@ struct TweakDescriptor: Codable {
   let max: TweakValue?
   let step: TweakValue?
   let options: [String]?
+  let yMin: Double?
+  let yMax: Double?
   let conflicted: Bool?
 }
 

--- a/snapo-link-android/samples/demo-tweaks/panel/app.js
+++ b/snapo-link-android/samples/demo-tweaks/panel/app.js
@@ -449,6 +449,12 @@ function updateAppIdentity(app) {
   document.title = `${app.name} · Snap-O Tweaks`;
 }
 
+const curveKeys = ["x1", "y1", "x2", "y2"];
+
+function sameCurve(left, right) {
+  return curveKeys.every((key) => left[key] === right[key]);
+}
+
 function updateTweakRow(tweak) {
   const fields = state.rows.get(tweak.name);
   if (!fields) return;
@@ -457,6 +463,16 @@ function updateTweakRow(tweak) {
   fields.row.dataset.changed = String(changed);
   fields.reset.hidden = !changed;
 
+  if (fields.curvePath) {
+    const { x1, y1, x2, y2 } = tweak.value;
+    fields.curvePath.setAttribute("d", `M2 24 C${2 + x1 * 22} ${24 - y1 * 22} ${2 + x2 * 22} ${24 - y2 * 22} 24 2`);
+    for (const key of curveKeys) {
+      if (fields[key] !== document.activeElement) {
+        fields[key].value = numberText(tweak.value[key]);
+        fields[key].setAttribute("aria-invalid", "false");
+      }
+    }
+  }
   if (fields.number) fields.number.value = numberText(tweak.value);
   if (fields.slider) fields.slider.value = numberText(tweak.value);
   if (fields.color) fields.color.value = tweak.value.slice(0, 7);
@@ -734,6 +750,47 @@ function makeEnumTweak(tweak) {
   });
 }
 
+function makeBezierTweak(tweak) {
+  const row = node("div", "tweak-row");
+  const { line, actions, reset } = makeTweakLine(tweak);
+  const namespace = "http://www.w3.org/2000/svg";
+  const preview = document.createElementNS(namespace, "svg");
+  const curvePath = document.createElementNS(namespace, "path");
+  preview.setAttribute("class", "curve-preview");
+  preview.setAttribute("viewBox", "0 0 26 26");
+  preview.setAttribute("role", "img");
+  preview.setAttribute("aria-label", `${tweak.name} preview`);
+  preview.append(curvePath);
+  actions.append(preview);
+
+  const coordinates = node("div", "curve-coordinates");
+  const inputs = {};
+  for (const key of curveKeys) {
+    const label = node("label", undefined, key.toUpperCase());
+    const input = node("input", "number-input");
+    input.type = "number";
+    input.step = "any";
+    input.min = String(key.startsWith("y") ? (tweak.yMin ?? 0) : 0);
+    input.max = String(key.startsWith("y") ? (tweak.yMax ?? 1) : 1);
+    input.setAttribute("aria-label", `${tweak.name} ${key.toUpperCase()}`);
+    input.addEventListener("input", () => {
+      const value = Number(input.value);
+      const valid = input.value !== "" && input.validity.valid && Number.isFinite(value);
+      input.setAttribute("aria-invalid", String(!valid));
+      if (valid) updateValue(tweak, { ...tweak.value, [key]: value });
+    });
+    input.addEventListener("blur", () => {
+      input.value = numberText(tweak.value[key]);
+      input.setAttribute("aria-invalid", "false");
+    });
+    inputs[key] = input;
+    label.append(input);
+    coordinates.append(label);
+  }
+  row.append(line, coordinates);
+  return registerTweakRow(tweak, row, { reset, curvePath, ...inputs });
+}
+
 function makeTweak(tweak) {
   switch (tweak.type) {
     case "int":
@@ -747,6 +804,8 @@ function makeTweak(tweak) {
       return makeStringTweak(tweak);
     case "enum":
       return makeEnumTweak(tweak);
+    case "bezier":
+      return makeBezierTweak(tweak);
     default:
       return null;
   }
@@ -864,7 +923,9 @@ function sameTweakShape(current, incoming) {
     return (
       tweak.name === next.name &&
       tweak.type === next.type &&
-      tweak.default === next.default &&
+      (tweak.type === "bezier" ? sameCurve(tweak.default, next.default) : tweak.default === next.default) &&
+      tweak.yMin === next.yMin &&
+      tweak.yMax === next.yMax &&
       tweak.min === next.min &&
       tweak.max === next.max &&
       tweak.step === next.step &&

--- a/snapo-link-android/samples/demo-tweaks/panel/app.test.mjs
+++ b/snapo-link-android/samples/demo-tweaks/panel/app.test.mjs
@@ -1772,3 +1772,84 @@ test("streams batched composition changes without polling tweak values", async (
     }
   }
 });
+
+test("Bezier rows edit whole curves, enforce bounds, reset, and survive streamed object defaults", async () => {
+  const document = makeDocument();
+  const initial = { x1: 0.4, y1: 0.2, x2: 0.2, y2: 0.8 };
+  const tweaks = [{ name: "Motion/Curve", type: "bezier", default: initial, value: initial, yMin: 0.2, yMax: 0.8 }];
+  const patches = [];
+  const originalDocument = globalThis.document;
+  const originalFetch = globalThis.fetch;
+  const originalEventSource = globalThis.EventSource;
+  let stream;
+  globalThis.document = document;
+  globalThis.EventSource = class {
+    constructor() { stream = this; this.listeners = new Map(); }
+    addEventListener(name, listener) { this.listeners.set(name, listener); }
+    close() {}
+    emit(tweaks) { this.listeners.get("tweaks")({ data: JSON.stringify({ tweaks }) }); }
+  };
+  globalThis.fetch = async (pathname, options) => {
+    const app = { ...demoApp, protocolVersion: 5 };
+    if (pathname === "/apps") return jsonResponse({ apps: [app], selectedAppId: app.id });
+    if (pathname === "/app") return jsonResponse(app);
+    if (pathname === "/tweaks" && options?.method === "PATCH") {
+      const { values } = JSON.parse(options.body);
+      patches.push(values);
+      return jsonResponse({ tweaks: applyTweakUpdates(tweaks, values) });
+    }
+    return jsonResponse({ tweaks });
+  };
+  try {
+    await import(`./app.js?bezier-test=${Date.now()}`);
+    await delay(0);
+    const list = findTweakList(document, "Motion");
+    const x1 = findInput(list, "Motion/Curve X1");
+    const y1 = findInput(list, "Motion/Curve Y1");
+    const preview = findInput(list, "Motion/Curve preview");
+    const originalPath = preview.children[0].getAttribute("d");
+    assert.equal(x1.value, "0.4");
+    assert.equal(x1.min, "0");
+    assert.equal(x1.max, "1");
+    assert.equal(y1.min, "0.2");
+    assert.equal(y1.max, "0.8");
+
+    for (const invalid of ["", "-0.1", "1.1"]) {
+      x1.value = invalid;
+      await x1.emit("input");
+      assert.equal(x1.getAttribute("aria-invalid"), "true");
+    }
+    y1.value = "0.1";
+    await y1.emit("input");
+    await delay(90);
+    assert.equal(patches.length, 0);
+    await y1.emit("blur");
+    assert.equal(y1.value, "0.2");
+
+    document.activeElement = x1;
+    x1.value = "0.65";
+    await x1.emit("input");
+    await delay(90);
+    assert.deepEqual(patches, [{ "Motion/Curve": { ...initial, x1: 0.65 } }]);
+    assert.notEqual(preview.children[0].getAttribute("d"), originalPath);
+    stream.emit(tweaks);
+    assert.equal(findInput(findTweakList(document, "Motion"), "Motion/Curve X1"), x1);
+    assert.equal(document.activeElement, x1);
+
+    document.activeElement = undefined;
+    stream.emit([{ ...tweaks[0], value: { ...initial, x1: 0.75 } }]);
+    assert.equal(x1.value, "0.75");
+    await findInput(list, "Reset Motion/Curve").emit("click");
+    await delay(0);
+    assert.deepEqual(patches.at(-1), { "Motion/Curve": null });
+    assert.equal(x1.value, "0.4");
+    assert.equal(preview.children[0].getAttribute("d"), originalPath);
+
+    stream.emit([{ ...tweaks[0], yMin: 0.1 }]);
+    assert.equal(findInput(findTweakList(document, "Motion"), "Motion/Curve Y1").min, "0.1");
+  } finally {
+    globalThis.document = originalDocument;
+    globalThis.fetch = originalFetch;
+    globalThis.EventSource = originalEventSource;
+  }
+});

--- a/snapo-link-android/samples/demo-tweaks/panel/styles.css
+++ b/snapo-link-android/samples/demo-tweaks/panel/styles.css
@@ -685,6 +685,34 @@ button {
   padding: 2px;
 }
 
+.curve-preview {
+  width: 26px;
+  height: 26px;
+  border: 1px solid var(--line);
+  border-radius: 4px;
+  padding: 2px;
+  fill: none;
+  stroke: var(--control-accent);
+  stroke-width: 1.5px;
+}
+
+.curve-coordinates {
+  display: grid;
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+  gap: 8px;
+}
+
+.curve-coordinates label {
+  display: grid;
+  gap: 4px;
+  color: var(--muted);
+  font-size: 11px;
+}
+
+.curve-coordinates .number-input {
+  width: 100%;
+}
+
 .boolean-input {
   width: 16px;
   height: 16px;

--- a/snapo-link-android/samples/demo-tweaks/src/main/AndroidManifest.xml
+++ b/snapo-link-android/samples/demo-tweaks/src/main/AndroidManifest.xml
@@ -9,6 +9,7 @@
         android:theme="@style/Theme.SnapOTweaksDemo">
         <activity
             android:name=".MainActivity"
+            android:windowSoftInputMode="adjustResize"
             android:exported="true">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />

--- a/snapo-link-android/samples/demo-tweaks/src/main/java/com/openai/snapo/demo/tweaks/OverviewScreen.kt
+++ b/snapo-link-android/samples/demo-tweaks/src/main/java/com/openai/snapo/demo/tweaks/OverviewScreen.kt
@@ -1,7 +1,7 @@
 package com.openai.snapo.demo.tweaks
 
 import android.content.Context
-import androidx.compose.animation.core.FastOutSlowInEasing
+import androidx.compose.animation.core.CubicBezierEasing
 import androidx.compose.animation.core.FiniteAnimationSpec
 import androidx.compose.animation.core.animateFloatAsState
 import androidx.compose.animation.core.spring
@@ -46,6 +46,7 @@ import androidx.compose.ui.semantics.Role
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
+import com.openai.snapo.tweaks.BezierCurve
 import com.openai.snapo.tweaks.TweakAction
 import com.openai.snapo.tweaks.tweak
 import kotlin.math.roundToInt
@@ -186,9 +187,10 @@ private fun MotionPreview() {
     } else {
         val durationMillis by tweak(400, "Motion/Duration", 100..1500, step = 50)
 
+        val curve by tweak(BezierCurve(0.4f, 0f, 0.2f, 1f), "Motion/Curve")
         tween(
             durationMillis = durationMillis,
-            easing = FastOutSlowInEasing,
+            easing = CubicBezierEasing(curve.x1, curve.y1, curve.x2, curve.y2),
         )
     }
     val progress = animateFloatAsState(

--- a/snapo-link-android/tweaks-core-noop/src/main/java/com/openai/snapo/tweaks/BezierCurve.kt
+++ b/snapo-link-android/tweaks-core-noop/src/main/java/com/openai/snapo/tweaks/BezierCurve.kt
@@ -1,0 +1,13 @@
+package com.openai.snapo.tweaks
+
+/** A cubic curve from (0, 0) to (1, 1). All control coordinates stay between 0 and 1. */
+data class BezierCurve(val x1: Float, val y1: Float, val x2: Float, val y2: Float) {
+    init {
+        require(x1.isFinite() && x1 in 0f..1f && x2.isFinite() && x2 in 0f..1f) {
+            "Bezier X coordinates must be between 0 and 1."
+        }
+        require(y1.isFinite() && y1 in 0f..1f && y2.isFinite() && y2 in 0f..1f) {
+            "Bezier Y coordinates must be between 0 and 1."
+        }
+    }
+}

--- a/snapo-link-android/tweaks-core-noop/src/main/java/com/openai/snapo/tweaks/TweakScope.kt
+++ b/snapo-link-android/tweaks-core-noop/src/main/java/com/openai/snapo/tweaks/TweakScope.kt
@@ -37,6 +37,12 @@ class TweakScope : Closeable {
         step: Int? = null,
     ): StateFlow<Int> = state(default)
 
+    fun tweak(
+        default: BezierCurve,
+        name: String,
+        yRange: ClosedFloatingPointRange<Float>? = null,
+    ): StateFlow<BezierCurve> = state(default)
+
     fun tweak(default: Boolean, name: String): StateFlow<Boolean> = state(default)
     fun tweak(default: String, name: String): StateFlow<String> = state(default)
     fun <E : Enum<E>> tweak(default: E, name: String): StateFlow<E> = state(default)

--- a/snapo-link-android/tweaks-core-noop/src/test/java/com/openai/snapo/tweaks/TweakScopeTest.kt
+++ b/snapo-link-android/tweaks-core-noop/src/test/java/com/openai/snapo/tweaks/TweakScopeTest.kt
@@ -33,6 +33,17 @@ class TweakScopeTest {
     }
 
     @Test
+    fun `curve defaults retain their type without an inspector`() {
+        val curve = BezierCurve(0.2f, 0.1f, 0.8f, 0.9f)
+        val scope = TweakScope()
+        val state = scope.tweak(curve, "Curve")
+        assertEquals(curve, state.value)
+        scope.close()
+        assertEquals(curve, state.value)
+        assertThrows(IllegalStateException::class.java) { scope.tweak(curve, "Closed") }
+    }
+
+    @Test
     fun `closing is idempotent and rejects new declarations`() {
         val scope = TweakScope()
         val value = scope.tweak(3, "Count")

--- a/snapo-link-android/tweaks-core/README.md
+++ b/snapo-link-android/tweaks-core/README.md
@@ -37,11 +37,25 @@ fun dispose() {
 
 Each declaration returns a read-only `StateFlow<T>`. Registration is immediate and does not depend on collectors. Read `.value` without launching a coroutine, or collect changes using your owner's coroutine scope. Changes are conflated: a slow collector gets the latest value and may skip intermediate slider positions.
 
-Supported defaults are `Boolean`, `Int`, `Float`, `String`, and enums. Numbers accept optional `range` and `step`. Use `tweakColor(defaultArgb, name)` for Android ARGB colors; an ordinary integer declaration remains a numeric control. Use `action(name) { ... }` for parameterless actions. Declaring an action never invokes it.
+Supported defaults are `Boolean`, `Int`, `Float`, `String`, `BezierCurve`, and enums. Numbers accept optional `range` and `step`. Use `tweakColor(defaultArgb, name)` for Android ARGB colors; an ordinary integer declaration remains a numeric control. Use `action(name) { ... }` for parameterless actions. Declaring an action never invokes it.
 
 Matching live declarations share one value. Their name, type, default, constraints, and enum options must agree. Conflicting declarations are rejected. Duplicate action names remain visible but cannot be invoked until only one owner remains.
 
 Closing a scope unregisters its declarations, releases its callbacks, and stops observing its app-owned sources. Repeated closes are harmless. New declarations after close fail. Previously returned flows retain their last value; they do not complete or cancel callers' collecting coroutines. A later matching ordinary declaration restores the last edited value within the same process.
+
+## Bézier curves
+
+```kotlin
+val falloff = tweaks.tweak(
+    BezierCurve(0.25f, 0.1f, 0.25f, 1f),
+    "Halo/Curve",
+    yRange = 0f..1f,
+)
+```
+
+Read `falloff.value` and apply its four coordinates to your renderer.
+All coordinates stay between 0 and 1. Optional `yRange` can narrow the Y range.
+Snap-O edits and resets each curve as one value. The overlay opens a dedicated curve editor.
 
 ## ViewModels
 
@@ -89,7 +103,7 @@ A View that owns its own tweaks must also manage that scope. Use a fresh scope f
 val setting = tweaks.tweak(source = mySettingSource, name = "Settings/Show hints")
 ```
 
-`TweakSource<T>` supplies the current value, a setter, `reset()`, `isModified`, and `observe(): Flow<Unit>`. Emit when either the effective value or override status changes. Generic sources support Boolean, Int, Float, and String; `tweakColor(source, name)` supports an ARGB Int source.
+`TweakSource<T>` supplies the current value, a setter, `reset()`, `isModified`, and `observe(): Flow<Unit>`. Emit when either the effective value or override status changes. Generic sources support Boolean, Int, Float, String, and BezierCurve; `tweakColor(source, name)` supports an ARGB Int source.
 
 Sources sharing a name must represent the same setting and type. The first active source supplies the authoritative value and handles edits, resets, status, and observation. The next source takes over when that owner closes. Their consistency remains the caller's responsibility. A returning source supplies its current value; Snap-O never replays historical values into it.
 

--- a/snapo-link-android/tweaks-core/src/main/java/com/openai/snapo/tweaks/BezierCurve.kt
+++ b/snapo-link-android/tweaks-core/src/main/java/com/openai/snapo/tweaks/BezierCurve.kt
@@ -1,0 +1,13 @@
+package com.openai.snapo.tweaks
+
+/** A cubic curve from (0, 0) to (1, 1). All control coordinates stay between 0 and 1. */
+data class BezierCurve(val x1: Float, val y1: Float, val x2: Float, val y2: Float) {
+    init {
+        require(x1.isFinite() && x1 in 0f..1f && x2.isFinite() && x2 in 0f..1f) {
+            "Bezier X coordinates must be between 0 and 1."
+        }
+        require(y1.isFinite() && y1 in 0f..1f && y2.isFinite() && y2 in 0f..1f) {
+            "Bezier Y coordinates must be between 0 and 1."
+        }
+    }
+}

--- a/snapo-link-android/tweaks-core/src/main/java/com/openai/snapo/tweaks/TweakScope.kt
+++ b/snapo-link-android/tweaks-core/src/main/java/com/openai/snapo/tweaks/TweakScope.kt
@@ -58,6 +58,14 @@ class TweakScope : Closeable {
         TweakDescriptor(name, TweakType.INT, default, range?.first, range?.last, step),
     ) { it as Int }
 
+    fun tweak(
+        default: BezierCurve,
+        name: String,
+        yRange: ClosedFloatingPointRange<Float>? = null,
+    ): StateFlow<BezierCurve> = register(
+        TweakDescriptor(name, TweakType.BEZIER, default, yMin = yRange?.start, yMax = yRange?.endInclusive),
+    ) { it as BezierCurve }
+
     fun tweak(default: Boolean, name: String): StateFlow<Boolean> = register(
         TweakDescriptor(name, TweakType.BOOLEAN, default),
     ) { it as Boolean }
@@ -80,7 +88,7 @@ class TweakScope : Closeable {
         TweakDescriptor(name, TweakType.COLOR, default.toTweakColorValue()),
     ) { (it as TweakColorValue).toArgb() }
 
-    /** Exposes a Boolean, Int, Float, or String using the source's own reset and override status. */
+    /** Exposes a Boolean, Int, Float, String, or BezierCurve using the source's own reset and override status. */
     @MainThread
     fun <T : Any> tweak(source: TweakSource<T>, name: String): StateFlow<T> =
         registerSource(source, name, color = false)
@@ -204,6 +212,7 @@ private class ScopeSourceBinding<T : Any>(
             initial is Int -> TweakType.INT
             initial is Float -> TweakType.FLOAT
             initial is String -> TweakType.STRING
+            initial is BezierCurve -> TweakType.BEZIER
             else -> error("Unsupported tweak value type: ${initial.javaClass.name}")
         }
         TweakDescriptor(name, type, encode(initial))

--- a/snapo-link-android/tweaks-core/src/main/java/com/openai/snapo/tweaks/internal/BezierWireValue.kt
+++ b/snapo-link-android/tweaks-core/src/main/java/com/openai/snapo/tweaks/internal/BezierWireValue.kt
@@ -1,0 +1,15 @@
+package com.openai.snapo.tweaks.internal
+
+import com.openai.snapo.tweaks.BezierCurve
+
+internal fun parseBezierCurve(value: Map<*, *>): BezierCurve? {
+    val keys = listOf("x1", "y1", "x2", "y2")
+    if (value.keys != keys.toSet()) return null
+    return runCatching {
+        val points = keys.map { key ->
+            val number = value[key] as? Number ?: return null
+            TweakNumbers.parse(number.toString()).toFloat()
+        }
+        BezierCurve(points[0], points[1], points[2], points[3])
+    }.getOrNull()
+}

--- a/snapo-link-android/tweaks-core/src/main/java/com/openai/snapo/tweaks/internal/TweakHttpServer.kt
+++ b/snapo-link-android/tweaks-core/src/main/java/com/openai/snapo/tweaks/internal/TweakHttpServer.kt
@@ -8,6 +8,7 @@ import android.os.Process
 import android.util.JsonReader
 import android.util.JsonToken
 import android.util.JsonWriter
+import com.openai.snapo.tweaks.BezierCurve
 import com.openai.snapo.tweaks.TweakColorValue
 import java.io.ByteArrayInputStream
 import java.io.ByteArrayOutputStream
@@ -27,7 +28,7 @@ import java.util.concurrent.TimeUnit
 import java.util.concurrent.TimeoutException
 import kotlin.concurrent.thread
 
-internal const val TweaksProtocolVersion: Int = 4
+internal const val TweaksProtocolVersion: Int = 5
 
 internal data class TweakBatchError(
     val name: String,
@@ -481,6 +482,7 @@ internal class TweakHttpServer(
     }
 
     private fun readJsonValue(reader: JsonReader): Any? = when (reader.peek()) {
+        JsonToken.BEGIN_OBJECT -> readCoordinateObject(reader)
         JsonToken.STRING -> reader.nextString()
         JsonToken.NUMBER -> TweakNumbers.parse(reader.nextString())
         JsonToken.BOOLEAN -> reader.nextBoolean()
@@ -489,7 +491,23 @@ internal class TweakHttpServer(
             null
         }
 
-        else -> throw HttpFailure(422, "Tweak values must be primitive JSON values.")
+        else -> throw HttpFailure(422, "Tweak values must be primitives or coordinate objects.")
+    }
+
+    private fun readCoordinateObject(reader: JsonReader): Map<String, Any?> {
+        val coordinates = linkedMapOf<String, Any?>()
+        reader.beginObject()
+        while (reader.hasNext()) {
+            val key = reader.nextName()
+            if (coordinates.containsKey(key)) invalidRequest("Duplicate coordinate: $key")
+            if (coordinates.size >= 4) throw HttpFailure(422, "A curve must contain exactly four coordinates.")
+            if (reader.peek() == JsonToken.BEGIN_OBJECT || reader.peek() == JsonToken.BEGIN_ARRAY) {
+                throw HttpFailure(422, "Curve coordinates must be numbers.")
+            }
+            coordinates[key] = readJsonValue(reader)
+        }
+        reader.endObject()
+        return coordinates
     }
 
     private fun updateOnMainThread(values: Map<String, Any?>): TweakBatchResult =
@@ -627,6 +645,8 @@ internal class TweakHttpServer(
     }
 
     private fun writeConstraints(writer: JsonWriter, descriptor: TweakDescriptor) {
+        descriptor.yMin?.let { writer.name("yMin").value(it) }
+        descriptor.yMax?.let { writer.name("yMax").value(it) }
         descriptor.min?.let { minimum -> writer.name("min").value(minimum) }
         descriptor.max?.let { maximum -> writer.name("max").value(maximum) }
         descriptor.step?.let { increment -> writer.name("step").value(increment) }
@@ -648,6 +668,14 @@ internal class TweakHttpServer(
             is Number -> writer.value(value)
             is String -> writer.value(value)
             is TweakColorValue -> writer.value(value.wireValue)
+            is BezierCurve -> {
+                writer.beginObject()
+                writer.name("x1").value(value.x1)
+                writer.name("y1").value(value.y1)
+                writer.name("x2").value(value.x2)
+                writer.name("y2").value(value.y2)
+                writer.endObject()
+            }
             else -> throw HttpFailure(500, "Unsupported tweak value.")
         }
     }

--- a/snapo-link-android/tweaks-core/src/main/java/com/openai/snapo/tweaks/internal/TweakRegistry.kt
+++ b/snapo-link-android/tweaks-core/src/main/java/com/openai/snapo/tweaks/internal/TweakRegistry.kt
@@ -1,6 +1,7 @@
 package com.openai.snapo.tweaks.internal
 
 import androidx.annotation.RestrictTo
+import com.openai.snapo.tweaks.BezierCurve
 import com.openai.snapo.tweaks.TweakColorValue
 import com.openai.snapo.tweaks.toTweakColorValue
 import java.io.Closeable
@@ -14,6 +15,7 @@ enum class TweakType(val wireName: String) {
     FLOAT("float"),
     BOOLEAN("boolean"),
     COLOR("color"),
+    BEZIER("bezier"),
     STRING("string"),
     ENUM("enum"),
     ACTION("action"),
@@ -28,6 +30,8 @@ data class TweakDescriptor(
     val max: Number? = null,
     val step: Number? = null,
     val options: List<String> = emptyList(),
+    val yMin: Float? = null,
+    val yMax: Float? = null,
 )
 
 @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
@@ -391,6 +395,7 @@ object TweakRegistry {
     }
 
     private fun validateDescriptor(descriptor: TweakDescriptor) {
+        validateBezierMetadata(descriptor)
         require(descriptor.name.isNotBlank()) { "Tweak names must not be blank." }
 
         when (descriptor.type) {
@@ -410,6 +415,7 @@ object TweakRegistry {
                 "String tweaks must have a string default: ${descriptor.name}"
             }
 
+            TweakType.BEZIER -> validateBezierDescriptor(descriptor)
             TweakType.ENUM -> validateEnumDescriptor(descriptor)
             TweakType.ACTION -> require(descriptor.default === Unit) {
                 "Actions must not declare a default value: ${descriptor.name}"
@@ -429,6 +435,40 @@ object TweakRegistry {
                 "Only numeric tweaks can define numeric constraints: ${descriptor.name}"
             }
         }
+    }
+
+    private fun validateBezierMetadata(descriptor: TweakDescriptor) {
+        if (descriptor.type != TweakType.BEZIER) {
+            require(descriptor.yMin == null && descriptor.yMax == null) {
+                "Only Bezier tweaks can define Y bounds: ${descriptor.name}"
+            }
+        }
+    }
+
+    private fun validateBezierDescriptor(descriptor: TweakDescriptor) {
+        require(descriptor.default is BezierCurve) { "Bezier tweaks require a curve default." }
+        require((descriptor.yMin == null) == (descriptor.yMax == null)) { "Supply both Y bounds." }
+        descriptor.yMin?.let { minimum ->
+            val maximum = requireNotNull(descriptor.yMax)
+            require(minimum in 0f..1f && maximum in 0f..1f && minimum < maximum) {
+                "Bezier Y bounds must be increasing within 0 and 1."
+            }
+        }
+        validateBezierValue(descriptor, descriptor.default)
+    }
+
+    private fun validateBezierValue(descriptor: TweakDescriptor, value: Any?): BezierCurve {
+        val curve = when (value) {
+            is BezierCurve -> value
+            is Map<*, *> -> parseBezierCurve(value)
+            else -> null
+        } ?: invalidValue(descriptor, "Expected a Bezier object with numeric x1, y1, x2, and y2 coordinates.")
+        val minimum = descriptor.yMin ?: return curve
+        val maximum = requireNotNull(descriptor.yMax)
+        if (curve.y1 !in minimum..maximum || curve.y2 !in minimum..maximum) {
+            invalidValue(descriptor, "Bezier Y coordinates must be between $minimum and $maximum.")
+        }
+        return curve
     }
 
     private fun validateEnumDescriptor(descriptor: TweakDescriptor) {
@@ -531,6 +571,7 @@ object TweakRegistry {
 
             TweakType.STRING, TweakType.ENUM -> validateStringValue(descriptor, value)
             TweakType.COLOR -> validateColorValue(descriptor, value)
+            TweakType.BEZIER -> validateBezierValue(descriptor, value)
 
             TweakType.ACTION -> invalidValue(
                 descriptor,

--- a/snapo-link-android/tweaks-core/src/test/java/com/openai/snapo/tweaks/TweakScopeTest.kt
+++ b/snapo-link-android/tweaks-core/src/test/java/com/openai/snapo/tweaks/TweakScopeTest.kt
@@ -61,13 +61,15 @@ class TweakScopeTest {
             scope.tweak("Hello", "Text"),
             scope.tweak(Mode.FIRST, "Mode"),
             scope.tweakColor(0xFF112233.toInt(), "Color"),
+            scope.tweak(BezierCurve(0f, 0f, 1f, 1f), "Curve"),
         )
         TweakRegistry.update(
             mapOf("Count" to 6, "Enabled" to true, "Text" to "World", "Mode" to "SECOND", "Color" to "#44556680"),
         )
-        assertEquals(listOf(6, true, "World", Mode.SECOND, 0x80445566.toInt()), values.map { it.value })
+        val expected = listOf(6, true, "World", Mode.SECOND, 0x80445566.toInt(), BezierCurve(0f, 0f, 1f, 1f))
+        assertEquals(expected, values.map { it.value })
         assertThrows(IllegalArgumentException::class.java) { scope.tweak(7, "Invalid", 0..5) }
-        assertEquals(5, TweakRegistry.snapshot().size)
+        assertEquals(6, TweakRegistry.snapshot().size)
     }
 
     @Test

--- a/snapo-link-android/tweaks-core/src/test/java/com/openai/snapo/tweaks/internal/BezierTweakTest.kt
+++ b/snapo-link-android/tweaks-core/src/test/java/com/openai/snapo/tweaks/internal/BezierTweakTest.kt
@@ -1,0 +1,90 @@
+package com.openai.snapo.tweaks.internal
+
+import com.openai.snapo.tweaks.BezierCurve
+import com.openai.snapo.tweaks.TweakScope
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertThrows
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class BezierTweakTest {
+    private val linear = BezierCurve(0f, 0f, 1f, 1f)
+
+    @After
+    fun clear() {
+        TweakRegistry.clear()
+        TweaksRuntimePolicy.configure(isDebuggable = false, allowRelease = false)
+    }
+
+    private fun BezierCurve.coordinates(): Map<String, Float> =
+        mapOf("x1" to x1, "y1" to y1, "x2" to x2, "y2" to y2)
+
+    @Test
+    fun `coordinate objects preserve normalized values`() {
+        val curve = BezierCurve(0.2f, 0.1f, 0.8f, 0.9f)
+        assertEquals(curve, parseBezierCurve(curve.coordinates()))
+    }
+
+    @Test
+    fun `malformed nonfinite and out of range coordinates are rejected`() {
+        listOf(
+            linear.coordinates() + ("x1" to -0.1f),
+            linear.coordinates() + ("x2" to 1.1f),
+            linear.coordinates() + ("y1" to -0.1f),
+            linear.coordinates() + ("y2" to 1.1f),
+            linear.coordinates() + ("y1" to Float.NaN),
+            linear.coordinates() + ("y2" to 1e99),
+            linear.coordinates() + ("x1" to true),
+            linear.coordinates() + ("y1" to "0.5"),
+            linear.coordinates() - "y1",
+            linear.coordinates() + ("extra" to 0f),
+        ).forEach { assertNull(it.toString(), parseBezierCurve(it)) }
+        assertThrows(IllegalArgumentException::class.java) { BezierCurve(0f, Float.NaN, 1f, 1f) }
+        assertThrows(IllegalArgumentException::class.java) { BezierCurve(0f, -0.1f, 1f, 1f) }
+        assertThrows(IllegalArgumentException::class.java) { BezierCurve(0f, 0f, 1f, 1.1f) }
+    }
+
+    @Test
+    fun `a whole curve updates resets and restores across owners`() {
+        TweaksRuntimePolicy.configure(isDebuggable = true, allowRelease = false)
+        val edited = BezierCurve(0.25f, 0.1f, 0.75f, 0.9f)
+        TweakScope().use { scope ->
+            val state = scope.tweak(linear, "Motion/Curve")
+            TweakRegistry.update(mapOf("Motion/Curve" to edited.coordinates()))
+            assertEquals(edited, state.value)
+            assertTrue(TweakRegistry.snapshot().single().modified)
+            assertThrows(TweakUpdateException::class.java) {
+                TweakRegistry.update(mapOf("Motion/Curve" to (linear.coordinates() + ("x1" to 2f))))
+            }
+            assertEquals(edited, state.value)
+        }
+        TweakScope().use { scope ->
+            val state = scope.tweak(linear, "Motion/Curve")
+            assertEquals(edited, state.value)
+            TweakRegistry.update(mapOf("Motion/Curve" to null))
+            assertEquals(linear, state.value)
+        }
+    }
+
+    @Test
+    fun `Y bounds constrain defaults and updates`() {
+        val default = BezierCurve(0f, 0.2f, 1f, 0.8f)
+        val descriptor = TweakDescriptor("Curve", TweakType.BEZIER, default, yMin = 0.2f, yMax = 0.8f)
+        val state = TweakRegistry.register(descriptor)
+        assertThrows(TweakUpdateException::class.java) {
+            TweakRegistry.update(mapOf("Curve" to linear.coordinates()))
+        }
+        assertEquals(default, state.value)
+        assertThrows(IllegalArgumentException::class.java) {
+            TweakRegistry.register(descriptor.copy(name = "Invalid", yMin = Float.NaN))
+        }
+        assertThrows(IllegalArgumentException::class.java) {
+            TweakRegistry.register(descriptor.copy(name = "Overshoot", yMin = -1f, yMax = 2f))
+        }
+        assertThrows(TweakUpdateException::class.java) {
+            TweakRegistry.register(descriptor.copy(name = "Outside", default = linear))
+        }
+    }
+}

--- a/snapo-link-android/tweaks-core/src/test/java/com/openai/snapo/tweaks/internal/TweakActionRegistryTest.kt
+++ b/snapo-link-android/tweaks-core/src/test/java/com/openai/snapo/tweaks/internal/TweakActionRegistryTest.kt
@@ -15,8 +15,8 @@ class TweakActionRegistryTest {
     }
 
     @Test
-    fun `protocol version distinguishes reset and modification aware clients`() {
-        assertEquals(4, TweaksProtocolVersion)
+    fun `protocol version includes Bezier curves`() {
+        assertEquals(5, TweaksProtocolVersion)
     }
 
     @Test

--- a/snapo-link-android/tweaks-noop/src/main/java/com/openai/snapo/tweaks/SnapOTweaks.kt
+++ b/snapo-link-android/tweaks-noop/src/main/java/com/openai/snapo/tweaks/SnapOTweaks.kt
@@ -83,6 +83,14 @@ sealed interface SnapOTweakValue {
 
     @Immutable
     @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
+    data class Curve(
+        val value: BezierCurve,
+        val yMin: Float? = null,
+        val yMax: Float? = null,
+    ) : SnapOTweakValue
+
+    @Immutable
+    @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
     data class Text(val value: String) : SnapOTweakValue
 
     @Immutable

--- a/snapo-link-android/tweaks-noop/src/main/java/com/openai/snapo/tweaks/Tweaks.kt
+++ b/snapo-link-android/tweaks-noop/src/main/java/com/openai/snapo/tweaks/Tweaks.kt
@@ -30,6 +30,14 @@ fun <T : Any> tweak(
     }
 }
 
+/** Returns the current curve default without registering an inspector. */
+@Composable
+fun tweak(
+    default: BezierCurve,
+    name: String,
+    yRange: ClosedFloatingPointRange<Float>? = null,
+): State<BezierCurve> = rememberUpdatedState(default)
+
 /** Returns observable release-build state for the current floating-point default. */
 @Composable
 fun tweak(

--- a/snapo-link-android/tweaks-overlay/src/main/java/com/openai/snapo/tweaks/overlay/TweakBezierPicker.kt
+++ b/snapo-link-android/tweaks-overlay/src/main/java/com/openai/snapo/tweaks/overlay/TweakBezierPicker.kt
@@ -1,0 +1,359 @@
+package com.openai.snapo.tweaks.overlay
+
+import androidx.compose.foundation.Canvas
+import androidx.compose.foundation.background
+import androidx.compose.foundation.border
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.gestures.awaitEachGesture
+import androidx.compose.foundation.gestures.awaitFirstDown
+import androidx.compose.foundation.gestures.drag
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.BoxWithConstraints
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.aspectRatio
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.layout.widthIn
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.PlainTooltip
+import androidx.compose.material3.Text
+import androidx.compose.material3.TooltipBox
+import androidx.compose.material3.TooltipDefaults
+import androidx.compose.material3.rememberTooltipState
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberUpdatedState
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.Path
+import androidx.compose.ui.graphics.drawscope.DrawScope
+import androidx.compose.ui.graphics.drawscope.Stroke
+import androidx.compose.ui.graphics.drawscope.inset
+import androidx.compose.ui.input.pointer.pointerInput
+import androidx.compose.ui.semantics.CustomAccessibilityAction
+import androidx.compose.ui.semantics.Role
+import androidx.compose.ui.semantics.contentDescription
+import androidx.compose.ui.semantics.customActions
+import androidx.compose.ui.semantics.selected
+import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.semantics.stateDescription
+import androidx.compose.ui.unit.dp
+import com.openai.snapo.tweaks.BezierCurve
+import com.openai.snapo.tweaks.SnapOTweakEntry
+import com.openai.snapo.tweaks.SnapOTweakValue
+import com.openai.snapo.tweaks.SnapOTweaks
+import kotlin.math.abs
+
+private val GraphInset = 24.dp
+private val CurveAccent = Color(0xFF5468FF)
+private val SecondHandleAccent = Color(0xFFD07818)
+private val CurvePresets = linkedMapOf(
+    "Linear" to BezierCurve(1f / 3f, 1f / 3f, 2f / 3f, 2f / 3f),
+    "Ease" to BezierCurve(0.25f, 0.1f, 0.25f, 1f),
+    "Ease in" to BezierCurve(0.42f, 0f, 1f, 1f),
+    "Ease out" to BezierCurve(0f, 0f, 0.58f, 1f),
+    "Ease in out" to BezierCurve(0.42f, 0f, 0.58f, 1f),
+)
+
+internal object BezierViewport {
+    fun point(x: Float, y: Float, width: Float, height: Float, padding: Float = 0f): Offset =
+        Offset(padding + (width - 2f * padding) * x, padding + (height - 2f * padding) * (1f - y))
+
+    fun value(position: Offset, width: Float, height: Float, padding: Float = 0f): Pair<Float, Float> =
+        ((position.x - padding) / (width - 2f * padding)).coerceIn(0f, 1f) to
+            (1f - (position.y - padding) / (height - 2f * padding)).coerceIn(0f, 1f)
+}
+
+internal fun moveBezierHandle(
+    value: SnapOTweakValue.Curve,
+    handle: Int,
+    x: Float,
+    y: Float,
+): SnapOTweakValue.Curve {
+    if (!x.isFinite() || !y.isFinite()) return value
+    val boundedX = x.coerceIn(0f, 1f)
+    val boundedY = y.coerceIn(value.yMin ?: 0f, value.yMax ?: 1f)
+    return value.copy(
+        value = if (handle == 0) {
+            value.value.copy(x1 = boundedX, y1 = boundedY)
+        } else {
+            value.value.copy(x2 = boundedX, y2 = boundedY)
+        }
+    )
+}
+
+@Composable
+internal fun TweakBezierChooser(tweak: SnapOTweakEntry, modifier: Modifier = Modifier) {
+    val value = tweak.value.value as SnapOTweakValue.Curve
+    var selectedHandle by remember(tweak.name) { mutableStateOf(0) }
+    val update: (SnapOTweakValue.Curve) -> Unit = { SnapOTweaks.update(tweak.name, it) }
+    BoxWithConstraints(modifier) {
+        val graphSize = minOf(
+            (maxHeight - 88.dp).coerceIn(96.dp, 220.dp),
+            (maxWidth - 144.dp).coerceAtLeast(96.dp),
+        )
+        Column(
+            Modifier.fillMaxWidth().verticalScroll(rememberScrollState()).padding(12.dp),
+            verticalArrangement = Arrangement.spacedBy(8.dp),
+            horizontalAlignment = Alignment.CenterHorizontally,
+        ) {
+            Box(Modifier.fillMaxWidth().height(graphSize)) {
+                CurvePresetButtons(value, Modifier.align(Alignment.CenterEnd).width(48.dp).height(graphSize), update)
+                BezierGraph(
+                    value,
+                    selectedHandle,
+                    { selectedHandle = it },
+                    update,
+                    Modifier.align(Alignment.Center).size(graphSize),
+                )
+            }
+            Row(
+                Modifier.widthIn(max = graphSize),
+                horizontalArrangement = Arrangement.spacedBy(8.dp),
+            ) {
+                val x = if (selectedHandle == 0) value.value.x1 else value.value.x2
+                val y = if (selectedHandle == 0) value.value.y1 else value.value.y2
+                CurveCoordinate("X${selectedHandle + 1}", x, 0f, 1f, Modifier.weight(1f)) {
+                    update(moveBezierHandle(value, selectedHandle, it, y))
+                }
+                CurveCoordinate(
+                    "Y${selectedHandle + 1}",
+                    y,
+                    value.yMin ?: 0f,
+                    value.yMax ?: 1f,
+                    Modifier.weight(1f),
+                ) {
+                    update(moveBezierHandle(value, selectedHandle, x, it))
+                }
+            }
+        }
+    }
+}
+
+internal fun bezierPresetName(curve: BezierCurve): String = CurvePresets.entries.firstOrNull { (_, preset) ->
+    abs(curve.x1 - preset.x1) < 0.00001f && abs(curve.y1 - preset.y1) < 0.00001f &&
+        abs(curve.x2 - preset.x2) < 0.00001f && abs(curve.y2 - preset.y2) < 0.00001f
+}?.key ?: "Custom"
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+private fun CurvePresetButtons(
+    value: SnapOTweakValue.Curve,
+    modifier: Modifier,
+    onChange: (SnapOTweakValue.Curve) -> Unit,
+) {
+    val currentPreset = bezierPresetName(value.value)
+    Column(
+        modifier,
+        verticalArrangement = Arrangement.SpaceEvenly,
+        horizontalAlignment = Alignment.CenterHorizontally,
+    ) {
+        CurvePresets.forEach { (name, curve) ->
+            val isSelected = name == currentPreset
+            val allowed = listOf(curve.y1, curve.y2).all {
+                it >= (value.yMin ?: 0f) && it <= (value.yMax ?: 1f)
+            }
+            TooltipBox(
+                positionProvider = TooltipDefaults.rememberTooltipPositionProvider(),
+                tooltip = { PlainTooltip { Text(name) } },
+                state = rememberTooltipState(),
+            ) {
+                Box(
+                    modifier = Modifier.size(32.dp)
+                        .clip(RoundedCornerShape(4.dp))
+                        .background(if (isSelected) CurveAccent.copy(alpha = 0.15f) else Color.Transparent)
+                        .clickable(enabled = allowed, role = Role.Button) { onChange(value.copy(value = curve)) }
+                        .semantics {
+                            contentDescription = "Apply $name curve"
+                            selected = isSelected
+                        },
+                    contentAlignment = Alignment.Center,
+                ) {
+                    BezierPreview(curve, Modifier.size(28.dp))
+                }
+            }
+        }
+    }
+}
+
+private fun validCoordinate(value: Float?, minimum: Float, maximum: Float): Boolean =
+    value != null && value.isFinite() && value in minimum..maximum
+
+@Composable
+private fun CurveCoordinate(
+    label: String,
+    value: Float,
+    minimum: Float,
+    maximum: Float,
+    modifier: Modifier,
+    onChange: (Float) -> Unit,
+) {
+    var edit by remember(label) { mutableStateOf(value to value.toString()) }
+    val draft = if (edit.first == value) edit.second else value.toString()
+    val number = draft.toFloatOrNull()
+    val valid = validCoordinate(number, minimum, maximum)
+    OutlinedTextField(
+        value = draft,
+        onValueChange = { text ->
+            edit = value to text
+            val next = text.toFloatOrNull()
+            if (next != null && validCoordinate(next, minimum, maximum)) {
+                edit = next to text
+                onChange(next)
+            }
+        },
+        modifier = modifier,
+        label = { Text(label) },
+        isError = !valid,
+        singleLine = true,
+    )
+}
+
+@Composable
+private fun BezierGraph(
+    value: SnapOTweakValue.Curve,
+    selected: Int,
+    onSelect: (Int) -> Unit,
+    onChange: (SnapOTweakValue.Curve) -> Unit,
+    modifier: Modifier,
+) {
+    val shape = RoundedCornerShape(6.dp)
+    Canvas(
+        modifier.fillMaxWidth().aspectRatio(1f)
+            .background(TweakOverlayColors.field, shape)
+            .border(1.dp, TweakOverlayColors.outline, shape)
+            .semantics {
+                contentDescription = "Bezier curve. Touch a handle to select it, then drag or edit its coordinates."
+                stateDescription = if (selected == 0) "Blue handle selected" else "Orange handle selected"
+                customActions = listOf(
+                    CustomAccessibilityAction("Select blue handle") {
+                        onSelect(0)
+                        true
+                    },
+                    CustomAccessibilityAction("Select orange handle") {
+                        onSelect(1)
+                        true
+                    },
+                )
+            }
+            .bezierGestures(value, selected, onSelect, onChange),
+    ) {
+        inset(GraphInset.toPx()) {
+            drawLine(TweakOverlayColors.outline, Offset(0f, size.height / 2), Offset(size.width, size.height / 2))
+            drawLine(TweakOverlayColors.outline, Offset(size.width / 2, 0f), Offset(size.width / 2, size.height))
+            drawBezier(value.value, handles = true, selected = selected)
+        }
+    }
+}
+
+@Composable
+private fun Modifier.bezierGestures(
+    value: SnapOTweakValue.Curve,
+    selected: Int,
+    onSelect: (Int) -> Unit,
+    onChange: (SnapOTweakValue.Curve) -> Unit,
+): Modifier {
+    val latest by rememberUpdatedState(value)
+    val latestSelected by rememberUpdatedState(selected)
+    val select by rememberUpdatedState(onSelect)
+    val update by rememberUpdatedState(onChange)
+    return pointerInput(Unit) {
+        awaitEachGesture {
+            val down = awaitFirstDown()
+            val frame = BezierViewport
+            val width = size.width.toFloat()
+            val height = size.height.toFloat()
+            val padding = GraphInset.toPx()
+            val first = frame.point(latest.value.x1, latest.value.y1, width, height, padding)
+            val second = frame.point(latest.value.x2, latest.value.y2, width, height, padding)
+            val handle = bezierHandleAt(down.position, first, second, 24.dp.toPx(), latestSelected)
+                ?: return@awaitEachGesture
+            val grabOffset = (if (handle == 0) first else second) - down.position
+            select(handle)
+            down.consume()
+            drag(down.id) { change ->
+                change.consume()
+                val (x, y) = frame.value(change.position + grabOffset, width, height, padding)
+                update(moveBezierHandle(latest, handle, x, y))
+            }
+        }
+    }
+}
+
+internal fun bezierHandleAt(position: Offset, first: Offset, second: Offset, radius: Float, selected: Int): Int? {
+    val firstDistance = (first - position).getDistance()
+    val secondDistance = (second - position).getDistance()
+    if (minOf(firstDistance, secondDistance) > radius) return null
+    // Repeated touches can reach either handle when the points coincide.
+    if ((first - second).getDistance() < 1f) return 1 - selected
+    return if (firstDistance <= secondDistance) 0 else 1
+}
+
+@Composable
+internal fun TweakBezierField(tweak: SnapOTweakEntry, onClick: () -> Unit) {
+    val curve = (tweak.value.value as SnapOTweakValue.Curve).value
+    Box(
+        modifier = Modifier
+            .size(48.dp)
+            .clickable(role = Role.Button, onClick = onClick)
+            .semantics { contentDescription = "Edit curve for ${tweak.name}" },
+        contentAlignment = Alignment.CenterEnd,
+    ) {
+        BezierPreview(curve, Modifier.size(28.dp))
+    }
+}
+
+@Composable
+private fun BezierPreview(curve: BezierCurve, modifier: Modifier = Modifier) {
+    val shape = RoundedCornerShape(4.dp)
+    Canvas(
+        modifier
+            .clip(shape)
+            .border(1.dp, TweakOverlayColors.outline, shape)
+            .background(TweakOverlayColors.surface)
+            .padding(3.dp),
+    ) { drawBezier(curve, handles = false) }
+}
+
+private fun DrawScope.drawBezier(curve: BezierCurve, handles: Boolean, selected: Int = 0) {
+    val viewport = BezierViewport
+    val start = viewport.point(0f, 0f, size.width, size.height)
+    val end = viewport.point(1f, 1f, size.width, size.height)
+    val first = viewport.point(curve.x1, curve.y1, size.width, size.height)
+    val second = viewport.point(curve.x2, curve.y2, size.width, size.height)
+    if (handles) {
+        drawLine(CurveAccent.copy(alpha = 0.6f), start, first)
+        drawLine(SecondHandleAccent.copy(alpha = 0.6f), end, second)
+    }
+    val path = Path().apply {
+        moveTo(start.x, start.y)
+        cubicTo(first.x, first.y, second.x, second.y, end.x, end.y)
+    }
+    drawPath(path, CurveAccent, style = Stroke((if (handles) 2.dp else 1.5.dp).toPx()))
+    if (handles) {
+        val points = listOf(first, second)
+        val colors = listOf(CurveAccent, SecondHandleAccent)
+        for (index in listOf(1 - selected, selected)) {
+            val point = points[index]
+            val color = colors[index]
+            if (index == selected) drawCircle(color, 12.dp.toPx(), point, style = Stroke(1.dp.toPx()))
+            drawCircle(color, 8.dp.toPx(), point)
+            drawCircle(TweakOverlayColors.surface, 8.dp.toPx(), point, style = Stroke(2.dp.toPx()))
+        }
+    }
+}

--- a/snapo-link-android/tweaks-overlay/src/main/java/com/openai/snapo/tweaks/overlay/TweakColorPicker.kt
+++ b/snapo-link-android/tweaks-overlay/src/main/java/com/openai/snapo/tweaks/overlay/TweakColorPicker.kt
@@ -162,7 +162,7 @@ internal fun TweakColorField(
         )
         TweakColorSwatch(
             color = color,
-            modifier = Modifier.size(20.dp),
+            modifier = Modifier.size(28.dp),
         )
     }
 }
@@ -300,7 +300,7 @@ private fun TweakColorPreview(
         TweakColorSwatch(
             color = color,
             modifier = Modifier
-                .size(34.dp)
+                .size(28.dp)
                 .semantics { contentDescription = "Current color: $label" },
         )
         Column {

--- a/snapo-link-android/tweaks-overlay/src/main/java/com/openai/snapo/tweaks/overlay/TweakOverlay.kt
+++ b/snapo-link-android/tweaks-overlay/src/main/java/com/openai/snapo/tweaks/overlay/TweakOverlay.kt
@@ -151,14 +151,15 @@ private fun TweakOverlayLayer(
 }
 
 @Composable
-private fun resolveSelectedColorTweak(
+private fun resolveSelectedEditorTweak(
     name: String?,
     tweaks: List<SnapOTweakEntry>,
     onMissing: () -> Unit,
 ): SnapOTweakEntry? {
     val selected = name?.let { selectedName ->
         tweaks.firstOrNull { tweak ->
-            tweak.name == selectedName && tweak.defaultValue is SnapOTweakValue.ColorValue
+            tweak.name == selectedName &&
+                (tweak.defaultValue is SnapOTweakValue.ColorValue || tweak.defaultValue is SnapOTweakValue.Curve)
         }
     }
 
@@ -200,12 +201,12 @@ private fun ExpandedTweakOverlay(
     onMinimize: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
-    var selectedColorTweakName by rememberSaveable { mutableStateOf<String?>(null) }
-    val selectedColorTweak = resolveSelectedColorTweak(
-        name = selectedColorTweakName,
+    var selectedEditorTweakName by rememberSaveable { mutableStateOf<String?>(null) }
+    val selectedEditorTweak = resolveSelectedEditorTweak(
+        name = selectedEditorTweakName,
         tweaks = tweaks,
     ) {
-        selectedColorTweakName = null
+        selectedEditorTweakName = null
     }
 
     Surface(
@@ -217,7 +218,7 @@ private fun ExpandedTweakOverlay(
         shadowElevation = 5.dp,
     ) {
         Column {
-            if (selectedColorTweak == null) {
+            if (selectedEditorTweak == null) {
                 TweakOverlayActions(
                     tweaks = tweaks,
                     onMinimize = onMinimize,
@@ -243,21 +244,19 @@ private fun ExpandedTweakOverlay(
 
                         TweakOverlayControl(
                             tweak = tweak,
-                            onSelectColor = { selectedColorTweakName = tweak.name },
+                            onSelectColor = { selectedEditorTweakName = tweak.name },
+                            onSelectCurve = { selectedEditorTweakName = tweak.name },
                         )
                     }
                 }
             } else {
-                TweakColorOverlayActions(
-                    tweak = selectedColorTweak,
-                    onClose = { selectedColorTweakName = null },
-                    onDrag = onDrag,
-                )
+                TweakEditorOverlayActions(selectedEditorTweak, { selectedEditorTweakName = null }, onDrag)
                 HorizontalDivider(color = TweakOverlayColors.outline)
-                TweakColorChooser(
-                    tweak = selectedColorTweak,
-                    modifier = Modifier.weight(1f),
-                )
+                if (selectedEditorTweak.defaultValue is SnapOTweakValue.Curve) {
+                    TweakBezierChooser(selectedEditorTweak, Modifier.weight(1f))
+                } else {
+                    TweakColorChooser(selectedEditorTweak, Modifier.weight(1f))
+                }
             }
         }
     }
@@ -292,7 +291,7 @@ private fun TweakOverlayActions(
 }
 
 @Composable
-private fun TweakColorOverlayActions(
+private fun TweakEditorOverlayActions(
     tweak: SnapOTweakEntry,
     onClose: () -> Unit,
     onDrag: (Float) -> Unit,

--- a/snapo-link-android/tweaks-overlay/src/main/java/com/openai/snapo/tweaks/overlay/TweakOverlayControls.kt
+++ b/snapo-link-android/tweaks-overlay/src/main/java/com/openai/snapo/tweaks/overlay/TweakOverlayControls.kt
@@ -69,6 +69,7 @@ private const val MaximumDiscreteSliderIntervals = 1_000
 internal fun TweakOverlayControl(
     tweak: SnapOTweakEntry,
     onSelectColor: () -> Unit,
+    onSelectCurve: () -> Unit = {},
 ) {
     Column(
         modifier = Modifier
@@ -103,6 +104,9 @@ internal fun TweakOverlayControl(
             }
             is SnapOTweakValue.Selection -> TweakOverlayLabelRow(tweak) {
                 TweakSelectionField(tweak)
+            }
+            is SnapOTweakValue.Curve -> TweakOverlayLabelRow(tweak) {
+                TweakBezierField(tweak, onSelectCurve)
             }
             is SnapOTweakValue.ColorValue -> TweakOverlayLabelRow(tweak) {
                 TweakColorField(tweak, onSelectColor)

--- a/snapo-link-android/tweaks-overlay/src/test/java/com/openai/snapo/tweaks/overlay/TweakBezierPickerTest.kt
+++ b/snapo-link-android/tweaks-overlay/src/test/java/com/openai/snapo/tweaks/overlay/TweakBezierPickerTest.kt
@@ -1,0 +1,70 @@
+package com.openai.snapo.tweaks.overlay
+
+import androidx.compose.ui.geometry.Offset
+import com.openai.snapo.tweaks.BezierCurve
+import com.openai.snapo.tweaks.SnapOTweakValue
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Test
+
+class TweakBezierPickerTest {
+    @Test
+    fun `touches away from both handles do not select a handle`() {
+        assertNull(bezierHandleAt(Offset(100f, 100f), Offset(40f, 180f), Offset(160f, 20f), 24f, 0))
+        assertNull(bezierHandleAt(Offset(65f, 180f), Offset(40f, 180f), Offset(160f, 20f), 24f, 0))
+    }
+
+    @Test
+    fun `touch selects the nearest handle within the hit radius`() {
+        val first = Offset(40f, 100f)
+        val second = Offset(70f, 100f)
+        assertEquals(0, bezierHandleAt(Offset(16f, 100f), first, second, 24f, 1))
+        assertEquals(1, bezierHandleAt(Offset(65f, 100f), first, second, 24f, 0))
+    }
+
+    @Test
+    fun `coincident handles remain reachable without selecting on distant touches`() {
+        val point = Offset(100f, 100f)
+        assertEquals(1, bezierHandleAt(point, point, point, 24f, 0))
+        assertEquals(0, bezierHandleAt(point, point, point, 24f, 1))
+        assertNull(bezierHandleAt(Offset.Zero, point, point, 24f, 0))
+    }
+
+    @Test
+    fun `preset name follows curve edits and tolerates float rounding`() {
+        assertEquals("Ease", bezierPresetName(BezierCurve(0.25f, 0.1f, 0.25f, 1f)))
+        assertEquals("Ease", bezierPresetName(BezierCurve(0.250001f, 0.1f, 0.25f, 1f)))
+        assertEquals("Custom", bezierPresetName(BezierCurve(0.3f, 0.1f, 0.25f, 1f)))
+    }
+
+    @Test
+    fun `moving one handle preserves the other and clamps declared bounds`() {
+        val original = SnapOTweakValue.Curve(BezierCurve(0.2f, 0.3f, 0.8f, 0.9f))
+        assertEquals(BezierCurve(0f, 1f, 0.8f, 0.9f), moveBezierHandle(original, 0, -1f, 2f).value)
+        assertEquals(original, moveBezierHandle(original, 0, Float.NaN, 0f))
+    }
+
+    @Test
+    fun `viewport round trips coordinates and clamps values outside the graph`() {
+        val point = BezierViewport.point(0.2f, 0.8f, 240f, 240f)
+        val (x, y) = BezierViewport.value(point, 240f, 240f)
+        assertEquals(0.2f, x, 0.00001f)
+        assertEquals(0.8f, y, 0.00001f)
+        assertEquals(0f to 1f, BezierViewport.value(Offset(-20f, -20f), 240f, 240f))
+    }
+
+    @Test
+    fun `padding touches reach corner handles without shifting their values`() {
+        val first = BezierViewport.point(0f, 0f, 200f, 200f, 24f)
+        val second = BezierViewport.point(1f, 1f, 200f, 200f, 24f)
+        val touch = Offset(8f, 184f)
+        assertEquals(0, bezierHandleAt(touch, first, second, 24f, 1))
+        assertEquals(1, bezierHandleAt(Offset(184f, 8f), first, second, 24f, 0))
+        val grabOffset = first - touch
+        assertEquals(0f to 0f, BezierViewport.value(touch + grabOffset, 200f, 200f, 24f))
+        val (x, y) = BezierViewport.value(touch + grabOffset + Offset(76f, -76f), 200f, 200f, 24f)
+        assertEquals(0.5f, x, 0.00001f)
+        assertEquals(0.5f, y, 0.00001f)
+        assertEquals(1f to 1f, BezierViewport.value(Offset(200f, 0f), 200f, 200f, 24f))
+    }
+}

--- a/snapo-link-android/tweaks/src/main/java/com/openai/snapo/tweaks/SnapOTweaks.kt
+++ b/snapo-link-android/tweaks/src/main/java/com/openai/snapo/tweaks/SnapOTweaks.kt
@@ -135,6 +135,14 @@ sealed interface SnapOTweakValue {
 
     @Immutable
     @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
+    data class Curve(
+        val value: BezierCurve,
+        val yMin: Float? = null,
+        val yMax: Float? = null,
+    ) : SnapOTweakValue
+
+    @Immutable
+    @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
     data class Text(val value: String) : SnapOTweakValue
 
     @Immutable
@@ -171,6 +179,7 @@ internal fun TweakDescriptor.toSnapOTweakValue(value: Any): SnapOTweakValue = wh
         step = step as Float?,
     )
 
+    TweakType.BEZIER -> SnapOTweakValue.Curve(value as BezierCurve, yMin, yMax)
     TweakType.BOOLEAN -> SnapOTweakValue.Toggle(value as Boolean)
     TweakType.COLOR -> SnapOTweakValue.ColorValue((value as TweakColorValue).color)
     TweakType.STRING -> SnapOTweakValue.Text(value as String)
@@ -181,6 +190,7 @@ internal fun TweakDescriptor.toSnapOTweakValue(value: Any): SnapOTweakValue = wh
 private fun SnapOTweakValue.toRegistryValue(): Any = when (this) {
     is SnapOTweakValue.Integer -> value
     is SnapOTweakValue.Floating -> value
+    is SnapOTweakValue.Curve -> value
     is SnapOTweakValue.Toggle -> value
     is SnapOTweakValue.ColorValue -> value.toTweakColorValue()
     is SnapOTweakValue.Text -> value

--- a/snapo-link-android/tweaks/src/main/java/com/openai/snapo/tweaks/Tweaks.kt
+++ b/snapo-link-android/tweaks/src/main/java/com/openai/snapo/tweaks/Tweaks.kt
@@ -1,3 +1,5 @@
+@file:Suppress("TooManyFunctions")
+
 package com.openai.snapo.tweaks
 
 import androidx.compose.runtime.Composable
@@ -21,7 +23,7 @@ import kotlinx.coroutines.flow.collect
 import kotlinx.coroutines.flow.collectLatest
 
 /**
- * Exposes an application-owned Boolean, Int, Float, String, or Color tweak.
+ * Exposes an application-owned Boolean, Int, Float, String, Color, or BezierCurve tweak.
  *
  * The first observed value is the inspector default; edits, resets, and status remain app-owned.
  * Sources with the same name must use the same setting and value type.
@@ -57,6 +59,17 @@ fun <T : Any> tweak(
 
     return registration
 }
+
+/** Exposes a cubic curve as one editable value. Optional bounds constrain both Y coordinates. */
+@Composable
+fun tweak(
+    default: BezierCurve,
+    name: String,
+    yRange: ClosedFloatingPointRange<Float>? = null,
+): State<BezierCurve> = rememberTweakState(
+    TweakDescriptor(name, TweakType.BEZIER, default, yMin = yRange?.start, yMax = yRange?.endInclusive),
+    default,
+) { it as BezierCurve }
 
 /** Exposes a floating-point tweak as observable state. */
 @Composable
@@ -303,9 +316,10 @@ internal class ExternalTweakBinding<T : Any>(
                 is Float -> TweakType.FLOAT
                 is String -> TweakType.STRING
                 is Color -> TweakType.COLOR
+                is BezierCurve -> TweakType.BEZIER
                 else -> throw IllegalArgumentException(
                     "Unsupported tweak value type: ${initial.javaClass.name}. " +
-                        "Supported types are Boolean, Int, Float, String, and Color.",
+                        "Supported types are Boolean, Int, Float, String, Color, and BezierCurve.",
                 )
             },
             default = encode(initial),

--- a/snapo-link-android/tweaks/src/test/java/com/openai/snapo/tweaks/TweakRegistrationTest.kt
+++ b/snapo-link-android/tweaks/src/test/java/com/openai/snapo/tweaks/TweakRegistrationTest.kt
@@ -466,7 +466,7 @@ class TweakRegistrationTest {
         }
 
         assertTrue(error.message.orEmpty().contains("java.lang.Long"))
-        assertTrue(error.message.orEmpty().contains("Boolean, Int, Float, String, and Color"))
+        assertTrue(error.message.orEmpty().contains("Boolean, Int, Float, String, Color, and BezierCurve"))
     }
 
     @Test

--- a/snapo-network-inspector-web/src/features/tweaks-inspector/BezierEditor.test.tsx
+++ b/snapo-network-inspector-web/src/features/tweaks-inspector/BezierEditor.test.tsx
@@ -1,0 +1,110 @@
+// @vitest-environment jsdom
+import { act, useState } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { BezierEditor } from "./BezierEditor";
+import type { BezierValue } from "../../network/bridge-types";
+
+const initial = { x1: 0.4, y1: 0, x2: 0.2, y2: 1 };
+
+describe("Bezier editor", () => {
+  let container: HTMLDivElement;
+  let root: Root;
+  const changed = vi.fn();
+  const reset = vi.fn();
+  beforeEach(async () => {
+    vi.stubGlobal("IS_REACT_ACT_ENVIRONMENT", true);
+    container = document.createElement("div");
+    document.body.append(container);
+    root = createRoot(container);
+    changed.mockClear();
+    reset.mockClear();
+    function Harness() {
+      const [value, setValue] = useState(initial);
+      return (
+        <BezierEditor
+          tweak={{ name: "Motion/Curve", type: "bezier", value, default: initial }}
+          onChange={(next: BezierValue) => {
+            changed(next);
+            setValue(next);
+          }}
+          onReset={() => {
+            reset();
+            setValue(initial);
+          }}
+        />
+      );
+    }
+    await act(async () => root.render(<Harness />));
+    await act(async () => container.querySelector("button")!.click());
+  });
+  afterEach(async () => {
+    await act(async () => root.unmount());
+    container.remove();
+    vi.unstubAllGlobals();
+  });
+  it("opens a dialog and emits one complete object for a keyboard adjustment", async () => {
+    expect(document.querySelector('[role="dialog"]')).not.toBeNull();
+    const handle = document.querySelector('[role="button"]')!;
+    await act(async () => handle.dispatchEvent(new KeyboardEvent("keydown", { key: "ArrowRight", bubbles: true })));
+    expect(changed).toHaveBeenLastCalledWith({ x1: 0.41, y1: 0, x2: 0.2, y2: 1 });
+  });
+  it("applies a whole preset and invokes the source reset", async () => {
+    const preset = document.querySelector<HTMLButtonElement>('[aria-label="Ease out"]')!;
+    await act(async () => preset.click());
+    expect(preset.getAttribute("aria-pressed")).toBe("true");
+    expect(changed).toHaveBeenLastCalledWith({ x1: 0, y1: 0, x2: 0.58, y2: 1 });
+    await act(async () => document.querySelector<HTMLButtonElement>('[aria-label="Reset curve"]')!.click());
+    expect(reset).toHaveBeenCalledOnce();
+    expect(document.querySelector<HTMLInputElement>('[aria-label="Motion/Curve X1"]')!.value).toBe("0.4");
+  });
+  it("keeps an unfinished coordinate local until it becomes valid", async () => {
+    const input = document.querySelector<HTMLInputElement>('[aria-label="Motion/Curve Y2"]')!;
+    const setValue = Object.getOwnPropertyDescriptor(HTMLInputElement.prototype, "value")!.set!;
+    await act(async () => {
+      setValue.call(input, "");
+      input.dispatchEvent(new Event("input", { bubbles: true }));
+    });
+    expect(input.value).toBe("");
+    expect(changed).not.toHaveBeenCalled();
+    await act(async () => {
+      setValue.call(input, "1.5");
+      input.dispatchEvent(new Event("input", { bubbles: true }));
+    });
+    expect(changed).not.toHaveBeenCalled();
+    await act(async () => {
+      setValue.call(input, "0.5");
+      input.dispatchEvent(new Event("input", { bubbles: true }));
+    });
+    expect(changed).toHaveBeenLastCalledWith({ ...initial, y2: 0.5 });
+  });
+
+  it("keeps the inspector and graph mounted across live changes", async () => {
+    const panel = document.querySelector('[role="dialog"]')!;
+    const graph = document.querySelector(".bezier-graph")!;
+    const handle = document.querySelector('[role="button"]')!;
+    await act(async () => handle.dispatchEvent(new KeyboardEvent("keydown", { key: "ArrowRight", bubbles: true })));
+    expect(document.querySelector('[role="dialog"]')).toBe(panel);
+    expect(document.querySelector(".bezier-graph")).toBe(graph);
+    expect(document.querySelector('[role="button"]')).toBe(handle);
+  });
+
+  it("closes on Escape and returns focus to the swatch", async () => {
+    await act(async () => window.dispatchEvent(new KeyboardEvent("keydown", { key: "Escape" })));
+    expect(document.querySelector('[role="dialog"]')).toBeNull();
+    expect(document.activeElement).toBe(container.querySelector("button"));
+  });
+
+  it("dismisses on an outside click but keeps editing on inside clicks", async () => {
+    await act(async () => document.querySelector("input")!.dispatchEvent(new Event("pointerdown", { bubbles: true })));
+    expect(document.querySelector('[role="dialog"]')).not.toBeNull();
+    await act(async () => document.body.dispatchEvent(new Event("pointerdown", { bubbles: true })));
+    expect(document.querySelector('[role="dialog"]')).toBeNull();
+  });
+
+  it("clamps keyboard edits to the normalized range", async () => {
+    const handle = document.querySelector('[role="button"]')!;
+    await act(async () => handle.dispatchEvent(new KeyboardEvent("keydown", { key: "ArrowDown", bubbles: true })));
+    expect(changed).toHaveBeenLastCalledWith(initial);
+  });
+});

--- a/snapo-network-inspector-web/src/features/tweaks-inspector/BezierEditor.tsx
+++ b/snapo-network-inspector-web/src/features/tweaks-inspector/BezierEditor.tsx
@@ -1,0 +1,288 @@
+import { createPortal } from "react-dom";
+import { useId, useLayoutEffect, useRef, useState } from "react";
+import { RotateCcw, X } from "lucide-react";
+import type { BezierValue, TweakValueDescriptor } from "../../network/bridge-types";
+import { bezierPresets, bezierValue, moveBezier, readBezier, type BezierCoordinates } from "./bezier";
+import "./bezier.css";
+
+const graphInset = 20;
+const graphExtent = 240;
+const graphSize = graphExtent + 2 * graphInset;
+const graphViewBox = `0 0 ${graphSize} ${graphSize}`;
+const arrowDirections: Record<string, readonly [number, number]> = {
+  ArrowLeft: [-1, 0],
+  ArrowRight: [1, 0],
+  ArrowUp: [0, 1],
+  ArrowDown: [0, -1]
+};
+
+function graphPoint(x: number, y: number): readonly [number, number] {
+  return [graphInset + x * graphExtent, graphInset + (1 - y) * graphExtent];
+}
+
+function curvePath([x1, y1, x2, y2]: BezierCoordinates): string {
+  return `M${graphPoint(0, 0)} C${graphPoint(x1, y1)} ${graphPoint(x2, y2)} ${graphPoint(1, 1)}`;
+}
+
+export function BezierEditor({
+  tweak,
+  onChange,
+  onReset
+}: {
+  tweak: TweakValueDescriptor;
+  onChange(value: BezierValue): void;
+  onReset?(): void;
+}): JSX.Element {
+  const panel = useRef<HTMLDivElement>(null);
+  const trigger = useRef<HTMLButtonElement>(null);
+  const panelId = useId();
+  const [open, setOpen] = useState(false);
+  const close = () => {
+    setOpen(false);
+    trigger.current?.focus();
+  };
+  useLayoutEffect(() => {
+    if (!open) return;
+    const position = () => {
+      const anchor = trigger.current?.getBoundingClientRect();
+      const element = panel.current;
+      if (!anchor || !element) return;
+      const { width, height } = element.getBoundingClientRect();
+      const left = Math.max(8, Math.min(anchor.right - width, window.innerWidth - width - 8));
+      const top = Math.max(8, Math.min(anchor.bottom + 6, window.innerHeight - height - 8));
+      element.style.left = `${left}px`;
+      element.style.top = `${top}px`;
+    };
+    const dismiss = (event: PointerEvent) => {
+      if (!panel.current?.contains(event.target as Node) && !trigger.current?.contains(event.target as Node)) {
+        setOpen(false);
+      }
+    };
+    const escape = (event: KeyboardEvent) => {
+      if (event.key === "Escape") {
+        event.preventDefault();
+        setOpen(false);
+        trigger.current?.focus();
+      }
+    };
+    position();
+    panel.current?.focus();
+    window.addEventListener("resize", position);
+    window.addEventListener("scroll", position, true);
+    window.addEventListener("pointerdown", dismiss);
+    window.addEventListener("keydown", escape);
+    return () => {
+      window.removeEventListener("resize", position);
+      window.removeEventListener("scroll", position, true);
+      window.removeEventListener("pointerdown", dismiss);
+      window.removeEventListener("keydown", escape);
+    };
+  }, [open]);
+  const value = readBezier(tweak.value);
+  const drag = useRef<{ index: number; pointerId: number } | null>(null);
+  if (!value) return <span>Invalid curve</span>;
+  const start = graphPoint(0, 0),
+    end = graphPoint(1, 1),
+    p1 = graphPoint(value[0], value[1]),
+    p2 = graphPoint(value[2], value[3]);
+  const emit = (next: BezierCoordinates) => onChange(bezierValue(next));
+  const finish = () => {
+    drag.current = null;
+  };
+  return (
+    <span>
+      <button
+        type="button"
+        className="bezier-open"
+        ref={trigger}
+        aria-expanded={open}
+        aria-controls={open ? panelId : undefined}
+        aria-label={`Edit ${tweak.name}`}
+        aria-haspopup="dialog"
+        title={`Edit ${tweak.name}`}
+        onClick={() => setOpen((current) => !current)}
+      >
+        <svg viewBox={graphViewBox} aria-hidden="true">
+          <path d={curvePath(value)} vectorEffect="non-scaling-stroke" />
+        </svg>
+      </button>
+      {open &&
+        typeof document !== "undefined" &&
+        createPortal(
+          <div
+            ref={panel}
+            id={panelId}
+            role="dialog"
+            tabIndex={-1}
+            className="bezier-panel"
+            aria-label={`Edit ${tweak.name}`}
+          >
+            <div className="bezier-heading">
+              <strong>{tweak.name.split("/").pop()}</strong>
+              {onReset && (
+                <button
+                  type="button"
+                  className="toolbar-icon-button"
+                  aria-label="Reset curve"
+                  title="Reset curve"
+                  onClick={onReset}
+                >
+                  <RotateCcw size={13} />
+                </button>
+              )}
+              <button
+                type="button"
+                className="toolbar-icon-button"
+                aria-label="Close curve editor"
+                title="Close"
+                onClick={close}
+              >
+                <X size={14} />
+              </button>
+            </div>
+            <div className="bezier-workspace">
+              <svg
+                className="bezier-graph"
+                viewBox={graphViewBox}
+                aria-label={`${tweak.name} curve`}
+                onPointerMove={(event) => {
+                  const active = drag.current;
+                  if (!active || active.pointerId !== event.pointerId) return;
+                  const matrix = event.currentTarget.getScreenCTM();
+                  if (!matrix) return;
+                  const p = new DOMPoint(event.clientX, event.clientY).matrixTransform(matrix.inverse());
+                  emit(
+                    moveBezier(
+                      value,
+                      active.index,
+                      (p.x - graphInset) / graphExtent,
+                      1 - (p.y - graphInset) / graphExtent,
+                      tweak.yMin,
+                      tweak.yMax
+                    )
+                  );
+                }}
+                onPointerUp={finish}
+                onPointerCancel={finish}
+                onLostPointerCapture={finish}
+              >
+                <path
+                  className="bezier-grid"
+                  d={`M${graphPoint(0, 1)} L${start} L${graphPoint(1, 0)} M${graphPoint(0, 0.5)} L${graphPoint(1, 0.5)} M${graphPoint(0.5, 1)} L${graphPoint(0.5, 0)}`}
+                />
+                <path className="bezier-arm" d={`M${start} L${p1} M${end} L${p2}`} />
+                <path className="bezier-line" d={curvePath(value)} />
+                {[p1, p2].map((p, index) => (
+                  <circle
+                    key={index}
+                    className={`bezier-handle bezier-handle-${index}`}
+                    cx={p[0]}
+                    cy={p[1]}
+                    r={8}
+                    tabIndex={0}
+                    role="button"
+                    aria-label={`${tweak.name} handle ${index + 1}: ${value[index * 2]}, ${value[index * 2 + 1]}. Use arrow keys to move.`}
+                    onPointerDown={(event) => {
+                      if (event.button !== 0) return;
+                      event.preventDefault();
+                      event.currentTarget.focus();
+                      drag.current = { index, pointerId: event.pointerId };
+                      event.currentTarget.ownerSVGElement?.setPointerCapture(event.pointerId);
+                    }}
+                    onKeyDown={(event) => {
+                      const direction = arrowDirections[event.key];
+                      if (!direction) return;
+                      event.preventDefault();
+                      const step = event.shiftKey ? 0.1 : 0.01;
+                      emit(
+                        moveBezier(
+                          value,
+                          index,
+                          value[index * 2] + direction[0] * step,
+                          value[index * 2 + 1] + direction[1] * step,
+                          tweak.yMin,
+                          tweak.yMax
+                        )
+                      );
+                    }}
+                  />
+                ))}
+              </svg>
+              <div className="bezier-presets" role="group" aria-label="Curve presets">
+                {Object.entries(bezierPresets).map(([name, preset]) => (
+                  <button
+                    key={name}
+                    type="button"
+                    className="bezier-preset"
+                    title={name}
+                    aria-label={name}
+                    aria-pressed={preset.every((coordinate, index) => Math.abs(coordinate - value[index]) < 0.00001)}
+                    disabled={[preset[1], preset[3]].some((y) => y < (tweak.yMin ?? 0) || y > (tweak.yMax ?? 1))}
+                    onClick={() => emit(preset)}
+                  >
+                    <svg viewBox={graphViewBox} aria-hidden="true">
+                      <path d={curvePath(preset)} vectorEffect="non-scaling-stroke" />
+                    </svg>
+                  </button>
+                ))}
+              </div>
+              <div className="bezier-coordinates">
+                {(["X1", "Y1", "X2", "Y2"] as const).map((label, i) => (
+                  <label key={label} className={`bezier-coordinate-${Math.floor(i / 2)}`}>
+                    {label}
+                    <BezierCoordinate
+                      label={`${tweak.name} ${label}`}
+                      min={i % 2 === 0 ? 0 : (tweak.yMin ?? 0)}
+                      max={i % 2 === 0 ? 1 : (tweak.yMax ?? 1)}
+                      value={value[i]}
+                      onChange={(coordinate) => {
+                        const next = [...value] as [number, number, number, number];
+                        next[i] = coordinate;
+                        emit(next);
+                      }}
+                    />
+                  </label>
+                ))}
+              </div>
+            </div>
+          </div>,
+          document.body
+        )}
+    </span>
+  );
+}
+
+function BezierCoordinate({
+  label,
+  value,
+  min,
+  max,
+  onChange
+}: {
+  label: string;
+  value: number;
+  min?: number;
+  max?: number;
+  onChange(value: number): void;
+}): JSX.Element {
+  const [draft, setDraft] = useState({ committed: value, text: String(value) });
+  const text = draft.committed === value ? draft.text : String(value);
+  return (
+    <input
+      className="tweaks-number"
+      type="number"
+      aria-label={label}
+      step="any"
+      min={min}
+      max={max}
+      value={text}
+      onChange={(event) => {
+        const next = event.currentTarget.valueAsNumber;
+        const valid = event.currentTarget.validity.valid && Number.isFinite(Math.fround(next));
+        setDraft({ committed: valid ? next : value, text: event.currentTarget.value });
+        if (valid) onChange(next);
+      }}
+      onBlur={() => setDraft({ committed: value, text: String(value) })}
+    />
+  );
+}

--- a/snapo-network-inspector-web/src/features/tweaks-inspector/TweaksInspectorApp.tsx
+++ b/snapo-network-inspector-web/src/features/tweaks-inspector/TweaksInspectorApp.tsx
@@ -1,3 +1,4 @@
+import { BezierEditor } from "./BezierEditor";
 import { ChevronDown, RotateCcw } from "lucide-react";
 import { useCallback, useEffect, useId, useMemo, useRef, useState, type CSSProperties } from "react";
 import type {
@@ -86,7 +87,11 @@ export function TweaksInspectorApp({
             .listTweaks(server)
             .then((response) => {
               if (!isCurrent()) return;
-              setTweaks((current) => reconcileStreamedTweaks(current, response.tweaks, pending, inFlight));
+              const pendingAtReply = new Map(pending);
+              const inFlightAtReply = new Set(inFlight);
+              setTweaks((current) =>
+                reconcileStreamedTweaks(current, response.tweaks, pendingAtReply, inFlightAtReply)
+              );
               setError(null);
             })
             .catch((cause: unknown) => {
@@ -108,7 +113,10 @@ export function TweaksInspectorApp({
     let retryDelay = 250;
 
     const applySnapshot = (incoming: TweakDescriptor[]) => {
-      setTweaks((current) => reconcileStreamedTweaks(current, incoming, queue.pending, queue.inFlight));
+      // Preserve the queue state at receipt, before React defers this update.
+      const pending = new Map(queue.pending);
+      const inFlight = new Set(queue.inFlight);
+      setTweaks((current) => reconcileStreamedTweaks(current, incoming, pending, inFlight));
       setHasSnapshot(true);
       setError(null);
     };
@@ -541,7 +549,12 @@ function TweakControl({
           </button>
         ) : null}
         <span className="tweaks-control-field">
-          <TweakField tweak={tweak} onChange={onChange} onOpenColorPanel={onOpenColorPanel} />
+          <TweakField
+            tweak={tweak}
+            onChange={onChange}
+            onOpenColorPanel={onOpenColorPanel}
+            onReset={() => onReset(tweak)}
+          />
         </span>
       </div>
 
@@ -608,11 +621,13 @@ export function TweakActionControl({
 export function TweakField({
   tweak,
   onChange,
-  onOpenColorPanel
+  onOpenColorPanel,
+  onReset
 }: {
   tweak: TweakValueDescriptor;
   onChange(tweak: TweakValueDescriptor, value: TweakValue): void;
   onOpenColorPanel?(tweak: TweakValueDescriptor): void;
+  onReset?(): void;
 }): JSX.Element | null {
   if (tweak.type === "boolean") {
     return (
@@ -628,6 +643,10 @@ export function TweakField({
 
   if (tweak.type === "color") {
     return <TweakColorField tweak={tweak} onChange={onChange} onOpenColorPanel={onOpenColorPanel} />;
+  }
+
+  if (tweak.type === "bezier") {
+    return <BezierEditor tweak={tweak} onChange={(value) => onChange(tweak, value)} onReset={onReset} />;
   }
 
   if (tweak.type === "enum") {

--- a/snapo-network-inspector-web/src/features/tweaks-inspector/bezier.css
+++ b/snapo-network-inspector-web/src/features/tweaks-inspector/bezier.css
@@ -1,0 +1,154 @@
+.bezier-open {
+  display: block;
+}
+
+.bezier-open svg,
+.bezier-preset svg {
+  display: block;
+  width: 100%;
+  height: 100%;
+  fill: none;
+  stroke: var(--accent-blue);
+  stroke-width: 1.5px;
+}
+
+.bezier-panel {
+  position: fixed;
+  z-index: 40;
+  width: min(340px, calc(100vw - 16px));
+  max-height: calc(100vh - 16px);
+  overflow: auto;
+  padding: 10px;
+  background: var(--surface-bright);
+  color: var(--on-surface);
+  border: 1px solid var(--outline);
+  border-radius: 5px;
+  box-shadow: 0 4px 16px #0002;
+  font-size: 12px;
+  outline: none;
+}
+
+.bezier-graph {
+  display: block;
+  width: 100%;
+  aspect-ratio: 1;
+  touch-action: none;
+  overflow: visible;
+}
+
+.bezier-grid {
+  fill: none;
+  stroke: var(--outline-variant);
+}
+
+.bezier-arm {
+  fill: none;
+  stroke: #9198a3;
+}
+
+.bezier-line {
+  fill: none;
+  stroke: #5468ff;
+  stroke-width: 2px;
+}
+
+.bezier-handle {
+  fill: #5468ff;
+  stroke: var(--surface);
+  stroke-width: 2px;
+}
+
+.bezier-handle-1 {
+  fill: #d07818;
+}
+
+.bezier-coordinate-0 {
+  color: #5468ff;
+}
+
+.bezier-coordinate-1 {
+  color: #d07818;
+}
+
+.bezier-handle:focus {
+  outline: none;
+}
+
+.bezier-handle:focus-visible {
+  stroke: var(--on-surface);
+}
+
+.bezier-workspace {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) 28px;
+  align-items: center;
+  column-gap: 10px;
+}
+
+.bezier-presets {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.bezier-coordinates {
+  display: grid;
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+  gap: 6px;
+  grid-column: 1;
+  margin: 4px 0 0;
+}
+
+.bezier-coordinates label {
+  display: grid;
+  gap: 4px;
+  font-size: 11px;
+}
+
+.bezier-coordinates input {
+  width: 100%;
+  min-width: 0;
+  padding: 5px;
+  text-align: left;
+}
+
+.bezier-preset {
+  width: 28px;
+  height: 28px;
+  border: 1px solid var(--outline-variant);
+  border-radius: 4px;
+  background: var(--surface-bright);
+  padding: 3px;
+}
+
+.bezier-preset:disabled {
+  opacity: 0.4;
+}
+
+.bezier-preset:hover:not(:disabled) {
+  background: var(--surface-container-low);
+}
+
+.bezier-preset[aria-pressed="true"] {
+  border-color: var(--accent-blue);
+  background: color-mix(in srgb, var(--accent-blue) 8%, var(--surface-bright));
+}
+
+.bezier-heading {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  margin-bottom: 4px;
+}
+
+.bezier-heading strong {
+  flex: 1;
+}
+
+.bezier-heading .toolbar-icon-button {
+  display: grid;
+  width: 22px;
+  height: 22px;
+  place-items: center;
+  border-radius: 3px;
+}

--- a/snapo-network-inspector-web/src/features/tweaks-inspector/bezier.test.ts
+++ b/snapo-network-inspector-web/src/features/tweaks-inspector/bezier.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it } from "vitest";
+import { bezierValue, moveBezier, readBezier } from "./bezier";
+
+describe("Bezier values", () => {
+  it("round trips normalized coordinates", () => {
+    const curve = [0.2, 0.1, 0.8, 0.9] as const;
+    expect(readBezier(bezierValue(curve))).toEqual(curve);
+  });
+  it.each([
+    { x1: 2, y1: 0, x2: 1, y2: 1 },
+    { x1: 0, y1: -0.1, x2: 1, y2: 1 },
+    { x1: 0, y1: 0, x2: 1, y2: 1.1 },
+    { x1: 0, y1: NaN, x2: 1, y2: 1 },
+    { x1: 0, y1: 0, x2: 1 },
+    { x1: 0, y1: 0, x2: 1, y2: 1, extra: 2 },
+    { x1: 0, y1: "0", x2: 1, y2: 1 },
+    "cubic-bezier(0, 0, 1, 1)"
+  ])("rejects malformed coordinate objects", (value) => {
+    expect(readBezier(value)).toBeNull();
+  });
+  it("moves one handle, preserving the other and respecting Y bounds", () => {
+    expect(moveBezier([0.2, 0.3, 0.8, 0.9], 0, -1, 2, 0, 1)).toEqual([0, 1, 0.8, 0.9]);
+    expect(moveBezier([0.2, 0.3, 0.8, 0.9], 1, 0.7, 2)).toEqual([0.2, 0.3, 0.7, 1]);
+  });
+});

--- a/snapo-network-inspector-web/src/features/tweaks-inspector/bezier.ts
+++ b/snapo-network-inspector-web/src/features/tweaks-inspector/bezier.ts
@@ -1,0 +1,40 @@
+import type { BezierValue } from "../../network/bridge-types";
+
+export type BezierCoordinates = readonly [number, number, number, number];
+
+export function readBezier(value: unknown): BezierCoordinates | null {
+  if (typeof value !== "object" || value === null) return null;
+  const object = value as Record<string, unknown>;
+  const points = [object.x1, object.y1, object.x2, object.y2];
+  if (Object.keys(object).length !== 4 || points.some((v) => typeof v !== "number" || !Number.isFinite(Math.fround(v))))
+    return null;
+  const coordinates = points as unknown as BezierCoordinates;
+  if (coordinates.some((v) => v < 0 || v > 1)) return null;
+  return coordinates;
+}
+
+export function bezierValue([x1, y1, x2, y2]: BezierCoordinates): BezierValue {
+  return { x1, y1, x2, y2 };
+}
+
+export function moveBezier(
+  value: BezierCoordinates,
+  index: number,
+  x: number,
+  y: number,
+  yMin?: number,
+  yMax?: number
+): BezierCoordinates {
+  const next = [...value];
+  next[index * 2] = Math.max(0, Math.min(1, Number(x.toFixed(6))));
+  next[index * 2 + 1] = Math.max(yMin ?? 0, Math.min(yMax ?? 1, Number(y.toFixed(6))));
+  return next as unknown as BezierCoordinates;
+}
+
+export const bezierPresets: Record<string, BezierCoordinates> = {
+  Linear: [1 / 3, 1 / 3, 2 / 3, 2 / 3],
+  Ease: [0.25, 0.1, 0.25, 1],
+  "Ease in": [0.42, 0, 1, 1],
+  "Ease out": [0, 0, 0.58, 1],
+  "Ease in out": [0.42, 0, 0.58, 1]
+};

--- a/snapo-network-inspector-web/src/features/tweaks-inspector/tweak-update-queue.test.ts
+++ b/snapo-network-inspector-web/src/features/tweaks-inspector/tweak-update-queue.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it, vi } from "vitest";
-import type { TweakUpdates } from "../../network/bridge-types";
+import type { TweakDescriptor, TweakUpdates } from "../../network/bridge-types";
 import { TweakUpdateQueue } from "./tweak-update-queue";
+import { applyTweakUpdates } from "./TweaksInspectorApp";
 
 describe("app-scoped tweak updates", () => {
   it("never sends a second app's pending edits to the first app", async () => {
@@ -72,6 +73,43 @@ describe("app-scoped tweak updates", () => {
 
     secondRequest.resolve({ tweaks: [{ name: "Motion/Duration", value: 500, modified: true }] });
     await flush;
+  });
+
+  it("preserves the latest drag position when React applies a reply after the next request starts", async () => {
+    const firstRequest = deferred<TweakUpdates>();
+    const secondRequest = deferred<TweakUpdates>();
+    const client = {
+      updateTweaks: vi.fn().mockReturnValueOnce(firstRequest.promise).mockReturnValueOnce(secondRequest.promise)
+    };
+    const name = "Motion/Curve";
+    const first = { x1: 0.4, y1: 0, x2: 0.2, y2: 1 };
+    const latest = { ...first, x1: 0.7 };
+    const renders: Array<(current: TweakDescriptor[]) => TweakDescriptor[]> = [];
+    const queue = new TweakUpdateQueue(
+      client,
+      { deviceId: "pixel", socketName: "snapo_tweaks_demo" },
+      {
+        ...callbacks(),
+        onUpdate(updates, pending) {
+          // React can defer this state updater until the queue has sent its next batch.
+          renders.push((current) => applyTweakUpdates(current, updates, pending));
+        }
+      }
+    );
+    queue.enqueue(name, first);
+    const flush = queue.flush();
+    queue.enqueue(name, latest);
+    firstRequest.resolve({ tweaks: [{ name, value: first, modified: true }] });
+    await vi.waitFor(() => expect(client.updateTweaks).toHaveBeenCalledTimes(2));
+
+    const current: TweakDescriptor[] = [{ name, type: "bezier", value: latest, default: first, modified: true }];
+    expect(queue.pending.size).toBe(0);
+    expect(queue.inFlight.has(name)).toBe(true);
+    expect(renders[0](current)).toEqual(current);
+
+    secondRequest.resolve({ tweaks: [{ name, value: latest, modified: true }] });
+    await flush;
+    expect(renders[1](current)).toEqual(current);
   });
 
   it("sends a null value to reset a tweak", async () => {

--- a/snapo-network-inspector-web/src/features/tweaks-inspector/tweak-update-queue.ts
+++ b/snapo-network-inspector-web/src/features/tweaks-inspector/tweak-update-queue.ts
@@ -59,7 +59,8 @@ export class TweakUpdateQueue {
         }
 
         if (generation !== this.generation) return;
-        this.callbacks.onUpdate(result.tweaks, this.pending);
+        // React may apply the reply after the next batch clears the pending map.
+        this.callbacks.onUpdate(result.tweaks, new Map(this.pending));
         if (result.errors?.length) {
           errors.push(...result.errors);
           this.callbacks.onRejected?.(result.errors, this.pending, this.inFlight, () => generation === this.generation);

--- a/snapo-network-inspector-web/src/network/bridge-types.ts
+++ b/snapo-network-inspector-web/src/network/bridge-types.ts
@@ -64,11 +64,18 @@ export interface AppInspectorState {
   isRestoring: boolean;
 }
 
-export type TweakValue = boolean | number | string;
+export interface BezierValue {
+  x1: number;
+  y1: number;
+  x2: number;
+  y2: number;
+}
+
+export type TweakValue = boolean | number | string | BezierValue;
 
 export interface TweakValueDescriptor {
   name: string;
-  type: "int" | "float" | "boolean" | "color" | "string" | "enum";
+  type: "int" | "float" | "boolean" | "color" | "string" | "enum" | "bezier";
   default: TweakValue;
   value: TweakValue;
   modified?: boolean;
@@ -76,6 +83,8 @@ export interface TweakValueDescriptor {
   max?: number;
   step?: number;
   options?: string[];
+  yMin?: number;
+  yMax?: number;
 }
 
 export interface TweakActionDescriptor {

--- a/snapo-network-inspector-web/src/styles.css
+++ b/snapo-network-inspector-web/src/styles.css
@@ -1820,7 +1820,8 @@ pre {
   gap: 7px;
 }
 
-.tweaks-color {
+.tweaks-color,
+.bezier-open {
   width: 26px;
   height: 26px;
   border: 1px solid var(--outline-variant);
@@ -1828,7 +1829,8 @@ pre {
   padding: 2px;
 }
 
-.tweaks-color-button {
+.tweaks-color-button,
+.bezier-open {
   background: var(--surface-bright);
 }
 

--- a/tests/snapo_cli/test_bezier.py
+++ b/tests/snapo_cli/test_bezier.py
@@ -1,0 +1,26 @@
+import json
+import unittest
+from test_snapo import snapo
+
+
+class BezierTests(unittest.TestCase):
+    def test_parse_normalized_curve(self):
+        value = {"x1": 0.2, "y1": 0.1, "x2": 0.8, "y2": 0.9}
+        self.assertEqual(value, snapo.parse_tweak_value({"type": "bezier"}, json.dumps(value)))
+
+    def test_invalid_curves(self):
+        for value in [{"x1": 2, "y1": 0, "x2": 1, "y2": 1},
+                      {"x1": 0, "y1": -0.1, "x2": 1, "y2": 1},
+                      {"x1": 0, "y1": 0, "x2": 1, "y2": 1.1},
+                      {"x1": 0, "y1": float("nan"), "x2": 1, "y2": 1},
+                      {"x1": 0, "y1": 1e99, "x2": 1, "y2": 1},
+                      {"x1": 0, "y1": 10**400, "x2": 1, "y2": 1},
+                      {"x1": False, "y1": 0, "x2": 1, "y2": 1},
+                      {"x1": 0, "y1": 0, "x2": 1}, [0, 0, 1, 1]]:
+            with self.subTest(value=value), self.assertRaises(snapo.SnapOError):
+                snapo.parse_tweak_value({"type": "bezier"}, json.dumps(value))
+
+    def test_y_bounds(self):
+        with self.assertRaises(snapo.SnapOError):
+            snapo.parse_tweak_value({"type": "bezier", "yMin": 0.2, "yMax": 0.8},
+                                   '{"x1":0.2,"y1":0,"x2":0.8,"y2":1}')


### PR DESCRIPTION
Snap-O can now edit cubic Bézier curves as one live tweak value, so apps can tune easing without exposing four unrelated numbers. The Android overlay and Mac inspector provide compact curve swatches, draggable graphs, coordinate fields, and stock presets.

## Summary

- Add `BezierCurve` to the Kotlin core and Compose APIs, app-owned sources, and matching no-op artifacts. Constrain all coordinates to [0, 1], with optional narrower Y bounds.
- Advance Tweaks to protocol 5 with structured `{x1, y1, x2, y2}` values, complete-curve updates and resets, and Swift, web, and CLI support. Curve inspection requires updated clients; Network Inspector remains at protocol 1.
- Add Android and Mac curve editors with distinct circular handles and preset thumbnails. Match curve previews to color swatches and demonstrate easing in the Android motion sample.
- Support Bézier preview and coordinate editing in the bundled browser demo, including whole-curve reset and stable streamed updates.
- Fix delayed tweak replies overwriting newer drag positions, and correct the demo's keyboard inset behavior. Document the protocol decision and host setup.

## Validation

- macOS unsigned debug build, including the embedded web production build.
- Web typecheck, ESLint, Stylelint, and 336 tests.
- Android live and no-op builds and unit tests; latest demo build, overlay unit tests, lint, and Detekt passed. Final Compose compilation and Detekt passed.
- 123 CLI tests, 12 release tests, and 48 bundled browser-panel tests.
- Rendered Mac editor inspection and Android demo inspection on a Pixel, including keyboard placement. Automated coverage includes corner hit testing, coordinate bounds, presets, resets, and delayed replies during dragging.

