### PR TITLE
Keep inspector discovery responsive when devices stall

### DIFF
--- a/.github/workflows/mac.yml
+++ b/.github/workflows/mac.yml
@@ -79,6 +79,9 @@ jobs:
       - name: Test capture startup
         working-directory: snapo-app-mac
         run: sh scripts/test-startup-capture.sh
+      - name: Test inspector recovery
+        working-directory: snapo-app-mac
+        run: sh scripts/test-inspector-recovery.sh
 
   build:
     runs-on: macos-26

--- a/snapo-app-mac/Snap-O/ADB/DeviceTracker.swift
+++ b/snapo-app-mac/Snap-O/ADB/DeviceTracker.swift
@@ -8,6 +8,7 @@ actor DeviceTracker {
   private let infoCache = DeviceInfoCache()
 
   private var trackTask: Task<Void, Never>?
+  private var propertyTask: Task<Void, Never>?
   private var continuations: [UUID: AsyncStream<[Device]>.Continuation] = [:]
   private(set) var latestDevices: [Device] = []
 
@@ -46,6 +47,8 @@ actor DeviceTracker {
     let task = trackTask
     task?.cancel()
     trackTask = nil
+    propertyTask?.cancel()
+    propertyTask = nil
     let activeContinuations = Array(continuations.values)
     continuations.removeAll()
     for continuation in activeContinuations {
@@ -87,9 +90,8 @@ actor DeviceTracker {
       do {
         for try await payload in stream {
           if Task.isCancelled { break }
-          let devices = await parseDevices(from: payload, exec: exec)
-          if Task.isCancelled { break }
-          broadcast(devices)
+          propertyTask?.cancel()
+          propertyTask = Task { await self.refreshProperties(from: payload, exec: exec) }
         }
         if Task.isCancelled { break }
         await handleTrackingInterruption()
@@ -104,8 +106,26 @@ actor DeviceTracker {
   }
 
   private func handleTrackingInterruption() async {
+    propertyTask?.cancel()
+    propertyTask = nil
     await infoCache.removeAll()
     if hasSeenFirstMessage { broadcast([]) }
+  }
+
+  private func refreshProperties(from payload: String, exec: ADBClient) async {
+    let deviceCount = payload.split(separator: "\n").compactMap(parseDeviceRow).count
+    while !Task.isCancelled {
+      let devices = await parseDevices(from: payload, exec: exec)
+      guard !Task.isCancelled else { return }
+      broadcast(devices)
+      guard devices.count < deviceCount else { return }
+      // Successful properties are cached; only failed devices need another shell request.
+      do {
+        try await Task.sleep(for: .seconds(3))
+      } catch {
+        return
+      }
+    }
   }
 
   // MARK: - Device parsing
@@ -211,6 +231,7 @@ actor DeviceTracker {
       manufacturer: manufacturer,
       avdName: avdName
     )
+    guard !Task.isCancelled else { return nil }
     await infoCache.set(info, for: id, transportID: transportID)
     return info
   }

--- a/snapo-app-mac/Snap-O/ADB/DeviceTracker.swift
+++ b/snapo-app-mac/Snap-O/ADB/DeviceTracker.swift
@@ -122,12 +122,12 @@ actor DeviceTracker {
       for (index, element) in parsed.enumerated() {
         group.addTask {
           let (id, fields) = element
-          let info = await self.deviceInfo(
+          guard let info = await self.deviceInfo(
             for: id,
             transportID: fields["transport_id"],
             fallbackModel: fields["model"],
             exec: exec
-          )
+          ) else { return nil }
           return (
             index,
             Device(
@@ -186,13 +186,13 @@ actor DeviceTracker {
     transportID: String?,
     fallbackModel: String?,
     exec: ADBClient
-  ) async -> DeviceInfo {
+  ) async -> DeviceInfo? {
     if let cached = await infoCache.value(for: id, transportID: transportID) {
       return cached
     }
 
-    // Single getprop dump and extract the properties we care about
-    let props = await (try? exec.getProperties(deviceID: id, prefix: "ro.")) ?? [:]
+    // A failed shell request means this device is not ready for discovery or capture.
+    guard let props = try? await exec.getProperties(deviceID: id, prefix: "ro.") else { return nil }
 
     let model = fallbackModel
       ?? cleanProp("ro.product.model", in: props)

--- a/snapo-app-mac/Snap-O/NetworkInspector/NetworkInspectorService.swift
+++ b/snapo-app-mac/Snap-O/NetworkInspector/NetworkInspectorService.swift
@@ -3,6 +3,7 @@ import SnapODeviceClient
 
 actor NetworkInspectorService {
   private static let maximumBufferedOutputs = 4096
+  private static let retryCooldown: Duration = .seconds(3)
   private static let bodyCommandTimeout: Duration = .seconds(10)
 
   private struct ServerState {
@@ -32,6 +33,7 @@ actor NetworkInspectorService {
   private let tweaksService: TweaksInspectorService
 
   private var servers: [String: ServerState] = [:]
+  private var retryAfter: [String: ContinuousClock.Instant] = [:]
   private var streams: [String: String] = [:]
   private var activeStreamConnections: [String: UUID] = [:]
   private var streamStartFlights: [String: StreamStartFlight] = [:]
@@ -330,6 +332,7 @@ actor NetworkInspectorService {
 
     let activeServers = Array(servers.values)
     servers.removeAll()
+    retryAfter.removeAll()
     for state in activeServers {
       state.recordTask.cancel()
       await state.session.close()
@@ -426,6 +429,7 @@ actor NetworkInspectorService {
     )
     let devicesByID = Dictionary(uniqueKeysWithValues: devices.map { ($0.id, $0) })
     let seenKeys = Set(references.map(\.key))
+    retryAfter = retryAfter.filter { seenKeys.contains($0.key) && $0.value > .now }
     for reference in references {
       guard let device = devicesByID[reference.deviceId] else { continue }
 
@@ -453,6 +457,7 @@ actor NetworkInspectorService {
     reference: NetworkServerReference,
     using adb: ADBClient
   ) async {
+    guard retryAfter[reference.key] == nil else { return }
     do {
       let session = try await NetworkSession.connect(
         to: reference,
@@ -488,7 +493,8 @@ actor NetworkInspectorService {
       )
       await populateProcessMetadata(reference: reference, connectionID: connectionID, using: adb)
     } catch {
-      return
+      guard !Task.isCancelled, !isStopped else { return }
+      retryAfter[reference.key] = .now.advanced(by: Self.retryCooldown)
     }
   }
 
@@ -537,6 +543,7 @@ actor NetworkInspectorService {
 
   private func sessionDidEnd(serverKey: String, connectionID: UUID) async {
     guard servers[serverKey]?.connectionID == connectionID else { return }
+    retryAfter[serverKey] = .now.advanced(by: Self.retryCooldown)
     await removeServer(serverKey, message: nil)
   }
 

--- a/snapo-app-mac/Snap-O/NetworkInspector/TweaksInspectorService.swift
+++ b/snapo-app-mac/Snap-O/NetworkInspector/TweaksInspectorService.swift
@@ -38,9 +38,11 @@ actor TweaksInspectorService {
   }
 
   private static let discoveryRequestTimeout: TimeInterval = 2
+  private static let retryCooldown: Duration = .seconds(3)
 
   private let adbService: ADBService
   private var connections: [String: Connection] = [:]
+  private var retryAfter: [String: ContinuousClock.Instant] = [:]
   private var isStopped = false
 
   init(adbService: ADBService) {
@@ -58,11 +60,13 @@ actor TweaksInspectorService {
     guard !isStopped else { return }
     let devicesByID = Dictionary(uniqueKeysWithValues: devices.map { ($0.id, $0) })
     let activeKeys = Set(references.map(\.key))
+    retryAfter = retryAfter.filter { activeKeys.contains($0.key) && $0.value > .now }
 
     await withTaskGroup(of: Void.self) { group in
       for reference in references {
         guard let device = devicesByID[reference.deviceId], !Task.isCancelled, !isStopped else { continue }
         let key = reference.key
+        guard retryAfter[key] == nil else { continue }
         if var connection = connections[key] {
           connection.app.deviceDisplayTitle = device.displayTitle
           connections[key] = connection
@@ -152,6 +156,7 @@ actor TweaksInspectorService {
     let adb = await adbService.exec()
     let forwards = connections.values.map(\.forward)
     connections.removeAll()
+    retryAfter.removeAll()
 
     for forward in forwards {
       await adb.removeForward(forward)
@@ -164,7 +169,7 @@ actor TweaksInspectorService {
     using adb: ADBClient
   ) async {
     let key = reference.key
-    guard !Task.isCancelled, !isStopped, connections[key] == nil else {
+    guard !Task.isCancelled, !isStopped, connections[key] == nil, retryAfter[key] == nil else {
       return
     }
 
@@ -203,6 +208,9 @@ actor TweaksInspectorService {
       connections[key] = Connection(id: UUID(), app: app, forward: handle, baseURL: baseURL)
       populateMetadata(for: key)
     } catch {
+      if !Task.isCancelled, !isStopped {
+        retryAfter[key] = .now.advanced(by: Self.retryCooldown)
+      }
       if let forward {
         await adb.removeForward(forward)
       }
@@ -315,6 +323,8 @@ actor TweaksInspectorService {
     let key = connection.reference.key
     guard connections[key]?.id == connection.id else { return }
 
+    // Frozen apps keep listening but cannot accept connections. Avoid filling their queues on every scan.
+    retryAfter[key] = .now.advanced(by: Self.retryCooldown)
     // A brief device disconnect can remove the forward without changing the Android socket.
     connections.removeValue(forKey: key)?.metadataTask?.cancel()
     let adb = await adbService.exec()

--- a/snapo-app-mac/SnapODeviceClient/Sources/SnapODeviceClient/ADB/ADBClient.swift
+++ b/snapo-app-mac/SnapODeviceClient/Sources/SnapODeviceClient/ADB/ADBClient.swift
@@ -15,6 +15,8 @@ public struct ADBClient: Sendable {
   public typealias PathResolver = @Sendable () async throws -> URL
   public typealias ServerObserver = @Sendable () async -> Void
 
+  private let connectionFactory: @Sendable () throws -> ADBSocketConnection
+  private let discoveryTimeout: Duration
   private let pathResolver: PathResolver
   private let notifyServerAvailable: ServerObserver
 
@@ -26,8 +28,20 @@ public struct ADBClient: Sendable {
     pathResolver: @escaping PathResolver = { throw ADBError.adbNotFound },
     serverObserver: @escaping ServerObserver = {}
   ) {
+    connectionFactory = { try ADBSocketConnection() }
+    discoveryTimeout = .seconds(2)
     self.pathResolver = pathResolver
     notifyServerAvailable = serverObserver
+  }
+
+  init(
+    discoveryTimeout: Duration,
+    connectionFactory: @escaping @Sendable () throws -> ADBSocketConnection
+  ) {
+    self.discoveryTimeout = discoveryTimeout
+    self.connectionFactory = connectionFactory
+    pathResolver = { throw ADBError.adbNotFound }
+    notifyServerAvailable = {}
   }
 
   public func screencapPNG(deviceID: String) async throws -> Data {
@@ -225,7 +239,7 @@ public struct ADBClient: Sendable {
   }
 
   public func getProperties(deviceID: String, prefix: String? = nil) async throws -> [String: String] {
-    let output = try await runShellString(deviceID: deviceID, command: "getprop")
+    let output = try await runDiscoveryShellString(deviceID: deviceID, command: "getprop")
     var result: [String: String] = [:]
     for line in output.split(separator: "\n") {
       guard let property = parsePropertyLine(line) else { continue }
@@ -287,7 +301,7 @@ public struct ADBClient: Sendable {
   }
 
   public func listUnixSockets(deviceID: String) async throws -> String {
-    try await runShellString(deviceID: deviceID, command: "cat /proc/net/unix")
+    try await runDiscoveryShellString(deviceID: deviceID, command: "cat /proc/net/unix")
   }
 
   public func forwardLocalAbstract(
@@ -295,26 +309,30 @@ public struct ADBClient: Sendable {
     abstractSocket: String
   ) async throws -> ADBForwardHandle {
     try await withConnection { connection in
-      let remote = "localabstract:\(abstractSocket)"
-      let portValue = try Self.allocateEphemeralPort()
-      _ = try connection.sendHostCommand(
-        "host-serial:\(deviceID):forward:tcp:\(portValue);\(remote)",
-        expectsResponse: false
-      )
-      return ADBForwardHandle(
-        deviceID: deviceID,
-        localPort: portValue,
-        remote: remote
-      )
+      try connection.withRequestTimeout(discoveryTimeout) {
+        let remote = "localabstract:\(abstractSocket)"
+        let portValue = try Self.allocateEphemeralPort()
+        _ = try connection.sendHostCommand(
+          "host-serial:\(deviceID):forward:tcp:\(portValue);\(remote)",
+          expectsResponse: false
+        )
+        return ADBForwardHandle(
+          deviceID: deviceID,
+          localPort: portValue,
+          remote: remote
+        )
+      }
     }
   }
 
   public func removeForward(_ handle: ADBForwardHandle) async {
     _ = try? await withConnection { connection in
-      try connection.sendHostCommand(
-        "host-serial:\(handle.deviceID):killforward:tcp:\(handle.localPort)",
-        expectsResponse: false
-      )
+      try connection.withRequestTimeout(discoveryTimeout) {
+        try connection.sendHostCommand(
+          "host-serial:\(handle.deviceID):killforward:tcp:\(handle.localPort)",
+          expectsResponse: false
+        )
+      }
     }
   }
 
@@ -324,6 +342,20 @@ public struct ADBClient: Sendable {
   }
 
   // MARK: - Private helpers
+
+  func runDiscoveryShellString(deviceID: String, command: String) async throws -> String {
+    let data = try await withConnection { connection in
+      try connection.withRequestTimeout(discoveryTimeout) {
+        try connection.sendTransport(to: deviceID)
+        try connection.sendShell(command)
+        return try connection.readToEnd()
+      }
+    }
+    guard let output = String(data: data, encoding: .utf8) else {
+      throw ADBError.parseFailure("non-utf8 output from adb")
+    }
+    return output
+  }
 
   private func runShellData(deviceID: String, command: String) async throws -> Data {
     try await withConnection { connection in
@@ -346,8 +378,14 @@ public struct ADBClient: Sendable {
     _ body: @escaping @Sendable (ADBSocketConnection) throws -> T
   ) async throws -> T {
     try await runWithRetry(maxAttempts: maxAttempts) { connection in
-      defer { connection.close() }
-      return try body(connection)
+      // Blocking ADB I/O must not occupy Swift's cooperative executor threads.
+      try await withCheckedThrowingContinuation { continuation in
+        DispatchQueue.global(qos: .userInitiated).async {
+          let result = Result { try body(connection) }
+          connection.close()
+          continuation.resume(with: result)
+        }
+      }
     }
   }
 
@@ -359,16 +397,18 @@ public struct ADBClient: Sendable {
     var didRestartServer = false
 
     for attempt in 0 ..< maxAttempts {
+      try Task.checkCancellation()
       try await ADBClient.serverLauncher.waitForOngoingRestart()
 
       do {
-        let connection = try ADBSocketConnection()
+        let connection = try connectionFactory()
         do {
           let value = try await withTaskCancellationHandler {
             try await operation(connection)
           } onCancel: {
             connection.close()
           }
+          try Task.checkCancellation()
           await notifyServerAvailable()
           return value
         } catch {

--- a/snapo-app-mac/SnapODeviceClient/Sources/SnapODeviceClient/ADB/ADBNetworkTransport.swift
+++ b/snapo-app-mac/SnapODeviceClient/Sources/SnapODeviceClient/ADB/ADBNetworkTransport.swift
@@ -25,9 +25,11 @@ public final class ADBNetworkTransport: NetworkSessionTransport, @unchecked Send
   ) async throws -> ADBNetworkTransport {
     let socket = try await adb.makeConnection()
     do {
-      try socket.sendTransport(to: reference.deviceId)
-      try socket.sendLocalAbstract(reference.socketName)
-      return try ADBNetworkTransport(socket: socket)
+      return try socket.withRequestTimeout(.seconds(2)) {
+        try socket.sendTransport(to: reference.deviceId)
+        try socket.sendLocalAbstract(reference.socketName)
+        return try ADBNetworkTransport(socket: socket)
+      }
     } catch {
       socket.close()
       throw error

--- a/snapo-app-mac/SnapODeviceClient/Sources/SnapODeviceClient/ADB/ADBSocketConnection.swift
+++ b/snapo-app-mac/SnapODeviceClient/Sources/SnapODeviceClient/ADB/ADBSocketConnection.swift
@@ -40,6 +40,7 @@ public final class ADBSocketConnection {
   private let socketDescriptor: Int32
   private let closeLock = NSLock()
   private var isClosed = false
+  private var ioTimeout: Duration?
   private var lineBuffer = Data()
   private var isSkippingOversizedLine = false
 
@@ -64,6 +65,34 @@ public final class ADBSocketConnection {
     guard shouldClose else { return }
     shutdown(socketDescriptor, SHUT_RDWR)
     Darwin.close(socketDescriptor)
+  }
+
+  /// Use only before handing the connection to concurrent readers or writers.
+  func withRequestTimeout<T>(_ timeout: Duration, _ body: () throws -> T) throws -> T {
+    let previous = ioTimeout
+    defer { try? setIOTimeout(previous) }
+    try setIOTimeout(timeout)
+    return try body()
+  }
+
+  private func setIOTimeout(_ timeout: Duration?) throws {
+    try closeLock.withLock {
+      guard !isClosed else { throw ADBError.protocolFailure("ADB connection closed") }
+      let parts = (timeout ?? .zero).components
+      var value = timeval(tv_sec: Int(parts.seconds), tv_usec: Int32(parts.attoseconds / 1_000_000_000_000))
+      for option in [SO_RCVTIMEO, SO_SNDTIMEO] {
+        guard setsockopt(socketDescriptor, SOL_SOCKET, option, &value, socklen_t(MemoryLayout<timeval>.size)) == 0 else {
+          throw Self.makeSocketError(errno, context: "setsockopt")
+        }
+      }
+      ioTimeout = timeout
+    }
+  }
+
+  private func checkOpen() throws {
+    guard !closeLock.withLock({ isClosed }) else {
+      throw ADBError.protocolFailure("ADB connection closed")
+    }
   }
 
   public func sendTrackDevices() throws {
@@ -246,6 +275,7 @@ public final class ADBSocketConnection {
 
       while remaining > 0 {
         try Task.checkCancellation()
+        try checkOpen()
         let written = Darwin.send(socketDescriptor, pointer, remaining, 0)
 
         if written > 0 {
@@ -260,6 +290,9 @@ public final class ADBSocketConnection {
 
         let errorCode = errno
         if errorCode == EINTR { continue }
+        if ioTimeout != nil, errorCode == EAGAIN || errorCode == EWOULDBLOCK {
+          throw ADBError.requestTimedOut("ADB write")
+        }
         throw Self.makeSocketError(errorCode, context: "send")
       }
     }
@@ -314,6 +347,7 @@ public final class ADBSocketConnection {
   private func readOnce(into buffer: inout [UInt8]) throws -> Int {
     while true {
       try Task.checkCancellation()
+      try checkOpen()
       let result = buffer.withUnsafeMutableBytes { pointer -> Int in
         guard let baseAddress = pointer.baseAddress else { return -1 }
         return Int(Darwin.recv(socketDescriptor, baseAddress, pointer.count, 0))
@@ -323,6 +357,9 @@ public final class ADBSocketConnection {
       if result == 0 { return 0 }
 
       if errno == EINTR { continue }
+      if ioTimeout != nil, errno == EAGAIN || errno == EWOULDBLOCK {
+        throw ADBError.requestTimedOut("ADB read")
+      }
       throw Self.makeSocketError(errno, context: "recv")
     }
   }

--- a/snapo-app-mac/SnapODeviceClient/Sources/SnapODeviceClient/NetworkServerDiscovery.swift
+++ b/snapo-app-mac/SnapODeviceClient/Sources/SnapODeviceClient/NetworkServerDiscovery.swift
@@ -81,7 +81,7 @@ public enum NetworkServerDiscovery {
     using adb: ADBClient
   ) async -> String? {
     guard let pid = InspectorKind.allCases.compactMap({ $0.pid(inSocketName: reference.socketName) }).first,
-          let output = try? await adb.runShellString(
+          let output = try? await adb.runDiscoveryShellString(
             deviceID: reference.deviceId,
             command: "cat /proc/\(pid)/cmdline 2>/dev/null"
           )
@@ -96,7 +96,7 @@ public enum NetworkServerDiscovery {
     using adb: ADBClient
   ) async -> Int? {
     guard let pid = InspectorKind.allCases.compactMap({ $0.pid(inSocketName: reference.socketName) }).first,
-          let output = try? await adb.runShellString(
+          let output = try? await adb.runDiscoveryShellString(
             deviceID: reference.deviceId,
             command: "cat /proc/\(pid)/status 2>/dev/null"
           ) else { return nil }

--- a/snapo-app-mac/SnapODeviceClient/Tests/SnapODeviceClientTests/ADBDiscoveryTimeoutTests.swift
+++ b/snapo-app-mac/SnapODeviceClient/Tests/SnapODeviceClientTests/ADBDiscoveryTimeoutTests.swift
@@ -1,0 +1,224 @@
+import Darwin
+import Foundation
+@testable import SnapODeviceClient
+import Testing
+
+@Suite("ADB discovery timeouts")
+struct ADBDiscoveryTimeoutTests {
+  @Test("a stalled device cannot hide healthy inspectors", arguments: FakeDiscoveryADB.Stall.allCases)
+  private func discoversHealthyDevice(stall: FakeDiscoveryADB.Stall) async {
+    let server = FakeDiscoveryADB(stall: stall)
+    defer { server.close() }
+    let adb = server.client()
+    let start = ContinuousClock.now
+    let sockets = await InspectorDiscovery.discover(on: ["stalled", "phone"], using: adb)
+    #expect(sockets.map(\.reference.deviceId) == ["phone", "phone"])
+    #expect(sockets.map(\.kind) == [.network, .tweaks])
+    #expect(start.duration(to: .now) < .seconds(2))
+    #expect(server.connectionCount == 2)
+
+    let recovered = await InspectorDiscovery.discover(on: ["phone"], using: adb)
+    #expect(recovered == sockets)
+  }
+
+  @Test("cancelling discovery interrupts a blocked read")
+  func cancelsBlockedRead() async throws {
+    let server = FakeDiscoveryADB(stall: .output)
+    defer { server.close() }
+    let task = Task {
+      try await server.client(timeout: .seconds(10)).listUnixSockets(deviceID: "stalled")
+    }
+    var requests = server.requests.stream.makeAsyncIterator()
+    _ = await requests.next()
+    let start = ContinuousClock.now
+    task.cancel()
+    do {
+      _ = try await task.value
+      Issue.record("Expected cancellation")
+    } catch is CancellationError {}
+    #expect(start.duration(to: .now) < .seconds(1))
+    #expect(server.connectionCount == 1)
+  }
+
+  @Test("connection setup deadlines do not limit subsequent streaming")
+  func restoresStreamingReads() throws {
+    var descriptors: [Int32] = [0, 0]
+    try #require(socketpair(AF_UNIX, SOCK_STREAM, 0, &descriptors) == 0)
+    let connection = ADBSocketConnection(connectedSocket: descriptors[0])
+    let peer = ADBSocketConnection(connectedSocket: descriptors[1])
+    defer {
+      connection.close()
+      peer.close()
+    }
+    do {
+      _ = try connection.withRequestTimeout(.milliseconds(5)) { try connection.readLine() }
+      Issue.record("Expected an idle socket to time out")
+    } catch ADBError.requestTimedOut {}
+    let writer = DispatchGroup()
+    writer.enter()
+    DispatchQueue.global().async {
+      defer { writer.leave() }
+      Thread.sleep(forTimeInterval: 0.05)
+      try? peer.writeLine("record")
+    }
+    defer { writer.wait() }
+    #expect(try connection.readLine() == "record")
+  }
+
+  @Test("legacy network discovery also returns healthy devices")
+  func discoversLegacyNetwork() async {
+    let server = FakeDiscoveryADB(stall: .output)
+    defer { server.close() }
+    let references = await NetworkServerDiscovery.discover(on: ["stalled", "phone"], using: server.client())
+    #expect(references == [NetworkServerReference(deviceId: "phone", socketName: "snapo_network_42")])
+  }
+
+  @Test("device properties and process metadata have bounded requests")
+  func boundsMetadata() async throws {
+    let server = FakeDiscoveryADB(stall: .output)
+    defer { server.close() }
+    let adb = server.client()
+    do {
+      _ = try await adb.getProperties(deviceID: "stalled")
+      Issue.record("Expected property request to time out")
+    } catch ADBError.requestTimedOut {
+      // A device timeout must not trigger the ADB server retry path.
+    }
+    let reference = NetworkServerReference(deviceId: "stalled", socketName: "snapo_network_42")
+    #expect(await NetworkServerDiscovery.packageNameHint(for: reference, using: adb) == nil)
+    #expect(await NetworkServerDiscovery.androidUserID(for: reference, using: adb) == nil)
+    #expect(server.connectionCount == 3)
+  }
+
+  @Test("port forward setup and cleanup time out without retrying")
+  func boundsPortForwarding() async throws {
+    let server = FakeDiscoveryADB(stall: .transport)
+    defer { server.close() }
+    let adb = server.client()
+    do {
+      _ = try await adb.forwardLocalAbstract(deviceID: "stalled", abstractSocket: "snapo_tweaks_42")
+      Issue.record("Expected port forwarding to time out")
+    } catch ADBError.requestTimedOut {}
+    let forward = try await adb.forwardLocalAbstract(deviceID: "cleanup", abstractSocket: "snapo_tweaks_42")
+    await adb.removeForward(forward)
+    #expect(server.connectionCount == 3)
+  }
+
+  @Test("native timeouts allow output that continues making progress")
+  func allowsContinuousOutput() async throws {
+    let server = FakeDiscoveryADB(stall: .trickle)
+    defer { server.close() }
+    let output = try await server.client().listUnixSockets(deviceID: "stalled")
+    #expect(output == String(repeating: "x", count: 50))
+  }
+}
+
+private final class FakeDiscoveryADB: @unchecked Sendable {
+  enum Stall: CaseIterable {
+    case transport, shell, output, partialStatus, partialOutput, trickle
+  }
+
+  let requests = AsyncStream<String>.makeStream()
+  private let stall: Stall
+  private let workers = DispatchGroup()
+  private let lock = NSLock()
+  private var peers: [ADBSocketConnection] = []
+
+  init(stall: Stall) {
+    self.stall = stall
+  }
+
+  var connectionCount: Int {
+    lock.withLock { peers.count }
+  }
+
+  func client(timeout: Duration = .milliseconds(100)) -> ADBClient {
+    ADBClient(discoveryTimeout: timeout) { try self.connect() }
+  }
+
+  func close() {
+    workers.wait()
+    lock.withLock { peers.forEach { $0.close() } }
+  }
+
+  private func connect() throws -> ADBSocketConnection {
+    var descriptors: [Int32] = [0, 0]
+    guard socketpair(AF_UNIX, SOCK_STREAM, 0, &descriptors) == 0 else {
+      throw POSIXError(.EIO)
+    }
+    let connection = ADBSocketConnection(connectedSocket: descriptors[0])
+    let peer = ADBSocketConnection(connectedSocket: descriptors[1])
+    let descriptor = descriptors[1]
+    var noSigPipe: Int32 = 1
+    _ = setsockopt(descriptor, SOL_SOCKET, SO_NOSIGPIPE, &noSigPipe, socklen_t(MemoryLayout<Int32>.size))
+    lock.withLock { peers.append(peer) }
+    workers.enter()
+    DispatchQueue.global().async { [stall, workers, requests] in
+      defer { workers.leave() }
+      do {
+        try peer.withRequestTimeout(.seconds(2)) {
+          let transport = try Self.readRequest(peer)
+          if transport.hasPrefix("host-serial:stalled:") { return }
+          if transport.hasPrefix("host-serial:cleanup:") {
+            if transport.contains(":forward:") { Self.send("OKAY", to: descriptor) }
+            return
+          }
+          let stalled = transport == "host:transport:stalled"
+          if stalled, stall == .transport { return }
+          if stalled, stall == .partialStatus {
+            Self.send("OK", to: descriptor)
+            return
+          }
+          Self.send("OKAY", to: descriptor)
+          let command = try Self.readRequest(peer)
+          requests.continuation.yield(command)
+          if stalled, stall == .shell { return }
+          Self.send("OKAY", to: descriptor)
+          if stalled {
+            if stall == .partialOutput { Self.send("1: 0 @snapo_network_99\n", to: descriptor) }
+            if stall == .trickle {
+              for _ in 0 ..< 50 {
+                if !Self.send("x", to: descriptor) { break }
+                Thread.sleep(forTimeInterval: 0.01)
+              }
+              peer.close()
+            }
+            return
+          }
+          Self.send("1: 0 @snapo_network_42\n2: 0 @snapo_tweaks_42\n", to: descriptor)
+          peer.close()
+        }
+      } catch {
+        peer.close()
+      }
+    }
+    return connection
+  }
+
+  private static func readRequest(_ peer: ADBSocketConnection) throws -> String {
+    func read(_ count: Int) throws -> Data {
+      var data = Data()
+      while data.count < count {
+        guard let chunk = try peer.readChunk(maxLength: count - data.count) else {
+          throw ADBError.protocolFailure("Test peer closed")
+        }
+        data.append(chunk)
+      }
+      return data
+    }
+    let header = try read(4)
+    guard let text = String(data: header, encoding: .ascii), let count = Int(text, radix: 16) else {
+      throw ADBError.protocolFailure("Invalid test request")
+    }
+    guard let request = try String(bytes: read(count), encoding: .utf8) else {
+      throw ADBError.protocolFailure("Invalid test request encoding")
+    }
+    return request
+  }
+
+  @discardableResult
+  private static func send(_ text: String, to descriptor: Int32) -> Bool {
+    let data = Data(text.utf8)
+    return data.withUnsafeBytes { Darwin.send(descriptor, $0.baseAddress, $0.count, 0) == $0.count }
+  }
+}

--- a/snapo-app-mac/Tests/InspectorRecovery/DeviceClientDouble.swift
+++ b/snapo-app-mac/Tests/InspectorRecovery/DeviceClientDouble.swift
@@ -1,0 +1,120 @@
+import Foundation
+
+public struct ADBForwardHandle: Sendable {
+  public let port: UInt16
+}
+
+public final class ADBClient: @unchecked Sendable {
+  private let lock = NSLock()
+  private var forwards = 0
+  private var propertiesRecovered = false
+  private var socketDevices: [String] = []
+  private let trackedDevices = AsyncThrowingStream<String, Error>.makeStream()
+  public init() {}
+  public var forwardCount: Int {
+    lock.withLock { forwards }
+  }
+
+  public func forwardLocalAbstract(deviceID: String, abstractSocket: String) async throws -> ADBForwardHandle {
+    lock.withLock { forwards += 1 }
+    if deviceID == "forward-failure" { throw ADBError.requestTimedOut("Test timeout") }
+    return ADBForwardHandle(port: deviceID == "frozen" ? 12345 : 12346)
+  }
+
+  public var scannedDeviceIDs: [String] {
+    lock.withLock { socketDevices }
+  }
+
+  public func recoverProperties() {
+    lock.withLock { propertiesRecovered = true }
+  }
+
+  public func emitDevices(_ payload: String) {
+    trackedDevices.continuation.yield(payload)
+  }
+
+  public func trackDevices() async throws -> (handle: TrackDevicesHandle, stream: AsyncThrowingStream<String, Error>) {
+    (TrackDevicesHandle { self.trackedDevices.continuation.finish() }, trackedDevices.stream)
+  }
+
+  public func getProperties(deviceID: String, prefix: String?) async throws -> [String: String] {
+    if deviceID == "stalled", !lock.withLock({ propertiesRecovered }) { throw ADBError.requestTimedOut("Test timeout") }
+    return ["ro.product.model": deviceID, "ro.build.version.release": "Test"]
+  }
+
+  public func openApp(deviceID: String, packageName: String, androidUserID: Int) async throws {}
+
+  public func removeForward(_ handle: ADBForwardHandle) async {}
+  public func listUnixSockets(deviceID: String) async throws -> String {
+    lock.withLock { socketDevices.append(deviceID) }
+    return "1: 0 @snapo_network_42\n2: 0 @snapo_tweaks_42"
+  }
+
+  public func runDiscoveryShellString(deviceID: String, command: String) async throws -> String {
+    command.contains("cmdline") ? "com.example.demo" : "Uid: 10000"
+  }
+}
+
+public actor NetworkSession {
+  public static let state = State()
+  private let recordsStream = AsyncStream<NetworkServerRecord>.makeStream()
+
+  public final class State: @unchecked Sendable {
+    private let lock = NSLock()
+    private var attempts = 0
+    private var frozen = true
+    private var frozenSession: NetworkSession?
+    public var count: Int {
+      lock.withLock { attempts }
+    }
+
+    public func unfreeze() {
+      lock.withLock { frozen = false }
+    }
+
+    public func disconnectFrozen() async {
+      let session = lock.withLock { frozenSession }
+      await session?.close()
+    }
+
+    func record(_ session: NetworkSession, device: String) {
+      if device == "frozen" { lock.withLock { frozenSession = session } }
+    }
+
+    func shouldFail(_ device: String) -> Bool {
+      lock.withLock {
+        attempts += 1
+        return device == "frozen" && frozen
+      }
+    }
+  }
+
+  public static func connect(
+    to reference: NetworkServerReference, using adb: ADBClient, defaultCommandTimeout: Duration
+  ) async throws -> NetworkSession {
+    if state.shouldFail(reference.deviceId) { throw ADBError.requestTimedOut("Test timeout") }
+    let session = NetworkSession()
+    state.record(session, device: reference.deviceId)
+    return session
+  }
+
+  public func records() -> AsyncStream<NetworkServerRecord> {
+    recordsStream.stream
+  }
+
+  public func close() {
+    recordsStream.continuation.finish()
+  }
+
+  public func send(method: String) async throws {}
+  public func command(method: String, params: [String: JSONValue], timeout: Duration) async throws -> NetworkCDPMessage {
+    NetworkCDPMessage(id: 1)
+  }
+}
+
+public struct TrackDevicesHandle: Sendable {
+  let onCancel: @Sendable () -> Void
+  public func cancel() {
+    onCancel()
+  }
+}

--- a/snapo-app-mac/Tests/InspectorRecovery/InspectorRecoveryTests.swift
+++ b/snapo-app-mac/Tests/InspectorRecovery/InspectorRecoveryTests.swift
@@ -128,7 +128,6 @@ struct InspectorRecoveryTests {
     print("A new service instance can reconnect immediately")
 
     adb.recoverProperties()
-    adb.emitDevices(payload)
     try await eventually { await tracker.latestDevices.map(\.id) == ["frozen", "healthy", "stalled"] }
     let recovered = NetworkInspectorService(adbService: adbService, deviceTracker: tracker)
     _ = await recovered.listInspectorApps()
@@ -146,7 +145,7 @@ struct InspectorRecoveryTests {
     await forwardFailure.stop()
     print("Port forwarding failures enter the same cooldown as failed inspector requests")
     await tracker.stopTracking()
-    print("Property failures are not cached; the device becomes eligible when tracking retries successfully")
+    print("Property failures recover without another device tracking event")
   }
 
   static func eventually(_ condition: () async -> Bool) async throws {

--- a/snapo-app-mac/Tests/InspectorRecovery/InspectorRecoveryTests.swift
+++ b/snapo-app-mac/Tests/InspectorRecovery/InspectorRecoveryTests.swift
@@ -1,0 +1,159 @@
+import Foundation
+import SnapODeviceClient
+
+actor ADBService {
+  let client = ADBClient()
+  func exec() -> ADBClient {
+    client
+  }
+}
+
+private final class InspectorHTTP: URLProtocol, @unchecked Sendable {
+  static let state = State()
+
+  final class State: @unchecked Sendable {
+    private let lock = NSLock()
+    private var frozenRequests = 0
+    private var frozen = true
+    var count: Int {
+      lock.withLock { frozenRequests }
+    }
+
+    func unfreeze() {
+      lock.withLock { frozen = false }
+    }
+
+    func shouldFail(port: Int?) -> Bool {
+      lock.withLock {
+        guard port == 12345 else { return false }
+        frozenRequests += 1
+        return frozen
+      }
+    }
+  }
+
+  override class func canInit(with request: URLRequest) -> Bool {
+    request.url?.host == "127.0.0.1"
+  }
+
+  override class func canonicalRequest(for request: URLRequest) -> URLRequest {
+    request
+  }
+
+  override func stopLoading() {}
+  override func startLoading() {
+    let url = request.url!
+    if Self.state.shouldFail(port: url.port) {
+      client?.urlProtocol(self, didFailWithError: URLError(.timedOut))
+      return
+    }
+    let icon = url.path == "/app/icon"
+    let response = HTTPURLResponse(url: url, statusCode: icon ? 404 : 200, httpVersion: nil, headerFields: nil)!
+    client?.urlProtocol(self, didReceive: response, cacheStoragePolicy: .notAllowed)
+    let body = url.path == "/app" ? #"{"name":"Demo","packageName":"com.example.demo","protocolVersion":4}"# : #"{"tweaks":[]}"#
+    client?.urlProtocol(self, didLoad: Data(body.utf8))
+    client?.urlProtocolDidFinishLoading(self)
+  }
+}
+
+enum SnapOLog {
+  static let tracker = 0
+}
+
+@main
+@MainActor
+struct InspectorRecoveryTests {
+  static func main() async throws {
+    URLProtocol.registerClass(InspectorHTTP.self)
+    defer { URLProtocol.unregisterClass(InspectorHTTP.self) }
+    let adbService = ADBService()
+    let adb = await adbService.exec()
+    let tracker = DeviceTracker(adbService: adbService)
+    await tracker.startTracking()
+    let payload = "frozen device transport_id:1\nhealthy device transport_id:2\nstalled device transport_id:3"
+    adb.emitDevices(payload)
+    try await eventually { await tracker.latestDevices.map(\.id) == ["frozen", "healthy"] }
+    let service = NetworkInspectorService(adbService: adbService, deviceTracker: tracker)
+    let frozen = NetworkServerReference(deviceId: "frozen", socketName: "snapo_tweaks_42")
+    let healthy = NetworkServerReference(deviceId: "healthy", socketName: "snapo_tweaks_42")
+    _ = await service.listInspectorApps()
+    try await eventually {
+      let apps = await service.listInspectorApps()
+      return InspectorHTTP.state.count == 1 && apps.count == 1 && apps.first?.inspectors.count == 2
+    }
+    let count = adb.forwardCount
+    let networkCount = NetworkSession.state.count
+    for _ in 0 ..< 50 {
+      _ = await service.listInspectorApps()
+      do {
+        _ = try await service.listTweaks(for: frozen)
+        fatalError("Frozen inspector should remain disconnected during cooldown")
+      } catch NetworkInspectorError.serverNotConnected {}
+    }
+    precondition(adb.forwardCount == count)
+    precondition(NetworkSession.state.count == networkCount)
+    precondition(InspectorHTTP.state.count == 1)
+    precondition(!adb.scannedDeviceIDs.contains("stalled"))
+    print("A device with failed properties is excluded from app discovery")
+    _ = try await service.listTweaks(for: healthy)
+    print("Both inspector kinds suppress repeated failed connections while healthy inspectors remain usable")
+
+    InspectorHTTP.state.unfreeze()
+    NetworkSession.state.unfreeze()
+    try await Task.sleep(for: .milliseconds(3200))
+    try await eventually { await service.listInspectorApps().count == 2 }
+    _ = try await service.listTweaks(for: frozen)
+    precondition(adb.forwardCount == count + 1)
+    precondition(NetworkSession.state.count == networkCount + 1)
+    print("Both inspector kinds reconnect automatically after cooldown")
+
+    await NetworkSession.state.disconnectFrozen()
+    try await eventually {
+      let apps = await service.listInspectorApps()
+      return apps.first(where: { $0.deviceId == "frozen" })?.inspectors.map(\.kind) == [.tweaks]
+    }
+    let disconnectedCount = NetworkSession.state.count
+    for _ in 0 ..< 50 {
+      _ = await service.listInspectorApps()
+    }
+    precondition(NetworkSession.state.count == disconnectedCount)
+    _ = try await service.listTweaks(for: frozen)
+    print("A lost network connection enters cooldown without delaying tweaks in the same process")
+    await service.stop()
+
+    let restarted = NetworkInspectorService(adbService: adbService, deviceTracker: tracker)
+    try await eventually { await restarted.listInspectorApps().count == 2 }
+    _ = try await restarted.listTweaks(for: frozen)
+    await restarted.stop()
+    print("A new service instance can reconnect immediately")
+
+    adb.recoverProperties()
+    adb.emitDevices(payload)
+    try await eventually { await tracker.latestDevices.map(\.id) == ["frozen", "healthy", "stalled"] }
+    let recovered = NetworkInspectorService(adbService: adbService, deviceTracker: tracker)
+    _ = await recovered.listInspectorApps()
+    precondition(adb.scannedDeviceIDs.contains("stalled"))
+    await recovered.stop()
+    let failingPayload = "forward-failure device transport_id:4"
+    adb.emitDevices(failingPayload)
+    try await eventually { await tracker.latestDevices.map(\.id) == ["forward-failure"] }
+    let forwardFailure = NetworkInspectorService(adbService: adbService, deviceTracker: tracker)
+    let beforeForwardFailure = adb.forwardCount
+    for _ in 0 ..< 50 {
+      _ = await forwardFailure.listInspectorApps()
+    }
+    precondition(adb.forwardCount == beforeForwardFailure + 1)
+    await forwardFailure.stop()
+    print("Port forwarding failures enter the same cooldown as failed inspector requests")
+    await tracker.stopTracking()
+    print("Property failures are not cached; the device becomes eligible when tracking retries successfully")
+  }
+
+  static func eventually(_ condition: () async -> Bool) async throws {
+    for _ in 0 ..< 500 {
+      if await condition() { return }
+      try await Task.sleep(for: .milliseconds(10))
+    }
+    fatalError("Condition did not become true")
+  }
+}

--- a/snapo-app-mac/scripts/test-inspector-recovery.sh
+++ b/snapo-app-mac/scripts/test-inspector-recovery.sh
@@ -1,0 +1,25 @@
+#!/bin/sh
+set -eu
+
+APP_DIR=$(CDPATH= cd -- "$(dirname -- "$0")/.." && pwd)
+TEST_DIR=$(mktemp -d "${TMPDIR:-/tmp}/snap-o-inspector-recovery.XXXXXX")
+trap 'rm -rf "$TEST_DIR"' EXIT
+cd "$APP_DIR"
+
+xcrun swiftc -swift-version 6 -parse-as-library -whole-module-optimization \
+  -module-name SnapODeviceClient -emit-module -emit-object \
+  SnapODeviceClient/Sources/SnapODeviceClient/Device.swift \
+  SnapODeviceClient/Sources/SnapODeviceClient/NetworkProtocol.swift \
+  SnapODeviceClient/Sources/SnapODeviceClient/InspectorDiscovery.swift \
+  SnapODeviceClient/Sources/SnapODeviceClient/NetworkServerDiscovery.swift \
+  Tests/InspectorRecovery/DeviceClientDouble.swift \
+  -emit-module-path "$TEST_DIR/SnapODeviceClient.swiftmodule" -o "$TEST_DIR/DeviceClient.o"
+xcrun swiftc -swift-version 6 -parse-as-library -I "$TEST_DIR" \
+  "$TEST_DIR/DeviceClient.o" Snap-O/Models/Device+Formatting.swift \
+  Snap-O/ADB/DeviceTracker.swift \
+  Snap-O/NetworkInspector/NetworkInspectorBridgeModels.swift \
+  Snap-O/NetworkInspector/TweakEventStreamDecoder.swift \
+  Snap-O/NetworkInspector/TweaksInspectorService.swift \
+  Snap-O/NetworkInspector/NetworkInspectorService.swift \
+  Tests/InspectorRecovery/InspectorRecoveryTests.swift -o "$TEST_DIR/inspector-recovery-tests"
+"$TEST_DIR/inspector-recovery-tests"

--- a/snapo-network-inspector-web/src/App.test.tsx
+++ b/snapo-network-inspector-web/src/App.test.tsx
@@ -208,41 +208,29 @@ describe("app inspector restoration UI", () => {
     expect(mocks.client.saveInspectorPreferences).not.toHaveBeenCalled();
   });
 
-  it("selects and saves a fallback when the remembered app is unavailable", async () => {
+  it("waits for the remembered app when another app arrives first", async () => {
     const other = { ...app(30, ["network"]), processName: "com.example.other", androidUserId: 10 };
     discovered = [other];
     await act(() => render(<App />, container));
     await act(async () => {
       await vi.advanceTimersByTimeAsync(0);
     });
-    await vi.waitFor(() => {
-      expect(container.querySelector('[data-inspector="network"]')?.getAttribute("data-socket")).toBe(
-        "snapo_network_30"
-      );
-    });
-    const saved = vi.mocked(mocks.client.saveInspectorPreferences).mock.lastCall![0];
-    expect(JSON.parse(saved!).last).toEqual({
-      deviceId: "phone",
-      processName: "com.example.other",
-      androidUserId: 10,
-      kind: "network"
-    });
+    expect(container.querySelector("[data-inspector]")).toBeNull();
+    expect(mocks.client.saveInspectorPreferences).not.toHaveBeenCalled();
 
-    discovered = [app(20, ["network", "tweaks"])];
+    discovered = [other, app(20, ["network", "tweaks"])];
     await act(async () => {
       await vi.advanceTimersByTimeAsync(2_500);
     });
-    expect(mocks.client.appInspectorStateChanged).toHaveBeenLastCalledWith(
-      expect.objectContaining({
-        selection: null,
-        selectedApp: expect.objectContaining({ id: other.id, androidUserId: 10 })
-      })
-    );
-    expect(mocks.client.saveInspectorPreferences).toHaveBeenCalledTimes(1);
-    expect(mocks.client.startStream).not.toHaveBeenCalledWith(discovered[0].inspectors[0].server);
+    await vi.waitFor(() => {
+      expect(container.querySelector('[data-inspector="network"]')?.getAttribute("data-socket")).toBe(
+        "snapo_network_20"
+      );
+    });
+    expect(mocks.client.saveInspectorPreferences).not.toHaveBeenCalled();
   });
 
-  it("saves a fallback for legacy preferences without guessing the saved profile", async () => {
+  it("preserves legacy preferences without guessing the saved profile", async () => {
     const legacy = { deviceId: "phone", processName: "com.example.demo", kind: "network" };
     vi.mocked(mocks.client.loadInspectorPreferences).mockResolvedValue(
       JSON.stringify({ last: legacy, apps: [legacy] })
@@ -255,47 +243,48 @@ describe("app inspector restoration UI", () => {
     await act(async () => {
       await vi.advanceTimersByTimeAsync(0);
     });
-    expect(container.querySelector('[data-inspector="tweaks"]')).not.toBeNull();
-    const saved = vi.mocked(mocks.client.saveInspectorPreferences).mock.lastCall![0];
-    expect(JSON.parse(saved!).last).toEqual({
-      deviceId: "phone",
-      processName: "com.example.other",
-      androidUserId: 10,
-      kind: "tweaks"
-    });
+    expect(container.querySelector("[data-inspector]")).toBeNull();
+    expect(mocks.client.saveInspectorPreferences).not.toHaveBeenCalled();
   });
 
-  it("keeps trying discovery until a usable fallback appears", async () => {
+  it("keeps trying discovery for the saved inspector after a failed scan", async () => {
     discovered = [];
     vi.mocked(mocks.client.listInspectorApps).mockRejectedValueOnce(new Error("Discovery unavailable"));
     await act(() => render(<App />, container));
     await act(async () => {
-      await vi.advanceTimersByTimeAsync(0);
+      await vi.advanceTimersByTimeAsync(2_500);
     });
+    discovered = [{ ...app(30, ["network"]), processName: "com.example.other" }];
     await act(async () => {
       await vi.advanceTimersByTimeAsync(2_500);
     });
+    expect(container.querySelector("[data-inspector]")).toBeNull();
     expect(mocks.client.saveInspectorPreferences).not.toHaveBeenCalled();
-    discovered = [{ ...app(30, ["network"]), processName: "com.example.other" }];
+    discovered = [app(20, ["network"])];
     await act(async () => {
       await vi.advanceTimersByTimeAsync(2_500);
     });
     await vi.waitFor(() => {
       expect(container.querySelector('[data-inspector="network"]')?.getAttribute("data-socket")).toBe(
-        "snapo_network_30"
+        "snapo_network_20"
       );
     });
-    expect(mocks.client.saveInspectorPreferences).toHaveBeenCalledTimes(1);
   });
 
-  it("selects an available inspector when the saved inspector is missing at startup", async () => {
+  it("waits for the saved inspector when another kind arrives first at startup", async () => {
     await act(() => render(<App />, container));
     await act(async () => {
       await vi.advanceTimersByTimeAsync(0);
     });
-    expect(container.querySelector('[data-inspector="tweaks"]')).not.toBeNull();
-    const saved = vi.mocked(mocks.client.saveInspectorPreferences).mock.lastCall![0];
-    expect(JSON.parse(saved!).last.kind).toBe("tweaks");
+    expect(container.querySelector("[data-inspector]")).toBeNull();
+    expect(mocks.client.saveInspectorPreferences).not.toHaveBeenCalled();
+    discovered = [app(20, ["network", "tweaks"])];
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(2_500);
+    });
+    await vi.waitFor(() => {
+      expect(container.querySelector('[data-inspector="network"]')).not.toBeNull();
+    });
   });
 
   it("shows status and an open action without a spinner until the remembered inspector appears", async () => {

--- a/snapo-network-inspector-web/src/features/app-inspector/restoration.test.ts
+++ b/snapo-network-inspector-web/src/features/app-inspector/restoration.test.ts
@@ -172,6 +172,39 @@ describe("inspector restoration", () => {
     expect(owner.selectApp(app(40)).selection?.server.socketName).toBe("snapo_network_40");
   });
 
+  it.each(["network", "tweaks"] as const)(
+    "keeps the chosen %s inspector through cooldown while other inspectors arrive first",
+    (kind) => {
+      const owner = selected(kind);
+      const saved = owner.serialize();
+      const otherKind = kind === "network" ? "tweaks" : "network";
+      const otherApp = app(20, [kind], "com.example.other");
+      for (let scan = 0; scan < 12; scan++) {
+        expect(owner.reconcile([otherApp, app(10, [otherKind])])).toMatchObject({
+          selection: null,
+          preferredKind: kind,
+          isRestoring: true
+        });
+        expect(owner.serialize()).toBe(saved);
+      }
+      expect(owner.reconcile([otherApp, app()]).selection).toMatchObject({ appId: "phone:pid:10", kind });
+    }
+  );
+
+  it.each(["network", "tweaks"] as const)(
+    "waits for the saved %s inspector on startup even when another app or inspector loads first",
+    (kind) => {
+      const saved = selected(kind).serialize();
+      const owner = new InspectorRestoration(saved);
+      const otherKind = kind === "network" ? "tweaks" : "network";
+      const otherApp = app(20, [kind], "com.example.other");
+      expect(owner.reconcile([otherApp]).selection).toBeNull();
+      expect(owner.reconcile([otherApp, app(10, [otherKind])]).selection).toBeNull();
+      expect(owner.serialize()).toBe(saved);
+      expect(owner.reconcile([otherApp, app()]).selection).toMatchObject({ appId: "phone:pid:10", kind });
+    }
+  );
+
   it("lets an explicit inspector choice cancel pending restoration", () => {
     const owner = selected();
     const partial = app(20, ["tweaks"]);
@@ -312,22 +345,16 @@ describe("inspector restoration", () => {
     expect(owner.reconcile([app(30)]).selection).toBeNull();
   });
 
-  it.each([undefined, null])("falls back for legacy preferences with Android user %s", (androidUserId) => {
+  it.each([undefined, null])("preserves legacy preferences with unknown Android user %s", (androidUserId) => {
     const legacy = { deviceId: "phone", processName: "com.example.demo", kind: "network", androidUserId };
-    const owner = new InspectorRestoration(JSON.stringify({ last: legacy, apps: [legacy] }));
+    const saved = JSON.stringify({ last: legacy, apps: [legacy] });
+    const owner = new InspectorRestoration(saved);
     const work = app(20, ["network"], "com.example.demo", "phone", 10);
     const unknownProfile = { ...app(40), androidUserId: null };
-    const first = app(30, ["tweaks"], "com.example.other", "phone", 10);
-    expect(owner.reconcile([first, app(), work, unknownProfile]).selection).toMatchObject({
-      appId: first.id,
-      kind: "tweaks"
-    });
-    expect(JSON.parse(owner.serialize()).last).toEqual({
-      deviceId: "phone",
-      processName: "com.example.other",
-      androidUserId: 10,
-      kind: "tweaks"
-    });
+    const other = app(30, ["tweaks"], "com.example.other", "phone", 10);
+    expect(owner.reconcile([other, app(), work, unknownProfile]).selection).toBeNull();
+    expect(owner.serialize()).toBe(saved);
+    expect(owner.selectApp(work).selection?.appId).toBe(work.id);
   });
 
   it.each([
@@ -335,43 +362,25 @@ describe("inspector restoration", () => {
     ["another process", app(20, ["network"], "com.example.demo:worker")],
     ["another device", app(20, ["network"], "com.example.demo", "tablet")],
     ["another profile", app(20, ["network"], "com.example.demo", "phone", 10)]
-  ])("saves a startup fallback when only %s is available", (_, first) => {
-    const owner = new InspectorRestoration(selected("tweaks").serialize());
+  ])("preserves the startup target when only %s is available", (_, first) => {
+    const saved = selected("tweaks").serialize();
+    const owner = new InspectorRestoration(saved);
     const later = app(40, ["tweaks"], "com.example.later");
-    expect(owner.reconcile([first, later]).selection).toMatchObject({ appId: first.id, kind: "network" });
-    expect(JSON.parse(owner.serialize()).last).toEqual({
-      deviceId: first.deviceId,
-      processName: first.processName,
-      androidUserId: first.androidUserId,
-      kind: "network"
-    });
-    expect(new InspectorRestoration(owner.serialize()).reconcile([later, first]).selection?.appId).toBe(first.id);
-    expect(owner.reconcile([app(), first, later]).selection?.appId).toBe(first.id);
+    expect(owner.reconcile([first, later]).selection).toBeNull();
+    expect(owner.serialize()).toBe(saved);
+    expect(owner.reconcile([app(), first, later]).selection).toMatchObject({ appId: app().id, kind: "tweaks" });
   });
 
-  it("uses an available inspector when the saved inspector is missing at startup", () => {
-    const owner = new InspectorRestoration(selected("tweaks").serialize());
-    expect(owner.reconcile([app(20, ["network"])]).selection?.kind).toBe("network");
-    expect(JSON.parse(owner.serialize()).last.kind).toBe("network");
-    expect(owner.reconcile([app(20)]).selection?.kind).toBe("network");
-  });
-
-  it("falls back to the first usable app instead of waiting for another app's saved inspector", () => {
-    const owner = new InspectorRestoration(selected("tweaks").serialize());
-    const first = app(20, ["network"], "com.example.other");
-    expect(owner.reconcile([first, app(30, ["network"])]).selection?.appId).toBe(first.id);
-  });
-
-  it("uses a fallback app's saved inspector only when it is available", () => {
+  it("waits for the saved inspector even when another app has a remembered inspector", () => {
     const owner = selected("tweaks");
     const other = app(20, ["network"], "com.example.other");
     owner.reconcile([app(), other]);
     owner.selectApp(other);
     const saved = owner.serialize();
-    expect(new InspectorRestoration(saved).reconcile([app(30)]).selection?.kind).toBe("tweaks");
     const restarted = new InspectorRestoration(saved);
-    expect(restarted.reconcile([app(30, ["network"])]).selection?.kind).toBe("network");
-    expect(JSON.parse(restarted.serialize()).last.kind).toBe("network");
+    expect(restarted.reconcile([app(30)]).selection).toBeNull();
+    expect(restarted.serialize()).toBe(saved);
+    expect(restarted.reconcile([app(30), other]).selection?.appId).toBe(other.id);
   });
 
   it.each([null, selected("tweaks").serialize()])(
@@ -385,8 +394,14 @@ describe("inspector restoration", () => {
       expect(owner.reconcile([unidentified, empty]).selection).toBeNull();
       expect(owner.serialize()).toBe(before);
       const ready = app(30, ["network"], "com.example.ready");
-      expect(owner.reconcile([unidentified, empty, ready]).selection?.appId).toBe(ready.id);
-      expect(JSON.parse(owner.serialize()).last.processName).toBe(ready.processName);
+      if (saved) {
+        expect(owner.reconcile([unidentified, empty, ready]).selection).toBeNull();
+        expect(owner.serialize()).toBe(before);
+        expect(owner.reconcile([ready, app()]).selection?.kind).toBe("tweaks");
+      } else {
+        expect(owner.reconcile([unidentified, empty, ready]).selection?.appId).toBe(ready.id);
+        expect(JSON.parse(owner.serialize()).last.processName).toBe(ready.processName);
+      }
     }
   );
 

--- a/snapo-network-inspector-web/src/features/app-inspector/restoration.ts
+++ b/snapo-network-inspector-web/src/features/app-inspector/restoration.ts
@@ -128,20 +128,10 @@ export class InspectorRestoration {
       exact ??
       (preference?.androidUserId != null ? apps.find((candidate) => matches(candidate, preference)) : undefined);
 
-    // Only startup may replace a missing saved app or inspector.
-    if (this.startupSelectionPending) {
-      const startupApp = app?.inspectors.some((option) => option.kind === this.kind)
-        ? app
-        : apps.find((candidate) => identity(candidate) && candidate.inspectors.length > 0);
-      if (startupApp) {
-        const preferredKind =
-          startupApp === app
-            ? this.kind
-            : (this.saved.apps.find((candidate) => matches(startupApp, candidate))?.kind ?? this.kind);
-        const option =
-          startupApp.inspectors.find((candidate) => candidate.kind === preferredKind) ?? startupApp.inspectors[0];
-        return this.selectInspector(startupApp, option);
-      }
+    // A saved choice must survive partial scans and slow inspector connections.
+    if (this.startupSelectionPending && !preference) {
+      const first = apps.find((candidate) => identity(candidate) && candidate.inspectors.length > 0);
+      if (first) return this.selectApp(first);
     }
 
     if (app && this.kind && this.target && app.id !== this.target.id && Object.keys(this.retained).length > 0) {
@@ -152,6 +142,7 @@ export class InspectorRestoration {
       this.remember(app, this.kind);
       const option = app.inspectors.find((candidate) => candidate.kind === this.kind);
       this.setCurrent(app, option);
+      if (option) this.startupSelectionPending = false;
     } else {
       this.current = null;
     }


### PR DESCRIPTION
A stalled device or emulator could block app discovery for healthy devices. Repeated attempts against frozen app processes also queued connections, while startup could replace the saved selection with whichever inspector appeared first.

## Summary

- Use native two-second socket I/O timeouts for discovery, process metadata, port forwarding, and network transport setup. Run blocking ADB request bodies off Swift's cooperative executor.
- Skip devices whose initial property request fails, and retry failed reads after three seconds using the existing cache and last device list. Recovery does not require another ADB tracking event.
- Apply independent three-second retry cooldowns to network and tweaks inspectors, including setup failures and lost connections.
- Preserve the saved device, Android profile, process identity, and inspector while discovery recovers. Keep explicit user selection and process reconnection behavior.
- Add socket-level timeout tests and a recovery integration test to macOS CI.

## Validation

- 57 Swift device-client tests passed.
- Recovery integration tests passed for failed device properties, recovery without another ADB tracking event, both inspector kinds, cooldowns, setup failures, and reconnection.
- 330 web tests, TypeScript, ESLint, and Prettier passed.
- SwiftFormat, SwiftLint, and the macOS Xcode build passed.
- Device checks confirmed a healthy physical device responds while an emulator's shell requests stall.

Timeouts bound idle I/O rather than total request duration. Cooldowns reduce queued connections to frozen processes; existing queues remain until the process resumes or exits.

