### PR TITLE
Run macOS tests and app build in parallel

### DIFF
--- a/.github/workflows/mac.yml
+++ b/.github/workflows/mac.yml
@@ -55,6 +55,31 @@ jobs:
         working-directory: snapo-network-inspector-web
         run: npm run build
 
+  test:
+    runs-on: macos-26
+
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+      - name: Set up Xcode
+        uses: maxim-lobanov/setup-xcode@ed7a3b1fda3918c0306d1b724322adc0b8cc0a90 # v1.7.0
+        with:
+          xcode-version: '26.1.1'
+      - name: Test shared device client
+        working-directory: snapo-app-mac/SnapODeviceClient
+        run: swift test
+      - name: Test live preview frame export
+        working-directory: snapo-app-mac
+        run: sh scripts/test-live-preview-frame-export.sh
+      - name: Test live preview pointer delivery
+        working-directory: snapo-app-mac
+        run: sh scripts/test-live-preview-pointer.sh
+      - name: Test capture mode transitions
+        working-directory: snapo-app-mac
+        run: sh scripts/test-capture-modes.sh
+      - name: Test capture startup
+        working-directory: snapo-app-mac
+        run: sh scripts/test-startup-capture.sh
+
   build:
     runs-on: macos-26
 
@@ -75,21 +100,6 @@ jobs:
           set -euo pipefail
           SNAPO_NODE_BIN_DIR=$(dirname "$(command -v node)")
           echo "SNAPO_NODE_BIN_DIR=${SNAPO_NODE_BIN_DIR}" >> "$GITHUB_ENV"
-      - name: Test shared device client
-        working-directory: snapo-app-mac/SnapODeviceClient
-        run: swift test
-      - name: Test live preview frame export
-        working-directory: snapo-app-mac
-        run: sh scripts/test-live-preview-frame-export.sh
-      - name: Test live preview pointer delivery
-        working-directory: snapo-app-mac
-        run: sh scripts/test-live-preview-pointer.sh
-      - name: Test capture mode transitions
-        working-directory: snapo-app-mac
-        run: sh scripts/test-capture-modes.sh
-      - name: Test capture startup
-        working-directory: snapo-app-mac
-        run: sh scripts/test-startup-capture.sh
       - name: Build Snap-O
         working-directory: snapo-app-mac
         run: |


### PR DESCRIPTION
The macOS workflow runs every test before starting the app build, increasing the time needed for PR checks. Each test compiles its own inputs, so the app build can run alongside the tests.

## Summary
- Move all five macOS test steps into an independent `test` job.
- Keep the app build in the `build` job, with its existing Node and Xcode setup.
- Use standard GitHub-hosted `macos-26` runners for both jobs.

## Validation
- Parsed the workflow YAML and verified that the jobs are independent, all five test commands are preserved, and the app build steps are unchanged.
- Built Snap-O locally with a fresh DerivedData directory and code signing disabled using Xcode 26.4.1. CI remains pinned to Xcode 26.1.1.
- `git diff --check` passed.
- GitHub Actions timing improvements remain to be measured after the PR runs.
