### PR TITLE
Make Tweaks sections collapsible and sliders compact

### DIFF
--- a/snapo-network-inspector-web/src/features/tweaks-inspector/TweaksInspectorApp.recovery.test.tsx
+++ b/snapo-network-inspector-web/src/features/tweaks-inspector/TweaksInspectorApp.recovery.test.tsx
@@ -91,6 +91,52 @@ describe("Tweaks connection recovery", () => {
     );
   }
 
+  it("collapses one named section and keeps it collapsed after a stream update", async () => {
+    const tweaks: TweakList = {
+      tweaks: [
+        { name: "Halo/Opacity", type: "float", value: 0.5, default: 0.5, min: 0, max: 1 },
+        { name: "Motion/Speed", type: "float", value: 1, default: 1, min: 0, max: 2 }
+      ]
+    };
+    vi.mocked(client.listTweaks).mockResolvedValue(tweaks);
+    await render();
+
+    const buttons = container.querySelectorAll<HTMLButtonElement>(".tweaks-section-toggle");
+    const halo = Array.from(buttons).find((button) => button.textContent?.includes("Halo"))!;
+    const motion = Array.from(buttons).find((button) => button.textContent?.includes("Motion"))!;
+    const haloList = document.getElementById(halo.getAttribute("aria-controls")!)!;
+    const motionList = document.getElementById(motion.getAttribute("aria-controls")!)!;
+    expect(halo.getAttribute("aria-expanded")).toBe("true");
+    expect(haloList.hidden).toBe(false);
+
+    await act(async () => halo.click());
+    expect(halo.getAttribute("aria-expanded")).toBe("false");
+    expect(haloList.hidden).toBe(true);
+    expect(motion.getAttribute("aria-expanded")).toBe("true");
+    expect(motionList.hidden).toBe(false);
+
+    await act(async () => receive({ streamId: "stream-1", server: selection.server, tweaks: tweaks.tweaks }));
+    expect(haloList.hidden).toBe(true);
+    await act(async () => halo.click());
+    expect(haloList.hidden).toBe(false);
+  });
+
+  it("places each bounded numeric slider beside its value", async () => {
+    vi.mocked(client.listTweaks).mockResolvedValue({
+      tweaks: [
+        { name: "Halo/Opacity", type: "float", value: 0.5, default: 0.5, min: 0, max: 1 },
+        { name: "Halo/Iterations", type: "int", value: 3, default: 3 }
+      ]
+    });
+    await render();
+
+    const range = container.querySelector<HTMLInputElement>('.tweaks-control-line-range input[type="range"]')!;
+    const number = range.parentElement!.querySelector<HTMLInputElement>('input[type="number"]')!;
+    expect(number.value).toBe("0.5");
+    expect(range.parentElement?.querySelector(".tweaks-control-label")?.textContent).toBe("Opacity");
+    expect(container.querySelectorAll('.tweaks-control-line input[type="range"]')).toHaveLength(1);
+  });
+
   it.each([true, false])("shows status text while loading with native picker %s", async (usesNativeServerPicker) => {
     Object.assign(client, { usesNativeServerPicker });
     let finish!: (value: TweakList) => void;

--- a/snapo-network-inspector-web/src/features/tweaks-inspector/TweaksInspectorApp.tsx
+++ b/snapo-network-inspector-web/src/features/tweaks-inspector/TweaksInspectorApp.tsx
@@ -66,7 +66,9 @@ export function TweaksInspectorApp({
   const [error, setError] = useState<string | null>(null);
   const [saving, setSaving] = useState(false);
   const [invokingActions, setInvokingActions] = useState(() => new Set<string>());
+  const [collapsedSections, setCollapsedSections] = useState(() => new Set<string>());
   const [orderByApp] = useState(() => new Map<string, TweakOrdering>());
+  const sectionListId = useId();
   const activeColorPanel = useRef<ActiveColorPanelSession | null>(null);
   const currentConnection = connectionState?.connection === connection ? connectionState : null;
   const canEdit = isConnected && currentConnection?.error === null;
@@ -358,25 +360,53 @@ export function TweaksInspectorApp({
             <div className="tweaks-columns">
               {sections.map((column, index) => (
                 <div className="tweaks-column" key={index}>
-                  {column.map((section) => (
-                    <section className="tweaks-section" key={section.name}>
-                      {section.name ? <h2>{section.name}</h2> : null}
-                      <div className="tweaks-section-list">
-                        {section.tweaks.map((tweak) => (
-                          <TweakControl
-                            key={tweak.name}
-                            tweak={tweak}
-                            protocolVersion={protocolVersion}
-                            onChange={updateTweak}
-                            onInvoke={invokeAction}
-                            invoking={invokingActions.has(tweak.name)}
-                            onReset={resetTweak}
-                            onOpenColorPanel={hasNativeColorPanel ? openNativeColorPanel : undefined}
-                          />
-                        ))}
-                      </div>
-                    </section>
-                  ))}
+                  {column.map((section) => {
+                    const sectionKey = `${selection.appId}\0${section.name}`;
+                    const collapsed = section.name !== "" && collapsedSections.has(sectionKey);
+                    return (
+                      <section className={`tweaks-section${collapsed ? " collapsed" : ""}`} key={section.name}>
+                        {section.name ? (
+                          <h2>
+                            <button
+                              className="tweaks-section-toggle"
+                              type="button"
+                              aria-expanded={!collapsed}
+                              aria-controls={`${sectionListId}-${section.order}`}
+                              onClick={() =>
+                                setCollapsedSections((current) => {
+                                  const next = new Set(current);
+                                  if (next.has(sectionKey)) next.delete(sectionKey);
+                                  else next.add(sectionKey);
+                                  return next;
+                                })
+                              }
+                            >
+                              <ChevronDown className="tweaks-section-chevron" size={14} aria-hidden="true" />
+                              <span>{section.name}</span>
+                            </button>
+                          </h2>
+                        ) : null}
+                        <div
+                          className="tweaks-section-list"
+                          id={section.name ? `${sectionListId}-${section.order}` : undefined}
+                          hidden={collapsed}
+                        >
+                          {section.tweaks.map((tweak) => (
+                            <TweakControl
+                              key={tweak.name}
+                              tweak={tweak}
+                              protocolVersion={protocolVersion}
+                              onChange={updateTweak}
+                              onInvoke={invokeAction}
+                              invoking={invokingActions.has(tweak.name)}
+                              onReset={resetTweak}
+                              onOpenColorPanel={hasNativeColorPanel ? openNativeColorPanel : undefined}
+                            />
+                          ))}
+                        </div>
+                      </section>
+                    );
+                  })}
                 </div>
               ))}
             </div>
@@ -532,10 +562,12 @@ function TweakControl({
 
   const label = tweakLabel(tweak.name);
   const changed = isModified(tweak, protocolVersion);
+  const hasRange =
+    (tweak.type === "int" || tweak.type === "float") && tweak.min !== undefined && tweak.max !== undefined;
 
   return (
     <div className="tweaks-control">
-      <div className="tweaks-control-line">
+      <div className={`tweaks-control-line${hasRange ? " tweaks-control-line-range" : ""}`}>
         <span className="tweaks-control-label">{label}</span>
         {changed ? (
           <button
@@ -548,6 +580,18 @@ function TweakControl({
             <RotateCcw size={13} aria-hidden="true" />
           </button>
         ) : null}
+        {hasRange ? (
+          <input
+            className="tweaks-range"
+            type="range"
+            aria-label={tweak.name}
+            min={tweak.min}
+            max={tweak.max}
+            step={tweak.step ?? (tweak.type === "int" ? 1 : 0.01)}
+            value={Number(tweak.value)}
+            onChange={(event) => onChange(tweak, Number(event.currentTarget.value))}
+          />
+        ) : null}
         <span className="tweaks-control-field">
           <TweakField
             tweak={tweak}
@@ -557,19 +601,6 @@ function TweakControl({
           />
         </span>
       </div>
-
-      {(tweak.type === "int" || tweak.type === "float") && tweak.min !== undefined && tweak.max !== undefined ? (
-        <input
-          className="tweaks-range"
-          type="range"
-          aria-label={tweak.name}
-          min={tweak.min}
-          max={tweak.max}
-          step={tweak.step ?? (tweak.type === "int" ? 1 : 0.01)}
-          value={Number(tweak.value)}
-          onChange={(event) => onChange(tweak, Number(event.currentTarget.value))}
-        />
-      ) : null}
 
       {tweak.type === "string" ? (
         <input

--- a/snapo-network-inspector-web/src/styles.css
+++ b/snapo-network-inspector-web/src/styles.css
@@ -1618,7 +1618,7 @@ pre {
   min-height: 0;
   overflow-y: auto;
   margin-inline: auto;
-  padding: 20px clamp(18px, 4vw, 36px) 48px;
+  padding: 20px clamp(28px, 4vw, 36px) 48px;
 }
 
 .tweaks-inspector > .empty-detail,
@@ -1667,9 +1667,41 @@ pre {
   line-height: 16px;
 }
 
+.tweaks-section.collapsed h2 {
+  margin-bottom: 0;
+}
+
+.tweaks-section-toggle {
+  position: relative;
+  display: flex;
+  width: calc(100% + 22px);
+  align-items: center;
+  margin-left: -22px;
+  border: 0;
+  background: transparent;
+  padding: 0 0 0 22px;
+  color: inherit;
+  font: inherit;
+  text-align: left;
+  cursor: pointer;
+}
+
+.tweaks-section-chevron {
+  position: absolute;
+  left: 3px;
+}
+
+.tweaks-section-toggle[aria-expanded="false"] .tweaks-section-chevron {
+  transform: rotate(-90deg);
+}
+
 .tweaks-section-list {
   display: grid;
   gap: 14px;
+}
+
+.tweaks-section-list[hidden] {
+  display: none;
 }
 
 .tweaks-control {
@@ -1694,6 +1726,10 @@ pre {
 .tweaks-control-label {
   min-width: 0;
   font-size: 12px;
+}
+
+.tweaks-control-line-range .tweaks-control-label {
+  flex: 1;
 }
 
 .tweaks-control-field {
@@ -1801,7 +1837,7 @@ pre {
 }
 
 .tweaks-range {
-  width: 100%;
+  width: clamp(90px, 35%, 170px);
   height: 17px;
   margin: 0;
   accent-color: var(--on-surface);


### PR DESCRIPTION
Long stacks of full-width sliders make Tweaks hard to scan in the macOS inspector. This change keeps every bounded slider available while making the list shorter and easier to navigate.

## Summary

- Put bounded numeric sliders beside their labels and exact values.
- Make named sections collapsible with Lucide chevrons in the gutter and no animation.
- Keep section state across tweak stream updates.

## Validation

- `npm run lint`
- `npm run format:check`
- `npm run typecheck`
- `npm run test -- src/features/tweaks-inspector/TweaksInspectorApp.recovery.test.tsx` (18 tests)
- `npm run build`
- `xcodebuild -project Snap-O.xcodeproj -scheme Snap-O CODE_SIGNING_ALLOWED=NO CODE_SIGNING_REQUIRED=NO build`
