### PR TITLE
Fix idle CLI network stream timeouts

### DIFF
--- a/cli/snapo
+++ b/cli/snapo
@@ -661,7 +661,8 @@ class NetworkSSE(NetworkHTTPResponse):
         if self.response.getheader("Content-Type", "").split(";")[0].strip() != "text/event-stream":
             self.close()
             raise SnapOError("Expected a network SSE response")
-        self.transport.socket.settimeout(30)
+        # Allow headroom beyond the server's 30-second heartbeat.
+        self.transport.socket.settimeout(60)
 
     def read_event(self):
         data = bytearray()

--- a/cli/tests/test_snapo.py
+++ b/cli/tests/test_snapo.py
@@ -196,6 +196,26 @@ class SSETests(unittest.TestCase):
         self.assertEqual(event["id"], "9")
         self.assertEqual(event["event"], "ready")
 
+    def test_idle_stream_survives_a_delayed_heartbeat(self):
+        message = {"method": "Network.loadingFinished", "snapoSequence": 1}
+
+        def handler(stream, _):
+            # Allow one second of scheduling delay beyond the server's 30-second heartbeat.
+            if wire.stopping.wait(31):
+                return
+            heartbeat = b": keep-alive\n\n"
+            stream.write(f"{len(heartbeat):x}\r\n".encode() + heartbeat + b"\r\n")
+            write_message(stream, message)
+
+        with WireServer(handler) as wire:
+            stream = snapo.NetworkSSE(
+                lambda timeout: snapo.LocalAbstractSocket(port=wire.port, timeout=timeout), "/network"
+            )
+            try:
+                self.assertEqual(stream.read_event()["data"], message)
+            finally:
+                stream.close()
+
     def test_partial_and_invalid_events_fail(self):
         for payload in (b'data: {}\n', b'data: "\xff"\n\n', b'data: nope\n\n'):
             with self.subTest(payload=payload), self.assertRaises(snapo.SnapOError):


### PR DESCRIPTION
Quiet Network streams can time out in the CLI because the server heartbeat and client read timeout are both 30 seconds. This ends request watching and interception even when the connection is healthy.

## Summary

- Increase the Network SSE read timeout to 60 seconds, leaving headroom for the 30-second heartbeat.
- Keep connection setup and ordinary HTTP timeouts unchanged.
- Add a socket regression test that delivers a heartbeat and event after 31 idle seconds. The test adds about 31 seconds to the CLI suite.

## Validation

- Confirmed the regression test fails with the previous timeout after 30 seconds.
- All 135 CLI tests pass with the new timeout.
- Python compilation and interception route smoke check pass.
- macOS app builds without signing and embeds the updated CLI.

A stalled SSE connection can now take up to 60 seconds to time out. Explicit socket closure still fails immediately.
