### PR TITLE
Exclude Python cache from generated docs

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -25,6 +25,7 @@ exclude_docs: |
   /README.md
   /requirements.txt
   /hooks.py
+  /__pycache__/
   /tests/
   !/.nojekyll
 


### PR DESCRIPTION
MkDocs copies Python's generated `__pycache__` directory into the site output after the documentation tests run. Excluding it keeps cache files out of the published site.

## Summary

- Exclude `__pycache__/` from the MkDocs output.

## Validation

- Ran four documentation tests successfully.
- Ran `mkdocs build --strict` and confirmed `site/__pycache__` is absent.
- Ran `git diff --check`.
