### PR TITLE
Move process reconnection into the native inspector toolbar

### DIFF
--- a/snapo-app-mac/Snap-O/CaptureWindow/CaptureToolbar.swift
+++ b/snapo-app-mac/Snap-O/CaptureWindow/CaptureToolbar.swift
@@ -153,6 +153,7 @@ struct CaptureToolbar: View {
 
             AppInspectorPicker(model: networkModel)
               .padding(.leading, 4)
+            AppInspectorReconnectButton(model: networkModel)
             AppInspectorViewPicker(model: networkModel)
           }
         }

--- a/snapo-app-mac/Snap-O/NetworkInspector/NetworkInspectorBridgeModels.swift
+++ b/snapo-app-mac/Snap-O/NetworkInspector/NetworkInspectorBridgeModels.swift
@@ -45,6 +45,7 @@ struct AppInspectorState: Codable {
   let displayedNetwork: SelectedAppInspector?
   let displayedTweaks: SelectedAppInspector?
   let selectedApp: InspectableApp?
+  let replacementApp: InspectableApp?
   let preferredKind: AppInspectorKind?
   let isRestoring: Bool
 }

--- a/snapo-app-mac/Snap-O/NetworkInspector/NetworkInspectorHostModel.swift
+++ b/snapo-app-mac/Snap-O/NetworkInspector/NetworkInspectorHostModel.swift
@@ -17,6 +17,7 @@ final class NetworkInspectorHostModel {
   private(set) var selectedInspector: SelectedAppInspector?
   private(set) var displayedNetwork: SelectedAppInspector?
   private(set) var selectedInspectorApp: InspectableApp?
+  private(set) var replacementApp: InspectableApp?
   private(set) var preferredInspectorKind: AppInspectorKind?
   private(set) var isRestoringInspector = false
   private(set) var searchText = ""
@@ -98,6 +99,13 @@ final class NetworkInspectorHostModel {
         appId: app.id, kind: option.kind, server: option.server, protocolVersion: option.protocolVersion
       )
     )
+  }
+
+  func reconnectToNewProcess() {
+    guard let app = replacementApp,
+          let option = app.inspectors.first(where: { $0.kind == preferredInspectorKind })
+    else { return }
+    selectInspector(app, option: option)
   }
 
   func setSearchText(_ searchText: String) {
@@ -187,6 +195,7 @@ final class NetworkInspectorHostModel {
     selectedInspector = state.selection
     displayedNetwork = state.displayedNetwork
     selectedInspectorApp = state.selectedApp
+    replacementApp = state.replacementApp
     preferredInspectorKind = state.preferredKind
     isRestoringInspector = state.isRestoring
   }

--- a/snapo-app-mac/Snap-O/NetworkInspector/NetworkInspectorServerPicker.swift
+++ b/snapo-app-mac/Snap-O/NetworkInspector/NetworkInspectorServerPicker.swift
@@ -67,6 +67,39 @@ struct AppInspectorPicker: View {
   }
 }
 
