### PR TITLE
Keep unsupported inspectors visible and explain compatibility

### DIFF
--- a/snapo-app-mac/Snap-O/CaptureWindow/CaptureWindow.swift
+++ b/snapo-app-mac/Snap-O/CaptureWindow/CaptureWindow.swift
@@ -312,7 +312,24 @@ struct CaptureWindow: View {
             if let inspectorModel = inspectorSession.model {
               InspectorWebView(model: inspectorModel)
                 .overlay {
-                  if inspectorModel.isWaiting || inspectorModel.selectedInspector == nil {
+                  if let compatibility = inspectorModel.compatibilityExplanation {
+                    VStack(alignment: .leading, spacing: 12) {
+                      Image(systemName: compatibility.isUnsupported ? "exclamationmark.triangle" : "wifi.exclamationmark")
+                        .font(.title2)
+                        .foregroundStyle(.secondary)
+                      Text(compatibility.title(for: inspectorModel.preferredInspectorID) ?? "Inspector unavailable").font(.headline)
+                      Text(compatibility.explanation ?? "")
+                        .foregroundStyle(.secondary)
+                        .multilineTextAlignment(.leading)
+                      if let version = compatibility.versionDetail {
+                        Text(version).font(.caption).foregroundStyle(.tertiary)
+                      }
+                    }
+                    .frame(maxWidth: 440, alignment: .leading)
+                    .padding(24)
+                    .frame(maxWidth: .infinity, maxHeight: .infinity)
+                    .background(Color(nsColor: .textBackgroundColor))
+                  } else if inspectorModel.isWaiting || inspectorModel.selectedInspector == nil {
                     VStack(spacing: 12) {
                       Text(inspectorModel.selectedInspectorApp.map { "Waiting for \($0.name)" } ?? "Select an app to inspect")
                         .foregroundStyle(.secondary)

--- a/snapo-app-mac/Snap-O/Inspectors/InspectorHTTPService.swift
+++ b/snapo-app-mac/Snap-O/Inspectors/InspectorHTTPService.swift
@@ -8,42 +8,51 @@ actor InspectorHTTPService {
     let deviceID: String
     var deviceDisplayTitle: String
     let socketName: String
-    var processNameHint: String?
-    var manifest: InspectorProcessMetadata?
+    var metadata = InspectorMetadata()
     var socketInode: String?
-    var awaitingManifest = false
+    var awaitingMetadata = false
     var isConnected = false
+    var metadataReadFailed = false
+    var checkingLegacy = false
+
+    var compatibility: InspectorCompatibility {
+      if awaitingMetadata { return metadataReadFailed ? .metadataUnavailable : .unknown }
+      if checkingLegacy { return .unknown }
+      if metadata.compatibility != .unknown { return metadata.compatibility }
+      return metadataReadFailed ? .metadataUnavailable : .unknown
+    }
 
     var name: String? {
-      manifest?.app?.name
+      metadata.process.name
     }
 
     var packageName: String? {
-      manifest?.app?.packageName
+      metadata.process.packageName
     }
 
     var processName: String? {
-      manifest?.processName ?? processNameHint
+      metadata.process.processName
     }
 
     var androidUserID: Int? {
-      manifest?.androidUserId
+      metadata.process.verifiedIdentity?.androidUserId
     }
 
     var appIconBase64: String? {
-      manifest?.app?.iconBase64
+      metadata.process.iconBase64
     }
 
     var descriptor: InspectorDescriptor? {
-      manifest?.app?.inspectors.first { $0.id == kind }
+      metadata.descriptor(for: kind)
     }
 
     var protocolVersion: Int? {
-      manifest?.app == nil ? nil : descriptor?.protocolVersion ?? 0
+      metadata.protocolVersion
     }
 
-    func needsManifestRead(lastAttempt: ContinuousClock.Instant?, now: ContinuousClock.Instant) -> Bool {
-      guard manifest == nil || awaitingManifest else { return false }
+    func needsMetadataRead(lastAttempt: ContinuousClock.Instant?, now: ContinuousClock.Instant) -> Bool {
+      guard metadata.process.verifiedIdentity == nil || awaitingMetadata || metadataReadFailed || metadata.needsLegacyProbe
+      else { return false }
       guard let lastAttempt else { return true }
       return lastAttempt.duration(to: now) >= .seconds(30)
     }
@@ -72,6 +81,7 @@ actor InspectorHTTPService {
   private var discoveredKeys: Set<String> = []
   private var retryAfter: [String: ContinuousClock.Instant] = [:]
   private var metadataTasks: [String: Task<Void, Never>] = [:]
+  private var legacyTasks: [String: Task<Void, Never>] = [:]
   private var metadataReadAt: [String: ContinuousClock.Instant] = [:]
   private let helperURL: URL
   private let session: URLSession
@@ -94,7 +104,7 @@ actor InspectorHTTPService {
     snapshotRevision += 1
     let apps = discoveredKeys.compactMap { key -> App? in
       guard var app = knownApps[key] else { return nil }
-      app.isConnected = connections[key]?.isReady == true && !app.awaitingManifest
+      app.isConnected = connections[key]?.isReady == true && !app.awaitingMetadata
       return app
     }.sorted {
       if $0.deviceID != $1.deviceID { return $0.deviceID < $1.deviceID }
@@ -139,6 +149,10 @@ actor InspectorHTTPService {
       guard let device = devicesByID[reference.deviceId] else { continue }
       if var previous = knownApps[reference.key], previous.socketInode != socket.inode {
         metadataReadAt[reference.key] = nil
+        legacyTasks.removeValue(forKey: reference.key)?.cancel()
+        previous.metadata.invalidateVersion()
+        previous.checkingLegacy = false
+        previous.metadataReadFailed = false
         if let connection = connections.removeValue(forKey: reference.key) {
           connection.healthTask?.cancel()
           await retireConnection(connection, using: adb)
@@ -146,7 +160,7 @@ actor InspectorHTTPService {
         if let processName = socket.processName, processName == previous.processName {
           // Keep display metadata, but verify the process before using a replacement listener.
           previous.socketInode = socket.inode
-          previous.awaitingManifest = true
+          previous.awaitingMetadata = true
           knownApps[reference.key] = previous
         } else {
           knownApps[reference.key] = nil
@@ -160,10 +174,15 @@ actor InspectorHTTPService {
       }
       knownApps[reference.key]?.deviceDisplayTitle = device.displayTitle
       if let processName = socket.processName {
-        knownApps[reference.key]?.processNameHint = processName
+        knownApps[reference.key]?.metadata.updateProcessName(processName)
       }
     }
-    populateManifests(sockets: sockets.filter { activeKeys.contains($0.reference.key) }, using: adb)
+    populateMetadata(sockets: sockets.filter { activeKeys.contains($0.reference.key) }, using: adb)
+    for key in legacyTasks.keys where !activeKeys.contains(key) {
+      legacyTasks.removeValue(forKey: key)?.cancel()
+      knownApps[key]?.checkingLegacy = false
+      metadataReadAt[key] = nil
+    }
     retryAfter = retryAfter.filter { activeKeys.contains($0.key) && $0.value > .now }
 
     await withTaskGroup(of: Void.self) { group in
@@ -230,6 +249,10 @@ actor InspectorHTTPService {
       task.cancel()
     }
     metadataTasks.removeAll()
+    for task in legacyTasks.values {
+      task.cancel()
+    }
+    legacyTasks.removeAll()
     metadataReadAt.removeAll()
     for connection in connections.values {
       connection.healthTask?.cancel()
@@ -289,25 +312,25 @@ actor InspectorHTTPService {
     }
   }
 
-  private func populateManifests(sockets: [DiscoveredInspectorSocket], using adb: ADBClient) {
+  private func populateMetadata(sockets: [DiscoveredInspectorSocket], using adb: ADBClient) {
     for (deviceID, sockets) in Dictionary(grouping: sockets, by: { $0.reference.deviceId }) {
       guard metadataTasks[deviceID] == nil else { continue }
       let pendingPIDs = Set(sockets.filter {
         guard let app = knownApps[$0.reference.key] else { return true }
-        return app.needsManifestRead(lastAttempt: metadataReadAt[$0.reference.key], now: .now)
+        return app.needsMetadataRead(lastAttempt: metadataReadAt[$0.reference.key], now: .now)
       }.map(\.pid))
       let pending = sockets.filter { pendingPIDs.contains($0.pid) }
       guard !pending.isEmpty else { continue }
       metadataTasks[deviceID] = Task { [weak self] in
-        await self?.loadManifests(deviceID: deviceID, sockets: pending, using: adb)
+        await self?.loadMetadata(deviceID: deviceID, sockets: pending, using: adb)
       }
     }
   }
 
-  private func loadManifests(deviceID: String, sockets: [DiscoveredInspectorSocket], using adb: ADBClient) async {
+  private func loadMetadata(deviceID: String, sockets: [DiscoveredInspectorSocket], using adb: ADBClient) async {
     defer { metadataTasks[deviceID] = nil }
     var batches: [[DiscoveredInspectorSocket]] = []
-    // Keep a process's visible inspectors together so every socket receives the same manifest.
+    // Keep a process's visible inspectors together so every socket receives the same package metadata.
     for process in Dictionary(grouping: sockets, by: \.pid).values {
       if let last = batches.indices.last, batches[last].count + process.count <= 64 {
         batches[last].append(contentsOf: process)
@@ -325,20 +348,40 @@ actor InspectorHTTPService {
         let key = socket.reference.key
         guard var app = knownApps[key], app.socketInode == socket.inode,
               discoveredKeys.contains(key) else { continue }
-        // Failed or unsupported metadata is retried without probing the app's HTTP server.
         metadataReadAt[key] = .now
-        guard let record = records?.first(where: { $0.pid == socket.pid }), record.app != nil else { continue }
-        guard app.manifest != record || app.awaitingManifest else { continue }
-        app.manifest = record
-        app.awaitingManifest = false
+        let hadResult = app.metadata.process.verifiedIdentity != nil || app.metadata.compatibility != .unknown || app.metadataReadFailed
+        let record = records?.first { $0.pid == socket.pid }
+        let updated = record.map { app.metadata.applyPackageMetadata($0, kind: app.kind) } ?? false
+        app.metadataReadFailed = !updated
+        if updated { app.awaitingMetadata = false }
+        let needsLegacy = app.metadata.needsLegacyProbe
+        app.checkingLegacy = needsLegacy && !hadResult
         knownApps[key] = app
+        if needsLegacy, legacyTasks[key] == nil {
+          legacyTasks[key] = Task { [weak self] in
+            await self?.loadLegacyMetadata(socket: socket, using: adb)
+          }
+        }
         changed = true
       }
       if changed { notifyChange() }
     }
   }
 
+  private func loadLegacyMetadata(socket: DiscoveredInspectorSocket, using adb: ADBClient) async {
+    let key = socket.reference.key
+    let metadata = try? await adb.legacyInspectorMetadata(reference: socket.reference, kind: socket.kind, pid: socket.pid)
+    guard !Task.isCancelled, !isStopped, discoveredKeys.contains(key),
+          var app = knownApps[key], app.socketInode == socket.inode else { return }
+    legacyTasks[key] = nil
+    app.checkingLegacy = false
+    if let metadata { app.metadata.applyLegacyMetadata(metadata, kind: app.kind) }
+    knownApps[key] = app
+    notifyChange()
+  }
+
   private func checkHealth(for key: String) {
+    guard knownApps[key]?.metadata.isLegacy != true else { return }
     guard let connection = connections[key], connection.healthTask == nil else { return }
     connections[key]?.healthTask = Task { [weak self] in
       await self?.loadHealth(for: key, connectionID: connection.id)
@@ -370,7 +413,8 @@ actor InspectorHTTPService {
 
   private func connection(for reference: InspectorServerReference) throws -> Connection {
     guard let connection = connections[reference.key], connection.isReady,
-          knownApps[reference.key]?.awaitingManifest == false else {
+          let app = knownApps[reference.key], !app.awaitingMetadata, let descriptor = app.descriptor,
+          descriptor.frontend == nil || descriptor.frontend?.hostApiVersion == 1 else {
       throw InspectorError.serverNotConnected(reference)
     }
     return connection

--- a/snapo-app-mac/Snap-O/Inspectors/InspectorHostModel.swift
+++ b/snapo-app-mac/Snap-O/Inspectors/InspectorHostModel.swift
@@ -15,6 +15,16 @@ final class InspectorHostModel {
   private(set) var isWaiting = true
   var isDevelopmentServerPresented = false
 
+  var selectedCompatibility: InspectorCompatibility {
+    selectedInspectorApp?.inspectors.first { $0.kind == preferredInspectorID }?.compatibility ?? .unknown
+  }
+
+  var compatibilityExplanation: InspectorCompatibility? {
+    // A development frontend can replace a missing archive, but not an unknown inspector identity.
+    if developmentURL != nil, case .missingFrontend = selectedCompatibility { return nil }
+    return selectedCompatibility.title(for: preferredInspectorID) == nil ? nil : selectedCompatibility
+  }
+
   var isPageReady: Bool {
     activePage?.isReady ?? false
   }
@@ -68,6 +78,7 @@ final class InspectorHostModel {
     let packageRevision: String?
     let frontend: InspectorFrontend?
     let developmentURL: URL?
+    let compatibility: InspectorCompatibility
   }
 
   private struct Page {
@@ -182,10 +193,10 @@ final class InspectorHostModel {
       .flatMap(InspectorWebPolicy.developmentURL)
     let identity = PageIdentity(
       appID: pageState.selectedApp?.id, server: pageState.selection?.server,
-      processIdentity: pageState.selectedApp?.manifest?.processIdentity,
-      storageIdentifier: scope, packageRevision: pageState.selectedApp?.manifest?.app?.revision,
-      frontend: pageState.selectedApp?.manifest?.app?.inspectors.first { $0.id == kind }?.frontend,
-      developmentURL: developmentURL
+      processIdentity: pageState.selectedApp?.metadata?.verifiedIdentity?.processIdentity,
+      storageIdentifier: scope, packageRevision: pageState.selectedApp?.metadata?.verifiedIdentity?.revision,
+      frontend: pageState.selectedApp?.metadata?.inspectors.first { $0.id == kind }?.frontend,
+      developmentURL: developmentURL, compatibility: selectedCompatibility
     )
     if pages[kind]?.identity != identity { replacePage(kind: kind, identity: identity) }
     for kind in pages.keys {
@@ -231,10 +242,10 @@ final class InspectorHostModel {
     let app = state.selectedApp?.id == page.identity.appID
       ? state.selectedApp : inspectorApps.first { $0.id == page.identity.appID }
     // Hidden pages retain their own app's metadata when another app is selected.
-    let manifest = app?.manifest ?? page.connection.manifest
-    let inspector = manifest?.app?.inspectors.first { $0.id == kind }
-    guard page.endpointID != endpoint?.id || page.connection.manifest != manifest || page.connection.inspector != inspector else { return }
-    page.connection.manifest = manifest
+    let metadata = app?.metadata ?? page.connection.metadata
+    let inspector = metadata?.inspectors.first { $0.id == kind }
+    guard page.endpointID != endpoint?.id || page.connection.metadata != metadata || page.connection.inspector != inspector else { return }
+    page.connection.metadata = metadata
     page.connection.inspector = inspector
     page.endpointID = endpoint?.id
     page.connection.revision += 1
@@ -245,7 +256,7 @@ final class InspectorHostModel {
   }
 
   private func replacePage(kind: InspectorID, identity: PageIdentity) {
-    let manifest = appInspector.snapshot.pageState(for: kind).selectedApp?.manifest
+    let metadata = appInspector.snapshot.pageState(for: kind).selectedApp?.metadata
     let previous = pages[kind]?.container
     previous?.stop()
     bindings[kind]?.cancel()
@@ -298,15 +309,20 @@ final class InspectorHostModel {
       defer {
         if pages[kind]?.container === container { pageTransitions[kind] = nil }
       }
+      switch identity.compatibility {
+      case .supported: break
+      case .missingFrontend where identity.developmentURL != nil: break
+      default: return
+      }
       do {
         let frontend: InspectorFrontendBundle?
         if identity.developmentURL != nil {
           frontend = nil
         } else if identity.frontend != nil {
-          guard let server = identity.server, let manifest,
-                let inspector = manifest.app?.inspectors.first(where: { $0.id == kind }),
+          guard let server = identity.server, let processIdentity = metadata?.verifiedIdentity,
+                let inspector = metadata?.inspectors.first(where: { $0.id == kind }),
                 inspector.frontend?.hostApiVersion == 1 else { throw InspectorError.frontendUnavailable }
-          frontend = try await service.inspectorFrontend(for: server, manifest: manifest, inspector: inspector)
+          frontend = try await service.inspectorFrontend(for: server, identity: processIdentity, inspector: inspector)
         } else {
           throw InspectorError.frontendUnavailable
         }

--- a/snapo-app-mac/Snap-O/Inspectors/InspectorMetadata.swift
+++ b/snapo-app-mac/Snap-O/Inspectors/InspectorMetadata.swift
@@ -1,0 +1,75 @@
+import Foundation
+import SnapODeviceClient
+
+struct InspectorMetadata: Equatable {
+  struct Process: Codable, Equatable {
+    var name: String?
+    var packageName: String?
+    var processName: String?
+    var iconBase64: String?
+    var verifiedIdentity: InspectorProcessIdentity?
+    var inspectors: [InspectorDescriptor] = []
+  }
+
+  var process = Process()
+  private(set) var protocolVersion: Int?
+  private(set) var compatibility: InspectorCompatibility = .unknown
+
+  var needsLegacyProbe: Bool {
+    compatibility == .unknown || compatibility == .missingDescriptor
+  }
+
+  var isLegacy: Bool {
+    if case .legacy = compatibility { return true }
+    return false
+  }
+
+  func descriptor(for kind: InspectorID) -> InspectorDescriptor? {
+    process.inspectors.first { $0.id == kind }
+  }
+
+  mutating func updateProcessName(_ name: String) {
+    process.processName = process.verifiedIdentity?.processName ?? name
+  }
+
+  mutating func invalidateVersion() {
+    protocolVersion = nil
+    compatibility = .unknown
+  }
+
+  @discardableResult
+  mutating func applyPackageMetadata(_ record: InspectorProcessMetadata, kind: InspectorID) -> Bool {
+    guard let app = record.app, let identity = InspectorProcessIdentity(metadata: record) else { return false }
+    let sameProcess = process.verifiedIdentity == identity
+    process = Process(
+      name: app.name, packageName: app.packageName, processName: record.processName ?? process.processName,
+      iconBase64: app.iconBase64, verifiedIdentity: identity, inspectors: app.inspectors
+    )
+    if let descriptor = descriptor(for: kind) {
+      protocolVersion = descriptor.protocolVersion
+      compatibility = descriptor.frontend.map {
+        $0.hostApiVersion == 1 ? .supported : .hostAPI(version: $0.hostApiVersion)
+      } ?? .missingFrontend(protocolVersion: descriptor.protocolVersion)
+    } else if app.errors?.contains(where: { $0.key == "snapo.inspector." + kind.rawValue }) == true {
+      protocolVersion = nil
+      compatibility = .invalidDescriptor
+    } else if !sameProcess || !isLegacy {
+      protocolVersion = nil
+      compatibility = .missingDescriptor
+    }
+    return true
+  }
+
+  @discardableResult
+  mutating func applyLegacyMetadata(_ value: LegacyInspectorMetadata, kind: InspectorID) -> Bool {
+    guard descriptor(for: kind) == nil, compatibility != .invalidDescriptor,
+          process.verifiedIdentity.map({ $0.packageName == value.packageName }) ?? true,
+          value.processName.map({ process.processName == nil || process.processName == $0 }) ?? true else { return false }
+    process.name = process.name ?? value.name
+    process.packageName = process.packageName ?? value.packageName
+    process.processName = process.processName ?? value.processName
+    protocolVersion = value.protocolVersion
+    compatibility = .legacy(protocolVersion: value.protocolVersion)
+    return true
+  }
+}

--- a/snapo-app-mac/Snap-O/Inspectors/InspectorModels.swift
+++ b/snapo-app-mac/Snap-O/Inspectors/InspectorModels.swift
@@ -8,6 +8,7 @@ struct AppInspectorOption: Equatable, Codable, Identifiable {
   let isConnected: Bool
   var name = ""
   var iconBase64: String?
+  var compatibility: InspectorCompatibility = .unknown
   var displayName: String {
     name.isEmpty ? kind.rawValue : name
   }
@@ -17,17 +18,92 @@ struct AppInspectorOption: Equatable, Codable, Identifiable {
   }
 }
 
+enum InspectorCompatibility: Equatable, Codable {
+  case unknown
+  case supported
+  case legacy(protocolVersion: Int)
+  case missingDescriptor
+  case invalidDescriptor
+  case missingFrontend(protocolVersion: Int)
+  case hostAPI(version: Int)
+  case metadataUnavailable
+
+  var isUnsupported: Bool {
+    switch self {
+    case .legacy, .missingDescriptor, .invalidDescriptor, .missingFrontend, .hostAPI: true
+    case .unknown, .supported, .metadataUnavailable: false
+    }
+  }
+
+  func title(for kind: InspectorID?) -> String? {
+    let toolName = kind.map { $0.rawValue.prefix(1).uppercased() + $0.rawValue.dropFirst() } ?? "tool"
+    return switch self {
+    case .unknown, .supported: nil
+    case .metadataUnavailable: "Inspector unavailable"
+    case .legacy, .missingDescriptor, .missingFrontend, .hostAPI: "Unsupported \(toolName) version"
+    default: "Unsupported inspector"
+    }
+  }
+
+  var explanation: String? {
+    switch self {
+    case .unknown, .supported: nil
+    case .legacy:
+      "This app uses an older Snap-O library that this version of Snap-O no longer supports." + Self.libraryGuidance
+    case .missingDescriptor:
+      "This app appears to use an older Snap-O library that this version of Snap-O no longer supports." + Self.libraryGuidance
+    case .invalidDescriptor:
+      "This app declares invalid inspector metadata. Fix the inspector’s configuration and rebuild the app."
+    case .missingFrontend:
+      "This app’s Snap-O library does not include an inspector interface for this version of Snap-O." + Self.libraryGuidance
+    case .hostAPI(let version):
+      version > 1
+        ? "This inspector requires host API \(version). This version of Snap-O supports host API 1. Update Snap-O to open it."
+        : "This inspector uses unsupported host API \(version)." + Self.libraryGuidance
+    case .metadataUnavailable:
+      "Snap-O could not reach this inspector or check its library version. Open the app on your device. Snap-O will retry automatically."
+    }
+  }
+
+  private static let libraryGuidance =
+    "\n\nUpdate the app’s Snap-O libraries and rebuild it, or use an older version of Snap-O that supports this app."
+
+  var versionDetail: String? {
+    switch self {
+    case .legacy(let version), .missingFrontend(let version): "Inspector protocol \(version)"
+    default: nil
+    }
+  }
+}
+
 struct InspectableApp: Equatable, Codable, Identifiable {
   let id: String
-  let name: String
-  let packageName: String?
-  let processName: String?
-  let androidUserId: Int?
+  let pid: Int?
   let deviceId: String
   let deviceDisplayTitle: String
-  let appIconBase64: String?
-  let inspectors: [AppInspectorOption]
-  var manifest: InspectorProcessMetadata?
+  var inspectors: [AppInspectorOption]
+  var metadata: InspectorMetadata.Process?
+
+  var name: String {
+    metadata?.name ?? processName ?? packageName ?? pid.map { "Process \($0)" }
+      ?? inspectors.first?.server.socketName ?? id
+  }
+
+  var packageName: String? {
+    metadata?.packageName
+  }
+
+  var processName: String? {
+    metadata?.processName
+  }
+
+  var androidUserId: Int? {
+    metadata?.verifiedIdentity?.androidUserId
+  }
+
+  var appIconBase64: String? {
+    metadata?.iconBase64
+  }
 }
 
 struct InspectorDiscoverySnapshot {
@@ -97,8 +173,51 @@ struct InspectorConnectionState: Encodable {
   var revision = 0
   var baseURL: String?
   var connected = false
-  var manifest: InspectorProcessMetadata?
+  var metadata: InspectorMetadata.Process?
   var inspector: InspectorDescriptor?
+
+  private enum CodingKeys: String, CodingKey {
+    case revision, baseURL, connected, manifest, inspector
+  }
+
+  func encode(to encoder: Encoder) throws {
+    var container = encoder.container(keyedBy: CodingKeys.self)
+    try container.encode(revision, forKey: .revision)
+    try container.encodeIfPresent(baseURL, forKey: .baseURL)
+    try container.encode(connected, forKey: .connected)
+    try container.encodeIfPresent(metadata.flatMap(FrontendManifest.init), forKey: .manifest)
+    try container.encodeIfPresent(inspector, forKey: .inspector)
+  }
+
+  /// Preserve the frontend contract without exposing discovery response types to the app model.
+  private struct FrontendManifest: Encodable {
+    struct Package: Encodable {
+      let packageName: String
+      let name: String
+      let revision: String
+      let iconBase64: String?
+      let inspectors: [InspectorDescriptor]
+    }
+
+    let version = 1
+    let pid: Int
+    let processName: String?
+    let androidUserId: Int
+    let processIdentity: String
+    let app: Package
+
+    init?(metadata: InspectorMetadata.Process) {
+      guard let identity = metadata.verifiedIdentity else { return nil }
+      pid = identity.pid
+      processName = identity.processName ?? metadata.processName
+      androidUserId = identity.androidUserId
+      processIdentity = identity.processIdentity
+      app = Package(
+        packageName: identity.packageName, name: metadata.name ?? identity.packageName, revision: identity.revision,
+        iconBase64: metadata.iconBase64, inspectors: metadata.inspectors
+      )
+    }
+  }
 }
 
 struct InspectorToolbar: Decodable {

--- a/snapo-app-mac/Snap-O/Inspectors/InspectorPicker.swift
+++ b/snapo-app-mac/Snap-O/Inspectors/InspectorPicker.swift
@@ -21,7 +21,7 @@ struct AppInspectorPicker: View {
         AppInspectorIcon(
           app: model.selectedInspectorApp,
           size: Metrics.iconSize,
-          statusSize: model.isRestoringInspector ? 0 : Metrics.statusSize
+          statusSize: model.isWaiting || model.compatibilityExplanation != nil ? 0 : Metrics.statusSize
         )
 
         HStack(spacing: 6) {
@@ -114,18 +114,14 @@ struct AppInspectorViewPicker: View {
             Label {
               Text(option.displayName)
             } icon: {
-              if let encoded = option.iconBase64, let data = Data(base64Encoded: encoded), let image = NSImage(data: data) {
-                Image(nsImage: image).resizable().scaledToFit().frame(width: 16, height: 16)
-              } else {
-                Image(systemName: "square")
-              }
+              InspectorToolIcon(option: option)
             }
             .labelStyle(.iconOnly)
             .font(.system(size: 15, weight: .medium))
             .foregroundStyle(model.preferredInspectorID == option.kind ? Color.accentColor : Color.primary)
             .frame(width: 34, height: 32)
           }
-          .help(option.displayName)
+          .help(option.displayName + (option.compatibility.isUnsupported ? ": Unsupported inspector" : ""))
         }
       }
       .snapOToolbarGroupStyle()
@@ -219,7 +215,8 @@ private struct AppInspectorPickerAppRow: View {
 
         AppInspectorPickerText(
           appName: app.name,
-          deviceName: app.deviceDisplayTitle
+          deviceName: app
+            .deviceDisplayTitle + (app.inspectors.contains { $0.compatibility.isUnsupported } ? " · Unsupported inspector" : "")
         )
 
         Spacer(minLength: CGFloat(app.inspectors.count) * Self.shortcutWidth + 8)
@@ -266,11 +263,7 @@ private struct AppInspectorPickerShortcut: View {
       Label {
         Text(option.displayName)
       } icon: {
-        if let encoded = option.iconBase64, let data = Data(base64Encoded: encoded), let image = NSImage(data: data) {
-          Image(nsImage: image).resizable().scaledToFit().frame(width: 16, height: 16)
-        } else {
-          Image(systemName: "square")
-        }
+        InspectorToolIcon(option: option)
       }
       .labelStyle(.iconOnly)
       .font(.system(size: 13))
@@ -285,9 +278,27 @@ private struct AppInspectorPickerShortcut: View {
       }
     }
     .buttonStyle(.plain)
-    .help("Open \(option.displayName)")
-    .accessibilityLabel("Open \(option.displayName) for \(appName)")
+    .help(option.compatibility.isUnsupported ? "\(option.displayName): Unsupported inspector" : "Open \(option.displayName)")
+    .accessibilityLabel("Open \(option.displayName) for \(appName)\(option.compatibility.isUnsupported ? ", unsupported inspector" : "")")
     .onHover { isHovering = $0 }
+  }
+}
+
+private struct InspectorToolIcon: View {
+  let option: AppInspectorOption
+
+  var body: some View {
+    if option.compatibility.isUnsupported {
+      Image(systemName: "exclamationmark.triangle.fill")
+    } else if let encoded = option.iconBase64, let data = Data(base64Encoded: encoded), let image = NSImage(data: data) {
+      Image(nsImage: image).resizable().scaledToFit().frame(width: 16, height: 16)
+    } else if option.compatibility == .unknown {
+      ProgressView().progressViewStyle(.circular).controlSize(.small).frame(width: 16, height: 16)
+    } else if option.compatibility == .metadataUnavailable {
+      Image(systemName: "wifi.exclamationmark")
+    } else {
+      Image(systemName: "wrench")
+    }
   }
 }
 

--- a/snapo-app-mac/Snap-O/Inspectors/InspectorSelection.swift
+++ b/snapo-app-mac/Snap-O/Inspectors/InspectorSelection.swift
@@ -69,7 +69,8 @@ struct InspectorSelection {
     }
     // Preserve saved choices while discovery returns partial results.
     if startupSelectionPending, saved.last == nil,
-       let first = apps.first(where: { Self.hasIdentity($0) && $0.inspectors.contains(where: \.isConnected) }) {
+       let first = apps.first(where: { Self.hasIdentity($0) && $0.inspectors.contains(where: \.isConnected) })
+       ?? apps.first(where: { Self.hasIdentity($0) && $0.inspectors.contains { $0.compatibility.isUnsupported } }) {
       selectApp(first)
       return
     }
@@ -99,7 +100,8 @@ struct InspectorSelection {
     }
     let preferredKind = saved.apps.first { $0.matches(app) }?.kind
       ?? app.inspectors.first { $0.kind == kind }?.kind
-      ?? app.inspectors.first(where: \.isConnected)?.kind ?? app.inspectors.first?.kind
+      ?? app.inspectors.first { $0.isConnected && !$0.compatibility.isUnsupported }?.kind
+      ?? app.inspectors.first?.kind
     if let preferredKind { selectKind(app, kind: preferredKind) }
   }
 
@@ -137,12 +139,8 @@ struct InspectorSelection {
     for option in app.inspectors {
       options[option.kind] = option
     }
-    target = InspectableApp(
-      id: app.id, name: app.name, packageName: app.packageName, processName: app.processName,
-      androidUserId: app.androidUserId, deviceId: app.deviceId, deviceDisplayTitle: app.deviceDisplayTitle,
-      appIconBase64: app.appIconBase64, inspectors: options.values.sorted { $0.kind.rawValue < $1.kind.rawValue },
-      manifest: app.manifest
-    )
+    target = app
+    target?.inspectors = options.values.sorted { $0.kind.rawValue < $1.kind.rawValue }
   }
 
   private mutating func setCurrent(_ app: InspectableApp, option: AppInspectorOption?) {

--- a/snapo-app-mac/Snap-O/Inspectors/InspectorService.swift
+++ b/snapo-app-mac/Snap-O/Inspectors/InspectorService.swift
@@ -28,10 +28,7 @@ actor InspectorService {
   func currentInspectors() async -> InspectorDiscoverySnapshot {
     let snapshot = await httpService.currentApps()
     let applications = snapshot.apps
-    let connectedServers = Set(applications.filter(\.isConnected).map {
-      InspectorServerReference(deviceId: $0.deviceID, socketName: $0.socketName)
-    })
-    let manifests = Dictionary(uniqueKeysWithValues: applications.map {
+    let appsByServer = Dictionary(uniqueKeysWithValues: applications.map {
       (InspectorServerReference(deviceId: $0.deviceID, socketName: $0.socketName), $0)
     })
     let endpoints = applications.map { app in
@@ -51,26 +48,29 @@ actor InspectorService {
       )
     }
     let apps = InspectorDiscovery.processes(from: endpoints).map { process in
-      InspectableApp(
+      let candidates = process.inspectors.compactMap { appsByServer[$0.reference]?.metadata.process }
+      var metadata = candidates.first { $0.verifiedIdentity != nil } ?? candidates.first ?? InspectorMetadata.Process()
+      metadata.name = process.metadata.appName
+      metadata.packageName = process.metadata.packageName
+      metadata.processName = process.metadata.processName ?? process.metadata.packageNameHint
+      metadata.iconBase64 = process.metadata.appIconBase64
+      return InspectableApp(
         id: process.id,
-        name: process.name,
-        packageName: process.metadata.packageName,
-        processName: process.metadata.processName ?? process.metadata.packageNameHint,
-        androidUserId: process.metadata.androidUserID,
+        pid: process.pid,
         deviceId: process.deviceId,
         deviceDisplayTitle: process.deviceDisplayTitle,
-        appIconBase64: process.metadata.appIconBase64,
         inspectors: process.inspectors.map { endpoint in
           AppInspectorOption(
             kind: endpoint.kind,
             server: endpoint.reference,
             protocolVersion: endpoint.protocolVersion,
-            isConnected: connectedServers.contains(endpoint.reference),
-            name: manifests[endpoint.reference]?.descriptor?.name ?? endpoint.kind.rawValue,
-            iconBase64: manifests[endpoint.reference]?.descriptor?.iconBase64
+            isConnected: appsByServer[endpoint.reference]?.isConnected == true,
+            name: appsByServer[endpoint.reference]?.descriptor?.name ?? endpoint.kind.rawValue,
+            iconBase64: appsByServer[endpoint.reference]?.descriptor?.iconBase64,
+            compatibility: appsByServer[endpoint.reference]?.compatibility ?? .unknown
           )
         },
-        manifest: process.inspectors.compactMap { manifests[$0.reference]?.manifest }.first
+        metadata: metadata
       )
     }
     return InspectorDiscoverySnapshot(apps: orderedInspectorApps(apps), revision: snapshot.revision)
@@ -93,11 +93,18 @@ actor InspectorService {
   }
 
   func inspectorFrontend(
-    for reference: InspectorServerReference, manifest: InspectorProcessMetadata, inspector: InspectorDescriptor
+    for reference: InspectorServerReference, identity: InspectorProcessIdentity, inspector: InspectorDescriptor
   ) async throws -> InspectorFrontendBundle {
-    guard let app = manifest.app, let user = manifest.androidUserId, let frontend = inspector.frontend,
+    guard let frontend = inspector.frontend,
           frontend.hostApiVersion == 1 else { throw InspectorError.frontendUnavailable }
-    let key = [reference.deviceId, String(user), app.packageName, app.revision, inspector.id.rawValue, frontend.assetPath]
+    let key = [
+      reference.deviceId,
+      String(identity.androidUserId),
+      identity.packageName,
+      identity.revision,
+      inspector.id.rawValue,
+      frontend.assetPath
+    ]
     if let index = frontends.firstIndex(where: { $0.key == key }) {
       let cached = frontends.remove(at: index)
       frontends.append(cached)
@@ -107,7 +114,7 @@ actor InspectorService {
     let helper = (Bundle.main.resourceURL ?? Bundle.main.bundleURL.appending(path: "Contents/Resources"))
       .appending(path: "snapo-discovery.jar")
     let bundle = try await adb.inspectorFrontend(
-      deviceID: reference.deviceId, socketName: reference.socketName, manifest: manifest, inspector: inspector, helperURL: helper
+      deviceID: reference.deviceId, socketName: reference.socketName, identity: identity, inspector: inspector, helperURL: helper
     )
     guard !Task.isCancelled, !isStopped else { throw CancellationError() }
     frontends.removeAll { $0.key == key }

--- a/snapo-app-mac/Snap-O/Inspectors/InspectorWebPolicy.swift
+++ b/snapo-app-mac/Snap-O/Inspectors/InspectorWebPolicy.swift
@@ -12,9 +12,8 @@ enum InspectorWebPolicy {
   }
 
   static func storageIdentifier(app: InspectableApp?, inspector: InspectorID) -> UUID? {
-    guard let app, let manifest = app.manifest, manifest.processIdentity != nil,
-          let package = manifest.app?.packageName, let user = manifest.androidUserId else { return nil }
-    let scope = ["snapo.inspector.v2", app.deviceId, String(user), package, inspector.rawValue]
+    guard let app, let identity = app.metadata?.verifiedIdentity else { return nil }
+    let scope = ["snapo.inspector.v2", app.deviceId, String(identity.androidUserId), identity.packageName, inspector.rawValue]
     guard let data = try? JSONEncoder().encode(scope) else { return nil }
     let bytes = Array(SHA256.hash(data: data).prefix(16))
     return UUID(uuid: (

--- a/snapo-app-mac/SnapODeviceClient/Sources/SnapODeviceClient/ADB/ADBClient.swift
+++ b/snapo-app-mac/SnapODeviceClient/Sources/SnapODeviceClient/ADB/ADBClient.swift
@@ -321,10 +321,25 @@ public struct ADBClient: Sendable {
     inspector: InspectorDescriptor,
     helperURL: URL
   ) async throws -> InspectorFrontendBundle {
-    guard inspector.frontend != nil, socketName == "snapo_\(inspector.id.rawValue)_\(manifest.pid)" else {
+    guard let identity = InspectorProcessIdentity(metadata: manifest) else {
+      throw ADBError.parseFailure("invalid inspector process identity")
+    }
+    return try await inspectorFrontend(
+      deviceID: deviceID, socketName: socketName, identity: identity, inspector: inspector, helperURL: helperURL
+    )
+  }
+
+  public func inspectorFrontend(
+    deviceID: String,
+    socketName: String,
+    identity: InspectorProcessIdentity,
+    inspector: InspectorDescriptor,
+    helperURL: URL
+  ) async throws -> InspectorFrontendBundle {
+    guard inspector.frontend != nil, socketName == "snapo_\(inspector.id.rawValue)_\(identity.pid)" else {
       throw ADBError.parseFailure("invalid inspector frontend request")
     }
-    let expected = try InspectorFrontendBundle.request(manifest: manifest, inspector: inspector)
+    let expected = try InspectorFrontendBundle.request(identity: identity, inspector: inspector)
     let command = try InspectorManifestReader.command(
       helper: Data(contentsOf: helperURL),
       socketNames: [socketName],
@@ -332,6 +347,40 @@ public struct ADBClient: Sendable {
     )
     let data = try await runInspectorReader(deviceID: deviceID, command: command, maximumBytes: 16 * 1024 * 1024)
     return try InspectorFrontendBundle(archive: data)
+  }
+
+  public func legacyInspectorMetadata(
+    reference: InspectorServerReference, kind: InspectorID, pid: Int
+  ) async throws -> LegacyInspectorMetadata? {
+    guard pid > 0, reference.socketName == "snapo_\(kind.rawValue)_\(pid)" else { return nil }
+    for request in LegacyInspectorReader.requests(kind: kind) {
+      try Task.checkCancellation()
+      do {
+        let metadata = try await withConnection(maxAttempts: 1) { connection in
+          try connection.withRequestTimeout(.seconds(2)) {
+            try connection.sendTransport(to: reference.deviceId)
+            try connection.sendLocalAbstract(reference.socketName)
+            try connection.writeLine(String(request.dropLast()))
+            let http = request.hasPrefix("GET ")
+            let deadline = ContinuousClock.now.advanced(by: .seconds(2))
+            var bytes = Data()
+            while true {
+              let chunk = try connection.readChunk(maxLength: 16384, deadline: deadline)
+              if let chunk { bytes.append(chunk) }
+              if let payload = try LegacyInspectorReader.payload(bytes, http: http, ended: chunk == nil) {
+                return try LegacyInspectorReader.decode(payload, kind: kind, pid: pid, http: http)
+              }
+              if chunk == nil { return nil }
+            }
+          }
+        }
+        if let metadata { return metadata }
+      } catch {
+        try Task.checkCancellation()
+        // A failed probe is not evidence that the app uses an old library.
+      }
+    }
+    return nil
   }
 
   private func runInspectorReader(deviceID: String, command: String, maximumBytes: Int) async throws -> Data {

--- a/snapo-app-mac/SnapODeviceClient/Sources/SnapODeviceClient/ADB/ADBSocketConnection.swift
+++ b/snapo-app-mac/SnapODeviceClient/Sources/SnapODeviceClient/ADB/ADBSocketConnection.swift
@@ -198,13 +198,13 @@ public final class ADBSocketConnection {
     while true {
       try Task.checkCancellation()
       let remaining = ContinuousClock.now.duration(to: deadline)
-      guard remaining > .zero else { throw ADBError.requestTimedOut("Waiting for uinput acknowledgment") }
+      guard remaining > .zero else { throw ADBError.requestTimedOut("Waiting for socket data") }
       let parts = remaining.components
       let milliseconds = parts.seconds * 1000 + parts.attoseconds / 1_000_000_000_000_000 + 1
       var descriptor = pollfd(fd: socketDescriptor, events: Int16(POLLIN), revents: 0)
       let result = Darwin.poll(&descriptor, 1, Int32(clamping: milliseconds))
       if result > 0 { return try readChunk(maxLength: maxLength) }
-      if result == 0 { throw ADBError.requestTimedOut("Waiting for uinput acknowledgment") }
+      if result == 0 { throw ADBError.requestTimedOut("Waiting for socket data") }
       if errno != EINTR { throw Self.makeSocketError(errno, context: "poll") }
     }
   }

--- a/snapo-app-mac/SnapODeviceClient/Sources/SnapODeviceClient/InspectorFrontendBundle.swift
+++ b/snapo-app-mac/SnapODeviceClient/Sources/SnapODeviceClient/InspectorFrontendBundle.swift
@@ -58,6 +58,13 @@ public struct InspectorFrontendBundle: Sendable {
   }
 
   static func request(manifest: InspectorProcessMetadata, inspector: InspectorDescriptor) throws -> Data {
+    guard let identity = InspectorProcessIdentity(metadata: manifest) else {
+      throw ADBError.parseFailure("inspector process identity is missing or invalid")
+    }
+    return try request(identity: identity, inspector: inspector)
+  }
+
+  static func request(identity: InspectorProcessIdentity, inspector: InspectorDescriptor) throws -> Data {
     struct Request: Encodable {
       let processIdentity: String
       let androidUserId: Int
@@ -67,12 +74,12 @@ public struct InspectorFrontendBundle: Sendable {
       let assetPath: String
       let hostApiVersion: Int
     }
-    guard let processIdentity = manifest.processIdentity, let user = manifest.androidUserId, let app = manifest.app,
-          let frontend = inspector.frontend, validPath(frontend.assetPath), frontend.assetPath.hasSuffix(".zip") else {
+    guard let frontend = inspector.frontend, validPath(frontend.assetPath), frontend.assetPath.hasSuffix(".zip") else {
       throw ADBError.parseFailure("inspector frontend metadata is missing or invalid")
     }
     return try JSONEncoder().encode(Request(
-      processIdentity: processIdentity, androidUserId: user, packageName: app.packageName, revision: app.revision,
+      processIdentity: identity.processIdentity, androidUserId: identity.androidUserId,
+      packageName: identity.packageName, revision: identity.revision,
       inspectorId: inspector.id, assetPath: frontend.assetPath, hostApiVersion: frontend.hostApiVersion
     ))
   }

--- a/snapo-app-mac/SnapODeviceClient/Sources/SnapODeviceClient/InspectorManifest.swift
+++ b/snapo-app-mac/SnapODeviceClient/Sources/SnapODeviceClient/InspectorManifest.swift
@@ -19,6 +19,12 @@ public struct InspectorPackageMetadata: Codable, Sendable, Equatable {
   public let revision: String
   public let iconBase64: String?
   public let inspectors: [InspectorDescriptor]
+  public let errors: [InspectorDescriptorError]?
+}
+
+public struct InspectorDescriptorError: Codable, Sendable, Equatable {
+  public let key: String
+  public let error: String
 }
 
 public struct InspectorProcessMetadata: Codable, Sendable, Equatable {
@@ -29,6 +35,28 @@ public struct InspectorProcessMetadata: Codable, Sendable, Equatable {
   public let processIdentity: String?
   public let app: InspectorPackageMetadata?
   public let error: String?
+}
+
+public struct InspectorProcessIdentity: Codable, Sendable, Equatable {
+  public let pid: Int
+  public let processName: String?
+  public let androidUserId: Int
+  public let processIdentity: String
+  public let packageName: String
+  public let revision: String
+
+  public init?(metadata: InspectorProcessMetadata) {
+    guard metadata.version == 1, metadata.pid > 0,
+          let identity = metadata.processIdentity, !identity.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty,
+          let user = metadata.androidUserId, user >= 0, let app = metadata.app,
+          !app.packageName.isEmpty, !app.revision.isEmpty else { return nil }
+    pid = metadata.pid
+    processName = metadata.processName
+    androidUserId = user
+    processIdentity = identity
+    packageName = app.packageName
+    revision = app.revision
+  }
 }
 
 enum InspectorManifestReader {

--- a/snapo-app-mac/SnapODeviceClient/Sources/SnapODeviceClient/LegacyInspectorMetadata.swift
+++ b/snapo-app-mac/SnapODeviceClient/Sources/SnapODeviceClient/LegacyInspectorMetadata.swift
@@ -1,0 +1,99 @@
+import Foundation
+
+/// Display evidence only. Legacy metadata never authorizes a frontend or inspector requests.
+public struct LegacyInspectorMetadata: Sendable, Equatable {
+  public let packageName: String
+  public let name: String?
+  public let processName: String?
+  public let protocolVersion: Int
+}
+
+enum LegacyInspectorReader {
+  static let maximumBytes = 1_048_576
+
+  static func requests(kind: InspectorID) -> [String] {
+    switch kind.rawValue {
+    case "network": ["HelloSnapO\n", httpRequest("/.snap-o/info")]
+    case "tweaks": [httpRequest("/.snap-o/info"), httpRequest("/app")]
+    default: []
+    }
+  }
+
+  private static func httpRequest(_ path: String) -> String {
+    "GET \(path) HTTP/1.1\r\nHost: localhost\r\nConnection: close\r\n\r\n"
+  }
+
+  static func payload(_ bytes: Data, http: Bool, ended: Bool = false) throws -> Data? {
+    guard bytes.count <= maximumBytes else { throw ADBError.parseFailure("legacy metadata is too large") }
+    if !http {
+      return bytes.firstIndex(of: 10).map { Data(bytes[..<$0]) }
+    }
+    guard let separator = bytes.range(of: Data("\r\n\r\n".utf8)) else {
+      guard bytes.count <= 8192 else { throw ADBError.parseFailure("legacy HTTP headers are too large") }
+      return nil
+    }
+    guard separator.lowerBound <= 8192,
+          let header = String(data: bytes[..<separator.lowerBound], encoding: .utf8) else {
+      throw ADBError.parseFailure("invalid legacy HTTP response")
+    }
+    let lines = header.components(separatedBy: "\r\n")
+    guard let status = lines.first?.split(separator: " "), status.count >= 2,
+          ["HTTP/1.0", "HTTP/1.1"].contains(String(status[0])), status[1] == "200" else {
+      throw ADBError.parseFailure("legacy metadata endpoint is unavailable")
+    }
+    var length: Int?
+    for line in lines.dropFirst() {
+      let parts = line.split(separator: ":", maxSplits: 1)
+      guard parts.count == 2 else { throw ADBError.parseFailure("invalid legacy HTTP header") }
+      let key = parts[0].lowercased()
+      guard key != "transfer-encoding" else { throw ADBError.parseFailure("unsupported legacy HTTP encoding") }
+      if key == "content-length" {
+        guard length == nil, let value = Int(parts[1].trimmingCharacters(in: .whitespaces)),
+              (0 ... maximumBytes).contains(value) else { throw ADBError.parseFailure("invalid legacy metadata length") }
+        length = value
+      }
+    }
+    let body = Data(bytes[separator.upperBound...])
+    if let length {
+      return body.count >= length ? Data(body.prefix(length)) : nil
+    }
+    return ended ? body : nil
+  }
+
+  static func decode(_ data: Data, kind: InspectorID, pid: Int, http: Bool) throws -> LegacyInspectorMetadata? {
+    struct Metadata: Decodable {
+      let packageName: String
+      let name: String?
+      let processName: String?
+      let pid: Int?
+      let protocolVersion: Int
+    }
+    struct Envelope: Decodable {
+      let method: String
+      let params: Metadata
+    }
+    guard data.count <= maximumBytes else { return nil }
+    let value: Metadata
+    if http {
+      value = try JSONDecoder().decode(Metadata.self, from: data)
+    } else {
+      let envelope = try JSONDecoder().decode(Envelope.self, from: data)
+      guard envelope.method == "SnapO.appInfo" else { return nil }
+      value = envelope.params
+    }
+    guard !value.packageName.isEmpty, value.packageName.count <= 255,
+          value.pid == nil || value.pid == pid else { return nil }
+    switch kind.rawValue {
+    case "network":
+      guard value.pid == pid, value.processName?.isEmpty == false,
+            value.protocolVersion == (http ? 2 : 1) else { return nil }
+    case "tweaks":
+      guard http, (1 ... 6).contains(value.protocolVersion), value.name?.isEmpty == false else { return nil }
+    default: return nil
+    }
+    return LegacyInspectorMetadata(
+      packageName: value.packageName, name: value.name, processName: value.processName,
+      protocolVersion: value.protocolVersion
+    )
+  }
+}

--- a/snapo-app-mac/SnapODeviceClient/Tests/SnapODeviceClientTests/ADBDiscoveryTimeoutTests.swift
+++ b/snapo-app-mac/SnapODeviceClient/Tests/SnapODeviceClientTests/ADBDiscoveryTimeoutTests.swift
@@ -124,6 +124,59 @@ struct ADBDiscoveryTimeoutTests {
     #expect(server.connectionCount == 3)
   }
 
+  @Test("legacy probes read identity without starting inspection")
+  func readsLegacyIdentity() async throws {
+    let raw = #"{"method":"SnapO.appInfo","params":{"protocolVersion":1,"packageName":"com.example.demo","processName":"com.example.demo","pid":42}}"#
+    let http = #"{"protocolVersion":2,"packageName":"com.example.demo","processName":"com.example.demo","pid":42}"#
+    for (reply, expectedVersion, expectedConnections) in [
+      (FakeDiscoveryADB.LegacyReply.raw(raw), 1, 1), (.http(http), 2, 2)
+    ] {
+      let server = FakeDiscoveryADB(stall: .output, legacyReply: reply)
+      defer { server.close() }
+      let metadata = try await server.client().legacyInspectorMetadata(
+        reference: InspectorServerReference(deviceId: "phone", socketName: "snapo_network_42"), kind: InspectorID(rawValue: "network"),
+        pid: 42
+      )
+      #expect(metadata?.protocolVersion == expectedVersion)
+      #expect(metadata?.packageName == "com.example.demo")
+      #expect(server.connectionCount == expectedConnections)
+    }
+  }
+
+  @Test("legacy probes have a total read deadline even when bytes keep arriving")
+  func boundsLegacyTrickle() async throws {
+    let server = FakeDiscoveryADB(stall: .output, legacyReply: .trickle)
+    defer { server.close() }
+    let start = ContinuousClock.now
+    let metadata = try await server.client().legacyInspectorMetadata(
+      reference: InspectorServerReference(deviceId: "phone", socketName: "snapo_network_42"), kind: InspectorID(rawValue: "network"),
+      pid: 42
+    )
+    #expect(metadata == nil)
+    #expect(start.duration(to: .now) < .seconds(6))
+    #expect(server.connectionCount == 2)
+  }
+
+  @Test("cancelling a legacy probe closes the socket without trying a fallback")
+  func cancelsLegacyProbe() async throws {
+    let server = FakeDiscoveryADB(stall: .output, legacyReply: .trickle)
+    defer { server.close() }
+    let task = Task {
+      try await server.client().legacyInspectorMetadata(
+        reference: InspectorServerReference(deviceId: "phone", socketName: "snapo_network_42"), kind: InspectorID(rawValue: "network"),
+        pid: 42
+      )
+    }
+    var requests = server.requests.stream.makeAsyncIterator()
+    _ = await requests.next()
+    task.cancel()
+    do {
+      _ = try await task.value
+      Issue.record("Expected cancellation")
+    } catch is CancellationError {}
+    #expect(server.connectionCount == 1)
+  }
+
   @Test("native timeouts allow output that continues making progress")
   func allowsContinuousOutput() async throws {
     let server = FakeDiscoveryADB(stall: .trickle)
@@ -138,14 +191,20 @@ private final class FakeDiscoveryADB: @unchecked Sendable {
     case transport, shell, output, partialStatus, partialOutput, trickle
   }
 
+  enum LegacyReply {
+    case raw(String), http(String), trickle
+  }
+
+  private let legacyReply: LegacyReply?
   let requests = AsyncStream<String>.makeStream()
   private let stall: Stall
   private let workers = DispatchGroup()
   private let lock = NSLock()
   private var peers: [ADBSocketConnection] = []
 
-  init(stall: Stall) {
+  init(stall: Stall, legacyReply: LegacyReply? = nil) {
     self.stall = stall
+    self.legacyReply = legacyReply
   }
 
   var connectionCount: Int {
@@ -174,7 +233,7 @@ private final class FakeDiscoveryADB: @unchecked Sendable {
     _ = setsockopt(descriptor, SOL_SOCKET, SO_NOSIGPIPE, &noSigPipe, socklen_t(MemoryLayout<Int32>.size))
     lock.withLock { peers.append(peer) }
     workers.enter()
-    DispatchQueue.global().async { [stall, workers, requests] in
+    DispatchQueue.global().async { [stall, workers, requests, legacyReply] in
       defer { workers.leave() }
       do {
         try peer.withRequestTimeout(.seconds(2)) {
@@ -195,6 +254,25 @@ private final class FakeDiscoveryADB: @unchecked Sendable {
           requests.continuation.yield(command)
           if stalled, stall == .shell { return }
           Self.send("OKAY", to: descriptor)
+          if command.hasPrefix("localabstract:"), let legacyReply {
+            defer { peer.close() }
+            guard let request = try peer.readLine() else { return }
+            switch legacyReply {
+            case .raw(let response):
+              guard request == "HelloSnapO" else { return }
+              Self.send(response + "\n", to: descriptor)
+            case .http(let body):
+              guard request == "GET /.snap-o/info HTTP/1.1" else { return }
+              while let header = try peer.readLine(), !header.isEmpty {}
+              Self.send("HTTP/1.1 200 OK\r\nContent-Length: \(body.utf8.count)\r\n\r\n" + body, to: descriptor)
+            case .trickle:
+              for _ in 0 ..< 100 {
+                if !Self.send("x", to: descriptor) { break }
+                Thread.sleep(forTimeInterval: 0.03)
+              }
+            }
+            return
+          }
           if stalled {
             if stall == .partialOutput { Self.send("1: 00000002 00000000 00010000 0001 01 101 @snapo_network_99\n", to: descriptor) }
             if stall == .trickle {

--- a/snapo-app-mac/SnapODeviceClient/Tests/SnapODeviceClientTests/InspectorDiscoveryTests.swift
+++ b/snapo-app-mac/SnapODeviceClient/Tests/SnapODeviceClientTests/InspectorDiscoveryTests.swift
@@ -284,3 +284,46 @@ private extension InspectorID {
   static let network = Self(rawValue: "network")
   static let tweaks = Self(rawValue: "tweaks")
 }
+
+extension InspectorDiscoveryTests {
+  @Test("legacy metadata accepts only recognized protocols and matching process identity")
+  func legacyMetadataEvidence() throws {
+    let network = Data(
+      #"{"method":"SnapO.appInfo","params":{"protocolVersion":1,"packageName":"com.example.demo","processName":"com.example.demo","pid":42}}"#
+        .utf8
+    )
+    #expect(try LegacyInspectorReader.decode(network, kind: .network, pid: 42, http: false)?.protocolVersion == 1)
+    #expect(try LegacyInspectorReader.decode(network, kind: .network, pid: 43, http: false) == nil)
+    let http = Data(#"{"protocolVersion":2,"packageName":"com.example.demo","processName":"com.example.demo","pid":42}"#.utf8)
+    #expect(try LegacyInspectorReader.decode(http, kind: .network, pid: 42, http: true)?.protocolVersion == 2)
+    for version in [5, 6, 7, 100] {
+      let tweaks = Data("{\"protocolVersion\":\(version),\"packageName\":\"com.example.demo\",\"name\":\"Demo\"}".utf8)
+      #expect(try (LegacyInspectorReader.decode(tweaks, kind: .tweaks, pid: 42, http: true) != nil) == (version < 7))
+    }
+    #expect(LegacyInspectorReader.requests(kind: InspectorID(rawValue: "custom")).isEmpty)
+    #expect(LegacyInspectorReader.requests(kind: .network).first == "HelloSnapO\n")
+    #expect(LegacyInspectorReader.requests(kind: .tweaks).allSatisfy { $0.hasPrefix("GET ") })
+  }
+
+  @Test("legacy metadata responses are bounded and reject redirects and malformed framing")
+  func legacyMetadataFraming() throws {
+    #expect(try LegacyInspectorReader.payload(Data("{}\nextra".utf8), http: false) == Data("{}".utf8))
+    #expect(try LegacyInspectorReader.payload(Data("{".utf8), http: false) == nil)
+    let response = "HTTP/1.1 200 OK\r\nContent-Length: 2\r\n\r\n{}"
+    #expect(try LegacyInspectorReader.payload(Data(response.utf8), http: true) == Data("{}".utf8))
+    #expect(try LegacyInspectorReader.payload(Data(response.dropLast().utf8), http: true) == nil)
+    #expect(try LegacyInspectorReader.payload(Data("HTTP/1.0 200 OK\r\n\r\n{}".utf8), http: true, ended: true) == Data("{}".utf8))
+    for invalid in [
+      "HTTP/1.1 302 Found\r\nLocation: https://example.com\r\n\r\n",
+      "HTTP/1.1 200 OK\r\nContent-Length: -1\r\n\r\n",
+      "HTTP/1.1 200 OK\r\nContent-Length: 2\r\nContent-Length: 3\r\n\r\n{}",
+      "HTTP/1.1 200 OK\r\nTransfer-Encoding: chunked\r\n\r\n",
+      String(repeating: "x", count: 8193)
+    ] {
+      #expect(throws: (any Error).self) { try LegacyInspectorReader.payload(Data(invalid.utf8), http: true) }
+    }
+    #expect(throws: (any Error).self) {
+      try LegacyInspectorReader.payload(Data(repeating: 120, count: LegacyInspectorReader.maximumBytes + 1), http: false)
+    }
+  }
+}

--- a/snapo-app-mac/SnapODeviceClient/Tests/SnapODeviceClientTests/InspectorFrontendTests.swift
+++ b/snapo-app-mac/SnapODeviceClient/Tests/SnapODeviceClientTests/InspectorFrontendTests.swift
@@ -66,6 +66,12 @@ struct InspectorFrontendTests {
     let inspector = try #require(manifest.app?.inspectors.first)
     let request = try InspectorFrontendBundle.request(manifest: manifest, inspector: inspector)
     let fields = try #require(JSONSerialization.jsonObject(with: request) as? [String: Any])
+    let identity = try #require(InspectorProcessIdentity(metadata: manifest))
+    let normalizedRequest = try InspectorFrontendBundle.request(identity: identity, inspector: inspector)
+    let normalizedFields = try #require(JSONSerialization.jsonObject(with: normalizedRequest) as? NSDictionary)
+    #expect(normalizedFields == fields as NSDictionary)
+    #expect(fields["androidUserId"] as? Int == 0)
+    #expect(fields["packageName"] as? String == "com.example.demo")
     #expect(fields["revision"] as? String == "12:34")
     #expect(fields["processIdentity"] as? String == "boot:42:1")
     #expect(fields["assetPath"] as? String == "snapo/inspectors/sample/frontend.zip")
@@ -76,5 +82,13 @@ struct InspectorFrontendTests {
     )
     #expect(command.contains("com.openai.snapo.discovery.FrontendMain snapo_sample_42"))
     #expect(command.contains(request.base64EncodedString()))
+    let original = try #require(JSONSerialization.jsonObject(with: JSONEncoder().encode(manifest)) as? [String: Any])
+    for (key, invalid) in [("androidUserId", NSNull()), ("androidUserId", -1), ("processIdentity", " "), ("pid", 0)] as [(String, Any)] {
+      var value = original
+      value[key] = invalid
+      let incomplete = try JSONDecoder().decode(InspectorProcessMetadata.self, from: JSONSerialization.data(withJSONObject: value))
+      #expect(InspectorProcessIdentity(metadata: incomplete) == nil)
+      #expect(throws: (any Error).self) { try InspectorFrontendBundle.request(manifest: incomplete, inspector: inspector) }
+    }
   }
 }

--- a/snapo-app-mac/Tests/InspectorRecovery/DeviceClientDouble.swift
+++ b/snapo-app-mac/Tests/InspectorRecovery/DeviceClientDouble.swift
@@ -7,12 +7,42 @@ public struct ADBForwardHandle: Sendable {
 public struct InspectorFrontendBundle: Sendable {}
 
 public final class ADBClient: @unchecked Sendable {
+  public enum MetadataFailure: Sendable {
+    case request, record
+  }
+
   private let lock = NSLock()
   private var forwards = 0
   private var removedForwards: [UInt16] = []
   private var propertiesRecovered = false
   private var metadataAvailable = false
   private var metadataRequests: [[String]] = []
+  private var metadataFailure: MetadataFailure?
+  private var legacyKinds: Set<InspectorID> = []
+  private var legacyRequests = 0
+  private var legacyBlocked = false
+  private var legacyCancellations = 0
+
+  public func setMetadataFailure(_ failure: MetadataFailure?) {
+    lock.withLock { metadataFailure = failure }
+  }
+
+  public func setLegacyBlocked(_ blocked: Bool) {
+    lock.withLock { legacyBlocked = blocked }
+  }
+
+  public var legacyCancellationCount: Int {
+    lock.withLock { legacyCancellations }
+  }
+
+  public func setLegacyKinds(_ kinds: Set<InspectorID>) {
+    lock.withLock { legacyKinds = kinds }
+  }
+
+  public var legacyRequestCount: Int {
+    lock.withLock { legacyRequests }
+  }
+
   private var socketDevices: [String] = []
   private var socketsByDevice: [String: [String]] = [:]
   private var socketGeneration = 0
@@ -53,12 +83,22 @@ public final class ADBClient: @unchecked Sendable {
     while !lock.withLock({ metadataAvailable }) {
       try await Task.sleep(for: .milliseconds(10))
     }
+    let failure = lock.withLock { metadataFailure }
+    if failure == .request { throw ADBError.requestTimedOut("Test metadata timeout") }
     let pids = Set(socketNames.compactMap { Int($0.split(separator: "_").last ?? "") })
+    if failure == .record {
+      return try pids.map { pid in
+        try JSONDecoder().decode(InspectorProcessMetadata.self, from: JSONSerialization.data(withJSONObject: [
+          "version": 1, "pid": pid, "error": "Test metadata failure"
+        ]))
+      }
+    }
     let inspectors: [[String: Any]] = [
-      ["id": "network", "name": "Network", "protocolVersion": 3],
-      ["id": "tweaks", "name": "Tweaks", "protocolVersion": 7]
+      ["id": "network", "name": "Network", "protocolVersion": 3, "frontend": ["assetPath": "network.zip", "hostApiVersion": 1]],
+      ["id": "tweaks", "name": "Tweaks", "protocolVersion": 7, "frontend": ["assetPath": "tweaks.zip", "hostApiVersion": 1]]
     ].filter { descriptor in
-      socketNames.contains { $0.hasPrefix("snapo_\(descriptor["id"]!)_") }
+      !lock.withLock { legacyKinds.contains(InspectorID(rawValue: descriptor["id"] as! String)) }
+        && socketNames.contains { $0.hasPrefix("snapo_\(descriptor["id"]!)_") }
     }
     return try pids.map { pid in
       let record: [String: Any] = [
@@ -74,8 +114,30 @@ public final class ADBClient: @unchecked Sendable {
     }
   }
 
+  public func legacyInspectorMetadata(
+    reference: InspectorServerReference,
+    kind: InspectorID,
+    pid: Int
+  ) async throws -> LegacyInspectorMetadata? {
+    lock.withLock { legacyRequests += 1 }
+    do {
+      while lock.withLock({ legacyBlocked }) {
+        try await Task.sleep(for: .milliseconds(10))
+      }
+      try Task.checkCancellation()
+    } catch {
+      if Task.isCancelled { lock.withLock { legacyCancellations += 1 } }
+      throw error
+    }
+    return lock.withLock {
+      legacyKinds.contains(kind) ? LegacyInspectorMetadata(
+        packageName: "com.example.demo", name: "Demo", processName: "com.example.demo", protocolVersion: 1
+      ) : nil
+    }
+  }
+
   public func inspectorFrontend(
-    deviceID: String, socketName: String, manifest: InspectorProcessMetadata,
+    deviceID: String, socketName: String, identity: InspectorProcessIdentity,
     inspector: InspectorDescriptor, helperURL: URL
   ) async throws -> InspectorFrontendBundle {
     InspectorFrontendBundle()

--- a/snapo-app-mac/Tests/InspectorRecovery/InspectorRecoveryTests.swift
+++ b/snapo-app-mac/Tests/InspectorRecovery/InspectorRecoveryTests.swift
@@ -152,7 +152,10 @@ struct InspectorRecoveryTests {
     precondition(InspectorHTTP.state.count == 2)
     precondition(!adb.scannedDeviceIDs.contains("stalled"))
     print("A device with failed properties is excluded from app discovery")
-    _ = try await service.inspectorEndpoint(for: healthy)
+    do {
+      _ = try await service.inspectorEndpoint(for: healthy)
+      fatalError("Metadata must be verified before authorizing an endpoint")
+    } catch InspectorError.serverNotConnected {}
     print("Both inspector kinds suppress repeated failed connections while healthy inspectors remain usable")
 
     adb.setMetadataAvailable(true)
@@ -247,6 +250,11 @@ struct InspectorRecoveryTests {
       restartedApp.inspectors.first { $0.kind == .network }?.protocolVersion == nil,
       "Metadata is not shared across service instances"
     )
+    adb.setMetadataAvailable(true)
+    try await eventually {
+      await restarted.discoverInspectors().apps.first { $0.deviceId == "frozen" }?
+        .inspectors.first { $0.kind == .tweaks }?.compatibility == .supported
+    }
     let ownerID = UUID()
     var invalidated = false
     var retired = false
@@ -296,6 +304,11 @@ struct InspectorRecoveryTests {
     await tracker.stopTracking()
     print("Property failures recover without another device tracking event")
     try await refreshesSiblingDescriptors()
+    try compatibilityStates()
+    try await normalizesMetadata()
+    try await mixedCompatibility()
+    try await preservesMetadataAfterFailure()
+    try await restartsCanceledLegacyProbe()
   }
 
   static func refreshesSiblingDescriptors() async throws {
@@ -310,7 +323,7 @@ struct InspectorRecoveryTests {
     let service = InspectorService(adbService: adbService, deviceTracker: tracker)
     _ = await service.discoverInspectors()
     try await eventually {
-      await service.currentInspectors().apps.first?.manifest?.app?.inspectors.map(\.id) == [.network]
+      await service.currentInspectors().apps.first?.metadata?.inspectors.map(\.id) == [.network]
     }
     precondition(adb.metadataSocketRequests.count == 1)
     precondition(Set(adb.metadataSocketRequests[0]) == ["snapo_network_42", "snapo_network_43"])
@@ -319,23 +332,23 @@ struct InspectorRecoveryTests {
     var cachedApp = InspectorHTTPService.App(
       kind: .network, pid: 42, deviceID: "healthy", deviceDisplayTitle: "Phone", socketName: "snapo_network_42"
     )
-    precondition(cachedApp.needsManifestRead(lastAttempt: nil, now: now))
-    precondition(!cachedApp.needsManifestRead(lastAttempt: now, now: now.advanced(by: .seconds(29))))
-    precondition(cachedApp.needsManifestRead(lastAttempt: now, now: now.advanced(by: .seconds(30))))
-    cachedApp.manifest = await service.currentInspectors().apps.first!.manifest!
+    precondition(cachedApp.needsMetadataRead(lastAttempt: nil, now: now))
+    precondition(!cachedApp.needsMetadataRead(lastAttempt: now, now: now.advanced(by: .seconds(29))))
+    precondition(cachedApp.needsMetadataRead(lastAttempt: now, now: now.advanced(by: .seconds(30))))
+    cachedApp.metadata.applyPackageMetadata(testManifest(pid: 42, kinds: [.network]), kind: .network)
     precondition(
-      !cachedApp.needsManifestRead(lastAttempt: now, now: now.advanced(by: .seconds(60))),
+      !cachedApp.needsMetadataRead(lastAttempt: now, now: now.advanced(by: .seconds(60))),
       "Successful metadata stays cached after the failed-read retry window"
     )
-    cachedApp.awaitingManifest = true
-    precondition(cachedApp.needsManifestRead(lastAttempt: nil, now: now), "A replacement socket invalidates cached metadata")
-    precondition(!cachedApp.needsManifestRead(lastAttempt: now, now: now), "Failed replacement reads still back off")
+    cachedApp.awaitingMetadata = true
+    precondition(cachedApp.needsMetadataRead(lastAttempt: nil, now: now), "A replacement socket invalidates cached metadata")
+    precondition(!cachedApp.needsMetadataRead(lastAttempt: now, now: now), "Failed replacement reads still back off")
 
     adb.setSocketNames(["snapo_network_42", "snapo_network_43", "snapo_tweaks_42"], deviceID: "healthy")
     _ = await service.discoverInspectors()
     try await eventually {
       let app = await service.currentInspectors().apps.first
-      return app?.manifest?.app?.inspectors.map(\.id) == [.network, .tweaks]
+      return app?.metadata?.inspectors.map(\.id) == [.network, .tweaks]
         && app?.inspectors.map(\.protocolVersion) == [3, 7]
     }
     precondition(adb.metadataSocketRequests.count == 2)
@@ -345,11 +358,262 @@ struct InspectorRecoveryTests {
 
     adb.setSocketNames(["snapo_network_42"], deviceID: "healthy")
     let remaining = await service.discoverInspectors().apps.first!
-    precondition(remaining.manifest?.app?.inspectors.map(\.id) == [.network, .tweaks])
+    precondition(remaining.metadata?.inspectors.map(\.id) == [.network, .tweaks])
     precondition(remaining.inspectors.map(\.kind) == [.network], "A cached descriptor cannot make an absent server available")
     await service.stop()
     await tracker.stopTracking()
     print("A new socket refreshes sibling metadata; only live sockets determine inspector availability")
+  }
+
+  static func compatibilityStates() throws {
+    func status(inspectors: [[String: Any]], errors: [[String: String]] = []) throws -> InspectorCompatibility {
+      let record: [String: Any] = [
+        "version": 1, "pid": 42, "processIdentity": "boot:42:1", "androidUserId": 0,
+        "app": ["name": "Demo", "packageName": "com.example.demo", "revision": "1", "inspectors": inspectors, "errors": errors]
+      ]
+      let manifest = try JSONDecoder().decode(InspectorProcessMetadata.self, from: JSONSerialization.data(withJSONObject: record))
+      var metadata = InspectorMetadata()
+      metadata.applyPackageMetadata(manifest, kind: .network)
+      return InspectorHTTPService.App(
+        kind: .network, pid: 42, deviceID: "phone", deviceDisplayTitle: "Phone", socketName: "snapo_network_42", metadata: metadata
+      ).compatibility
+    }
+    let descriptor: [String: Any] = ["id": "network", "name": "Network", "protocolVersion": 3]
+    let missingFrontend = try status(inspectors: [descriptor])
+    precondition(missingFrontend == .missingFrontend(protocolVersion: 3))
+    let missingDescriptor = try status(inspectors: [])
+    precondition(missingDescriptor == .missingDescriptor)
+    let invalidDescriptor = try status(inspectors: [], errors: [["key": "snapo.inspector.network", "error": "Invalid XML"]])
+    precondition(invalidDescriptor == .invalidDescriptor)
+    let siblingError = try status(inspectors: [], errors: [["key": "snapo.inspector.tweaks", "error": "Invalid XML"]])
+    precondition(siblingError == .missingDescriptor)
+    for version in [0, 1, 2] {
+      var value = descriptor
+      value["frontend"] = ["assetPath": "frontend.zip", "hostApiVersion": version]
+      let actual = try status(inspectors: [value])
+      precondition(actual == (version == 1 ? .supported : .hostAPI(version: version)))
+    }
+    var pending = InspectorHTTPService.App(
+      kind: .network,
+      pid: 42,
+      deviceID: "phone",
+      deviceDisplayTitle: "Phone",
+      socketName: "snapo_network_42"
+    )
+    precondition(pending.compatibility == .unknown)
+    pending.metadataReadFailed = true
+    precondition(pending.compatibility == .metadataUnavailable && !pending.compatibility.isUnsupported)
+    print("Missing metadata, invalid descriptors, missing frontends, and host API versions remain distinct")
+  }
+
+  static func normalizesMetadata() async throws {
+    let adb = ADBClient()
+    adb.setLegacyKinds([.network])
+    let legacy = try await adb.legacyInspectorMetadata(
+      reference: InspectorServerReference(deviceId: "phone", socketName: "snapo_network_42"), kind: .network, pid: 42
+    )!
+    func record(
+      package: String = "com.example.demo",
+      processName: String = "com.example.demo",
+      revision: String = "1",
+      kinds: [InspectorID] = []
+    ) throws -> InspectorProcessMetadata {
+      let value: [String: Any] = [
+        "version": 1, "pid": 42, "processIdentity": "boot:42:1", "androidUserId": 0, "processName": processName,
+        "app": [
+          "name": "Package label",
+          "packageName": package,
+          "revision": revision,
+          "inspectors": kinds.map { kind in
+            [
+              "id": kind.rawValue,
+              "name": kind.rawValue,
+              "protocolVersion": 4,
+              "frontend": ["assetPath": "frontend.zip", "hostApiVersion": 1]
+            ] as [String: Any]
+          }
+        ]
+      ]
+      return try JSONDecoder().decode(InspectorProcessMetadata.self, from: JSONSerialization.data(withJSONObject: value))
+    }
+    var metadata = InspectorMetadata()
+    precondition(metadata.applyLegacyMetadata(legacy, kind: .network))
+    precondition(metadata.process.name == "Demo" && metadata.process.packageName == "com.example.demo")
+    precondition(metadata.process.verifiedIdentity == nil && metadata.process.inspectors.isEmpty)
+    precondition(metadata.compatibility == .legacy(protocolVersion: 1))
+    let legacyConnection = try JSONSerialization.jsonObject(with: JSONEncoder().encode(
+      InspectorConnectionState(metadata: metadata.process)
+    )) as! [String: Any]
+    precondition(legacyConnection["manifest"] == nil)
+
+    let modern = try record(kinds: [.network])
+    precondition(metadata.applyPackageMetadata(modern, kind: .network))
+    precondition(metadata.process.name == "Package label" && metadata.process.verifiedIdentity != nil)
+    precondition(metadata.compatibility == .supported && metadata.protocolVersion == 4)
+    precondition(!metadata.applyLegacyMetadata(legacy, kind: .network))
+
+    let withoutDescriptor = try record()
+    metadata.applyPackageMetadata(withoutDescriptor, kind: .network)
+    precondition(metadata.applyLegacyMetadata(legacy, kind: .network))
+    precondition(metadata.process.name == "Package label")
+    let sibling = try record(kinds: [.tweaks])
+    metadata.applyPackageMetadata(sibling, kind: .network)
+    precondition(metadata.compatibility == .legacy(protocolVersion: 1))
+    let replacement = try record(revision: "2")
+    metadata.applyPackageMetadata(replacement, kind: .network)
+    precondition(metadata.compatibility == .missingDescriptor && metadata.protocolVersion == nil)
+
+    for mismatch in try [record(package: "com.example.other"), record(processName: "com.example.demo:other")] {
+      metadata.applyPackageMetadata(mismatch, kind: .network)
+      let previous = metadata
+      precondition(!metadata.applyLegacyMetadata(legacy, kind: .network) && metadata == previous)
+    }
+    print("Metadata normalization merges display fields, preserves verified identity, and rejects stale or conflicting legacy evidence")
+  }
+
+  static func mixedCompatibility() async throws {
+    let adbService = ADBService()
+    let adb = await adbService.exec()
+    adb.setMetadataAvailable(true)
+    adb.setLegacyKinds([.network])
+    let tracker = DeviceTracker(adbService: adbService)
+    await tracker.startTracking()
+    adb.emitDevices("healthy device transport_id:1")
+    try await eventually { await tracker.latestDevices.count == 1 }
+    let service = InspectorService(adbService: adbService, deviceTracker: tracker)
+    try await eventually {
+      let options = await service.discoverInspectors().apps.first?.inspectors
+      return options?.first { $0.kind == .network }?.compatibility == .legacy(protocolVersion: 1)
+        && options?.first { $0.kind == .tweaks }?.compatibility == .supported
+        && options?.allSatisfy(\.isConnected) == true
+    }
+    let app = await service.currentInspectors().apps.first!
+    precondition(app.inspectors.count == 2)
+    var selection = InspectorSelection()
+    selection.reconcile([app])
+    precondition(selection.state.preferredKind == .tweaks, "Initial selection prefers a compatible sibling")
+    selection.selectInspector(app, option: app.inspectors[0])
+    precondition(selection.state.preferredKind == .network, "Unsupported inspectors remain selectable")
+    do {
+      _ = try await service.inspectorEndpoint(for: app.inspectors[0].server)
+      fatalError("Legacy metadata must not authorize an inspector endpoint")
+    } catch InspectorError.serverNotConnected {}
+    _ = try await service.inspectorEndpoint(for: app.inspectors[1].server)
+    for _ in 0 ..< 5 {
+      _ = await service.discoverInspectors()
+    }
+    precondition(adb.legacyRequestCount == 1, "Known legacy metadata is cached and modern siblings are not probed")
+    adb.setLegacyKinds([])
+    adb.replaceListeners()
+    try await eventually {
+      await service.discoverInspectors().apps.first?.inspectors.allSatisfy { $0.compatibility == .supported } == true
+    }
+    precondition(adb.legacyRequestCount == 1, "Replacement listeners use fresh manifests before legacy detection")
+    await service.stop()
+    await tracker.stopTracking()
+    print("Unsupported inspectors remain visible and selectable beside usable siblings; listener replacement clears compatibility")
+  }
+
+  private static func refresh(_ service: InspectorHTTPService, using adb: ADBClient) async {
+    let device = Device(id: "healthy", model: "Phone", androidVersion: "Test", vendorModel: nil, manufacturer: nil, avdName: nil)
+    let sockets = await InspectorDiscovery.discover(on: [device.id], using: adb)
+    await service.refresh(devices: [device], sockets: sockets, using: adb)
+  }
+
+  static func preservesMetadataAfterFailure() async throws {
+    for failure: ADBClient.MetadataFailure in [.request, .record] {
+      let adbService = ADBService()
+      let adb = await adbService.exec()
+      adb.setMetadataAvailable(true)
+      adb.setSocketNames(["snapo_network_42"], deviceID: "healthy")
+      let service = InspectorHTTPService(adbService: adbService)
+      await refresh(service, using: adb)
+      try await eventually {
+        let app = await service.currentApps().apps.first
+        return app?.compatibility == .supported && app?.isConnected == true
+      }
+      let original = await service.currentApps().apps.first!
+      let network = InspectorServerReference(deviceId: "healthy", socketName: "snapo_network_42")
+      let tweaks = InspectorServerReference(deviceId: "healthy", socketName: "snapo_tweaks_42")
+      adb.setMetadataFailure(failure)
+      adb.setSocketNames([network.socketName, tweaks.socketName], deviceID: "healthy")
+      await refresh(service, using: adb)
+      try await eventually {
+        let apps = await service.currentApps().apps
+        return apps.count == 2 && apps.allSatisfy(\.metadataReadFailed) && !apps.contains(where: \.checkingLegacy)
+      }
+      let failed = await service.currentApps().apps
+      precondition(failed[0].metadata.process == original.metadata.process, "Failed sibling discovery must preserve verified metadata")
+      precondition(failed[0].compatibility == .supported && failed[0].isConnected)
+      precondition(failed[1].compatibility == .metadataUnavailable)
+      _ = try await service.endpoint(for: network)
+      do {
+        _ = try await service.endpoint(for: tweaks)
+        fatalError("A new sibling cannot use another socket's cached descriptor")
+      } catch InspectorError.serverNotConnected {}
+      let now = ContinuousClock.now
+      precondition(!failed[0].needsMetadataRead(lastAttempt: now, now: now.advanced(by: .seconds(29))))
+      precondition(failed[0].needsMetadataRead(lastAttempt: now, now: now.advanced(by: .seconds(30))))
+      await refresh(service, using: adb)
+      precondition(adb.metadataSocketRequests.count == 2, "Failed metadata refreshes must still back off")
+
+      adb.replaceListeners()
+      await refresh(service, using: adb)
+      try await eventually {
+        let apps = await service.currentApps().apps
+        return adb.metadataSocketRequests.count == 3 && apps.allSatisfy(\.metadataReadFailed)
+      }
+      let replacement = await service.currentApps().apps.first!
+      precondition(replacement.metadata.process == original.metadata.process, "Retain display metadata while a replacement is unverified")
+      precondition(replacement.awaitingMetadata && !replacement.isConnected && replacement.compatibility == .metadataUnavailable)
+      do {
+        _ = try await service.endpoint(for: network)
+        fatalError("Preserved metadata cannot authorize a replacement listener after a failed read")
+      } catch InspectorError.serverNotConnected {}
+
+      adb.setMetadataFailure(nil)
+      adb.replaceListeners()
+      await refresh(service, using: adb)
+      try await eventually {
+        await service.currentApps().apps.allSatisfy { $0.compatibility == .supported && $0.isConnected && !$0.metadataReadFailed }
+      }
+      _ = try await service.endpoint(for: network)
+      _ = try await service.endpoint(for: tweaks)
+      await service.stop()
+    }
+    print("Failed refreshes preserve verified siblings, back off, and never authorize unverified replacement listeners")
+  }
+
+  static func restartsCanceledLegacyProbe() async throws {
+    let adbService = ADBService()
+    let adb = await adbService.exec()
+    adb.setMetadataAvailable(true)
+    adb.setLegacyKinds([.network])
+    adb.setLegacyBlocked(true)
+    adb.setSocketNames(["snapo_network_42"], deviceID: "healthy")
+    let service = InspectorHTTPService(adbService: adbService)
+    await refresh(service, using: adb)
+    try await eventually {
+      await service.currentApps().apps.first?.checkingLegacy == true && adb.legacyRequestCount == 1
+    }
+    adb.setSocketNames([], deviceID: "healthy")
+    await refresh(service, using: adb)
+    try await eventually { adb.legacyCancellationCount == 1 }
+    adb.setSocketNames(["snapo_network_42"], deviceID: "healthy")
+    await refresh(service, using: adb)
+    try await eventually { adb.legacyRequestCount == 2 }
+    let returned = await service.currentApps().apps.first!
+    precondition(!returned.checkingLegacy, "A canceled probe must not leave the cached loading flag set")
+    precondition(adb.metadataSocketRequests.count == 2, "Rediscovery must not wait for the failed-request cooldown")
+    adb.setLegacyBlocked(false)
+    try await eventually { await service.currentApps().apps.first?.compatibility == .legacy(protocolVersion: 1) }
+    adb.setLegacyBlocked(true)
+    adb.replaceListeners()
+    await refresh(service, using: adb)
+    try await eventually { adb.legacyRequestCount == 3 }
+    await service.stop()
+    try await eventually { adb.legacyCancellationCount == 2 }
+    print("Socket removal clears canceled probe state; rediscovery retries immediately and shutdown cancels active probes")
   }
 
   static func eventually(line: Int = #line, _ condition: () async -> Bool) async throws {

--- a/snapo-app-mac/Tests/InspectorSelection/InspectorSelectionTests.swift
+++ b/snapo-app-mac/Tests/InspectorSelection/InspectorSelectionTests.swift
@@ -6,15 +6,28 @@ private func app(
   process: String? = "com.example.demo", device: String = "phone", user: Int? = 0,
   package: String? = "com.example.demo", version: Int? = 4, connectedKinds: [InspectorID]? = nil
 ) -> InspectableApp {
-  InspectableApp(
-    id: "\(device):pid:\(pid)", name: "Demo", packageName: package, processName: process,
-    androidUserId: user, deviceId: device, deviceDisplayTitle: "Phone", appIconBase64: nil,
+  let manifest = testManifest(pid: pid, kinds: kinds, version: version ?? 4)
+  var record = try! JSONSerialization.jsonObject(with: JSONEncoder().encode(manifest)) as! [String: Any]
+  record["androidUserId"] = user as Any? ?? NSNull()
+  record["processName"] = process as Any? ?? NSNull()
+  var packageRecord = record["app"] as! [String: Any]
+  packageRecord["packageName"] = package ?? "com.example.demo"
+  record["app"] = packageRecord
+  let identity = InspectorProcessIdentity(metadata: try! JSONDecoder().decode(
+    InspectorProcessMetadata.self, from: JSONSerialization.data(withJSONObject: record)
+  ))
+  let metadata = InspectorMetadata.Process(
+    name: "Demo", packageName: package, processName: process,
+    verifiedIdentity: identity, inspectors: manifest.app!.inspectors
+  )
+  return InspectableApp(
+    id: "\(device):pid:\(pid)", pid: pid, deviceId: device, deviceDisplayTitle: "Phone",
     inspectors: kinds.map {
       AppInspectorOption(
         kind: $0, server: .init(deviceId: device, socketName: "snapo_\($0.rawValue)_\(pid)"), protocolVersion: version,
-        isConnected: connectedKinds?.contains($0) ?? true
+        isConnected: connectedKinds?.contains($0) ?? true, compatibility: .supported
       )
-    }, manifest: testManifest(pid: pid, kinds: kinds, version: version ?? 4)
+    }, metadata: metadata
   )
 }
 
@@ -34,6 +47,8 @@ struct InspectorSelectionTests {
   @MainActor static func main() async throws {
     try WorkspaceLayoutTests.run()
     restoration()
+    metadataDisplay()
+    compatibilityTitles()
     disconnectedInspectorMetadata()
     profilesAndIdentity()
     fallback()
@@ -44,9 +59,47 @@ struct InspectorSelectionTests {
     print("Inspector selection, restoration, and launch tests passed")
   }
 
+  private static func metadataDisplay() {
+    var value = app()
+    value.metadata?.name = "Updated label"
+    value.metadata?.iconBase64 = "updated-icon"
+    expect(value.name == "Updated label" && value.appIconBase64 == "updated-icon", "Display the current metadata")
+    value.metadata?.name = nil
+    expect(value.name == "com.example.demo", "Fall back to the process name")
+    value.metadata?.processName = nil
+    value.metadata?.packageName = "com.example.package"
+    expect(value.name == "com.example.package", "Fall back to the package name")
+    value.metadata = nil
+    expect(value.name == "Process 10", "Keep a label before metadata arrives")
+    expect(value.androidUserId == nil && value.appIconBase64 == nil, "Do not retain details outside metadata")
+  }
+
+  private static func compatibilityTitles() {
+    expect(
+      InspectorCompatibility.legacy(protocolVersion: 1).title(for: .network) == "Unsupported Network version",
+      "Name the socket's tool"
+    )
+    expect(
+      InspectorCompatibility.missingDescriptor.title(for: .tweaks) == "Unsupported Tweaks version",
+      "Name tools without manifest metadata"
+    )
+    expect(
+      InspectorCompatibility.hostAPI(version: 2).title(for: InspectorID(rawValue: "sample")) == "Unsupported Sample version",
+      "Custom socket identifiers do not need a built-in tool mapping"
+    )
+    expect(
+      InspectorCompatibility.missingDescriptor.title(for: nil) == "Unsupported tool version",
+      "Keep a fallback without a selected tool"
+    )
+    expect(
+      InspectorCompatibility.metadataUnavailable.title(for: .network) == "Inspector unavailable",
+      "Do not confuse reachability with version support"
+    )
+  }
+
   private static func restoration() {
     var owner = selected(.tweaks)
-    expect(owner.state.selectedApp?.manifest == app().manifest, "Selection retains the process manifest for the inspector page")
+    expect(owner.state.selectedApp?.metadata == app().metadata, "Selection retains the process manifest for the inspector page")
     let displayed = owner.state.displayed[.tweaks]
     owner.reconcile([])
     expect(owner.state.selection == nil && owner.state.displayed[.tweaks] == displayed, "Retain disconnected values")
@@ -82,7 +135,7 @@ struct InspectorSelectionTests {
     expect(owner.state.selection?.kind == .tweaks, "Restore other app's inspector")
     owner.reconcile([app(20, process: "com.example.other", version: 5)])
     expect(owner.state.selection?.protocolVersion == 5, "Update protocol metadata")
-    expect(owner.state.selectedApp?.manifest?.app?.inspectors.first?.protocolVersion == 5, "Refresh the selected process manifest")
+    expect(owner.state.selectedApp?.metadata?.inspectors.first?.protocolVersion == 5, "Refresh the selected process manifest")
   }
 
   private static func disconnectedInspectorMetadata() {
@@ -414,7 +467,7 @@ struct InspectorSelectionTests {
     await settle()
     continuation.yield(())
     await settle()
-    expect(model.snapshot.state.selectedApp?.manifest == app().manifest, "Publish completed metadata before the polling scan returns")
+    expect(model.snapshot.state.selectedApp?.metadata == app().metadata, "Publish completed metadata before the polling scan returns")
     expect(scans == 1, "A discovery update does not start another device scan")
     scanReply?.resume(returning: InspectorDiscoverySnapshot(apps: [app(20)], revision: 1))
     await settle()
@@ -423,7 +476,7 @@ struct InspectorSelectionTests {
     continuation.yield(())
     await settle()
     expect(model.snapshot.state.selection == nil, "Publish a failed health check without another poll")
-    expect(model.snapshot.state.selectedApp?.manifest == app().manifest, "Keep metadata when the health check disconnects")
+    expect(model.snapshot.state.selectedApp?.metadata == app().metadata, "Keep metadata when the health check disconnects")
     expect(scans == 1, "Health updates do not start another device scan")
     model.stop()
     let stoppedRevision = model.snapshot.revision

--- a/snapo-app-mac/Tests/InspectorSelection/InspectorTestFixtures.swift
+++ b/snapo-app-mac/Tests/InspectorSelection/InspectorTestFixtures.swift
@@ -24,3 +24,11 @@ func testManifest(pid: Int, kinds: [InspectorID], version: Int = 4, includeFront
   ]
   return try! JSONDecoder().decode(InspectorProcessMetadata.self, from: JSONSerialization.data(withJSONObject: record))
 }
+
+func testProcessMetadata(pid: Int, kinds: [InspectorID], version: Int = 4, includeFrontend: Bool = true) -> InspectorMetadata.Process {
+  var metadata = InspectorMetadata()
+  metadata.applyPackageMetadata(
+    testManifest(pid: pid, kinds: kinds, version: version, includeFrontend: includeFrontend), kind: kinds.first ?? .network
+  )
+  return metadata.process
+}

--- a/snapo-app-mac/Tests/InspectorSelection/InspectorWebViewTests.swift
+++ b/snapo-app-mac/Tests/InspectorSelection/InspectorWebViewTests.swift
@@ -13,6 +13,8 @@ actor InspectorHTTPService {
 actor InspectorService {
   private let invalidFrontend: Bool
   private var apps: [InspectableApp]
+  private(set) var frontendRequests = 0
+  private(set) var endpointRequests = 0
   private let updates = AsyncStream<Void>.makeStream(bufferingPolicy: .bufferingNewest(1))
   let endpoint = InspectorHTTPService.Endpoint(id: UUID(), baseURL: URL(string: "http://127.0.0.1:1234/")!)
   init(apps: [InspectableApp], invalidFrontend: Bool = false) {
@@ -42,14 +44,16 @@ actor InspectorService {
     for reference: InspectorServerReference, ownerID: UUID? = nil,
     invalidated: (@MainActor @Sendable () async -> Void)? = nil
   ) async throws -> InspectorHTTPService.Endpoint {
-    endpoint
+    endpointRequests += 1
+    return endpoint
   }
 
   func releaseInspectorEndpoint(ownerID: UUID) {}
 
   func inspectorFrontend(
-    for reference: InspectorServerReference, manifest: InspectorProcessMetadata, inspector: InspectorDescriptor
+    for reference: InspectorServerReference, identity: InspectorProcessIdentity, inspector: InspectorDescriptor
   ) async throws -> InspectorFrontendBundle {
+    frontendRequests += 1
     if invalidFrontend { return try InspectorFrontendBundle(files: ["index.html": Data([0xFF])]) }
     return try Self.frontendFixture(inspector.id)
   }
@@ -83,16 +87,22 @@ struct InspectorWebViewTests {
     _ pid: Int,
     connectedKinds: [InspectorID]? = nil,
     kinds: [InspectorID] = [.network, .tweaks, .sample],
-    includeFrontend: Bool = true
+    includeFrontend: Bool = true,
+    compatibility: [InspectorID: InspectorCompatibility] = [:]
   ) -> InspectableApp {
     InspectableApp(
-      id: "phone:pid:\(pid)", name: "Demo \(pid)", packageName: "com.example.demo\(pid)",
-      processName: "com.example.demo\(pid)", androidUserId: 0, deviceId: "phone", deviceDisplayTitle: "Phone",
-      appIconBase64: nil, inspectors: kinds.map { kind in
-        AppInspectorOption(kind: kind, server: InspectorServerReference(
-          deviceId: "phone", socketName: "snapo_\(kind.rawValue)_\(pid)"
-        ), protocolVersion: 4, isConnected: connectedKinds?.contains(kind) ?? true)
-      }, manifest: testManifest(pid: pid, kinds: kinds, includeFrontend: includeFrontend)
+      id: "phone:pid:\(pid)", pid: pid, deviceId: "phone", deviceDisplayTitle: "Phone",
+      inspectors: kinds.map { kind in
+        AppInspectorOption(
+          kind: kind,
+          server: InspectorServerReference(
+            deviceId: "phone", socketName: "snapo_\(kind.rawValue)_\(pid)"
+          ),
+          protocolVersion: 4,
+          isConnected: connectedKinds?.contains(kind) ?? true,
+          compatibility: compatibility[kind] ?? (includeFrontend ? .supported : .missingFrontend(protocolVersion: 4))
+        )
+      }, metadata: testProcessMetadata(pid: pid, kinds: kinds, includeFrontend: includeFrontend)
     )
   }
 
@@ -278,6 +288,40 @@ struct InspectorWebViewTests {
     try await testSecurity()
     try await testFrontendSources(preferences: preferences)
     try await testFrontendErrors(preferences: preferences)
+    try await testUnsupportedInspectors(preferences: preferences)
+  }
+
+  static func testUnsupportedInspectors(preferences: UserDefaults) async throws {
+    for compatibility: InspectorCompatibility in [
+      .legacy(protocolVersion: 1),
+      .missingDescriptor,
+      .invalidDescriptor,
+      .hostAPI(version: 2),
+      .metadataUnavailable
+    ] {
+      preferences.set(
+        #"{"apps":[],"last":{"deviceId":"phone","processName":"com.example.demo70","androidUserId":0,"kind":"network"}}"#,
+        forKey: "inspectorPreferences"
+      )
+      let provider = app(70, kinds: [.network, .sample], compatibility: [.network: compatibility])
+      let service = InspectorService(apps: [provider])
+      let model = InspectorHostModel(service: service, preferences: preferences)
+      defer { model.stop() }
+      try await eventually("Compatibility provider should be discovered") { model.inspectorApps.count == 1 }
+      model.selectInspector(provider, option: provider.inspectors[0])
+      try await eventually("Unsupported inspectors should show their native explanation") {
+        model.compatibilityExplanation == compatibility
+      }
+      try await Task.sleep(for: .milliseconds(50))
+      precondition(!model.isPageReady && model.toolbarActions.isEmpty)
+      let frontendRequests = await service.frontendRequests
+      let endpointRequests = await service.endpointRequests
+      precondition(frontendRequests == 0 && endpointRequests == 0, "Compatibility explanations must not load or authorize a frontend")
+      model.selectInspector(provider, option: provider.inspectors[1])
+      try await eventually("A compatible sibling should remain usable") { model.isPageReady }
+      precondition(model.compatibilityExplanation == nil)
+    }
+    print("Unsupported and unreachable inspectors show native explanations without authorizing a frontend; compatible siblings still load")
   }
 
   static func testFrontendErrors(preferences: UserDefaults) async throws {
@@ -288,9 +332,9 @@ struct InspectorWebViewTests {
       defer { model.stop() }
       try await eventually("The frontend provider should be discovered") { model.inspectorApps.count == 1 }
       model.selectInspector(provider, option: provider.inspectors[0])
-      let message = includeFrontend ? "invalid inspector frontend assets" : "no compatible frontend"
       try await eventually("Missing or invalid APK frontends must report a native error") {
-        model.frontendError?.contains(message) == true
+        includeFrontend ? model.frontendError?.contains("invalid inspector frontend assets") == true
+          : model.compatibilityExplanation == .missingFrontend(protocolVersion: 4)
       }
       precondition(!model.isPageReady)
     }
@@ -496,12 +540,12 @@ struct InspectorWebViewTests {
     precondition(scope != nil && scope != InspectorWebPolicy.storageIdentifier(app: app(20), inspector: .sample))
     precondition(scope != InspectorWebPolicy.storageIdentifier(app: first, inspector: .network))
     var restarted = app(11)
-    restarted.manifest = first.manifest
+    restarted.metadata = first.metadata
     precondition(
       scope == InspectorWebPolicy.storageIdentifier(app: restarted, inspector: .sample),
       "Process IDs do not partition a provider's preferences"
     )
-    restarted.manifest = nil
+    restarted.metadata = nil
     precondition(InspectorWebPolicy.storageIdentifier(app: restarted, inspector: .sample) == nil, "Unknown providers use ephemeral storage")
     var nested: Any = "value"
     for _ in 0 ..< 10 {

--- a/snapo-app-mac/scripts/test-inspector-recovery.sh
+++ b/snapo-app-mac/scripts/test-inspector-recovery.sh
@@ -12,6 +12,7 @@ xcrun swiftc -swift-version 6 -parse-as-library -whole-module-optimization \
   SnapODeviceClient/Sources/SnapODeviceClient/InspectorServerReference.swift \
   SnapODeviceClient/Sources/SnapODeviceClient/InspectorDiscovery.swift \
   SnapODeviceClient/Sources/SnapODeviceClient/InspectorManifest.swift \
+  SnapODeviceClient/Sources/SnapODeviceClient/LegacyInspectorMetadata.swift \
   SnapODeviceClient/Sources/SnapODeviceClient/DeviceDiscovery.swift \
   Tests/InspectorRecovery/DeviceClientDouble.swift \
   -emit-module-path "$TEST_DIR/SnapODeviceClient.swiftmodule" -o "$TEST_DIR/DeviceClient.o"
@@ -19,6 +20,7 @@ xcrun swiftc -swift-version 6 -parse-as-library -I "$TEST_DIR" \
   "$TEST_DIR/DeviceClient.o" Snap-O/Models/Device+Formatting.swift \
   Snap-O/ADB/DeviceTracker.swift \
   Snap-O/Inspectors/InspectorModels.swift \
+  Snap-O/Inspectors/InspectorMetadata.swift \
   Tests/InspectorSelection/InspectorTestFixtures.swift \
   Snap-O/Inspectors/InspectorSelection.swift \
   Snap-O/Inspectors/AppInspectorModel.swift \

--- a/snapo-app-mac/scripts/test-inspector-selection.sh
+++ b/snapo-app-mac/scripts/test-inspector-selection.sh
@@ -13,6 +13,7 @@ xcrun swiftc -swift-version 6 -parse-as-library \
   "$TEST_DIR/package/debug/SnapODeviceClient.build/"*.o \
   "$TEST_DIR/package/debug/ZIPFoundation.build/"*.o \
   Snap-O/Inspectors/InspectorModels.swift \
+  Snap-O/Inspectors/InspectorMetadata.swift \
   Tests/InspectorSelection/InspectorTestFixtures.swift \
   Snap-O/Inspectors/InspectorSelection.swift \
   Snap-O/Inspectors/AppInspectorModel.swift \
@@ -26,6 +27,7 @@ xcrun swiftc -swift-version 6 -parse-as-library \
   "$TEST_DIR/package/debug/SnapODeviceClient.build/"*.o \
   "$TEST_DIR/package/debug/ZIPFoundation.build/"*.o \
   Snap-O/Inspectors/InspectorModels.swift \
+  Snap-O/Inspectors/InspectorMetadata.swift \
   Tests/InspectorSelection/InspectorTestFixtures.swift \
   Snap-O/Inspectors/InspectorSelection.swift \
   Snap-O/Inspectors/AppInspectorModel.swift \


### PR DESCRIPTION
Apps using older Snap-O libraries could disappear from the inspector picker or appear stuck loading. Keep these apps visible and explain why their inspectors cannot open.

## Summary

- Show unsupported inspectors with clear guidance to update the app’s libraries or use an older compatible Snap-O.
- Detect older libraries through bounded, read-only metadata requests.
- Keep compatible inspectors usable when another inspector in the same app is unsupported.
- Use one metadata model for app details and compatibility. Legacy metadata cannot authorize frontend loading.
- Preserve metadata during temporary failures and retry after inspectors reconnect.

## Validation

- macOS app build passed.
- All 62 shared-client tests passed.
- Recovery, selection, and WebKit tests passed.
- Added coverage for legacy metadata, mixed compatibility, failed refreshes, cancellation, and display fallbacks.
- SwiftFormat and SwiftLint passed.
