### PR TITLE
Fix inspector loading spinner in WebKit

### DIFF
--- a/snapo-network-inspector-web/src/components/LoadingSpinner.tsx
+++ b/snapo-network-inspector-web/src/components/LoadingSpinner.tsx
@@ -3,7 +3,7 @@ export function LoadingSpinner({ size }: { size: number }): JSX.Element {
   return (
     <span className="body-loading-spinner" aria-hidden="true">
       <svg width={size} height={size} viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={2}>
-        <circle cx={12} cy={12} r={9} pathLength={100} strokeDasharray="80 20" strokeLinecap="round" />
+        <circle cx={12} cy={12} r={9} strokeLinecap="round" />
       </svg>
     </span>
   );

--- a/snapo-network-inspector-web/src/styles.css
+++ b/snapo-network-inspector-web/src/styles.css
@@ -707,13 +707,16 @@ body.split-pane-resizing {
 }
 
 .body-loading-spinner circle {
+  /* Use the radius-9 circumference directly for WebKit compatibility. */
+  stroke-dasharray: 45.24 11.31;
+
   /* Move the gap so the circle stays fixed on the pixel grid. */
   animation: loading-spinner-gap 1s linear infinite;
 }
 
 @keyframes loading-spinner-gap {
   to {
-    stroke-dashoffset: -100;
+    stroke-dashoffset: -56.55;
   }
 }
 


### PR DESCRIPTION
The “Waiting for inspector” indicator can render as a solid ring in the macOS web view, making loading appear stalled. Use explicit SVG dash lengths so the spinner keeps a visible moving gap in WebKit.

## Summary
- Replace normalized `pathLength` dashes with lengths based on the circle’s circumference.
- Match the animation offset to that circumference while keeping the circle fixed on the pixel grid.

## Validation
- Frontend production build, TypeScript typecheck, CSS lint, and diff whitespace checks passed.
- All 53 tests passed across the app, Tweaks app, and Tweaks recovery suites.
- Rendered the updated component and stylesheet in a macOS `WKWebView`. Two snapshots confirmed a visible gap at different positions, and computed dash offsets changed between frames.
