### PR TITLE
Use native Preact APIs in the inspectors

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -3,7 +3,7 @@ Snap-O is a public, open-source Android inspection tool.
 ## Repository Layout
 
 - `snapo-app-mac/`: macOS app and shared Swift device client.
-- `snapo-network-inspector-web/`: Preact UI embedded in the macOS app.
+- `snapo-network-inspector-web/`: Web UI embedded in the macOS app.
 - `snapo-link-android/`: Android libraries and sample apps.
 - `contracts/`: shared protocol definitions and fixtures.
 - `docs/`: Markdown sources for GitHub Pages. See `docs/README.md` for the build and authoring conventions.

--- a/snapo-network-inspector-web/README.md
+++ b/snapo-network-inspector-web/README.md
@@ -2,7 +2,7 @@
 
 This project contains the Preact App Inspector renderer embedded in Snap-O's native macOS app. The Swift app hosts the built files in a `WKWebView` and provides device, Network Inspector, and Snap-O Tweaks operations through the WebKit message bridge in `src/network/client.ts`.
 
-Components use `preact/compat` to preserve React-compatible input events and memoization. Icons use `lucide-preact`; React and ReactDOM are not runtime dependencies.
+Components use `preact` and `preact/hooks` with native DOM events. Text inputs use `onInput` for live edits. Expensive render trees use `useMemo` to retain unchanged children. Icons use `lucide-preact`; React, ReactDOM, and `preact/compat` are not used.
 
 The renderer also retains its HTTP transport so it can run in a browser-hosted environment. It contains only portable web UI code.
 

--- a/snapo-network-inspector-web/eslint.config.mjs
+++ b/snapo-network-inspector-web/eslint.config.mjs
@@ -28,7 +28,20 @@ export default defineConfig(
     plugins: {
       "react-hooks": reactHooks
     },
-    rules: reactHooks.configs.recommended.rules
+    rules: {
+      ...reactHooks.configs.recommended.rules,
+      "no-restricted-imports": [
+        "error",
+        {
+          patterns: [
+            {
+              group: ["react", "react/*", "react-dom", "react-dom/*", "preact/compat", "preact/compat/*"],
+              message: "Use preact, preact/hooks, and native DOM events."
+            }
+          ]
+        }
+      ]
+    }
   },
   prettier
 );

--- a/snapo-network-inspector-web/src/App.test.tsx
+++ b/snapo-network-inspector-web/src/App.test.tsx
@@ -1,6 +1,6 @@
 // @vitest-environment jsdom
 import { act } from "preact/test-utils";
