### PR TITLE
Document Snap-O 8.0.0

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -81,7 +81,7 @@ Use the serial and socket returned by `network list` or `tweaks apps` in subsequ
 
 ## Bézier curves
 
-Use the CLI from `main` with an Android app built from source for Bézier support. Android 7.0.0 does not include this type.
+Use the CLI bundled with Snap-O 8.0.0 or the script from `main` with an app using the Android 8.0.0 Tweaks libraries.
 Pass all four coordinates as one quoted JSON object:
 
 ```bash

--- a/docs/network-inspector.md
+++ b/docs/network-inspector.md
@@ -52,7 +52,7 @@ Use the OkHttp interceptor for OkHttp directly or through Ktor's OkHttp engine.
 
 ``` { .toml title="gradle/libs.versions.toml" data-emphasis-lines="2,5,6" }
 [versions]
-snapo = "7.0.0"
+snapo = "8.0.0"
 
 [libraries]
 snapo-network-okhttp3 = { module = "com.openai.snapo:network-okhttp3", version.ref = "snapo" }
@@ -72,8 +72,8 @@ dependencies {
 
 ``` { .kotlin title="app/build.gradle.kts" data-emphasis-lines="2,3" }
 dependencies {
-    debugImplementation("com.openai.snapo:network-okhttp3:7.0.0")
-    releaseImplementation("com.openai.snapo:network-okhttp3-noop:7.0.0")
+    debugImplementation("com.openai.snapo:network-okhttp3:8.0.0")
+    releaseImplementation("com.openai.snapo:network-okhttp3-noop:8.0.0")
 }
 ```
 
@@ -94,7 +94,7 @@ Use the HttpURLConnection interceptor on Android 7.0 (API 24) or newer.
 
 ``` { .toml title="gradle/libs.versions.toml" data-emphasis-lines="2,5,6" }
 [versions]
-snapo = "7.0.0"
+snapo = "8.0.0"
 
 [libraries]
 snapo-network-httpurlconnection = { module = "com.openai.snapo:network-httpurlconnection", version.ref = "snapo" }
@@ -114,8 +114,8 @@ dependencies {
 
 ``` { .kotlin title="app/build.gradle.kts" data-emphasis-lines="2,3" }
 dependencies {
-    debugImplementation("com.openai.snapo:network-httpurlconnection:7.0.0")
-    releaseImplementation("com.openai.snapo:network-httpurlconnection-noop:7.0.0")
+    debugImplementation("com.openai.snapo:network-httpurlconnection:8.0.0")
+    releaseImplementation("com.openai.snapo:network-httpurlconnection-noop:8.0.0")
 }
 ```
 

--- a/docs/network-intercept.md
+++ b/docs/network-intercept.md
@@ -202,5 +202,5 @@ Read the runner's error output. Check body sizes, JSON shape, and the deadline. 
 
 </details>
 
-Try shared state and delays with the [route examples](https://github.com/openai/snap-o/blob/6.0.0/examples/routes.py) and the [OkHttp and Ktor Tasks demos](https://github.com/openai/snap-o/blob/6.0.0/snapo-link-android/samples/README.md). See the [handler API reference](https://github.com/openai/snap-o/blob/6.0.0/skills/snap-o-network-inspector/references/interception.md) and [interception protocol](https://github.com/openai/snap-o/blob/6.0.0/contracts/network/interception.md) for more details.
+Try shared state and delays with the [route examples](https://github.com/openai/snap-o/blob/8.0.0/examples/routes.py) and the [OkHttp and Ktor Tasks demos](https://github.com/openai/snap-o/blob/8.0.0/snapo-link-android/samples/README.md). See the [handler API reference](https://github.com/openai/snap-o/blob/8.0.0/skills/snap-o-network-inspector/references/interception.md) and [interception protocol](https://github.com/openai/snap-o/blob/8.0.0/contracts/network/interception.md) for more details.
 {style="margin-top: 26px"}

--- a/docs/tweaks-protocol.md
+++ b/docs/tweaks-protocol.md
@@ -87,7 +87,7 @@ Host: 127.0.0.1
 | `4` | Adds explicit `null` resets and authoritative, sparse `modified: true` status. |
 | `5` | Adds `bezier` curve objects with all four coordinates within `[0, 1]`. |
 
-Protocol 5 is available on `main`; Android 7.0.0 reports protocol 4. Older clients that accept only primitive values cannot decode lists containing curves. Updated clients still support older servers.
+Android 8.0.0 reports protocol 5; Android 7.0.0 reports protocol 4. Older clients that accept only primitive values cannot decode lists containing curves. Updated clients still support older servers.
 
 The Tweaks protocol version is independent of the Network Inspector protocol version.
 

--- a/docs/tweaks.md
+++ b/docs/tweaks.md
@@ -45,7 +45,7 @@ The overlay dependencies are optional. Add both only if you want an on-device fl
 
 ``` { .toml title="gradle/libs.versions.toml" data-emphasis-lines="2,5,6,8,9,10" }
 [versions]
-snapo = "7.0.0"
+snapo = "8.0.0"
 
 [libraries]
 snapo-tweaks = { module = "com.openai.snapo:tweaks", version.ref = "snapo" }
@@ -73,12 +73,12 @@ dependencies {
 
 ``` { .kotlin title="app/build.gradle.kts" data-emphasis-lines="2,3,5,6,7" }
 dependencies {
-    debugImplementation("com.openai.snapo:tweaks:7.0.0")
-    releaseImplementation("com.openai.snapo:tweaks-noop:7.0.0")
+    debugImplementation("com.openai.snapo:tweaks:8.0.0")
+    releaseImplementation("com.openai.snapo:tweaks-noop:8.0.0")
 
     // Optional: add both if you want the in-app overlay panel.
-    debugImplementation("com.openai.snapo:tweaks-overlay:7.0.0")
-    releaseImplementation("com.openai.snapo:tweaks-overlay-noop:7.0.0")
+    debugImplementation("com.openai.snapo:tweaks-overlay:8.0.0")
+    releaseImplementation("com.openai.snapo:tweaks-overlay-noop:8.0.0")
 }
 ```
 
@@ -116,10 +116,10 @@ Use `tweaks-core` in Views, ViewModels, services, and ordinary Kotlin classes. I
 
 ``` { .kotlin title="build.gradle.kts" }
 dependencies {
-    debugImplementation("com.openai.snapo:tweaks-core:7.0.0")
-    releaseImplementation("com.openai.snapo:tweaks-core-noop:7.0.0")
+    debugImplementation("com.openai.snapo:tweaks-core:8.0.0")
+    releaseImplementation("com.openai.snapo:tweaks-core-noop:8.0.0")
     // Optional View bindings work with both core variants.
-    implementation("com.openai.snapo:tweaks-views:7.0.0")
+    implementation("com.openai.snapo:tweaks-views:8.0.0")
 }
 ```
 
@@ -139,7 +139,7 @@ class PreviewViewModel : ViewModel() {
 }
 ```
 
-Defaults can be Boolean, Int, Float, String, or enum values. Source builds also support [Bézier curves](#bezier-curves). Numbers accept optional ranges and steps. Use `tweakColor(defaultArgb, name)` for ARGB colors, `action(name) { ... }` for callbacks, and `tweak(source, name)` for app-owned settings. Declaring an action never runs it; inspector callbacks run on main.
+Defaults can be Boolean, Int, Float, String, or enum values. The 8.0.0 libraries also support [Bézier curves](#bezier-curves). Numbers accept optional ranges and steps. Use `tweakColor(defaultArgb, name)` for ARGB colors, `action(name) { ... }` for callbacks, and `tweak(source, name)` for app-owned settings. Declaring an action never runs it; inspector callbacks run on main.
 
 ### Bind values to a View
 
@@ -164,7 +164,7 @@ Register app-owned sources and close scopes containing them on main. Ordinary de
 
 ## Expose values from Compose {#expose-values data-step="3"}
 
-Replace a fixed UI value with a tweak at the place that consumes it. Snap-O registers the control while that composable is in composition and returns observable `State<T>` that updates as you edit its value. Ordinary tweaks support integers, floating-point numbers, booleans, strings, colors, and enums. Source builds also support [Bézier curves](#bezier-curves).
+Replace a fixed UI value with a tweak at the place that consumes it. Snap-O registers the control while that composable is in composition and returns observable `State<T>` that updates as you edit its value. Ordinary tweaks support integers, floating-point numbers, booleans, strings, colors, and enums. The 8.0.0 libraries also support [Bézier curves](#bezier-curves).
 
 ``` { .kotlin title="Kotlin · typography" }
 import androidx.compose.material3.Text
@@ -290,8 +290,7 @@ fun MotionTrack(modifier: Modifier = Modifier) {
 
 ### Bézier curves {#bezier-curves}
 
-Bézier curve support is available on `main` and is not included in Android 7.0.0 or macOS 6.0.0.
-Build the Android libraries and inspector from source to use it. Curve inspection requires Tweaks protocol 5 support.
+Bézier curves are available in Android 8.0.0 and the Snap-O 8.0.0 Mac app. Curve inspection requires Tweaks protocol 5 support; update older Mac clients before connecting to an app that exposes curves.
 
 A `BezierCurve` has fixed endpoints `(0, 0)` and `(1, 1)`, plus two editable control points.
 Declare one inside a composable:


### PR DESCRIPTION
The setup guides still name 7.0.0 and describe Bézier curves as source-only. Update them for the 8.0.0 release so users can install the libraries and use curve editing.

## Summary
- Use 8.0.0 in Android dependency examples.
- Describe released Bézier support in the Mac app, Android libraries, CLI, and protocol guide.
- Pin interception reference links to the release tag.

## Validation
- Strict MkDocs build and all four documentation tests pass.
- Generated site links, anchors, and asset targets checked.
- Merge after Maven Central synchronization is verified.