+struct AppInspectorReconnectButton: View {
+  @Bindable var model: NetworkInspectorHostModel
+  @Environment(\.colorScheme)
+  private var colorScheme
+
+  private var backgroundColor: Color {
+    colorScheme == .dark
+      ? Color(red: 184 / 255, green: 106 / 255, blue: 0)
+      : Color(red: 246 / 255, green: 158 / 255, blue: 0)
+  }
+
+  var body: some View {
+    if model.replacementApp != nil {
+      Button {
+        model.reconnectToNewProcess()
+      } label: {
+        Label("New process", systemImage: "arrow.clockwise")
+          .font(.system(size: 12, weight: .medium))
+          .foregroundStyle(.white)
+          .padding(.horizontal, 12)
+          .frame(height: SnapOToolbarStyle.singleControlSize)
+          .background(backgroundColor, in: Capsule())
+          .contentShape(Capsule())
+      }
+      .buttonStyle(.plain)
+      .fixedSize()
+      .help("Reconnect to the new process")
+      .accessibilityLabel("Reconnect to new process")
+      .disabled(!model.isPageReady)
+    }
+  }
+}
+
 struct AppInspectorViewPicker: View {
   @Bindable var model: NetworkInspectorHostModel
 

--- a/snapo-network-inspector-web/src/App.test.tsx
+++ b/snapo-network-inspector-web/src/App.test.tsx
@@ -764,7 +764,7 @@ describe("app inspector restoration UI", () => {
     expect(mocks.client.startStream).toHaveBeenCalledTimes(starts);
   });
 
-  it("retains old-process traffic when a new PID has nothing to replay", async () => {
+  it("keeps old-process traffic visible until the native reconnect action", async () => {
     await captureTraffic();
     discovered = [];
     await act(async () => {
@@ -774,11 +774,39 @@ describe("app inspector restoration UI", () => {
     await act(async () => {
       await vi.advanceTimersByTimeAsync(2_500);
     });
+    expect(mocks.model?.selectedServer?.socketName).toBe("snapo_network_20");
+    expect(mocks.model?.visibleRecords).toHaveLength(1);
+    expect(mocks.model?.selectedRecord).toMatchObject({ responseBody: "cached response" });
+    expect(mocks.client.startStream).not.toHaveBeenCalledWith(discovered[0].inspectors[0].server);
+    expect(mocks.client.appInspectorStateChanged).toHaveBeenLastCalledWith(
+      expect.objectContaining({ selection: null, replacementApp: discovered[0] })
+    );
+    await act(async () => nativeSelect({ appId: discovered[0].id, ...discovered[0].inspectors[0] }));
     expect(mocks.model?.selectedServer?.socketName).toBe("snapo_network_30");
     expect(mocks.model?.visibleRecords).toHaveLength(0);
     expect(mocks.model?.allRecords).toMatchObject([
       { server: { socketName: "snapo_network_20" }, responseBody: "cached response" }
     ]);
+  });
+
+  it("ignores a native reconnect click after the replacement process disappears", async () => {
+    await captureTraffic();
+    discovered = [app(30, ["network", "tweaks"])];
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(2_500);
+    });
+    const replacement = discovered[0];
+    discovered = [];
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(2_500);
+    });
+    await act(async () => nativeSelect({ appId: replacement.id, ...replacement.inspectors[0] }));
+    expect(mocks.model?.selectedServer?.socketName).toBe("snapo_network_20");
+    expect(mocks.model?.visibleRecords).toHaveLength(1);
+    expect(mocks.client.startStream).not.toHaveBeenCalledWith(replacement.inspectors[0].server);
+    expect(mocks.client.appInspectorStateChanged).toHaveBeenLastCalledWith(
+      expect.objectContaining({ selection: null, replacementApp: null })
+    );
   });
 
   it("allows browsing another captured request without loading bodies offline", async () => {

--- a/snapo-network-inspector-web/src/App.tsx
+++ b/snapo-network-inspector-web/src/App.tsx
@@ -10,7 +10,7 @@ import { useAppInspector } from "./features/app-inspector/useAppInspector";
 
 export function App(): JSX.Element {
   const client = useMemo(() => createNetworkClient(), []);
-  const { apps, selection, displayedNetwork, displayedTweaks, selectedApp, isRestoring, loading, select, appLaunch } =
+  const { selection, displayedNetwork, displayedTweaks, selectedApp, isRestoring, loading, appLaunch } =
     useAppInspector(client);
   const pending = loading || isRestoring || (selection != null && isInspectorMetadataPending(selection));
   const showsNetwork = displayedNetwork != null || (!pending && selection?.kind !== "tweaks");
@@ -40,13 +40,7 @@ export function App(): JSX.Element {
           appLaunch={appLaunch}
         />
       ) : (
-        <NetworkInspectorApp
-          model={networkModel}
-          inspectorApps={apps}
-          selectedApp={selectedApp}
-          appLaunch={appLaunch}
-          onInspectorSelect={select}
-        />
+        <NetworkInspectorApp model={networkModel} selectedApp={selectedApp} appLaunch={appLaunch} />
       )}
     </div>
   );

--- a/snapo-network-inspector-web/src/App.tweaks.test.tsx
+++ b/snapo-network-inspector-web/src/App.tweaks.test.tsx
@@ -2,7 +2,7 @@
 import { act } from "preact/test-utils";
 import { render } from "preact";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import type { AppInspectorKind, InspectableApp, TweakList } from "./network/bridge-types";
+import type { AppInspectorKind, InspectableApp, SelectedAppInspector, TweakList } from "./network/bridge-types";
 import type { NetworkClient } from "./network/client";
 import { InspectorRestoration } from "./features/app-inspector/restoration";
 import { App } from "./App";
@@ -31,6 +31,7 @@ describe("retained Tweaks view", () => {
   let container: HTMLDivElement;
   let discovered: InspectableApp[];
   let selectApp: (id: string) => void;
+  let nativeSelect: (selection: SelectedAppInspector) => void;
 
   beforeEach(() => {
     vi.useFakeTimers();
@@ -43,7 +44,10 @@ describe("retained Tweaks view", () => {
       listInspectorApps: vi.fn(async () => discovered),
       openApp: vi.fn(async () => {}),
       appInspectorStateChanged: vi.fn(),
-      onNativeSelectedInspector: vi.fn(() => () => {}),
+      onNativeSelectedInspector: vi.fn((callback) => {
+        nativeSelect = callback;
+        return () => {};
+      }),
       onNativeSelectedApp: vi.fn((callback) => {
         selectApp = callback;
         return () => {};
@@ -120,6 +124,12 @@ describe("retained Tweaks view", () => {
     expect(container.querySelector('input[type="text"]')).toBe(input);
     expect(input.value).toBe("Cached value");
     expect(container.querySelector("fieldset")?.disabled).toBe(true);
+    expect(mocks.client.listTweaks).toHaveBeenCalledTimes(1);
+    expect(mocks.client.appInspectorStateChanged).toHaveBeenLastCalledWith(
+      expect.objectContaining({ selection: null, replacementApp: discovered[0] })
+    );
+    expect(container.querySelector(".replacement-banner")).toBeNull();
+    await act(async () => nativeSelect({ appId: discovered[0].id, ...discovered[0].inspectors[0] }));
     await act(async () =>
       finish({ tweaks: [{ name: "Demo title", type: "string", value: "Fresh value", default: "Default" }] })
     );

--- a/snapo-network-inspector-web/src/features/app-inspector/restoration.test.ts
+++ b/snapo-network-inspector-web/src/features/app-inspector/restoration.test.ts
@@ -36,7 +36,7 @@ describe("inspector restoration", () => {
     expect(owner.reconcile([app()]).selection).toBe(current);
   });
 
-  it("waits through an empty scan and Tweaks-first discovery, then restores Network", () => {
+  it("waits for an explicit reconnect after Network appears on the new process", () => {
     const owner = selected();
     const displayedNetwork = owner.snapshot().selection;
     const saved = owner.serialize();
@@ -49,9 +49,36 @@ describe("inspector restoration", () => {
     expect(owner.serialize()).toBe(saved);
     expect(owner.snapshot().displayedNetwork).toBe(displayedNetwork);
     expect(owner.reconcile([app(20)])).toMatchObject({
+      selection: null,
+      displayedNetwork,
+      selectedApp: { id: "phone:pid:10" },
+      replacementApp: app(20),
+      isRestoring: true
+    });
+    expect(owner.selectApp(app(20))).toMatchObject({
       selection: { kind: "network", server: { socketName: "snapo_network_20" } },
+      replacementApp: null,
       isRestoring: false
     });
+  });
+
+  it.each(["network", "tweaks"] as const)("pins %s across process changes until explicitly reconnected", (kind) => {
+    const owner = selected(kind);
+    const initial = owner.snapshot();
+    const displayed = kind === "network" ? "displayedNetwork" : "displayedTweaks";
+    for (const pid of [20, 20, 30]) {
+      const state = owner.reconcile([app(pid)]);
+      expect(state.selection).toBeNull();
+      expect(state[displayed]).toBe(initial.selection);
+      expect(state.selectedApp?.id).toBe(initial.selectedApp?.id);
+      expect(state.replacementApp?.id).toBe(app(pid).id);
+    }
+    expect(owner.reconcile([]).replacementApp).toBeNull();
+    owner.selectApp(app(30));
+    expect(owner.snapshot().selection).toBeNull();
+    owner.reconcile([app(30)]);
+    expect(owner.snapshot().selection?.kind).toBe(kind);
+    expect(owner.snapshot().replacementApp).toBeNull();
   });
 
   it("does not show the previous app's history after an explicit app change", () => {
@@ -71,7 +98,8 @@ describe("inspector restoration", () => {
     expect(kinds()).toEqual(["network", "tweaks"]);
     expect(owner.snapshot().selection).toBeNull();
     owner.reconcile([app(20)]);
-    expect(owner.snapshot().selectedApp?.inspectors).toEqual(app(20).inspectors);
+    expect(owner.snapshot().selectedApp?.inspectors).toEqual(app().inspectors);
+    expect(owner.selectApp(app(20)).selectedApp?.inspectors).toEqual(app(20).inspectors);
   });
 
   it("treats cached inspector choices as intent without reconnecting stale sockets", () => {
@@ -94,7 +122,11 @@ describe("inspector restoration", () => {
     owner.reconcile([app(20, ["tweaks"])]);
     const partial = owner.snapshot().selectedApp!;
     expect(owner.selectInspector(partial, partial.inspectors[0]).selection).toBeNull();
-    expect(owner.selectInspector(partial, partial.inspectors[1]).selection?.server.socketName).toBe("snapo_tweaks_20");
+    expect(owner.selectInspector(partial, partial.inspectors[1]).selection).toBeNull();
+    const replacement = owner.snapshot().replacementApp!;
+    expect(owner.selectInspector(replacement, replacement.inspectors[0]).selection?.server.socketName).toBe(
+      "snapo_tweaks_20"
+    );
     expect(owner.reconcile([app(20)]).selection?.kind).toBe("tweaks");
   });
 
@@ -110,7 +142,8 @@ describe("inspector restoration", () => {
     const displayedTweaks = owner.snapshot().selection;
     expect(owner.reconcile([])).toMatchObject({ selection: null, displayedTweaks, isRestoring: true });
     expect(owner.reconcile([app(20, ["network"])])).toMatchObject({ selection: null, displayedTweaks });
-    expect(owner.reconcile([app(20)]).displayedTweaks?.server.socketName).toBe("snapo_tweaks_20");
+    expect(owner.reconcile([app(20)])).toMatchObject({ selection: null, displayedTweaks, replacementApp: app(20) });
+    expect(owner.selectApp(app(20)).displayedTweaks?.server.socketName).toBe("snapo_tweaks_20");
     const other = app(30, ["network"], "com.example.other");
     owner.reconcile([app(20), other]);
     expect(owner.selectApp(other).displayedTweaks).toBeNull();
@@ -134,8 +167,9 @@ describe("inspector restoration", () => {
       app(20, ["network"], "com.example.demo:worker"),
       app(10, ["network"], "com.example.demo", "tablet")
     ];
-    expect(owner.reconcile(others).selection).toBeNull();
-    expect(owner.reconcile([...others, app(40)]).selection?.server.socketName).toBe("snapo_network_40");
+    expect(owner.reconcile(others)).toMatchObject({ selection: null, replacementApp: null });
+    expect(owner.reconcile([...others, app(40)])).toMatchObject({ selection: null, replacementApp: app(40) });
+    expect(owner.selectApp(app(40)).selection?.server.socketName).toBe("snapo_network_40");
   });
 
   it("lets an explicit inspector choice cancel pending restoration", () => {
@@ -247,7 +281,9 @@ describe("inspector restoration", () => {
     expect(owner.reconcile([personal]).selection).toBeNull();
     expect(owner.snapshot().selectedApp?.androidUserId).toBe(10);
     const replacement = app(40, ["network", "tweaks"], "com.example.demo", "phone", 10);
-    expect(owner.reconcile([personal, replacement]).selection?.appId).toBe(replacement.id);
+    expect(owner.snapshot().replacementApp).toBeNull();
+    expect(owner.reconcile([personal, replacement])).toMatchObject({ selection: null, replacementApp: replacement });
+    expect(owner.selectApp(replacement).selection?.appId).toBe(replacement.id);
     const restored = new InspectorRestoration(owner.serialize());
     expect(restored.reconcile([personal, replacement]).selection).toMatchObject({
       appId: replacement.id,
@@ -370,7 +406,12 @@ describe("inspector restoration", () => {
     });
     expect(owner.reconcile([app(20, ["tweaks"]), other]).selection).toBeNull();
     expect(owner.serialize()).toBe(saved);
-    expect(owner.reconcile([other, app(40)]).selection).toMatchObject({ appId: "phone:pid:40", kind: "network" });
+    expect(owner.reconcile([other, app(40)])).toMatchObject({
+      selection: null,
+      displayedNetwork,
+      replacementApp: app(40)
+    });
+    expect(owner.selectApp(app(40)).selection).toMatchObject({ appId: "phone:pid:40", kind: "network" });
   });
 
   it("does not override an explicit startup choice while its identity is pending", () => {

--- a/snapo-network-inspector-web/src/features/app-inspector/restoration.ts
+++ b/snapo-network-inspector-web/src/features/app-inspector/restoration.ts
@@ -104,6 +104,7 @@ export class InspectorRestoration {
       displayedNetwork: this.kind === "network" ? (this.retained.network ?? null) : null,
       displayedTweaks: this.kind === "tweaks" ? (this.retained.tweaks ?? null) : null,
       selectedApp: this.target,
+      replacementApp: this.replacementApp(),
       preferredKind: this.kind,
       isRestoring:
         this.awaitingAppIdentity ||
@@ -143,7 +144,10 @@ export class InspectorRestoration {
       }
     }
 
-    if (app && this.kind) {
+    if (app && this.kind && this.target && app.id !== this.target.id && Object.keys(this.retained).length > 0) {
+      // Keep the previous process visible until the user chooses to reconnect.
+      this.current = null;
+    } else if (app && this.kind) {
       this.updateTarget(app);
       this.remember(app, this.kind);
       const option = app.inspectors.find((candidate) => candidate.kind === this.kind);
@@ -173,6 +177,18 @@ export class InspectorRestoration {
   selectInspector(app: InspectableApp, option: AppInspectorOption): AppInspectorState {
     this.selectKind(app, option.kind);
     return this.snapshot();
+  }
+
+  private replacementApp(): InspectableApp | null {
+    if (this.current || !this.target || !identity(this.target) || !this.kind) return null;
+    return (
+      this.apps.find(
+        (app) =>
+          app.id !== this.target?.id &&
+          sameApp(this.target, app) &&
+          app.inspectors.some((option) => option.kind === this.kind)
+      ) ?? null
+    );
   }
 
   private selectKind(app: InspectableApp, kind: AppInspectorKind): void {

--- a/snapo-network-inspector-web/src/features/network-inspector/NetworkInspectorApp.tsx
+++ b/snapo-network-inspector-web/src/features/network-inspector/NetworkInspectorApp.tsx
@@ -1,5 +1,5 @@
 import type { JSX } from "preact";
-import type { AppInspectorOption, InspectableApp } from "../../network/bridge-types";
+import type { InspectableApp } from "../../network/bridge-types";
 import { DetailContent } from "./components/DetailPane";
 import type { AppLaunchControl } from "../app-inspector/useAppLaunch";
 import { Sidebar } from "./components/Sidebar";
@@ -9,16 +9,12 @@ import { useSearchHighlights } from "./hooks/useSearchHighlights";
 
 export function NetworkInspectorApp({
   model,
-  inspectorApps = [],
   selectedApp = null,
-  appLaunch,
-  onInspectorSelect
+  appLaunch
 }: {
   model: NetworkInspectorModel;
-  inspectorApps?: InspectableApp[];
   selectedApp?: InspectableApp | null;
   appLaunch?: AppLaunchControl | null;
-  onInspectorSelect?(app: InspectableApp, option?: AppInspectorOption): void;
 }): JSX.Element {
   const {
     containerRef,
@@ -40,7 +36,6 @@ export function NetworkInspectorApp({
     >
       <Sidebar
         selectedServer={model.selectedServer}
-        replacementServer={model.replacementServer}
         exclusionFilters={model.exclusionFilters}
         hiddenRequestCount={model.hiddenRequestCount}
         records={model.visibleRecords}
@@ -48,19 +43,6 @@ export function NetworkInspectorApp({
         placeholder={model.sidebarPlaceholder}
         selectedRecordId={model.selectedRecordId}
         client={model.client}
-        onReplacementServerClick={(server) => {
-          const app = inspectorApps.find((candidate) =>
-            candidate.inspectors.some(
-              (option) =>
-                option.kind === "network" &&
-                option.server.deviceId === server.deviceId &&
-                option.server.socketName === server.socketName
-            )
-          );
-          const option = app?.inspectors.find((candidate) => candidate.kind === "network");
-          if (app && option && onInspectorSelect) onInspectorSelect(app, option);
-          else model.selectReplacementServer(server);
-        }}
         onAddExclusionFilter={model.addExclusionFilter}
         onRemoveExclusionFilter={model.removeExclusionFilter}
         onRecordSelect={model.selectRecord}

--- a/snapo-network-inspector-web/src/features/network-inspector/components/Sidebar.tsx
+++ b/snapo-network-inspector-web/src/features/network-inspector/components/Sidebar.tsx
@@ -1,5 +1,4 @@
 import type { JSX } from "preact";
-import { RefreshCw } from "lucide-preact";
 import type { NetworkClient } from "../../../network/client";
 import type { InspectorRecord } from "../../../network/cdp";
 import type { SnapOServer } from "../../../network/bridge-types";
@@ -9,7 +8,6 @@ import { RecordList } from "./RecordList";
 
 export function Sidebar({
   selectedServer,
-  replacementServer,
   exclusionFilters,
   hiddenRequestCount,
   records,
@@ -17,13 +15,11 @@ export function Sidebar({
   placeholder,
   selectedRecordId,
   client,
-  onReplacementServerClick,
   onAddExclusionFilter,
   onRemoveExclusionFilter,
   onRecordSelect
 }: {
   selectedServer: SnapOServer | null;
-  replacementServer: SnapOServer | null;
   exclusionFilters: string[];
   hiddenRequestCount: number;
   records: InspectorRecord[];
@@ -31,30 +27,12 @@ export function Sidebar({
   placeholder: string | null;
   selectedRecordId: string | null;
   client: NetworkClient;
-  onReplacementServerClick(server: SnapOServer): void;
   onAddExclusionFilter(value: string): void;
   onRemoveExclusionFilter(filter: string): void;
   onRecordSelect(id: string): void;
 }): JSX.Element {
   return (
     <aside className="sidebar">
-      {replacementServer == null ? null : (
-        <div className="server-picker-frame">
-          <button
-            className="replacement-banner"
-            type="button"
-            onClick={() => onReplacementServerClick(replacementServer)}
-          >
-            <span>
-              <span className="replacement-title">New process available</span>
-              <span className="replacement-detail">
-                {replacementServer.pid == null ? "Tap to switch process" : `PID ${replacementServer.pid}`}
-              </span>
-            </span>
-            <RefreshCw size={20} aria-hidden="true" />
-          </button>
-        </div>
-      )}
       {serverHasProtocolWarning(selectedServer) ? <ProtocolWarning server={selectedServer} /> : null}
       <ExclusionFilterControl
         exclusionFilters={exclusionFilters}

--- a/snapo-network-inspector-web/src/features/network-inspector/hooks/useNetworkInspectorModel.ts
+++ b/snapo-network-inspector-web/src/features/network-inspector/hooks/useNetworkInspectorModel.ts
@@ -26,7 +26,6 @@ import {
   isCompletedRecord,
   mergeServersWithRetainedSelection,
   pickSelectedServer,
-  replacementCandidate,
   serverModelFor,
   shouldRequestRequestBody,
   shouldRequestResponseBody,
@@ -42,7 +41,6 @@ export interface NetworkInspectorModel {
   selectedServer: SnapOServer | null;
   selectedRecord: InspectorRecord | null;
   selectedRecordId: string | null;
-  replacementServer: SnapOServer | null;
   visibleRecords: InspectorRecord[];
   allRecords: InspectorRecord[];
   sidebarPlaceholder: string | null;
@@ -53,7 +51,6 @@ export interface NetworkInspectorModel {
   serverRecordCount: number;
   hasClearableItems: boolean;
   streamIsRetrying: boolean;
-  selectReplacementServer(server: SnapOServer): void;
   selectRecord(id: string): void;
   addExclusionFilter(value: string): void;
   removeExclusionFilter(filter: string): void;
@@ -364,10 +361,6 @@ export function useNetworkInspectorModel(
     bodyLoader.schedule(jobs);
   }, [bodyCache, bodyLoader, isActive, selectedRecord, selectedServerIsConnected, state.requests]);
 
-  const replacementServer = useMemo(
-    () => replacementCandidate(displayServers, selectedServerModel),
-    [displayServers, selectedServerModel]
-  );
   const sidebarPlaceholder = useMemo(
     () =>
       sidebarPlaceholderText({
@@ -432,10 +425,6 @@ export function useNetworkInspectorModel(
     sortNewestFirst
   ]);
 
-  const selectReplacementServer = useCallback(
-    (server: SnapOServer) => selectServer({ deviceId: server.deviceId, socketName: server.socketName }),
-    [selectServer]
-  );
   const selectRecord = useCallback((id: string) => setPreferredRecordId(id), []);
   const openDocs = useCallback(() => void client.openExternal(docsUrl), [client]);
 
@@ -446,7 +435,6 @@ export function useNetworkInspectorModel(
     selectedServer: selectedServerModel,
     selectedRecord,
     selectedRecordId,
-    replacementServer,
     visibleRecords,
     allRecords,
     sidebarPlaceholder,
@@ -457,7 +445,6 @@ export function useNetworkInspectorModel(
     serverRecordCount,
     hasClearableItems,
     streamIsRetrying,
-    selectReplacementServer,
     selectRecord,
     addExclusionFilter,
     removeExclusionFilter,

--- a/snapo-network-inspector-web/src/features/network-inspector/lib/debug.ts
+++ b/snapo-network-inspector-web/src/features/network-inspector/lib/debug.ts
@@ -31,28 +31,7 @@ export function applyDebugInspectorPreset(
         isProtocolOlderThanSupported: false
       };
       return nextServers;
-    case "replacementProcess":
-      return withReplacementProcess(nextServers, selectedIndex);
   }
-}
-
-function withReplacementProcess(servers: SnapOServer[], selectedIndex: number): SnapOServer[] {
-  const selected = servers[selectedIndex];
-  const replacementSocketName = `${selected.socketName}:debug-replacement`;
-  const replacement: SnapOServer = {
-    ...selected,
-    server: `${selected.deviceId}:${replacementSocketName}`,
-    socketName: replacementSocketName,
-    isConnected: true,
-    pid: selected.pid == null ? 99999 : selected.pid + 1
-  };
-  const nextServers = [...servers];
-  nextServers[selectedIndex] = { ...selected, isConnected: false };
-  nextServers.push(replacement);
-  return nextServers.sort((left, right) => {
-    const device = left.deviceId.localeCompare(right.deviceId);
-    return device !== 0 ? device : left.socketName.localeCompare(right.socketName);
-  });
 }
 
 function serverMatches(

--- a/snapo-network-inspector-web/src/features/network-inspector/lib/records.ts
+++ b/snapo-network-inspector-web/src/features/network-inspector/lib/records.ts
@@ -141,19 +141,6 @@ export function serverModelFor(servers: SnapOServer[], selected: ServerId | null
   );
 }
 
-export function replacementCandidate(servers: SnapOServer[], selectedServer: SnapOServer | null): SnapOServer | null {
-  if (selectedServer == null || selectedServer.isConnected) return null;
-  return (
-    servers.find(
-      (server) =>
-        server.isConnected &&
-        server.deviceId === selectedServer.deviceId &&
-        server.displayName === selectedServer.displayName &&
-        server.socketName !== selectedServer.socketName
-    ) ?? null
-  );
-}
-
 export function splitUrl(url: string): { primary: string; secondary: string } {
   try {
     const parsed = new URL(url);

--- a/snapo-network-inspector-web/src/network/bridge-types.ts
+++ b/snapo-network-inspector-web/src/network/bridge-types.ts
@@ -60,6 +60,7 @@ export interface AppInspectorState {
   displayedNetwork: SelectedAppInspector | null;
   displayedTweaks: SelectedAppInspector | null;
   selectedApp: InspectableApp | null;
+  replacementApp: InspectableApp | null;
   preferredKind: AppInspectorKind | null;
   isRestoring: boolean;
 }
@@ -215,4 +216,4 @@ export interface SaveFileResult {
   path?: string | null;
 }
 
-export type DebugInspectorPreset = "live" | "protocolOlder" | "protocolNewer" | "replacementProcess";
+export type DebugInspectorPreset = "live" | "protocolOlder" | "protocolNewer";

--- a/snapo-network-inspector-web/src/styles.css
+++ b/snapo-network-inspector-web/src/styles.css
@@ -163,47 +163,12 @@ body.split-pane-resizing {
   user-select: none;
 }
 
-.server-picker-frame {
-  padding: 10px 8px 0;
-  display: flex;
-  flex-direction: column;
-  gap: 8px;
-}
-
 .record-primary,
 .record-secondary,
 .title-row h1 {
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
-}
-
-.replacement-banner {
-  width: 100%;
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  padding: 8px 10px;
-  background: var(--warning-strong);
-  color: var(--on-warning-strong);
-  text-align: left;
-}
-
-.replacement-title,
-.replacement-detail {
-  display: block;
-}
-
-.replacement-title {
-  font-size: 12px;
-  line-height: 16px;
-  font-weight: 500;
-}
-
-.replacement-detail {
-  color: rgb(255 255 255 / 85%);
-  font-size: 12px;
-  line-height: 16px;
 }
 
 .protocol-warning {
@@ -387,7 +352,6 @@ body.split-pane-resizing {
   min-height: 0;
 }
 
-.sidebar > .server-picker-frame + .record-list-frame,
 .sidebar > .protocol-warning + .record-list-frame {
   margin-top: 8px;
 }


### PR DESCRIPTION
A restarted app could automatically replace the visible process and clear its request list. Keep the captured process visible until the user explicitly reconnects, and put that action beside the native app selector for both inspectors.

## Summary

- Add a native New process button with white text, the existing orange colors, and the toolbar control height.
- Retain previous Network traffic and disabled Tweaks values until reconnect; remove the web banner and its unused code.
- Match replacement processes by app, device, process, and Android profile. Ignore stale reconnect events.
- Preserve automatic startup restoration and reconnection to the same process.

## Validation

- 328 web tests pass, including retained data, manual reconnect, stale clicks, and profile isolation.
- TypeScript, ESLint, Stylelint, formatting, and production build pass.
- macOS app builds; SwiftLint and SwiftFormat pass.
- 50 shared Swift device-client tests pass.
- Native frame export, pointer delivery, capture modes, and startup regression scripts pass.
- Production Tweaks bundle smoke test passes initial values, edits, and live updates.
- Final toolbar screenshot capture was unavailable; the native build and behavior tests passed.

## Stack

Merge in this order:

1. #294 — Preact runtime
2. #295 — Native Preact APIs
3. #296 — Native-only hosting
4. #297 — Native reconnect toolbar