-import { createRoot } from "preact/compat/client";
+import { render } from "preact";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type {
   AppInspectorKind,
@@ -86,7 +86,6 @@ function app(pid: number, kinds: AppInspectorKind[]): InspectableApp {
 }
 
 describe("app inspector restoration UI", () => {
-  let root: ReturnType<typeof createRoot>;
   let container: HTMLDivElement;
   let discovered: InspectableApp[];
   let nativeSelect: (selection: SelectedAppInspector) => void;
@@ -159,12 +158,11 @@ describe("app inspector restoration UI", () => {
     } as unknown as NetworkClient;
     container = document.createElement("div");
     document.body.append(container);
-    root = createRoot(container);
   });
 
   afterEach(async () => {
     await act(async () => {
-      await root.unmount();
+      await render(null, container);
     });
     container.remove();
     vi.useRealTimers();
@@ -173,7 +171,7 @@ describe("app inspector restoration UI", () => {
   async function renderWaitingForInspector() {
     const starter = { ...app(1, ["tweaks"]), processName: "com.example.starter", packageName: "com.example.starter" };
     vi.mocked(mocks.client.listInspectorApps).mockResolvedValueOnce([starter, ...discovered]);
-    await act(() => root.render(<App />));
+    await act(() => render(<App />, container));
     await act(async () => {
       await vi.advanceTimersByTimeAsync(0);
     });
@@ -193,7 +191,7 @@ describe("app inspector restoration UI", () => {
           finish = resolve;
         })
     );
-    await act(() => root.render(<App />));
+    await act(() => render(<App />, container));
     await act(async () => {
       await vi.advanceTimersByTimeAsync(0);
     });
@@ -212,7 +210,7 @@ describe("app inspector restoration UI", () => {
   it("selects and saves a fallback when the remembered app is unavailable", async () => {
     const other = { ...app(30, ["network"]), processName: "com.example.other", androidUserId: 10 };
     discovered = [other];
-    await act(() => root.render(<App />));
+    await act(() => render(<App />, container));
     await act(async () => {
       await vi.advanceTimersByTimeAsync(0);
     });
@@ -248,7 +246,7 @@ describe("app inspector restoration UI", () => {
       { ...app(30, ["tweaks"]), processName: "com.example.other", androidUserId: 10 },
       app(20, ["network"])
     ];
-    await act(() => root.render(<App />));
+    await act(() => render(<App />, container));
     await act(async () => {
       await vi.advanceTimersByTimeAsync(0);
     });
@@ -265,7 +263,7 @@ describe("app inspector restoration UI", () => {
   it("keeps trying discovery until a usable fallback appears", async () => {
     discovered = [];
     vi.mocked(mocks.client.listInspectorApps).mockRejectedValueOnce(new Error("Discovery unavailable"));
-    await act(() => root.render(<App />));
+    await act(() => render(<App />, container));
     await act(async () => {
       await vi.advanceTimersByTimeAsync(0);
     });
@@ -282,7 +280,7 @@ describe("app inspector restoration UI", () => {
   });
 
   it("selects an available inspector when the saved inspector is missing at startup", async () => {
-    await act(() => root.render(<App />));
+    await act(() => render(<App />, container));
     await act(async () => {
       await vi.advanceTimersByTimeAsync(0);
     });
@@ -546,7 +544,7 @@ describe("app inspector restoration UI", () => {
       await container.querySelector<HTMLButtonElement>(".inspector-open-app")!.click();
     });
     await act(async () => {
-      await root.render(null);
+      await render(null, container);
     });
     const scans = vi.mocked(mocks.client.listInspectorApps);
     const scanCount = scans.mock.calls.length;
@@ -641,7 +639,7 @@ describe("app inspector restoration UI", () => {
   it("waits without selecting a placeholder, then opens its identified replacement", async () => {
     vi.mocked(mocks.client.loadInspectorPreferences).mockResolvedValue(null);
     discovered = [{ ...app(10, ["network"]), processName: null, name: "snapo_network_10" }];
-    await act(() => root.render(<App />));
+    await act(() => render(<App />, container));
     await act(async () => {
       await vi.advanceTimersByTimeAsync(0);
     });
@@ -678,7 +676,7 @@ describe("app inspector restoration UI", () => {
 
   async function captureTraffic() {
     discovered = [app(20, ["network", "tweaks"])];
-    await act(() => root.render(<App />));
+    await act(() => render(<App />, container));
     await act(async () => {
       await vi.advanceTimersByTimeAsync(0);
     });

--- a/snapo-network-inspector-web/src/App.tsx
+++ b/snapo-network-inspector-web/src/App.tsx
@@ -1,5 +1,5 @@
 import type { JSX } from "preact";
-import { useMemo } from "preact/compat";
+import { useMemo } from "preact/hooks";
 import { createNetworkClient } from "./network/client";
 import { NetworkInspectorApp } from "./features/network-inspector/NetworkInspectorApp";
 import { useNetworkInspectorModel } from "./features/network-inspector/hooks/useNetworkInspectorModel";

--- a/snapo-network-inspector-web/src/App.tweaks.test.tsx
+++ b/snapo-network-inspector-web/src/App.tweaks.test.tsx
@@ -1,6 +1,6 @@
 // @vitest-environment jsdom
 import { act } from "preact/test-utils";
-import { createRoot } from "preact/compat/client";
+import { render } from "preact";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { AppInspectorKind, InspectableApp, TweakList } from "./network/bridge-types";
 import type { NetworkClient } from "./network/client";
@@ -28,7 +28,6 @@ function app(pid: number, kind: AppInspectorKind = "tweaks"): InspectableApp {
 }
 
 describe("retained Tweaks view", () => {
-  let root: ReturnType<typeof createRoot>;
   let container: HTMLDivElement;
   let discovered: InspectableApp[];
   let selectApp: (id: string) => void;
@@ -63,12 +62,11 @@ describe("retained Tweaks view", () => {
     } as unknown as NetworkClient;
     container = document.createElement("div");
     document.body.append(container);
-    root = createRoot(container);
   });
 
   afterEach(async () => {
     await act(async () => {
-      await root.unmount();
+      await render(null, container);
     });
     container.remove();
     vi.useRealTimers();
@@ -82,7 +80,7 @@ describe("retained Tweaks view", () => {
     };
     discovered = [app(10, "network")];
     vi.mocked(mocks.client.listInspectorApps).mockResolvedValueOnce([starter, ...discovered]);
-    await act(() => root.render(<App />));
+    await act(() => render(<App />, container));
     await act(async () => {
       await vi.advanceTimersByTimeAsync(0);
     });
@@ -92,7 +90,7 @@ describe("retained Tweaks view", () => {
   }
 
   it("preserves the real Tweaks view through disconnect and PID replacement", async () => {
-    await act(() => root.render(<App />));
+    await act(() => render(<App />, container));
     await act(async () => {
       await vi.advanceTimersByTimeAsync(0);
     });
@@ -188,7 +186,7 @@ describe("retained Tweaks view", () => {
 
   it("keeps a successfully loaded empty view through disconnect", async () => {
     vi.mocked(mocks.client.listTweaks).mockResolvedValue({ tweaks: [] });
-    await act(() => root.render(<App />));
+    await act(() => render(<App />, container));
     await act(async () => {
       await vi.advanceTimersByTimeAsync(0);
     });
@@ -205,7 +203,7 @@ describe("retained Tweaks view", () => {
     { packageName: "com.example.other", processName: "com.example.other", androidUserId: 0 },
     { packageName: "com.example.demo", processName: "com.example.demo", androidUserId: 10 }
   ])("does not show another app or profile's cached values while loading", async (target) => {
-    await act(() => root.render(<App />));
+    await act(() => render(<App />, container));
     await act(async () => {
       await vi.advanceTimersByTimeAsync(0);
     });

--- a/snapo-network-inspector-web/src/features/app-inspector/components/AppInspectorPicker.test.tsx
+++ b/snapo-network-inspector-web/src/features/app-inspector/components/AppInspectorPicker.test.tsx
@@ -1,6 +1,5 @@
 // @vitest-environment jsdom
-import { isValidElement } from "preact";
-import { Children, type ReactNode } from "preact/compat";
+import { isValidElement, toChildArray, type ComponentChildren } from "preact";
 import { renderToStaticMarkup } from "preact-render-to-string";
 import { describe, expect, it, vi } from "vitest";
 import type { InspectableApp, SelectedAppInspector } from "../../../network/bridge-types";
@@ -175,17 +174,17 @@ describe("app-first inspector menu", () => {
   });
 });
 
-function menuButtons(tree: ReactNode): Map<string, () => void> {
+function menuButtons(tree: ComponentChildren): Map<string, () => void> {
   const buttons = new Map<string, () => void>();
-  const visit = (node: ReactNode) => {
-    Children.forEach(node, (child) => {
+  const visit = (node: ComponentChildren) => {
+    toChildArray(node).forEach((child) => {
       if (!isValidElement(child)) return;
       const {
         children,
         "aria-label": label,
         onClick
       } = child.props as {
-        children?: ReactNode;
+        children?: ComponentChildren;
         "aria-label"?: string;
         onClick?: () => void;
       };

--- a/snapo-network-inspector-web/src/features/app-inspector/components/AppInspectorPicker.tsx
+++ b/snapo-network-inspector-web/src/features/app-inspector/components/AppInspectorPicker.tsx
@@ -1,6 +1,6 @@
 import type { JSX } from "preact";
 import { Check, ChevronDown, Network, SlidersHorizontal } from "lucide-preact";
-import { useEffect, useId, useRef, useState } from "preact/compat";
+import { useEffect, useId, useRef, useState } from "preact/hooks";
 import type {
   AppInspectorKind,
   AppInspectorOption,

--- a/snapo-network-inspector-web/src/features/app-inspector/useAppInspector.ts
+++ b/snapo-network-inspector-web/src/features/app-inspector/useAppInspector.ts
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useRef, useState } from "preact/compat";
+import { useCallback, useEffect, useRef, useState } from "preact/hooks";
 import type { AppInspectorOption, InspectableApp } from "../../network/bridge-types";
 import type { NetworkClient } from "../../network/client";
 import { InspectorRestoration } from "./restoration";

--- a/snapo-network-inspector-web/src/features/app-inspector/useAppLaunch.ts
+++ b/snapo-network-inspector-web/src/features/app-inspector/useAppLaunch.ts
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useRef, useState } from "preact/compat";
+import { useCallback, useEffect, useRef, useState } from "preact/hooks";
 import type { InspectableApp, OpenAppInput } from "../../network/bridge-types";
 import type { NetworkClient } from "../../network/client";
 

--- a/snapo-network-inspector-web/src/features/network-inspector/NetworkInspectorApp.tsx
+++ b/snapo-network-inspector-web/src/features/network-inspector/NetworkInspectorApp.tsx
@@ -1,5 +1,4 @@
 import type { JSX } from "preact";
-import { type CSSProperties } from "preact/compat";
 import type {
   AppInspectorKind,
   AppInspectorOption,
@@ -43,7 +42,11 @@ export function NetworkInspectorApp({
   useSearchHighlights(containerRef, model.searchText);
 
   return (
-    <div className="app-shell" ref={containerRef} style={{ "--sidebar-width": `${sidebarWidth}px` } as CSSProperties}>
+    <div
+      className="app-shell"
+      ref={containerRef}
+      style={{ "--sidebar-width": `${sidebarWidth}px` } as JSX.CSSProperties}
+    >
       <Sidebar
         servers={model.servers}
         selectedServer={model.selectedServer}

--- a/snapo-network-inspector-web/src/features/network-inspector/components/ContextMenu.tsx
+++ b/snapo-network-inspector-web/src/features/network-inspector/components/ContextMenu.tsx
@@ -1,5 +1,5 @@
 import type { JSX } from "preact";
-import { useLayoutEffect, useRef, type KeyboardEvent } from "preact/compat";
+import { useLayoutEffect, useRef } from "preact/hooks";
 
 export interface ContextMenuState {
   x: number;
@@ -51,7 +51,7 @@ export function ContextMenu({
     if (autoFocus) menuRef.current?.querySelector<HTMLButtonElement>("button:not(:disabled)")?.focus();
   }, [autoFocus, menu]);
 
-  const handleKeyDown = (event: KeyboardEvent<HTMLDivElement>) => {
+  const handleKeyDown = (event: JSX.TargetedKeyboardEvent<HTMLDivElement>) => {
     // Callers dismiss menus on window keydown. Let the menu finish handling its own keys first.
     event.stopPropagation();
     if (event.defaultPrevented || event.isComposing || event.altKey || event.ctrlKey || event.metaKey) return;

--- a/snapo-network-inspector-web/src/features/network-inspector/components/DetailPane.tsx
+++ b/snapo-network-inspector-web/src/features/network-inspector/components/DetailPane.tsx
@@ -1,5 +1,5 @@
 import type { ComponentChildren, JSX } from "preact";
-import { memo, type ReactNode } from "preact/compat";
+import { useMemo } from "preact/hooks";
 import type { NetworkClient } from "../../../network/client";
 import type { InspectorRecord } from "../../../network/cdp";
 import type { InspectableApp, SnapOServer } from "../../../network/bridge-types";
@@ -11,7 +11,7 @@ import { isUnsupportedLegacyProtocolRequestSelection, unsupportedLegacyProtocolM
 import { RequestDetail } from "./RequestDetail";
 import { WebSocketDetail } from "./WebSocketDetail";
 
-export const DetailContent = memo(function DetailContent({
+export function DetailContent({
   client,
   record,
   servers,
@@ -36,42 +36,62 @@ export const DetailContent = memo(function DetailContent({
   onOpenDocs(): void;
   onRetryResponseBody(): void;
 }): JSX.Element {
-  if (record == null) {
-    const canOpenApp =
-      selectedApp != null &&
-      appLaunch != null &&
-      serverScopedItems === 0 &&
-      (!selectedServer?.isConnected || !selectedServer.hasAppInfo || streamIsRetrying);
-    const empty = resolveDetailEmptyState({ servers, selectedServer, serverScopedItems, streamIsRetrying, canOpenApp });
-    return (
-      <EmptyState title={empty.title} body={empty.body} showDocsLink={empty.showDocsLink} onOpenDocs={onOpenDocs}>
-        {canOpenApp ? <OpenAppButton app={selectedApp} launch={appLaunch} /> : null}
-      </EmptyState>
-    );
-  }
+  return useMemo(() => {
+    if (record == null) {
+      const canOpenApp =
+        selectedApp != null &&
+        appLaunch != null &&
+        serverScopedItems === 0 &&
+        (!selectedServer?.isConnected || !selectedServer.hasAppInfo || streamIsRetrying);
+      const empty = resolveDetailEmptyState({
+        servers,
+        selectedServer,
+        serverScopedItems,
+        streamIsRetrying,
+        canOpenApp
+      });
+      return (
+        <EmptyState title={empty.title} body={empty.body} showDocsLink={empty.showDocsLink} onOpenDocs={onOpenDocs}>
+          {canOpenApp ? <OpenAppButton app={selectedApp} launch={appLaunch} /> : null}
+        </EmptyState>
+      );
+    }
 
-  if (isUnsupportedLegacyProtocolRequestSelection(record, selectedServer)) {
+    if (isUnsupportedLegacyProtocolRequestSelection(record, selectedServer)) {
+      return (
+        <EmptyState
+          title="This app server uses an unsupported protocol"
+          body={unsupportedLegacyProtocolMessage(selectedServer)}
+          showDocsLink={false}
+          onOpenDocs={onOpenDocs}
+        />
+      );
+    }
+
+    if (record.kind === "websocket") return <WebSocketDetail client={client} record={record} uiState={uiState} />;
     return (
-      <EmptyState
-        title="This app server uses an unsupported protocol"
-        body={unsupportedLegacyProtocolMessage(selectedServer)}
-        showDocsLink={false}
-        onOpenDocs={onOpenDocs}
+      <RequestDetail
+        client={client}
+        record={record}
+        uiState={uiState}
+        isConnected={selectedServer?.isConnected === true}
+        onRetryResponseBody={onRetryResponseBody}
       />
     );
-  }
-
-  if (record.kind === "websocket") return <WebSocketDetail client={client} record={record} uiState={uiState} />;
-  return (
-    <RequestDetail
-      client={client}
-      record={record}
-      uiState={uiState}
-      isConnected={selectedServer?.isConnected === true}
-      onRetryResponseBody={onRetryResponseBody}
-    />
-  );
-});
+  }, [
+    client,
+    record,
+    servers,
+    selectedServer,
+    selectedApp,
+    appLaunch,
+    serverScopedItems,
+    streamIsRetrying,
+    uiState,
+    onOpenDocs,
+    onRetryResponseBody
+  ]);
+}
 
 function EmptyState({
   title,
@@ -100,7 +120,7 @@ function EmptyState({
   );
 }
 
-function emptyStateBody(body: string): ReactNode {
+function emptyStateBody(body: string): ComponentChildren {
   const marker = "`com.openai.snapo`";
   if (!body.includes(marker)) return body;
   const [before, after] = body.split(marker, 2);

--- a/snapo-network-inspector-web/src/features/network-inspector/components/ExclusionFilterControl.tsx
+++ b/snapo-network-inspector-web/src/features/network-inspector/components/ExclusionFilterControl.tsx
@@ -1,6 +1,6 @@
 import type { JSX } from "preact";
 import { Plus, Settings2, X } from "lucide-preact";
-import { type FormEvent, useEffect, useId, useRef, useState } from "preact/compat";
+import { useEffect, useId, useRef, useState } from "preact/hooks";
 import { normalizeExclusionFilter } from "../lib/exclusionFilters";
 
 export function ExclusionFilterControl({
@@ -88,7 +88,7 @@ export function ExclusionFilterPopover({
     inputRef.current?.focus();
   }, []);
 
-  const addFilter = (event: FormEvent<HTMLFormElement>) => {
+  const addFilter = (event: JSX.TargetedSubmitEvent<HTMLFormElement>) => {
     event.preventDefault();
     if (!canAddFilter || normalizedFilter == null) return;
 
@@ -111,7 +111,7 @@ export function ExclusionFilterPopover({
         <input
           ref={inputRef}
           value={filterText}
-          onChange={(event) => setFilterText(event.currentTarget.value)}
+          onInput={(event) => setFilterText(event.currentTarget.value)}
           placeholder="Text to exclude"
           aria-label="Text to exclude"
           spellcheck={false}

--- a/snapo-network-inspector-web/src/features/network-inspector/components/PayloadView.tsx
+++ b/snapo-network-inspector-web/src/features/network-inspector/components/PayloadView.tsx
@@ -1,6 +1,6 @@
-import type { JSX } from "preact";
+import type { JSX, ComponentChildren } from "preact";
 import { Check, Copy, Download } from "lucide-preact";
-import { useEffect, useMemo, useState, type ReactNode } from "preact/compat";
+import { useEffect, useMemo, useState } from "preact/hooks";
 import type { NetworkClient } from "../../../network/client";
 import {
   bodyMetadata as payloadMetadata,
@@ -158,7 +158,7 @@ function JsonOutline({
   uiState: InspectorUiState;
   depth?: number;
   initiallyExpanded: boolean;
-  trailing?: ReactNode;
+  trailing?: ComponentChildren;
 }): JSX.Element {
   const [menu, setMenu] = useState<ContextMenuState | null>(null);
   const expandable = node.children.length > 0;
@@ -316,14 +316,14 @@ function JsonInlinePreview({ node }: { node: JsonNode }): JSX.Element {
   return <span className="json-preview">{inlinePreviewParts(node, 120)}</span>;
 }
 
-function inlinePreviewParts(node: JsonNode, maxLength: number): ReactNode {
+function inlinePreviewParts(node: JsonNode, maxLength: number): ComponentChildren {
   const fullText = inlinePreviewText(node);
   if (fullText.length > maxLength)
     return <span className="json-punctuation">{`${fullText.slice(0, Math.max(0, maxLength - 3))}...`}</span>;
   return renderInlinePreviewNode(node);
 }
 
-function renderInlinePreviewNode(node: JsonNode): ReactNode {
+function renderInlinePreviewNode(node: JsonNode): ComponentChildren {
   if (node.type === "object") {
     if (node.children.length === 0) return <span className="json-punctuation">{"{ }"}</span>;
     return (

--- a/snapo-network-inspector-web/src/features/network-inspector/components/RecordList.test.tsx
+++ b/snapo-network-inspector-web/src/features/network-inspector/components/RecordList.test.tsx
@@ -1,8 +1,8 @@
 // @vitest-environment jsdom
 
 import { act } from "preact/test-utils";
-import { useState } from "preact/compat";
-import { createRoot } from "preact/compat/client";
+import { useState } from "preact/hooks";
+import { render as renderPreact } from "preact";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { NetworkClient } from "../../../network/client";
 import { recordId, type RequestRecord } from "../../../network/cdp";
@@ -15,7 +15,6 @@ const onSelect = vi.fn();
 const onAddExclusionFilter = vi.fn();
 const scrollIntoView = vi.fn();
 let container: HTMLDivElement;
-let root: ReturnType<typeof createRoot>;
 
 beforeEach(() => {
   Object.defineProperty(Element.prototype, "scrollIntoView", { configurable: true, value: scrollIntoView });
@@ -25,18 +24,17 @@ beforeEach(() => {
   scrollIntoView.mockClear();
   container = document.createElement("div");
   document.body.append(container);
-  root = createRoot(container);
 });
 
 afterEach(() => {
-  act(() => root.unmount());
+  act(() => renderPreact(null, container));
   container.remove();
   Reflect.deleteProperty(Element.prototype, "scrollIntoView");
   vi.unstubAllGlobals();
 });
 
 function render(visibleRecords = records, initialId: string | null = recordId(records[0])) {
-  act(() => root.render(<Harness records={visibleRecords} initialId={initialId} />));
+  act(() => renderPreact(<Harness records={visibleRecords} initialId={initialId} />, container));
   return container.querySelector<HTMLDivElement>('[role="listbox"]')!;
 }
 

--- a/snapo-network-inspector-web/src/features/network-inspector/components/RecordList.tsx
+++ b/snapo-network-inspector-web/src/features/network-inspector/components/RecordList.tsx
@@ -1,14 +1,5 @@
 import type { JSX } from "preact";
-import {
-  memo,
-  useCallback,
-  useEffect,
-  useId,
-  useRef,
-  useState,
-  type KeyboardEvent,
-  type MouseEvent
-} from "preact/compat";
+import { useCallback, useEffect, useId, useMemo, useRef, useState } from "preact/hooks";
 import type { NetworkClient } from "../../../network/client";
 import { recordId, type InspectorRecord } from "../../../network/cdp";
 import { ContextMenu, type ContextMenuItem, type ContextMenuState } from "./ContextMenu";
@@ -17,7 +8,7 @@ import { copyCurl, exportAsHar } from "../lib/exportActions";
 import { exclusionFilterForUrl } from "../lib/exclusionFilters";
 import { contextMenuExportSelection, splitUrl } from "../lib/records";
 
-export const RecordList = memo(function RecordList({
+export function RecordList({
   records,
   allRecords,
   placeholder,
@@ -74,7 +65,7 @@ export const RecordList = memo(function RecordList({
     setMenu(null);
     listRef.current?.focus({ preventScroll: true });
   };
-  const handleKeyDown = (event: KeyboardEvent<HTMLDivElement>) => {
+  const handleKeyDown = (event: JSX.TargetedKeyboardEvent<HTMLDivElement>) => {
     if (event.defaultPrevented || event.isComposing || event.altKey || event.ctrlKey || event.metaKey) return;
     if (event.key === "ContextMenu" || (event.key === "F10" && event.shiftKey)) {
       if (openActiveContextMenu()) {
@@ -110,7 +101,7 @@ export const RecordList = memo(function RecordList({
     listRef.current?.children.item(nextIndex)?.scrollIntoView({ block: "nearest" });
   };
   const handleContextMenu = useCallback(
-    (record: InspectorRecord, event: MouseEvent<HTMLButtonElement>) => {
+    (record: InspectorRecord, event: JSX.TargetedMouseEvent<HTMLButtonElement>) => {
       event.preventDefault();
       event.stopPropagation();
       openContextMenu(record, event.clientX, event.clientY, false);
@@ -168,7 +159,7 @@ export const RecordList = memo(function RecordList({
       {menu == null ? null : <ContextMenu menu={menu} autoFocus={menu.keyboard} onClose={closeContextMenu} />}
     </div>
   );
-});
+}
 
 function handleRecordListScroll(
   event: JSX.TargetedEvent<HTMLDivElement>,
@@ -177,7 +168,7 @@ function handleRecordListScroll(
   setShowTopFade(event.currentTarget.scrollTop > 0);
 }
 
-const RecordRow = memo(function RecordRow({
+function RecordRow({
   id,
   optionId,
   record,
@@ -190,29 +181,31 @@ const RecordRow = memo(function RecordRow({
   record: InspectorRecord;
   selected: boolean;
   onSelect(id: string): void;
-  onContextMenu(record: InspectorRecord, event: MouseEvent<HTMLButtonElement>): void;
+  onContextMenu(record: InspectorRecord, event: JSX.TargetedMouseEvent<HTMLButtonElement>): void;
 }): JSX.Element {
-  const path = splitUrl(record.url);
-  return (
-    <button
-      id={optionId}
-      type="button"
-      role="option"
-      aria-selected={selected}
-      tabIndex={-1}
-      className={`record-row ${selected ? "selected" : ""}`}
-      onClick={() => onSelect(id)}
-      onContextMenu={(event) => onContextMenu(record, event)}
-    >
-      <span className="record-main">
-        <span className="record-primary">{path.primary}</span>
-        <span className="record-secondary">{path.secondary}</span>
-      </span>
-      <span className="record-method">{record.method}</span>
-      <StatusView record={record} />
-    </button>
-  );
-});
+  return useMemo(() => {
+    const path = splitUrl(record.url);
+    return (
+      <button
+        id={optionId}
+        type="button"
+        role="option"
+        aria-selected={selected}
+        tabIndex={-1}
+        className={`record-row ${selected ? "selected" : ""}`}
+        onClick={() => onSelect(id)}
+        onContextMenu={(event) => onContextMenu(record, event)}
+      >
+        <span className="record-main">
+          <span className="record-primary">{path.primary}</span>
+          <span className="record-secondary">{path.secondary}</span>
+        </span>
+        <span className="record-method">{record.method}</span>
+        <StatusView record={record} />
+      </button>
+    );
+  }, [id, optionId, record, selected, onSelect, onContextMenu]);
+}
 
 export function sidebarContextMenuItems(
   clicked: InspectorRecord,

--- a/snapo-network-inspector-web/src/features/network-inspector/components/RequestDetail.test.tsx
+++ b/snapo-network-inspector-web/src/features/network-inspector/components/RequestDetail.test.tsx
@@ -1,10 +1,61 @@
 // @vitest-environment jsdom
 import { renderToStaticMarkup } from "preact-render-to-string";
-import { describe, expect, it } from "vitest";
+import { render } from "preact";
+import { act } from "preact/test-utils";
+import { describe, expect, it, vi } from "vitest";
 import type { NetworkClient } from "../../../network/client";
 import type { RequestRecord } from "../../../network/cdp";
 import type { InspectorUiState } from "../hooks/useInspectorUiState";
 import { RequestDetail } from "./RequestDetail";
+import { SseEventList } from "./StreamEvents";
+import { useInspectorUiState } from "../hooks/useInspectorUiState";
+import * as payload from "../../../network/payload";
+
+describe("stream event rendering", () => {
+  it("reuses existing payloads on append while updating copy feedback and pretty mode", async () => {
+    vi.useFakeTimers();
+    const makePayload = vi.spyOn(payload, "makeBodyPayload");
+    const container = document.createElement("div");
+    const client = { copyText: vi.fn(async () => {}) } as unknown as NetworkClient;
+    const events = Array.from({ length: 100 }, (_, index) => ({
+      sequence: index + 1,
+      timestamp: index,
+      data: `{"item":${index}}`,
+      raw: `data: {"item":${index}}\n\n`
+    }));
+    function Stream({ events }: { events: RequestRecord["streamEvents"] }) {
+      const uiState = useInspectorUiState();
+      return <SseEventList client={client} events={events} status="Streaming" storageKey="stream" uiState={uiState} />;
+    }
+    try {
+      await act(() => render(<Stream events={events} />, container));
+      expect(makePayload).toHaveBeenCalledTimes(100);
+      const firstRow = container.querySelector(".event-row")!;
+      makePayload.mockClear();
+      await act(() => render(<Stream events={[...events, { ...events[0], sequence: 101 }]} />, container));
+      expect(makePayload).toHaveBeenCalledTimes(1);
+      expect(container.querySelectorAll(".event-row")).toHaveLength(101);
+      expect(container.querySelector(".event-row")).toBe(firstRow);
+
+      const toggle = firstRow.querySelector<HTMLButtonElement>(".inline-text-toggle")!;
+      await act(() => toggle.click());
+      expect(toggle.textContent).toBe("RAW");
+      const copy = firstRow.querySelector<HTMLButtonElement>('button[aria-label="Copy"]')!;
+      await act(async () => copy.click());
+      expect(client.copyText).toHaveBeenCalledWith(events[0].data);
+      expect(copy.getAttribute("aria-label")).toBe("Copied");
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(1_000);
+      });
+      expect(copy.getAttribute("aria-label")).toBe("Copy");
+      expect(makePayload).toHaveBeenCalledTimes(1);
+    } finally {
+      act(() => render(null, container));
+      makePayload.mockRestore();
+      vi.useRealTimers();
+    }
+  });
+});
 
 describe("Response Body loading state", () => {
   it("shows an uncached body as offline instead of loading forever", () => {

--- a/snapo-network-inspector-web/src/features/network-inspector/components/RequestDetail.tsx
+++ b/snapo-network-inspector-web/src/features/network-inspector/components/RequestDetail.tsx
@@ -1,6 +1,6 @@
 import type { JSX } from "preact";
-import { memo, useEffect, useState } from "preact/compat";
 import { LoadingSpinner } from "../../../components/LoadingSpinner";
+import { useEffect, useMemo, useState } from "preact/hooks";
 import type { NetworkClient } from "../../../network/client";
 import { recordId, type Header, type RequestRecord } from "../../../network/cdp";
 import { decodeRequestBodyForDisplay, makeBodyPayload } from "../../../network/payload";
@@ -13,7 +13,7 @@ import { HeadersTable, Section } from "./Section";
 import { FailureMessage, StatusBadge } from "./Status";
 import { SseCopyAllButton, SseEventList, type SseStatus } from "./StreamEvents";
 
-export const RequestDetail = memo(function RequestDetail({
+export function RequestDetail({
   client,
   record,
   uiState,
@@ -26,152 +26,154 @@ export const RequestDetail = memo(function RequestDetail({
   isConnected?: boolean;
   onRetryResponseBody(): void;
 }): JSX.Element {
-  const isSseResponse = isLikelyStreamingRequest(record);
-  const streamStatus = sseStatus(record, isConnected);
-  const streamClosedWithError =
-    isSseResponse && record.streamClosed != null && record.streamClosed.reason !== "completed";
   const requestBodyDisplayText = useRequestBodyDisplayText(record);
-  const requestBody = makeBodyPayload({
-    body: record.requestBody,
-    displayText: requestBodyDisplayText,
-    headers: record.requestHeaders,
-    encoding: record.requestBodyEncoding
-  });
-  const responseBody = isSseResponse
-    ? null
-    : makeBodyPayload({
-        body: record.responseBody,
-        headers: record.responseHeaders,
-        base64Encoded: record.responseBodyBase64Encoded,
-        totalBytes: record.encodedDataLength
-      });
-  const isResponseBodyLoading = !isSseResponse && shouldRequestResponseBody(record);
-  const responseBodyLoadError = !isSseResponse && responseBody == null ? record.responseBodyLoadError : null;
-  const responseBodyIsOffline =
-    !isConnected && responseBody == null && (isResponseBodyLoading || responseBodyLoadError === "failed");
-  const prefix = `request:${recordId(record)}`;
   const timingText = useAdaptiveTimingText(record.startedAt, record.endedAt, record.status);
+  return useMemo(() => {
+    const isSseResponse = isLikelyStreamingRequest(record);
+    const streamStatus = sseStatus(record, isConnected);
+    const streamClosedWithError =
+      isSseResponse && record.streamClosed != null && record.streamClosed.reason !== "completed";
+    const requestBody = makeBodyPayload({
+      body: record.requestBody,
+      displayText: requestBodyDisplayText,
+      headers: record.requestHeaders,
+      encoding: record.requestBodyEncoding
+    });
+    const responseBody = isSseResponse
+      ? null
+      : makeBodyPayload({
+          body: record.responseBody,
+          headers: record.responseHeaders,
+          base64Encoded: record.responseBodyBase64Encoded,
+          totalBytes: record.encodedDataLength
+        });
+    const isResponseBodyLoading = !isSseResponse && shouldRequestResponseBody(record);
+    const responseBodyLoadError = !isSseResponse && responseBody == null ? record.responseBodyLoadError : null;
+    const responseBodyIsOffline =
+      !isConnected && responseBody == null && (isResponseBodyLoading || responseBodyLoadError === "failed");
+    const prefix = `request:${recordId(record)}`;
 
-  return (
-    <div className="detail-scroll">
-      <header className="detail-header">
-        <div className="title-row">
-          <span className="detail-method">{record.method}</span>
-          <h1>{record.url}</h1>
-        </div>
-        <div className="detail-meta">
-          <StatusBadge record={record} />
-          <span>{timingText}</span>
-        </div>
-        {streamClosedWithError ? null : <FailureMessage status={record.status} />}
-      </header>
+    return (
+      <div className="detail-scroll">
+        <header className="detail-header">
+          <div className="title-row">
+            <span className="detail-method">{record.method}</span>
+            <h1>{record.url}</h1>
+          </div>
+          <div className="detail-meta">
+            <StatusBadge record={record} />
+            <span>{timingText}</span>
+          </div>
+          {streamClosedWithError ? null : <FailureMessage status={record.status} />}
+        </header>
 
-      {record.requestHeaders.length === 0 ? null : (
-        <Section
-          title="Request Headers"
-          storageKey={`${prefix}:requestHeaders`}
-          uiState={uiState}
-          initiallyExpanded={false}
-        >
-          <HeadersTable headers={record.requestHeaders} />
-        </Section>
-      )}
-      {requestBody == null ? null : (
-        <Section
-          title="Request Body"
-          meta={payloadMetadata(requestBody)}
-          storageKey={`${prefix}:requestBody`}
-          uiState={uiState}
-          initiallyExpanded={false}
-        >
-          <BodySection
-            client={client}
-            payload={requestBody}
-            storageKey={`${prefix}:requestBody:payload`}
+        {record.requestHeaders.length === 0 ? null : (
+          <Section
+            title="Request Headers"
+            storageKey={`${prefix}:requestHeaders`}
             uiState={uiState}
-          />
-        </Section>
-      )}
-      {!isSseResponse && isConnected && record.status.kind === "pending" && !record.hasReceivedResponse ? (
-        <div className="pending-response">Waiting for response</div>
-      ) : null}
-      {record.responseHeaders.length === 0 ? null : (
-        <Section title="Response Headers" storageKey={`${prefix}:responseHeaders`} uiState={uiState}>
-          <HeadersTable headers={record.responseHeaders} />
-        </Section>
-      )}
-      {isSseResponse ? (
-        <Section
-          title={
-            <>
-              Server-Sent Events
-              <span className="section-status">· {streamStatus}</span>
-            </>
-          }
-          storageKey={`${prefix}:stream`}
-          uiState={uiState}
-          trailing={<SseCopyAllButton client={client} events={record.streamEvents} />}
-        >
-          <SseEventList
-            client={client}
-            events={record.streamEvents}
-            closed={record.streamClosed}
-            status={streamStatus}
-            storageKey={`${prefix}:stream`}
+            initiallyExpanded={false}
+          >
+            <HeadersTable headers={record.requestHeaders} />
+          </Section>
+        )}
+        {requestBody == null ? null : (
+          <Section
+            title="Request Body"
+            meta={payloadMetadata(requestBody)}
+            storageKey={`${prefix}:requestBody`}
             uiState={uiState}
-          />
-        </Section>
-      ) : null}
-      {responseBody == null && !isResponseBodyLoading && responseBodyLoadError == null ? null : (
-        <Section
-          title="Response Body"
-          meta={
-            responseBodyLoadError != null
-              ? null
-              : responseBody == null
-                ? responseBodyCaptureMetadata(record)
-                : payloadMetadata(responseBody)
-          }
-          storageKey={`${prefix}:responseBody`}
-          uiState={uiState}
-        >
-          {responseBodyIsOffline ? (
-            <div className="body-load-message" role="status">
-              Response body isn’t cached on this Mac.
-            </div>
-          ) : responseBodyLoadError != null ? (
-            <div className="body-load-message" role="status">
-              <span>
-                {responseBodyLoadError === "unavailable"
-                  ? "This response is no longer available. Try making the request again."
-                  : "Couldn’t load the response. Try again."}
-              </span>
-              {responseBodyLoadError === "failed" ? (
-                <button className="text-button" type="button" onClick={onRetryResponseBody}>
-                  Retry
-                </button>
-              ) : null}
-            </div>
-          ) : responseBody == null ? (
-            <div className="payload-card">
-              <div className="body-loading" role="status">
-                <LoadingSpinner size={14} />
-                <span>Loading</span>
-              </div>
-            </div>
-          ) : (
+            initiallyExpanded={false}
+          >
             <BodySection
               client={client}
-              payload={responseBody}
-              storageKey={`${prefix}:responseBody:payload`}
+              payload={requestBody}
+              storageKey={`${prefix}:requestBody:payload`}
               uiState={uiState}
             />
-          )}
-        </Section>
-      )}
-    </div>
-  );
-});
+          </Section>
+        )}
+        {!isSseResponse && isConnected && record.status.kind === "pending" && !record.hasReceivedResponse ? (
+          <div className="pending-response">Waiting for response</div>
+        ) : null}
+        {record.responseHeaders.length === 0 ? null : (
+          <Section title="Response Headers" storageKey={`${prefix}:responseHeaders`} uiState={uiState}>
+            <HeadersTable headers={record.responseHeaders} />
+          </Section>
+        )}
+        {isSseResponse ? (
+          <Section
+            title={
+              <>
+                Server-Sent Events
+                <span className="section-status">· {streamStatus}</span>
+              </>
+            }
+            storageKey={`${prefix}:stream`}
+            uiState={uiState}
+            trailing={<SseCopyAllButton client={client} events={record.streamEvents} />}
+          >
+            <SseEventList
+              client={client}
+              events={record.streamEvents}
+              closed={record.streamClosed}
+              status={streamStatus}
+              storageKey={`${prefix}:stream`}
+              uiState={uiState}
+            />
+          </Section>
+        ) : null}
+        {responseBody == null && !isResponseBodyLoading && responseBodyLoadError == null ? null : (
+          <Section
+            title="Response Body"
+            meta={
+              responseBodyLoadError != null
+                ? null
+                : responseBody == null
+                  ? responseBodyCaptureMetadata(record)
+                  : payloadMetadata(responseBody)
+            }
+            storageKey={`${prefix}:responseBody`}
+            uiState={uiState}
+          >
+            {responseBodyIsOffline ? (
+              <div className="body-load-message" role="status">
+                Response body isn’t cached on this Mac.
+              </div>
+            ) : responseBodyLoadError != null ? (
+              <div className="body-load-message" role="status">
+                <span>
+                  {responseBodyLoadError === "unavailable"
+                    ? "This response is no longer available. Try making the request again."
+                    : "Couldn’t load the response. Try again."}
+                </span>
+                {responseBodyLoadError === "failed" ? (
+                  <button className="text-button" type="button" onClick={onRetryResponseBody}>
+                    Retry
+                  </button>
+                ) : null}
+              </div>
+            ) : responseBody == null ? (
+              <div className="payload-card">
+                <div className="body-loading" role="status">
+                  <LoadingSpinner size={14} />
+                  <span>Loading</span>
+                </div>
+              </div>
+            ) : (
+              <BodySection
+                client={client}
+                payload={responseBody}
+                storageKey={`${prefix}:responseBody:payload`}
+                uiState={uiState}
+              />
+            )}
+          </Section>
+        )}
+      </div>
+    );
+  }, [client, record, uiState, isConnected, onRetryResponseBody, requestBodyDisplayText, timingText]);
+}
 
 function sseStatus(record: RequestRecord, isConnected: boolean): SseStatus {
   if (record.streamClosed != null) return "Closed";

--- a/snapo-network-inspector-web/src/features/network-inspector/components/Section.tsx
+++ b/snapo-network-inspector-web/src/features/network-inspector/components/Section.tsx
@@ -1,5 +1,4 @@
-import type { JSX } from "preact";
-import type { ClipboardEvent, ReactNode } from "preact/compat";
+import type { JSX, ComponentChildren } from "preact";
 import type { InspectorUiState } from "../hooks/useInspectorUiState";
 
 export function Section({
@@ -11,13 +10,13 @@ export function Section({
   trailing,
   children
 }: {
-  title: ReactNode;
+  title: ComponentChildren;
   meta?: string | null;
   storageKey: string;
   uiState: InspectorUiState;
   initiallyExpanded?: boolean;
-  trailing?: ReactNode;
-  children: ReactNode;
+  trailing?: ComponentChildren;
+  children: ComponentChildren;
 }): JSX.Element {
   const expanded = uiState.sectionExpanded(storageKey, initiallyExpanded);
   return (
@@ -60,7 +59,7 @@ export function HeadersTable({ headers }: { headers: HeaderRow[] }): JSX.Element
   );
 }
 
-function copyHeaders(event: ClipboardEvent<HTMLDivElement>, headers: HeaderRow[]): void {
+function copyHeaders(event: JSX.TargetedClipboardEvent<HTMLDivElement>, headers: HeaderRow[]): void {
   if (event.clipboardData == null) return;
   const selectedHeaders = selectedHeaderRows(event.currentTarget, headers);
   const copiedHeaders = selectedHeaders.length > 0 ? selectedHeaders : headers;

--- a/snapo-network-inspector-web/src/features/network-inspector/components/ServerPicker.tsx
+++ b/snapo-network-inspector-web/src/features/network-inspector/components/ServerPicker.tsx
@@ -1,6 +1,6 @@
 import type { JSX } from "preact";
 import { ChevronDown } from "lucide-preact";
-import { useEffect, useId, useRef, useState } from "preact/compat";
+import { useEffect, useId, useRef, useState } from "preact/hooks";
 import type { SnapOServer } from "../../../network/bridge-types";
 import type { ServerId } from "../../../network/cdp";
 

--- a/snapo-network-inspector-web/src/features/network-inspector/components/Sidebar.tsx
+++ b/snapo-network-inspector-web/src/features/network-inspector/components/Sidebar.tsx
@@ -1,6 +1,5 @@
 import type { JSX } from "preact";
 import { RefreshCw, SortAsc, SortDesc, Trash2 } from "lucide-preact";
-import { memo } from "preact/compat";
 import type { NetworkClient } from "../../../network/client";
 import type { InspectorRecord, ServerId } from "../../../network/cdp";
 import type {
@@ -16,7 +15,7 @@ import { ExclusionFilterControl } from "./ExclusionFilterControl";
 import { RecordList } from "./RecordList";
 import { ServerSelect } from "./ServerPicker";
 
-export const Sidebar = memo(function Sidebar({
+export function Sidebar({
   servers,
   selectedServer,
   replacementServer,
@@ -120,7 +119,7 @@ export const Sidebar = memo(function Sidebar({
           <div className="search-row">
             <input
               value={searchText}
-              onChange={(event) => onSearchTextChange(event.currentTarget.value)}
+              onInput={(event) => onSearchTextChange(event.currentTarget.value)}
               placeholder="Filter by keyword"
               aria-label="Filter by keyword"
             />
@@ -169,7 +168,7 @@ export const Sidebar = memo(function Sidebar({
       />
     </aside>
   );
-});
+}
 
 function ProtocolWarning({ server }: { server: SnapOServer }): JSX.Element {
   return (

--- a/snapo-network-inspector-web/src/features/network-inspector/components/StreamEvents.tsx
+++ b/snapo-network-inspector-web/src/features/network-inspector/components/StreamEvents.tsx
@@ -1,5 +1,5 @@
 import type { JSX } from "preact";
-import { memo } from "preact/compat";
+import { useMemo } from "preact/hooks";
 import type { NetworkClient } from "../../../network/client";
 import type { RequestRecord } from "../../../network/cdp";
 import { makeBodyPayload } from "../../../network/payload";
@@ -18,14 +18,14 @@ const emptyStreamMessages = {
 
 export type SseStatus = keyof typeof emptyStreamMessages;
 
-export const SseCopyAllButton = memo(function SseCopyAllButton({
+export function SseCopyAllButton({
   client,
   events
 }: {
   client: NetworkClient;
   events: RequestRecord["streamEvents"];
 }): JSX.Element {
-  const text = streamEventsRaw(events);
+  const text = useMemo(() => streamEventsRaw(events), [events]);
   const copyFeedback = useCopyFeedback(client, text);
   return (
     <button
@@ -37,9 +37,9 @@ export const SseCopyAllButton = memo(function SseCopyAllButton({
       {copyFeedback.copied ? "Copied" : "Copy All"}
     </button>
   );
-});
+}
 
-export const SseEventList = memo(function SseEventList({
+export function SseEventList({
   client,
   events,
   closed,
@@ -54,27 +54,29 @@ export const SseEventList = memo(function SseEventList({
   storageKey: string;
   uiState: InspectorUiState;
 }): JSX.Element {
-  return (
-    <div className="event-list">
-      {events.length === 0 ? (
-        <div className="messages-empty">{emptyStreamMessages[status]}</div>
-      ) : (
-        events.map((event) => (
-          <SseEventCard
-            key={event.sequence}
-            client={client}
-            event={event}
-            storageKey={`${storageKey}:event:${event.sequence}`}
-            uiState={uiState}
-          />
-        ))
-      )}
-      {closed == null ? null : <StreamCloseMessage closed={closed} />}
-    </div>
-  );
-});
+  return useMemo(() => {
+    return (
+      <div className="event-list">
+        {events.length === 0 ? (
+          <div className="messages-empty">{emptyStreamMessages[status]}</div>
+        ) : (
+          events.map((event) => (
+            <SseEventCard
+              key={event.sequence}
+              client={client}
+              event={event}
+              storageKey={`${storageKey}:event:${event.sequence}`}
+              uiState={uiState}
+            />
+          ))
+        )}
+        {closed == null ? null : <StreamCloseMessage closed={closed} />}
+      </div>
+    );
+  }, [client, events, closed, status, storageKey, uiState]);
+}
 
-const SseEventCard = memo(function SseEventCard({
+function SseEventCard({
   client,
   event,
   storageKey,
@@ -86,48 +88,51 @@ const SseEventCard = memo(function SseEventCard({
   uiState: InspectorUiState;
 }): JSX.Element {
   const rawText = event.data ?? event.raw;
-  const payload = makeBodyPayload({ body: rawText, headers: [] });
+  const payload = useMemo(() => makeBodyPayload({ body: rawText, headers: [] }), [rawText]);
   const prettyText = payload?.prettyText ?? null;
   const pretty = uiState.prettyEnabled(storageKey, prettyText != null);
   const displayText = pretty && prettyText != null ? prettyText : rawText;
   const copyFeedback = useCopyFeedback(client, displayText);
 
-  return (
-    <div className="event-row">
-      <div className="event-meta">
-        <div className="event-info">
-          <span>#{event.sequence}</span>
-          <span>{formatTime(event.timestamp)}</span>
-          {event.eventName ? <span className="event-name">{event.eventName}</span> : null}
+  return useMemo(
+    () => (
+      <div className="event-row">
+        <div className="event-meta">
+          <div className="event-info">
+            <span>#{event.sequence}</span>
+            <span>{formatTime(event.timestamp)}</span>
+            {event.eventName ? <span className="event-name">{event.eventName}</span> : null}
+          </div>
+          <span className="event-actions">
+            {prettyText == null ? null : (
+              <InlineTextToggle
+                label={pretty ? "PRETTY" : "RAW"}
+                onClick={() => uiState.setPrettyEnabled(storageKey, !pretty)}
+              />
+            )}
+            <InlineCopyButton copied={copyFeedback.copied} onCopy={copyFeedback.copy} iconOnly />
+          </span>
         </div>
-        <span className="event-actions">
-          {prettyText == null ? null : (
-            <InlineTextToggle
-              label={pretty ? "PRETTY" : "RAW"}
-              onClick={() => uiState.setPrettyEnabled(storageKey, !pretty)}
-            />
-          )}
-          <InlineCopyButton copied={copyFeedback.copied} onCopy={copyFeedback.copy} iconOnly />
-        </span>
+        {payload == null ? (
+          <pre>{event.raw || "<empty>"}</pre>
+        ) : (
+          <PayloadView
+            client={client}
+            payload={payload}
+            storageKey={storageKey}
+            uiState={uiState}
+            showsToggle={false}
+            showsCopyButton={false}
+            prettyInitiallyExpanded={false}
+            embedded
+          />
+        )}
+        <SseEventMetadata event={event} />
       </div>
-      {payload == null ? (
-        <pre>{event.raw || "<empty>"}</pre>
-      ) : (
-        <PayloadView
-          client={client}
-          payload={payload}
-          storageKey={storageKey}
-          uiState={uiState}
-          showsToggle={false}
-          showsCopyButton={false}
-          prettyInitiallyExpanded={false}
-          embedded
-        />
-      )}
-      <SseEventMetadata event={event} />
-    </div>
+    ),
+    [client, event, storageKey, uiState, payload, prettyText, pretty, copyFeedback]
   );
-});
+}
 
 function SseEventMetadata({ event }: { event: RequestRecord["streamEvents"][number] }): JSX.Element | null {
   if (event.comment == null && event.lastEventId == null && event.retryMillis == null) return null;

--- a/snapo-network-inspector-web/src/features/network-inspector/components/WebSocketDetail.tsx
+++ b/snapo-network-inspector-web/src/features/network-inspector/components/WebSocketDetail.tsx
@@ -1,5 +1,5 @@
 import type { JSX } from "preact";
-import { memo } from "preact/compat";
+import { useMemo } from "preact/hooks";
 import type { NetworkClient } from "../../../network/client";
 import { recordId, type WebSocketRecord } from "../../../network/cdp";
 import type { InspectorUiState } from "../hooks/useInspectorUiState";
@@ -8,7 +8,7 @@ import { HeadersTable, Section } from "./Section";
 import { FailureMessage, StatusBadge } from "./Status";
 import { WebSocketMessageCard } from "./WebSocketMessages";
 
-export const WebSocketDetail = memo(function WebSocketDetail({
+export function WebSocketDetail({
   client,
   record,
   uiState
@@ -17,57 +17,59 @@ export const WebSocketDetail = memo(function WebSocketDetail({
   record: WebSocketRecord;
   uiState: InspectorUiState;
 }): JSX.Element {
-  const prefix = `websocket:${recordId(record)}`;
   const timingText = useAdaptiveTimingText(record.startedAt, record.endedAt, record.status);
-  return (
-    <div className="detail-scroll">
-      <header className="detail-header">
-        <div className="title-row">
-          <span className="detail-method">{record.method}</span>
-          <h1>{record.url}</h1>
-        </div>
-        <div className="detail-meta">
-          <StatusBadge record={record} />
-          <span>{timingText}</span>
-        </div>
-        <FailureMessage status={record.status} />
-        <WebSocketCloseDetails record={record} />
-      </header>
-      {record.requestHeaders.length === 0 ? null : (
-        <Section
-          title="Request Headers"
-          storageKey={`${prefix}:requestHeaders`}
-          uiState={uiState}
-          initiallyExpanded={false}
-        >
-          <HeadersTable headers={record.requestHeaders} />
-        </Section>
-      )}
-      {record.responseHeaders.length === 0 ? null : (
-        <Section title="Response Headers" storageKey={`${prefix}:responseHeaders`} uiState={uiState}>
-          <HeadersTable headers={record.responseHeaders} />
-        </Section>
-      )}
-      <Section title="Messages" storageKey={`${prefix}:messages`} uiState={uiState}>
-        {record.messages.length === 0 ? (
-          <div className="messages-empty">No messages yet</div>
-        ) : (
-          <div className="message-list">
-            {record.messages.map((message) => (
-              <WebSocketMessageCard
-                key={message.id}
-                client={client}
-                message={message}
-                storageKey={`${prefix}:message:${message.id}`}
-                uiState={uiState}
-              />
-            ))}
+  return useMemo(() => {
+    const prefix = `websocket:${recordId(record)}`;
+    return (
+      <div className="detail-scroll">
+        <header className="detail-header">
+          <div className="title-row">
+            <span className="detail-method">{record.method}</span>
+            <h1>{record.url}</h1>
           </div>
+          <div className="detail-meta">
+            <StatusBadge record={record} />
+            <span>{timingText}</span>
+          </div>
+          <FailureMessage status={record.status} />
+          <WebSocketCloseDetails record={record} />
+        </header>
+        {record.requestHeaders.length === 0 ? null : (
+          <Section
+            title="Request Headers"
+            storageKey={`${prefix}:requestHeaders`}
+            uiState={uiState}
+            initiallyExpanded={false}
+          >
+            <HeadersTable headers={record.requestHeaders} />
+          </Section>
         )}
-      </Section>
-    </div>
-  );
-});
+        {record.responseHeaders.length === 0 ? null : (
+          <Section title="Response Headers" storageKey={`${prefix}:responseHeaders`} uiState={uiState}>
+            <HeadersTable headers={record.responseHeaders} />
+          </Section>
+        )}
+        <Section title="Messages" storageKey={`${prefix}:messages`} uiState={uiState}>
+          {record.messages.length === 0 ? (
+            <div className="messages-empty">No messages yet</div>
+          ) : (
+            <div className="message-list">
+              {record.messages.map((message) => (
+                <WebSocketMessageCard
+                  key={message.id}
+                  client={client}
+                  message={message}
+                  storageKey={`${prefix}:message:${message.id}`}
+                  uiState={uiState}
+                />
+              ))}
+            </div>
+          )}
+        </Section>
+      </div>
+    );
+  }, [client, record, uiState, timingText]);
+}
 
 function WebSocketCloseDetails({ record }: { record: WebSocketRecord }): JSX.Element | null {
   const closeRequested = record.closeRequested;

--- a/snapo-network-inspector-web/src/features/network-inspector/components/WebSocketMessages.tsx
+++ b/snapo-network-inspector-web/src/features/network-inspector/components/WebSocketMessages.tsx
@@ -1,6 +1,6 @@
 import type { JSX } from "preact";
 import { Inbox, Send } from "lucide-preact";
-import { memo } from "preact/compat";
+import { useMemo } from "preact/hooks";
 import type { NetworkClient } from "../../../network/client";
 import type { WebSocketMessageRecord } from "../../../network/cdp";
 import { formatBytes, makeBodyPayload } from "../../../network/payload";
@@ -9,7 +9,7 @@ import type { InspectorUiState } from "../hooks/useInspectorUiState";
 import { formatTime } from "../lib/format";
 import { InlineCopyButton, InlineTextToggle, PayloadView } from "./PayloadView";
 
-export const WebSocketMessageCard = memo(function WebSocketMessageCard({
+export function WebSocketMessageCard({
   client,
   message,
   storageKey,
@@ -21,52 +21,55 @@ export const WebSocketMessageCard = memo(function WebSocketMessageCard({
   uiState: InspectorUiState;
 }): JSX.Element {
   const preview = message.preview ?? "";
-  const payload = makeBodyPayload({ body: preview, headers: [] });
+  const payload = useMemo(() => makeBodyPayload({ body: preview, headers: [] }), [preview]);
   const prettyText = payload?.prettyText ?? null;
   const pretty = uiState.prettyEnabled(storageKey, prettyText != null);
   const displayText = pretty && prettyText != null ? prettyText : preview;
   const copyFeedback = useCopyFeedback(client, displayText);
 
-  return (
-    <div className="message-card">
-      <div className="message-meta">
-        {message.direction === "outgoing" ? (
-          <Send size={10} class="message-direction outgoing" />
-        ) : (
-          <Inbox size={10} class="message-direction incoming" />
-        )}
-        {message.payloadSize == null ? null : (
-          <span className="message-payload-size">{formatBytes(message.payloadSize)}</span>
-        )}
-        {message.enqueued == null ? null : (
-          <span className="message-enqueue-state">{message.enqueued ? "enqueued" : "immediate"}</span>
-        )}
-        <span>{formatTime(message.timestamp)}</span>
-        <span className="message-opcode">{message.opcode}</span>
-        <span className="message-actions">
-          {prettyText == null ? null : (
-            <InlineTextToggle
-              label={pretty ? "PRETTY" : "RAW"}
-              onClick={() => uiState.setPrettyEnabled(storageKey, !pretty)}
-            />
+  return useMemo(
+    () => (
+      <div className="message-card">
+        <div className="message-meta">
+          {message.direction === "outgoing" ? (
+            <Send size={10} class="message-direction outgoing" />
+          ) : (
+            <Inbox size={10} class="message-direction incoming" />
           )}
-          {displayText.length === 0 ? null : (
-            <InlineCopyButton copied={copyFeedback.copied} onCopy={copyFeedback.copy} iconOnly />
+          {message.payloadSize == null ? null : (
+            <span className="message-payload-size">{formatBytes(message.payloadSize)}</span>
           )}
-        </span>
+          {message.enqueued == null ? null : (
+            <span className="message-enqueue-state">{message.enqueued ? "enqueued" : "immediate"}</span>
+          )}
+          <span>{formatTime(message.timestamp)}</span>
+          <span className="message-opcode">{message.opcode}</span>
+          <span className="message-actions">
+            {prettyText == null ? null : (
+              <InlineTextToggle
+                label={pretty ? "PRETTY" : "RAW"}
+                onClick={() => uiState.setPrettyEnabled(storageKey, !pretty)}
+              />
+            )}
+            {displayText.length === 0 ? null : (
+              <InlineCopyButton copied={copyFeedback.copied} onCopy={copyFeedback.copy} iconOnly />
+            )}
+          </span>
+        </div>
+        {payload == null ? null : (
+          <PayloadView
+            client={client}
+            payload={payload}
+            storageKey={storageKey}
+            uiState={uiState}
+            showsToggle={false}
+            showsCopyButton={false}
+            prettyInitiallyExpanded={false}
+            embedded
+          />
+        )}
       </div>
-      {payload == null ? null : (
-        <PayloadView
-          client={client}
-          payload={payload}
-          storageKey={storageKey}
-          uiState={uiState}
-          showsToggle={false}
-          showsCopyButton={false}
-          prettyInitiallyExpanded={false}
-          embedded
-        />
-      )}
-    </div>
+    ),
+    [client, message, storageKey, uiState, payload, prettyText, pretty, displayText, copyFeedback]
   );
-});
+}

--- a/snapo-network-inspector-web/src/features/network-inspector/hooks/useAdaptiveTimingText.ts
+++ b/snapo-network-inspector-web/src/features/network-inspector/hooks/useAdaptiveTimingText.ts
@@ -1,4 +1,4 @@
-import { useEffect, useState } from "preact/compat";
+import { useEffect, useState } from "preact/hooks";
 import type { RequestStatus } from "../../../network/cdp";
 import { formatTiming } from "../lib/format";
 

--- a/snapo-network-inspector-web/src/features/network-inspector/hooks/useCopyFeedback.ts
+++ b/snapo-network-inspector-web/src/features/network-inspector/hooks/useCopyFeedback.ts
@@ -1,4 +1,4 @@
-import { useEffect, useState } from "preact/compat";
+import { useCallback, useEffect, useMemo, useState } from "preact/hooks";
 import type { NetworkClient } from "../../../network/client";
 
 export function useCopyFeedback(
@@ -16,11 +16,9 @@ export function useCopyFeedback(
     return () => window.clearTimeout(timer);
   }, [token, text]);
 
-  return {
-    copied: token !== 0,
-    copy: () => {
-      void client.copyText(text).then(() => setToken((current) => current + 1));
-    },
-    copyWithoutClipboard: () => setToken((current) => current + 1)
-  };
+  const copy = useCallback(() => {
+    void client.copyText(text).then(() => setToken((current) => current + 1));
+  }, [client, text]);
+  const copyWithoutClipboard = useCallback(() => setToken((current) => current + 1), []);
+  return useMemo(() => ({ copied: token !== 0, copy, copyWithoutClipboard }), [token, copy, copyWithoutClipboard]);
 }

--- a/snapo-network-inspector-web/src/features/network-inspector/hooks/useInspectorUiState.ts
+++ b/snapo-network-inspector-web/src/features/network-inspector/hooks/useInspectorUiState.ts
@@ -1,4 +1,4 @@
-import { useCallback, useMemo, useState } from "preact/compat";
+import { useCallback, useMemo, useState } from "preact/hooks";
 
 interface InspectorUiPreferences {
   sections: Record<string, boolean>;

--- a/snapo-network-inspector-web/src/features/network-inspector/hooks/useNetworkInspectorModel.ts
+++ b/snapo-network-inspector-web/src/features/network-inspector/hooks/useNetworkInspectorModel.ts
@@ -1,4 +1,4 @@
-import { type Dispatch, type SetStateAction, useCallback, useEffect, useMemo, useRef, useState } from "preact/compat";
+import { type Dispatch, type StateUpdater, useCallback, useEffect, useMemo, useRef, useState } from "preact/hooks";
 import { createNetworkClient, type NetworkClient } from "../../../network/client";
 import { bodyLoadPriority, RequestBodyLoader, type BodyLoadJob } from "../../../network/body-loader";
 import { hydratedBodyRetentionLimitBytes, RequestBodyCache } from "../../../network/body-retention";
@@ -522,7 +522,7 @@ function hydrateCachedBodies(records: InspectorRecord[], bodyCache: RequestBodyC
 function selectDeviceServer(
   deviceId: string,
   servers: SnapOServer[],
-  setPreferredServer: Dispatch<SetStateAction<ServerId | null>>
+  setPreferredServer: Dispatch<StateUpdater<ServerId | null>>
 ): void {
   setPreferredServer((current) => {
     if (current?.deviceId === deviceId) return current;

--- a/snapo-network-inspector-web/src/features/network-inspector/hooks/usePersistentSplitPane.ts
+++ b/snapo-network-inspector-web/src/features/network-inspector/hooks/usePersistentSplitPane.ts
@@ -1,14 +1,5 @@
-import {
-  useCallback,
-  useEffect,
-  useLayoutEffect,
-  useMemo,
-  useRef,
-  useState,
-  type KeyboardEvent,
-  type PointerEvent,
-  type RefObject
-} from "preact/compat";
+import type { JSX, RefObject } from "preact";
+import { useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState } from "preact/hooks";
 
 const sidebarWidthStorageKey = "snapo.networkInspector.sidebarWidth.v1";
 const defaultSidebarWidthRatio = 0.28;
@@ -23,10 +14,10 @@ export interface PersistentSplitPane {
   sidebarWidth: number;
   minSidebarWidth: number;
   maxSidebarWidth: number;
-  beginResize(event: PointerEvent<HTMLDivElement>): void;
-  continueResize(event: PointerEvent<HTMLDivElement>): void;
-  endResize(event: PointerEvent<HTMLDivElement>): void;
-  resizeWithKeyboard(event: KeyboardEvent<HTMLDivElement>): void;
+  beginResize(event: JSX.TargetedPointerEvent<HTMLDivElement>): void;
+  continueResize(event: JSX.TargetedPointerEvent<HTMLDivElement>): void;
+  endResize(event: JSX.TargetedPointerEvent<HTMLDivElement>): void;
+  resizeWithKeyboard(event: JSX.TargetedKeyboardEvent<HTMLDivElement>): void;
 }
 
 export function usePersistentSplitPane(): PersistentSplitPane {
@@ -75,7 +66,7 @@ export function usePersistentSplitPane(): PersistentSplitPane {
   );
 
   const beginResize = useCallback(
-    (event: PointerEvent<HTMLDivElement>) => {
+    (event: JSX.TargetedPointerEvent<HTMLDivElement>) => {
       event.preventDefault();
       event.currentTarget.setPointerCapture(event.pointerId);
       document.body.classList.add("split-pane-resizing");
@@ -85,14 +76,14 @@ export function usePersistentSplitPane(): PersistentSplitPane {
   );
 
   const continueResize = useCallback(
-    (event: PointerEvent<HTMLDivElement>) => {
+    (event: JSX.TargetedPointerEvent<HTMLDivElement>) => {
       if (!event.currentTarget.hasPointerCapture(event.pointerId)) return;
       resizeFromClientX(event.clientX);
     },
     [resizeFromClientX]
   );
 
-  const endResize = useCallback((event: PointerEvent<HTMLDivElement>) => {
+  const endResize = useCallback((event: JSX.TargetedPointerEvent<HTMLDivElement>) => {
     if (event.currentTarget.hasPointerCapture(event.pointerId)) {
       event.currentTarget.releasePointerCapture(event.pointerId);
     }
@@ -100,7 +91,7 @@ export function usePersistentSplitPane(): PersistentSplitPane {
   }, []);
 
   const resizeWithKeyboard = useCallback(
-    (event: KeyboardEvent<HTMLDivElement>) => {
+    (event: JSX.TargetedKeyboardEvent<HTMLDivElement>) => {
       switch (event.key) {
         case "ArrowLeft":
           event.preventDefault();

--- a/snapo-network-inspector-web/src/features/network-inspector/hooks/useSearchHighlights.ts
+++ b/snapo-network-inspector-web/src/features/network-inspector/hooks/useSearchHighlights.ts
@@ -1,4 +1,5 @@
-import { useLayoutEffect, type RefObject } from "preact/compat";
+import type { RefObject } from "preact";
+import { useLayoutEffect } from "preact/hooks";
 import { parseKeywordSearchQuery, searchHighlightRanges } from "../../../network/keyword-search";
 
 const SearchHighlightName = "network-search-match";

--- a/snapo-network-inspector-web/src/features/tweaks-inspector/BezierEditor.test.tsx
+++ b/snapo-network-inspector-web/src/features/tweaks-inspector/BezierEditor.test.tsx
@@ -1,7 +1,7 @@
 // @vitest-environment jsdom
 import { act } from "preact/test-utils";
-import { useState } from "preact/compat";
-import { createRoot } from "preact/compat/client";
+import { useState } from "preact/hooks";
+import { render } from "preact";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { BezierEditor } from "./BezierEditor";
 import type { BezierValue } from "../../network/bridge-types";
@@ -10,13 +10,11 @@ const initial = { x1: 0.4, y1: 0, x2: 0.2, y2: 1 };
 
 describe("Bezier editor", () => {
   let container: HTMLDivElement;
-  let root: ReturnType<typeof createRoot>;
   const changed = vi.fn();
   const reset = vi.fn();
   beforeEach(async () => {
     container = document.createElement("div");
     document.body.append(container);
-    root = createRoot(container);
     changed.mockClear();
     reset.mockClear();
     function Harness() {
@@ -36,7 +34,7 @@ describe("Bezier editor", () => {
       );
     }
     await act(async () => {
-      await root.render(<Harness />);
+      await render(<Harness />, container);
     });
     await act(async () => {
       await container.querySelector("button")!.click();
@@ -44,7 +42,7 @@ describe("Bezier editor", () => {
   });
   afterEach(async () => {
     await act(async () => {
-      await root.unmount();
+      await render(null, container);
     });
     container.remove();
     vi.unstubAllGlobals();

--- a/snapo-network-inspector-web/src/features/tweaks-inspector/BezierEditor.tsx
+++ b/snapo-network-inspector-web/src/features/tweaks-inspector/BezierEditor.tsx
@@ -1,6 +1,5 @@
-import type { JSX } from "preact";
-import { createPortal } from "preact/compat";
-import { useId, useLayoutEffect, useRef, useState } from "preact/compat";
+import { render, type ComponentChildren, type JSX } from "preact";
+import { useId, useLayoutEffect, useRef, useState } from "preact/hooks";
 import { RotateCcw, X } from "lucide-preact";
 import type { BezierValue, TweakValueDescriptor } from "../../network/bridge-types";
 import { bezierPresets, bezierValue, moveBezier, readBezier, type BezierCoordinates } from "./bezier";
@@ -107,9 +106,8 @@ export function BezierEditor({
           <path d={curvePath(value)} vectorEffect="non-scaling-stroke" />
         </svg>
       </button>
-      {open &&
-        typeof document !== "undefined" &&
-        createPortal(
+      {open && typeof document !== "undefined" && (
+        <BezierPanelPortal>
           <div
             ref={panel}
             id={panelId}
@@ -241,11 +239,24 @@ export function BezierEditor({
                 ))}
               </div>
             </div>
-          </div>,
-          document.body
-        )}
+          </div>
+        </BezierPanelPortal>
+      )}
     </span>
   );
+}
+
+function BezierPanelPortal({ children }: { children: ComponentChildren }): null {
+  const [container] = useState(() => document.createElement("div"));
+  useLayoutEffect(() => {
+    document.body.append(container);
+    return () => {
+      render(null, container);
+      container.remove();
+    };
+  }, [container]);
+  useLayoutEffect(() => render(children, container), [children, container]);
+  return null;
 }
 
 function BezierCoordinate({
@@ -272,7 +283,7 @@ function BezierCoordinate({
       min={min}
       max={max}
       value={text}
-      onChange={(event) => {
+      onInput={(event) => {
         const next = event.currentTarget.valueAsNumber;
         const valid = event.currentTarget.validity.valid && Number.isFinite(Math.fround(next));
         setDraft({ committed: valid ? next : value, text: event.currentTarget.value });

--- a/snapo-network-inspector-web/src/features/tweaks-inspector/TweaksInspectorApp.recovery.test.tsx
+++ b/snapo-network-inspector-web/src/features/tweaks-inspector/TweaksInspectorApp.recovery.test.tsx
@@ -1,6 +1,6 @@
 // @vitest-environment jsdom
 import { act } from "preact/test-utils";
-import { createRoot } from "preact/compat/client";
+import { render as renderPreact } from "preact";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { SelectedAppInspector, TweakList, TweakStreamEvent } from "../../network/bridge-types";
 import type { NetworkClient } from "../../network/client";
@@ -21,7 +21,6 @@ const modifiedResponse: TweakList = {
 const connectionError = new Error("Could not connect to the server.");
 
 describe("Tweaks connection recovery", () => {
-  let root: ReturnType<typeof createRoot>;
   let container: HTMLDivElement;
   let client: NetworkClient;
   let receive: (event: TweakStreamEvent) => void;
@@ -49,18 +48,17 @@ describe("Tweaks connection recovery", () => {
     } as unknown as NetworkClient;
     container = document.createElement("div");
     document.body.append(container);
-    root = createRoot(container);
   });
 
   afterEach(async () => {
-    await act(async () => root.unmount());
+    await act(async () => renderPreact(null, container));
     container.remove();
     vi.useRealTimers();
   });
 
   async function render(selected = selection, isConnected = true) {
     await act(async () =>
-      root.render(
+      renderPreact(
         <TweaksInspectorApp
           client={client}
           apps={[]}
@@ -85,7 +83,8 @@ describe("Tweaks connection recovery", () => {
           }}
           isConnected={isConnected}
           onSelect={() => {}}
-        />
+        />,
+        container
       )
     );
     await act(async () => {
@@ -137,6 +136,28 @@ describe("Tweaks connection recovery", () => {
     expect(number.value).toBe("0.5");
     expect(range.parentElement?.querySelector(".tweaks-control-label")?.textContent).toBe("Opacity");
     expect(container.querySelectorAll('.tweaks-control-line input[type="range"]')).toHaveLength(1);
+  });
+
+  it("keeps enum options open for internal focus and closes them when focus leaves", async () => {
+    vi.mocked(client.listTweaks).mockResolvedValue({
+      tweaks: [{ name: "Theme", type: "enum", value: "Light", default: "Light", options: ["Light", "Dark"] }]
+    });
+    await render();
+    const trigger = container.querySelector<HTMLButtonElement>('[aria-haspopup="listbox"]')!;
+    await act(() => {
+      trigger.focus();
+      trigger.click();
+    });
+    const option = container.querySelector<HTMLButtonElement>('[role="option"]')!;
+    await act(() => option.focus());
+    expect(container.querySelector('[role="listbox"]')).not.toBeNull();
+
+    const outside = document.createElement("button");
+    container.append(outside);
+    await act(() => outside.focus());
+    expect(container.querySelector('[role="listbox"]')).toBeNull();
+    expect(trigger.getAttribute("aria-expanded")).toBe("false");
+    expect(client.updateTweaks).not.toHaveBeenCalled();
   });
 
   it.each([true, false])("shows status text while loading with native picker %s", async (usesNativeServerPicker) => {
@@ -363,7 +384,7 @@ describe("Tweaks connection recovery", () => {
       });
       expect(client.listTweaks).toHaveBeenCalledTimes(count + 1);
     }
-    await act(async () => root.render(null));
+    await act(async () => renderPreact(null, container));
     const count = vi.mocked(client.listTweaks).mock.calls.length;
     await act(async () => {
       await vi.advanceTimersByTimeAsync(20_000);
@@ -479,7 +500,7 @@ describe("Tweaks connection recovery", () => {
     await act(async () =>
       receive({ streamId: "new-stream", server: selection.server, tweaks: modifiedResponse.tweaks })
     );
-    await act(async () => root.render(null));
+    await act(async () => renderPreact(null, container));
     await act(async () => finish({ streamId: "new-stream" }));
     expect(client.stopTweakStream).toHaveBeenCalledExactlyOnceWith("new-stream");
     expect(container.textContent).toBe("");

--- a/snapo-network-inspector-web/src/features/tweaks-inspector/TweaksInspectorApp.test.ts
+++ b/snapo-network-inspector-web/src/features/tweaks-inspector/TweaksInspectorApp.test.ts
@@ -1,5 +1,5 @@
 // @vitest-environment jsdom
-import { createElement, type MouseEvent, type PointerEvent, type ReactElement } from "preact/compat";
+import { createElement, type JSX, type VNode } from "preact";
 import { renderToStaticMarkup } from "preact-render-to-string";
 import { describe, expect, it, vi } from "vitest";
 import type {
@@ -201,8 +201,8 @@ describe("enumerated tweak values", () => {
       onClose: () => events.push("close")
     });
 
-    option.props.onPointerDown({ button: 0, preventDefault } as unknown as PointerEvent<HTMLButtonElement>);
-    option.props.onClick({ detail: 1 } as MouseEvent<HTMLButtonElement>);
+    option.props.onPointerDown({ button: 0, preventDefault } as unknown as JSX.TargetedPointerEvent<HTMLButtonElement>);
+    option.props.onClick({ detail: 1 } as JSX.TargetedMouseEvent<HTMLButtonElement>);
 
     expect(preventDefault).toHaveBeenCalledOnce();
     expect(events).toEqual(["change:Dark", "close"]);
@@ -214,7 +214,7 @@ describe("enumerated tweak values", () => {
     const preventDefault = vi.fn();
     const option = enumListboxOption(1, { onChange, onClose });
 
-    option.props.onPointerDown({ button: 2, preventDefault } as unknown as PointerEvent<HTMLButtonElement>);
+    option.props.onPointerDown({ button: 2, preventDefault } as unknown as JSX.TargetedPointerEvent<HTMLButtonElement>);
 
     expect(preventDefault).not.toHaveBeenCalled();
     expect(onChange).not.toHaveBeenCalled();
@@ -227,10 +227,10 @@ describe("enumerated tweak values", () => {
     const current = enumListboxOption(0, { onChange, onClose });
     const changed = enumListboxOption(1, { onChange, onClose });
 
-    current.props.onClick({ detail: 0 } as MouseEvent<HTMLButtonElement>);
+    current.props.onClick({ detail: 0 } as JSX.TargetedMouseEvent<HTMLButtonElement>);
     expect(onChange).not.toHaveBeenCalled();
 
-    changed.props.onClick({ detail: 0 } as MouseEvent<HTMLButtonElement>);
+    changed.props.onClick({ detail: 0 } as JSX.TargetedMouseEvent<HTMLButtonElement>);
 
     expect(onChange).toHaveBeenCalledExactlyOnceWith(enumTweak(), "Dark");
     expect(onClose).toHaveBeenCalledTimes(2);
@@ -675,9 +675,9 @@ function enumListboxOption(
     onChange(tweak: TweakValueDescriptor, value: TweakValueDescriptor["value"]): void;
     onClose(): void;
   }
-): ReactElement<{
-  onPointerDown(event: PointerEvent<HTMLButtonElement>): void;
-  onClick(event: MouseEvent<HTMLButtonElement>): void;
+): VNode<{
+  onPointerDown(event: JSX.TargetedPointerEvent<HTMLButtonElement>): void;
+  onClick(event: JSX.TargetedMouseEvent<HTMLButtonElement>): void;
 }> {
   const listbox = TweakEnumListbox({
     id: "appearance-theme-options",

--- a/snapo-network-inspector-web/src/features/tweaks-inspector/TweaksInspectorApp.test.ts
+++ b/snapo-network-inspector-web/src/features/tweaks-inspector/TweaksInspectorApp.test.ts
@@ -1,5 +1,6 @@
 // @vitest-environment jsdom
-import { createElement, type JSX, type VNode } from "preact";
+import { createElement, render, type JSX, type VNode } from "preact";
+import { act } from "preact/test-utils";
 import { renderToStaticMarkup } from "preact-render-to-string";
 import { describe, expect, it, vi } from "vitest";
 import type {
@@ -143,6 +144,30 @@ describe("editable tweak colors", () => {
 
     expect(markup).toContain('type="color"');
     expect(markup).not.toContain("tweaks-color-button");
+  });
+
+  it("updates browser color edits before commit while preserving alpha", () => {
+    const container = document.createElement("div");
+    const tweak = colorTweak();
+    const onChange = vi.fn();
+    document.body.append(container);
+    try {
+      act(() => render(createElement(TweakColorField, { tweak, onChange }), container));
+      const input = container.querySelector<HTMLInputElement>('input[type="color"]')!;
+      for (const color of ["#112233", "#445566"]) {
+        act(() => {
+          input.value = color;
+          input.dispatchEvent(new Event("input", { bubbles: true }));
+        });
+      }
+      expect(onChange.mock.calls).toEqual([
+        [tweak, "#11223380"],
+        [tweak, "#44556680"]
+      ]);
+    } finally {
+      act(() => render(null, container));
+      container.remove();
+    }
   });
 
   it("renders an accessible native-panel swatch instead of the HTML color input", () => {

--- a/snapo-network-inspector-web/src/features/tweaks-inspector/TweaksInspectorApp.tsx
+++ b/snapo-network-inspector-web/src/features/tweaks-inspector/TweaksInspectorApp.tsx
@@ -887,7 +887,7 @@ export function TweakColorField({
           type="color"
           aria-label={`${tweak.name} color`}
           value={committed.slice(0, 7)}
-          onChange={(event) => {
+          onInput={(event) => {
             onChange(tweak, tweakColorWithPreservedAlpha(committed, event.currentTarget.value));
           }}
         />

--- a/snapo-network-inspector-web/src/features/tweaks-inspector/TweaksInspectorApp.tsx
+++ b/snapo-network-inspector-web/src/features/tweaks-inspector/TweaksInspectorApp.tsx
@@ -1,7 +1,7 @@
 import type { JSX } from "preact";
 import { BezierEditor } from "./BezierEditor";
 import { ChevronDown, RotateCcw } from "lucide-preact";
-import { useCallback, useEffect, useId, useMemo, useRef, useState, type CSSProperties } from "preact/compat";
+import { useCallback, useEffect, useId, useMemo, useRef, useState } from "preact/hooks";
 import type {
   AppInspectorOption,
   InspectableApp,
@@ -590,7 +590,7 @@ function TweakControl({
             max={tweak.max}
             step={tweak.step ?? (tweak.type === "int" ? 1 : 0.01)}
             value={Number(tweak.value)}
-            onChange={(event) => onChange(tweak, Number(event.currentTarget.value))}
+            onInput={(event) => onChange(tweak, Number(event.currentTarget.value))}
           />
         ) : null}
         <span className="tweaks-control-field">
@@ -609,7 +609,7 @@ function TweakControl({
           type="text"
           aria-label={tweak.name}
           value={String(tweak.value)}
-          onChange={(event) => onChange(tweak, event.currentTarget.value)}
+          onInput={(event) => onChange(tweak, event.currentTarget.value)}
         />
       ) : null}
     </div>
@@ -695,7 +695,7 @@ export function TweakField({
         max={tweak.max}
         step={tweak.step ?? (tweak.type === "int" ? 1 : 0.01)}
         value={Number(tweak.value)}
-        onChange={(event) => {
+        onInput={(event) => {
           const value = Number(event.currentTarget.value);
           if (event.currentTarget.validity.valid && Number.isFinite(value)) {
             onChange(tweak, value);
@@ -715,7 +715,7 @@ function TweakEnumField({
   tweak: TweakValueDescriptor;
   onChange(tweak: TweakValueDescriptor, value: TweakValue): void;
 }): JSX.Element {
-  const [listboxStyle, setListboxStyle] = useState<CSSProperties | null>(null);
+  const [listboxStyle, setListboxStyle] = useState<JSX.CSSProperties | null>(null);
   const rootRef = useRef<HTMLDivElement>(null);
   const triggerRef = useRef<HTMLButtonElement>(null);
   const listboxId = useId();
@@ -787,7 +787,7 @@ function TweakEnumField({
       className="tweaks-select-wrap"
       ref={rootRef}
       onKeyDown={navigate}
-      onBlur={(event) => {
+      onFocusOut={(event) => {
         if (!(event.relatedTarget instanceof Node) || !event.currentTarget.contains(event.relatedTarget))
           setListboxStyle(null);
       }}
@@ -820,7 +820,7 @@ export function TweakEnumListbox({
   onClose
 }: {
   id: string;
-  style?: CSSProperties;
+  style?: JSX.CSSProperties;
   tweak: TweakValueDescriptor;
   onChange(tweak: TweakValueDescriptor, value: TweakValue): void;
   onClose(): void;
@@ -898,7 +898,7 @@ export function TweakColorField({
         aria-label={`${tweak.name} hex`}
         maxLength={9}
         value={value}
-        onChange={(event) => {
+        onInput={(event) => {
           const next = event.currentTarget.value;
           setDraft({ committed, value: next });
 

--- a/snapo-network-inspector-web/src/preview/main.tsx
+++ b/snapo-network-inspector-web/src/preview/main.tsx
@@ -1,5 +1,5 @@
 import { render, type JSX } from "preact";
-import { useState } from "preact/compat";
+import { useState } from "preact/hooks";
 import { RequestDetail } from "../features/network-inspector/components/RequestDetail";
 import { useInspectorUiState } from "../features/network-inspector/hooks/useInspectorUiState";
 import { createNetworkClient } from "../network/client";

--- a/snapo-network-inspector-web/vite.config.ts
+++ b/snapo-network-inspector-web/vite.config.ts
@@ -3,7 +3,7 @@ import { defineConfig } from "vite";
 
 export default defineConfig({
   base: "./",
-  plugins: [preact()],
+  plugins: [preact({ reactAliasesEnabled: false })],
   server: {
     host: "127.0.0.1",
     port: 5173


### PR DESCRIPTION
After switching the runtime to Preact, the inspectors still use React compatibility APIs. This removes that compatibility layer while preserving input, rendering, and interaction behavior.

## Summary

- Use native Preact hooks, rendering, DOM events, and component types.
- Keep expensive render output and derived data stable with useMemo.
- Preserve the Tweaks curve editor overlay, focus handling, and live input updates.
- Disable React aliases and reject compatibility imports in lint checks.

## Validation

- Regression test confirms consecutive browser color input events update live and preserve alpha; it fails before the fix.

- 343 web tests pass at this layer, including curve editing, focus, and streamed content.
- TypeScript, ESLint, Stylelint, formatting, and production build pass.

## Stack

Merge in this order:

1. #294 — Preact runtime
2. #295 — Native Preact APIs
3. #296 — Native-only hosting
4. #297 — Native reconnect toolbar
