### PR TITLE
Fix network inspector sort icon direction

### DIFF
--- a/snapo-app-mac/Snap-O/NetworkInspector/NetworkInspectorToolbarControls.swift
+++ b/snapo-app-mac/Snap-O/NetworkInspector/NetworkInspectorToolbarControls.swift
@@ -31,7 +31,7 @@ struct NetworkInspectorToolbarControls: View {
         } label: {
           Label(
             model.sortNewestFirst ? "Newest First" : "Oldest First",
-            systemImage: model.sortNewestFirst ? "arrow.down" : "arrow.up"
+            systemImage: model.sortNewestFirst ? "arrow.up" : "arrow.down"
           )
           .labelStyle(.iconOnly)
           .font(.system(size: 15, weight: .medium))


### PR DESCRIPTION
The network inspector showed a down arrow when the newest requests were at the top. This made the sort direction confusing.

## Summary
- Show an up arrow for newest first and a down arrow for oldest first.

## Validation
- macOS app build passed with code signing disabled.
